### PR TITLE
feat: headless Docker auth, walkthrough evals, and product improvements

### DIFF
--- a/apps/common/apps.py
+++ b/apps/common/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class CommonConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.common"

--- a/apps/common/auth_flow.py
+++ b/apps/common/auth_flow.py
@@ -1,0 +1,248 @@
+"""
+Drive `claude setup-token` via PTY for headless Docker auth.
+
+Flow:
+  1. start() — spawns process, captures auth URL, returns it
+  2. complete(code) — sends code to PTY, captures OAuth token, persists it
+  3. poll() — check if auth completed via browser polling (no code needed)
+
+The resulting token is stored at TOKEN_FILE and exported as
+CLAUDE_CODE_OAUTH_TOKEN so the CLI backend picks it up automatically.
+"""
+import logging
+import os
+import pty
+import re
+import select
+import subprocess
+import threading
+import time
+
+logger = logging.getLogger(__name__)
+
+TOKEN_FILE = os.environ.get(
+    "CLAUDE_TOKEN_FILE", "/root/claude-data/oauth-token"
+)
+
+_lock = threading.Lock()
+_session = None  # type: _AuthSession | None
+
+
+# ── ANSI / parsing helpers ──────────────────────────────────────────
+
+_ANSI_RE = re.compile(
+    r"\x1b[\[\(][0-9;?]*[a-zA-Z]"
+    r"|\x1b[><=][0-9;]*[a-zA-Z]?"
+    r"|\x1b\[[?0-9;]*[a-zA-Z]"
+)
+
+
+def _strip_ansi(text):
+    return _ANSI_RE.sub("", text)
+
+
+def _extract_url(raw):
+    clean = _strip_ansi(raw).replace("\n", "").replace("\r", "")
+    # After ANSI strip + newline removal, prompt text like
+    # "Pastecodehereifprompted>" is concatenated right after the URL.
+    # Use non-greedy match with lookahead to stop before "Paste".
+    m = re.search(
+        r"(https://claude\.com/cai/oauth/authorize\S+?)(?=Paste|\s|$)",
+        clean,
+    )
+    return m.group(1) if m else None
+
+
+def _extract_token(raw):
+    clean = _strip_ansi(raw)
+    m = re.search(r"(sk-ant-oat\S+)", clean)
+    return m.group(1) if m else None
+
+
+# ── Session object ──────────────────────────────────────────────────
+
+class _AuthSession:
+    """Manages a single setup-token PTY subprocess."""
+
+    def __init__(self):
+        self.master_fd = None
+        self.process = None
+        self.buffer = ""
+        self.token = None
+        self.url = None
+        self.started_at = time.time()
+
+    def spawn(self):
+        master, slave = pty.openpty()
+        env = {k: v for k, v in os.environ.items() if k != "ANTHROPIC_API_KEY"}
+        self.process = subprocess.Popen(
+            ["claude", "setup-token"],
+            stdin=slave, stdout=slave, stderr=slave,
+            close_fds=True, start_new_session=True, env=env,
+        )
+        os.close(slave)
+        self.master_fd = master
+        threading.Thread(target=self._read_loop, daemon=True).start()
+
+    def _read_loop(self):
+        """Background reader — keeps PTY buffer drained."""
+        while self.master_fd is not None:
+            try:
+                r, _, _ = select.select([self.master_fd], [], [], 1.0)
+                if r:
+                    chunk = os.read(self.master_fd, 4096)
+                    if not chunk:
+                        break
+                    text = chunk.decode("utf-8", errors="replace")
+                    with _lock:
+                        self.buffer += text
+                        if not self.url:
+                            self.url = _extract_url(self.buffer)
+                        if not self.token:
+                            self.token = _extract_token(self.buffer)
+            except OSError:
+                break
+
+    def send(self, text):
+        if self.master_fd is not None:
+            os.write(self.master_fd, text.encode())
+
+    def cleanup(self):
+        if self.process:
+            try:
+                self.process.terminate()
+                self.process.wait(timeout=3)
+            except Exception:
+                try:
+                    self.process.kill()
+                except Exception:
+                    pass
+            self.process = None
+        if self.master_fd is not None:
+            try:
+                os.close(self.master_fd)
+            except OSError:
+                pass
+            self.master_fd = None
+
+
+# ── Public API ──────────────────────────────────────────────────────
+
+def start():
+    """Spawn setup-token, return auth URL (or token if auth is instant)."""
+    global _session
+    cancel()
+
+    session = _AuthSession()
+    session.spawn()
+
+    with _lock:
+        _session = session
+
+    # Wait for URL (or instant token) up to 15 s
+    deadline = time.time() + 15
+    while time.time() < deadline:
+        time.sleep(0.5)
+        with _lock:
+            if session.token:
+                store_token(session.token)
+                _cleanup_locked()
+                return {"auth_url": None, "token": session.token, "status": "complete"}
+            if session.url:
+                return {"auth_url": session.url, "token": None, "status": "awaiting_code"}
+
+    cancel()
+    raise RuntimeError("Timed out waiting for auth URL from setup-token")
+
+
+def complete(code=None):
+    """Send the pasted code (or just check if polling completed). Returns token."""
+    global _session
+
+    with _lock:
+        if _session is None:
+            raise RuntimeError("No active auth flow. Call start() first.")
+        session = _session
+        if session.token:
+            token = session.token
+            store_token(token)
+            _cleanup_locked()
+            return token
+
+    if code:
+        session.send(code + "\r")
+
+    deadline = time.time() + 15
+    while time.time() < deadline:
+        time.sleep(0.5)
+        with _lock:
+            if session.token:
+                token = session.token
+                store_token(token)
+                _cleanup_locked()
+                return token
+
+    raise RuntimeError("Timed out waiting for token. Code may be invalid.")
+
+
+def poll():
+    """Non-blocking check — has auth completed?"""
+    with _lock:
+        if _session is None:
+            return {
+                "active": False,
+                "authenticated": bool(get_stored_token()),
+            }
+        if _session.token:
+            token = _session.token
+            store_token(token)
+            _cleanup_locked()
+            return {"active": False, "authenticated": True}
+        elapsed = int(time.time() - _session.started_at)
+        return {"active": True, "authenticated": False, "elapsed_seconds": elapsed}
+
+
+def cancel():
+    """Kill any running auth session."""
+    with _lock:
+        _cleanup_locked()
+
+
+def _cleanup_locked():
+    global _session
+    if _session is not None:
+        _session.cleanup()
+        _session = None
+
+
+# ── Token persistence ───────────────────────────────────────────────
+
+def store_token(token):
+    """Persist token to disk and set env var."""
+    try:
+        os.makedirs(os.path.dirname(TOKEN_FILE), exist_ok=True)
+        with open(TOKEN_FILE, "w") as f:
+            f.write(token)
+        os.chmod(TOKEN_FILE, 0o600)
+    except OSError:
+        logger.debug("Could not persist token to %s", TOKEN_FILE)
+    os.environ["CLAUDE_CODE_OAUTH_TOKEN"] = token
+
+
+def load_stored_token():
+    """Load persisted token into env. Called at container boot."""
+    try:
+        if os.path.exists(TOKEN_FILE):
+            with open(TOKEN_FILE) as f:
+                token = f.read().strip()
+            if token:
+                os.environ["CLAUDE_CODE_OAUTH_TOKEN"] = token
+                return token
+    except OSError:
+        pass
+    return None
+
+
+def get_stored_token():
+    """Return current token from env or disk."""
+    return os.environ.get("CLAUDE_CODE_OAUTH_TOKEN") or load_stored_token()

--- a/apps/common/management/commands/seed_demo.py
+++ b/apps/common/management/commands/seed_demo.py
@@ -1,0 +1,298 @@
+"""
+Seed the database with realistic demo data for walkthrough runs.
+
+Usage:
+    python manage.py seed_demo          # Create demo data
+    python manage.py seed_demo --reset  # Wipe and re-create
+"""
+from datetime import timedelta
+
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from apps.collections.models import Collection, Source
+from apps.workspace.models import WorkspaceSession
+from apps.skills.models import Skill
+from apps.evals.models import EvalSuite, EvalCase, EvalRun
+
+
+# ── Demo source material ────────────────────────────────────────────
+
+ONBOARDING_TRANSCRIPT = """\
+Agent: Welcome! I see you're setting up CommCare for your CHW program. Let's \
+walk through the key steps.
+
+User: We have 200 community health workers across 3 districts. They need to do \
+household registration, child growth monitoring, and referral tracking.
+
+Agent: Great. Let's start with the application structure. I'll create three \
+modules: Household Registration, Child Health Visit, and Referral Follow-up. \
+Each one maps to a distinct workflow your CHWs perform in the field.
+
+User: Should we use case management or form-based?
+
+Agent: Case management. Each household is a case, children are sub-cases. This \
+lets CHWs see their full caseload, filter by due visits, and track referral \
+status over time. Form-based would lose that continuity.
+
+User: What about the registration form?
+
+Agent: The registration form captures: head of household name, GPS coordinates, \
+number of children under 5, and a photo. GPS auto-captures on save. The photo \
+helps CHWs identify the right household on return visits.
+
+User: We also need to calculate Z-scores for growth monitoring.
+
+Agent: I'll add a hidden value that computes weight-for-age Z-score using WHO \
+standards. The form will show a color-coded indicator: green (normal), yellow \
+(moderate), red (severe). If red, it auto-creates a referral case.
+
+User: And the referral tracking?
+
+Agent: Referral follow-up form: date of referral, facility referred to, \
+outcome (treated/not seen/referred further), and a follow-up date. If outcome \
+is "not seen", it flags for supervisor review and schedules a re-visit in 48 hours.
+"""
+
+CODE_REVIEW_CONVERSATION = """\
+User: Can you review this pull request? It adds a new caching layer for our API.
+
+Agent: Looking at the changes...
+
+1. Cache key generation uses f"api:{endpoint}:{user_id}" which correctly \
+differentiates per-user and per-endpoint.
+
+2. Cache invalidation via @invalidate_cache on write endpoints clears all keys \
+matching the endpoint prefix. Aggressive but safe.
+
+3. Race condition: There's a TOCTOU issue in get_or_set(). Between checking if \
+the key exists and setting it, another request could write a different value. \
+Use Redis SETNX for critical paths.
+
+4. Error handling: If Redis is down, the decorator falls through to the database. \
+Good. But add a metric counter for cache misses due to connection errors.
+
+5. Memory: No eviction policy configured. Add maxmemory-policy allkeys-lru.
+"""
+
+
+# ── Skill definitions with eval history ─────────────────────────────
+
+SKILLS = [
+    {
+        "name": "CommCare App Configuration",
+        "description": "Guide users through configuring CommCare mobile apps with case management, calculated fields, and staged deployment.",
+        "definition": {
+            "name": "CommCare App Configuration",
+            "description": "Walk through the full setup of a CommCare application: define modules and forms, configure case management, add calculated properties, and plan a staged rollout.",
+            "steps": [
+                {"name": "Gather requirements", "description": "Understand program scope: users, geography, workflows.", "tools": [], "inputs": ["program_description"], "outputs": ["requirements_summary"]},
+                {"name": "Design app structure", "description": "Create modules and forms. Choose case management for longitudinal tracking.", "tools": ["commcare_app_builder"], "inputs": ["requirements_summary"], "outputs": ["module_list", "case_hierarchy"]},
+                {"name": "Configure calculations", "description": "Add hidden values for computed indicators (Z-scores, risk flags) with color coding.", "tools": ["commcare_app_builder"], "inputs": ["module_list"], "outputs": ["calculated_fields"]},
+                {"name": "Plan deployment", "description": "Set up user groups, staged rollout, and data integration.", "tools": ["commcare_admin"], "inputs": ["case_hierarchy"], "outputs": ["deployment_plan"]},
+            ],
+        },
+        "eval_cases": [
+            {"name": "CHW program with growth monitoring", "input_data": {"prompt": "Set up a CHW program for 200 workers doing household registration and child health visits."}, "expected_output": {"contains": ["case management", "household", "z-score", "referral"]}},
+            {"name": "Staged rollout recommendation", "input_data": {"prompt": "We have 5 districts. How should we deploy?"}, "expected_output": {"contains": ["staged", "rollout", "pilot"]}},
+            {"name": "GPS and photo capture", "input_data": {"prompt": "How do we verify CHWs are visiting the right households?"}, "expected_output": {"contains": ["GPS", "photo"]}},
+        ],
+        "eval_runs": [
+            {"score": 0.33, "days_ago": 12, "failures": {"CHW program with growth monitoring": "Expected 'z-score' in output but not found. Output focused on registration workflow only.", "GPS and photo capture": "Expected 'photo' in output but not found. Response mentioned GPS but not photo verification."}},
+            {"score": 0.67, "days_ago": 9, "failures": {"GPS and photo capture": "Expected 'photo' in output but not found. Response covered GPS tracking but omitted photo capture."}},
+            {"score": 0.67, "days_ago": 6, "failures": {"CHW program with growth monitoring": "Expected 'z-score' in output but not found. Output mentioned 'growth monitoring' but not WHO Z-score calculation."}},
+            {"score": 1.0, "days_ago": 3},
+            {"score": 1.0, "days_ago": 1},
+        ],
+    },
+    {
+        "name": "Code Review Analysis",
+        "description": "Structured code review: identify bugs, race conditions, security issues, and operational risks with severity ratings.",
+        "definition": {
+            "name": "Code Review Analysis",
+            "description": "Systematically review code changes for correctness, security, performance, and operational readiness.",
+            "steps": [
+                {"name": "Read the diff", "description": "Parse code changes and understand the intent.", "tools": ["git_diff"], "inputs": ["pull_request_url"], "outputs": ["change_summary"]},
+                {"name": "Check correctness", "description": "Look for logic errors, race conditions, edge cases.", "tools": [], "inputs": ["change_summary"], "outputs": ["correctness_issues"]},
+                {"name": "Check security", "description": "Review for injection risks, auth bypasses, missing rate limits.", "tools": [], "inputs": ["change_summary"], "outputs": ["security_issues"]},
+                {"name": "Synthesize review", "description": "Prioritize by severity, recommend fixes, give verdict.", "tools": [], "inputs": ["correctness_issues", "security_issues"], "outputs": ["review_summary", "verdict"]},
+            ],
+        },
+        "eval_cases": [
+            {"name": "Caching layer review", "input_data": {"prompt": "Review a Redis caching implementation for a REST API."}, "expected_output": {"contains": ["cache", "invalidation", "TTL"]}},
+            {"name": "Race condition detection", "input_data": {"prompt": "This code reads a value, checks it, then writes. Any issues?"}, "expected_output": {"contains": ["race condition", "TOCTOU"]}},
+        ],
+        "eval_runs": [
+            {"score": 0.5, "days_ago": 14, "failures": {"Race condition detection": "Expected 'TOCTOU' in output but not found. Response identified the race condition but used 'check-then-act' terminology."}},
+            {"score": 1.0, "days_ago": 10},
+            {"score": 1.0, "days_ago": 7},
+            {"score": 1.0, "days_ago": 4},
+            {"score": 0.5, "days_ago": 2, "failures": {"Race condition detection": "Expected 'TOCTOU' in output but not found. Response focused on mutex locks instead of naming the vulnerability class."}},
+            {"score": 1.0, "days_ago": 0},
+        ],
+    },
+    {
+        "name": "Incident Response Runbook",
+        "description": "Triage production incidents: classify severity, identify blast radius, coordinate response, and write post-mortems.",
+        "definition": {
+            "name": "Incident Response Runbook",
+            "description": "Structured approach to production incidents from alert to post-mortem.",
+            "steps": [
+                {"name": "Classify severity", "description": "Determine SEV level from symptoms and affected users.", "tools": ["monitoring_dashboard"], "inputs": ["alert_description"], "outputs": ["severity_level", "blast_radius"]},
+                {"name": "Identify root cause", "description": "Trace from symptom to cause using logs, metrics, and recent deploys.", "tools": ["log_search", "deploy_history"], "inputs": ["severity_level"], "outputs": ["root_cause"]},
+                {"name": "Mitigate", "description": "Apply immediate fix: rollback, feature flag, or hotfix.", "tools": ["deploy_tool"], "inputs": ["root_cause"], "outputs": ["mitigation_status"]},
+                {"name": "Write post-mortem", "description": "Document timeline, root cause, impact, and action items.", "tools": [], "inputs": ["root_cause", "mitigation_status"], "outputs": ["post_mortem"]},
+            ],
+        },
+        "eval_cases": [
+            {"name": "Database connection exhaustion", "input_data": {"prompt": "All API endpoints returning 500s. Connection pool at 100%."}, "expected_output": {"contains": ["connection pool", "SEV", "rollback"]}},
+            {"name": "Memory leak detection", "input_data": {"prompt": "Service memory usage growing 2% per hour. No recent deploys."}, "expected_output": {"contains": ["memory leak", "heap", "profil"]}},
+        ],
+        "eval_runs": [
+            {"score": 0.5, "days_ago": 8, "failures": {"Memory leak detection": "Expected 'heap' in output but not found. Response discussed memory monitoring but not heap analysis."}},
+            {"score": 0.5, "days_ago": 5, "failures": {"Database connection exhaustion": "Expected 'rollback' in output but not found. Response suggested scaling the pool instead of rolling back."}},
+            {"score": 1.0, "days_ago": 2},
+        ],
+    },
+    {
+        "name": "Data Migration Planner",
+        "description": "Plan and execute database migrations: assess risk, write rollback strategies, and validate data integrity.",
+        "definition": {
+            "name": "Data Migration Planner",
+            "description": "Plan safe database migrations with rollback strategies and integrity checks.",
+            "steps": [
+                {"name": "Assess migration scope", "description": "Identify tables, row counts, and downstream dependencies.", "tools": ["database_client"], "inputs": ["migration_description"], "outputs": ["scope_assessment"]},
+                {"name": "Design rollback", "description": "Create a reversible migration plan with point-in-time recovery.", "tools": [], "inputs": ["scope_assessment"], "outputs": ["rollback_plan"]},
+                {"name": "Validate integrity", "description": "Write checksums and row count assertions for pre/post migration.", "tools": ["database_client"], "inputs": ["scope_assessment"], "outputs": ["validation_queries"]},
+            ],
+        },
+        "eval_cases": [
+            {"name": "Column rename migration", "input_data": {"prompt": "Rename user.email_address to user.email across 2M rows."}, "expected_output": {"contains": ["rollback", "downtime", "index"]}},
+            {"name": "Table split migration", "input_data": {"prompt": "Split the orders table into orders and order_items. 10M rows."}, "expected_output": {"contains": ["foreign key", "backfill", "validate"]}},
+        ],
+        "eval_runs": [
+            {"score": 0.5, "days_ago": 10, "failures": {"Table split migration": "Expected 'backfill' in output but not found. Response covered schema changes but not data migration strategy."}},
+            {"score": 1.0, "days_ago": 6},
+            {"score": 1.0, "days_ago": 3},
+            {"score": 1.0, "days_ago": 1},
+        ],
+    },
+    {
+        "name": "API Design Review",
+        "description": "Review API designs for RESTful conventions, versioning, error handling, and pagination patterns.",
+        "definition": {
+            "name": "API Design Review",
+            "description": "Evaluate API designs against best practices for consistency, usability, and evolvability.",
+            "steps": [
+                {"name": "Check resource naming", "description": "Verify RESTful URL patterns, plural nouns, no verbs in paths.", "tools": [], "inputs": ["api_spec"], "outputs": ["naming_issues"]},
+                {"name": "Check error handling", "description": "Verify consistent error envelope, HTTP status codes, error codes.", "tools": [], "inputs": ["api_spec"], "outputs": ["error_issues"]},
+                {"name": "Check pagination", "description": "Verify cursor or offset pagination on list endpoints.", "tools": [], "inputs": ["api_spec"], "outputs": ["pagination_issues"]},
+            ],
+        },
+        "eval_cases": [
+            {"name": "REST convention violations", "input_data": {"prompt": "Review: POST /api/getUsers, PUT /api/user/delete/123"}, "expected_output": {"contains": ["GET", "DELETE", "plural"]}},
+            {"name": "Missing pagination", "input_data": {"prompt": "GET /api/orders returns all 50K orders in one response."}, "expected_output": {"contains": ["pagination", "cursor", "limit"]}},
+        ],
+        "eval_runs": [
+            {"score": 1.0, "days_ago": 7},
+            {"score": 1.0, "days_ago": 4},
+            {"score": 1.0, "days_ago": 1},
+        ],
+    },
+]
+
+
+class Command(BaseCommand):
+    help = "Seed database with demo data for walkthrough runs"
+
+    def add_arguments(self, parser):
+        parser.add_argument("--reset", action="store_true", help="Wipe and re-create")
+
+    def handle(self, *args, **options):
+        if options["reset"]:
+            self.stdout.write("Resetting demo data...")
+            EvalRun.objects.all().delete()
+            EvalCase.objects.all().delete()
+            EvalSuite.objects.all().delete()
+            Skill.objects.all().delete()
+            WorkspaceSession.objects.all().delete()
+            Source.objects.all().delete()
+            Collection.objects.all().delete()
+
+        self._create_published_skills()
+        self._create_collection_for_walkthrough()
+        self.stdout.write(self.style.SUCCESS("Demo data seeded."))
+
+    def _create_published_skills(self):
+        now = timezone.now()
+
+        for spec in SKILLS:
+            skill, created = Skill.objects.get_or_create(
+                name=spec["name"],
+                defaults={
+                    "description": spec["description"],
+                    "definition": spec["definition"],
+                    "version": 1,
+                    "usage_count": len(spec["eval_runs"]),
+                },
+            )
+            if not created:
+                self.stdout.write(f"  '{skill.name}' exists, skipping.")
+                continue
+
+            suite = EvalSuite.objects.create(skill=skill)
+
+            for case_spec in spec["eval_cases"]:
+                EvalCase.objects.create(
+                    suite=suite,
+                    name=case_spec["name"],
+                    input_data=case_spec["input_data"],
+                    expected_output=case_spec["expected_output"],
+                )
+
+            cases = list(suite.cases.all())
+            for run_spec in spec["eval_runs"]:
+                score = run_spec["score"]
+                failures = run_spec.get("failures", {})
+                case_results = []
+                for c in cases:
+                    if c.name in failures:
+                        case_results.append({
+                            "case_id": c.id, "case_name": c.name,
+                            "passed": False,
+                            "reasons": [failures[c.name]],
+                            "output_preview": "The AI response addressed the topic but missed specific expected terms.",
+                        })
+                    else:
+                        case_results.append({
+                            "case_id": c.id, "case_name": c.name,
+                            "passed": True, "reasons": [],
+                            "output_preview": "AI produced a comprehensive response covering all expected terms.",
+                        })
+
+                run = EvalRun.objects.create(
+                    suite=suite, status="completed",
+                    results={"cases": case_results},
+                    overall_score=score,
+                    runtime=f"{1.2 + len(cases) * 0.4:.1f}s",
+                )
+                # Backdate the timestamp
+                EvalRun.objects.filter(pk=run.pk).update(
+                    created_at=now - timedelta(days=run_spec["days_ago"])
+                )
+
+            self.stdout.write(
+                f"  Created '{skill.name}' — {len(cases)} cases, {len(spec['eval_runs'])} runs"
+            )
+
+    def _create_collection_for_walkthrough(self):
+        collection, created = Collection.objects.get_or_create(
+            name="Customer Onboarding Workflow",
+            defaults={"description": "Extract a reusable onboarding skill from a support conversation"},
+        )
+        if not created:
+            self.stdout.write("  Collection exists, skipping.")
+            return
+        Source.objects.create(collection=collection, source_type="transcript", title="CommCare Setup Session", content=ONBOARDING_TRANSCRIPT)
+        Source.objects.create(collection=collection, source_type="transcript", title="Code Review Session", content=CODE_REVIEW_CONVERSATION)
+        self.stdout.write(f"  Created collection with 2 sources")

--- a/apps/common/urls.py
+++ b/apps/common/urls.py
@@ -3,4 +3,7 @@ from . import views
 
 urlpatterns = [
     path("status/", views.ai_status, name="ai-status"),
+    path("auth/start/", views.auth_start, name="auth-start"),
+    path("auth/complete/", views.auth_complete, name="auth-complete"),
+    path("auth/poll/", views.auth_poll, name="auth-poll"),
 ]

--- a/apps/common/views.py
+++ b/apps/common/views.py
@@ -1,9 +1,12 @@
-"""AI backend status endpoint."""
+"""AI backend status and auth endpoints."""
+import json
+
 from django.conf import settings
 from django.http import JsonResponse
-from django.views.decorators.http import require_GET
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_GET, require_http_methods
 
-from .envelope import start_timing, success_response
+from .envelope import error_response, start_timing, success_response
 
 
 @require_GET
@@ -14,12 +17,19 @@ def ai_status(request):
 
     if backend == "cli":
         from .anthropic_client import cli_auth_status
+
         auth = cli_auth_status()
+        if auth["logged_in"]:
+            detail = "Authenticated via Claude subscription"
+        elif not auth["installed"]:
+            detail = "Claude CLI not installed"
+        else:
+            detail = "Sign in to connect your Claude subscription"
         return JsonResponse(success_response({
             "backend": "cli",
             "ready": auth["logged_in"],
-            "detail": auth["output"] if not auth["logged_in"] else "Authenticated via subscription",
-            "setup_command": "docker compose exec -it backend claude setup-token" if not auth["logged_in"] else None,
+            "detail": detail,
+            "setup_hint": "POST /api/ai/auth/start/ to begin login" if not auth["logged_in"] else None,
         }))
     else:
         has_key = bool(getattr(settings, "ANTHROPIC_API_KEY", ""))
@@ -27,5 +37,62 @@ def ai_status(request):
             "backend": "api",
             "ready": has_key,
             "detail": "API key configured" if has_key else "No ANTHROPIC_API_KEY set",
-            "setup_command": None,
         }))
+
+
+# ── Auth flow endpoints (for CLI backend in Docker) ─────────────────
+
+
+@csrf_exempt
+@require_http_methods(["POST"])
+def auth_start(request):
+    """POST /api/ai/auth/start/ — begin setup-token flow, return auth URL."""
+    start_timing()
+    from . import auth_flow
+
+    try:
+        result = auth_flow.start()
+        return JsonResponse(success_response(result))
+    except FileNotFoundError:
+        return JsonResponse(
+            error_response("cli_not_found", "Claude CLI not installed"),
+            status=500,
+        )
+    except RuntimeError as e:
+        return JsonResponse(error_response("auth_start_failed", str(e)), status=500)
+
+
+@csrf_exempt
+@require_http_methods(["POST"])
+def auth_complete(request):
+    """POST /api/ai/auth/complete/ — send pasted code, get back OAuth token."""
+    start_timing()
+    from . import auth_flow
+
+    code = None
+    if request.body:
+        try:
+            body = json.loads(request.body)
+            code = body.get("code", "").strip()
+        except (json.JSONDecodeError, AttributeError):
+            pass
+
+    try:
+        token = auth_flow.complete(code or None)
+        # Redact middle of token for the response
+        visible = token[:12] + "..." + token[-4:]
+        return JsonResponse(success_response({
+            "token_preview": visible,
+            "status": "authenticated",
+        }))
+    except RuntimeError as e:
+        return JsonResponse(error_response("auth_complete_failed", str(e)), status=400)
+
+
+@require_GET
+def auth_poll(request):
+    """GET /api/ai/auth/poll/ — check if setup-token completed without code paste."""
+    start_timing()
+    from . import auth_flow
+
+    return JsonResponse(success_response(auth_flow.poll()))

--- a/apps/evals/runner.py
+++ b/apps/evals/runner.py
@@ -23,14 +23,20 @@ def run_skill_step(skill_definition, input_data):
 
 
 def check_expected(output: str, expected: dict) -> tuple[bool, list[str]]:
-    """Check if output meets expected criteria."""
+    """Check if output meets expected criteria. Returns (passed, reasons)."""
     reasons = []
     passed = True
+    output_lower = output.lower()
 
     for term in expected.get("contains", []):
-        if term.lower() not in output.lower():
+        if term.lower() not in output_lower:
             passed = False
-            reasons.append(f"Missing expected term: '{term}'")
+            # Show a snippet of what the output actually contains
+            preview = output[:200].replace("\n", " ")
+            reasons.append(
+                f"Expected '{term}' in output but not found. "
+                f"Output starts with: \"{preview}...\""
+            )
 
     return passed, reasons
 

--- a/apps/evals/urls.py
+++ b/apps/evals/urls.py
@@ -7,4 +7,5 @@ urlpatterns = [
     path("<int:skill_id>/run/", views.run_eval, name="run-eval"),
     path("<int:skill_id>/history/", views.eval_history, name="eval-history"),
     path("<int:skill_id>/cases/", views.propose_eval_case, name="propose-eval-case"),
+    path("<int:skill_id>/cases/<int:case_id>/", views.eval_case_detail, name="eval-case-detail"),
 ]

--- a/apps/evals/views.py
+++ b/apps/evals/views.py
@@ -107,3 +107,35 @@ def propose_eval_case(request, skill_id):
     )
     serializer = EvalCaseSerializer(case)
     return Response(success_response(serializer.data), status=status.HTTP_201_CREATED)
+
+
+@api_view(["PATCH", "DELETE"])
+def eval_case_detail(request, skill_id, case_id):
+    """PATCH/DELETE — Edit or delete an eval case."""
+    start_timing()
+
+    try:
+        case = EvalCase.objects.select_related("suite__skill").get(
+            pk=case_id, suite__skill_id=skill_id
+        )
+    except EvalCase.DoesNotExist:
+        return Response(
+            error_response("NOT_FOUND", "Eval case not found."),
+            status=status.HTTP_404_NOT_FOUND,
+        )
+
+    if request.method == "DELETE":
+        case.delete()
+        return Response(success_response({"deleted": True}))
+
+    # PATCH
+    if "name" in request.data:
+        case.name = request.data["name"]
+    if "input_data" in request.data:
+        case.input_data = request.data["input_data"]
+    if "expected_output" in request.data:
+        case.expected_output = request.data["expected_output"]
+    case.save()
+
+    serializer = EvalCaseSerializer(case)
+    return Response(success_response(serializer.data))

--- a/apps/skills/serializers.py
+++ b/apps/skills/serializers.py
@@ -5,6 +5,8 @@ from .models import Skill
 
 class SkillSerializer(serializers.ModelSerializer):
     eval_score = serializers.SerializerMethodField()
+    eval_trend = serializers.SerializerMethodField()
+    last_eval_at = serializers.SerializerMethodField()
 
     class Meta:
         model = Skill
@@ -16,6 +18,8 @@ class SkillSerializer(serializers.ModelSerializer):
             "version",
             "usage_count",
             "eval_score",
+            "eval_trend",
+            "last_eval_at",
             "created_at",
             "updated_at",
         ]
@@ -24,5 +28,33 @@ class SkillSerializer(serializers.ModelSerializer):
         try:
             latest_run = obj.eval_suite.runs.order_by("-created_at").first()
             return latest_run.overall_score if latest_run else None
+        except Exception:
+            return None
+
+    def get_eval_trend(self, obj):
+        """Return 'improving', 'declining', or 'stable' from last 2 runs."""
+        try:
+            runs = list(
+                obj.eval_suite.runs.order_by("-created_at").values_list(
+                    "overall_score", flat=True
+                )[:2]
+            )
+            if len(runs) < 2:
+                return None
+            current, previous = runs[0], runs[1]
+            if current is None or previous is None:
+                return None
+            if current > previous:
+                return "improving"
+            elif current < previous:
+                return "declining"
+            return "stable"
+        except Exception:
+            return None
+
+    def get_last_eval_at(self, obj):
+        try:
+            latest_run = obj.eval_suite.runs.order_by("-created_at").first()
+            return latest_run.created_at.isoformat() if latest_run else None
         except Exception:
             return None

--- a/apps/workspace/views.py
+++ b/apps/workspace/views.py
@@ -190,24 +190,58 @@ def publish_skill(request, session_id):
             status=400,
         )
 
-    # Create the skill
-    skill = Skill.objects.create(
-        name=approach.get("name", "Untitled Skill"),
-        description=approach.get("description", ""),
-        definition=approach,
-        workspace_session=session,
-    )
+    # Check if this is a revision of an existing skill
+    try:
+        body = json.loads(request.body) if request.body else {}
+    except json.JSONDecodeError:
+        body = {}
+    revise_skill_id = body.get("revise_skill_id")
 
-    # Create eval suite and cases
-    eval_suite = EvalSuite.objects.create(skill=skill)
-    eval_cases = session.proposed_eval_cases or []
-    for case_data in eval_cases:
-        EvalCase.objects.create(
-            suite=eval_suite,
-            name=case_data.get("name", "Unnamed Case"),
-            input_data=case_data.get("input", {}),
-            expected_output=case_data.get("expected", {}),
+    if revise_skill_id:
+        # Revise existing skill — bump version, update definition
+        try:
+            skill = Skill.objects.get(pk=revise_skill_id)
+        except Skill.DoesNotExist:
+            return JsonResponse(
+                error_response("NOT_FOUND", "Skill to revise not found."),
+                status=404,
+            )
+        skill.definition = approach
+        skill.description = approach.get("description", skill.description)
+        skill.version += 1
+        skill.workspace_session = session
+        skill.save(update_fields=["definition", "description", "version", "workspace_session"])
+
+        # Update eval cases if new ones proposed
+        eval_cases = session.proposed_eval_cases or []
+        if eval_cases:
+            suite, _ = EvalSuite.objects.get_or_create(skill=skill)
+            for case_data in eval_cases:
+                EvalCase.objects.create(
+                    suite=suite,
+                    name=case_data.get("name", "Unnamed Case"),
+                    input_data=case_data.get("input", {}),
+                    expected_output=case_data.get("expected", {}),
+                )
+    else:
+        # Create new skill
+        skill = Skill.objects.create(
+            name=approach.get("name", "Untitled Skill"),
+            description=approach.get("description", ""),
+            definition=approach,
+            workspace_session=session,
         )
+
+        # Create eval suite and cases
+        eval_suite = EvalSuite.objects.create(skill=skill)
+        eval_cases = session.proposed_eval_cases or []
+        for case_data in eval_cases:
+            EvalCase.objects.create(
+                suite=eval_suite,
+                name=case_data.get("name", "Unnamed Case"),
+                input_data=case_data.get("input", {}),
+                expected_output=case_data.get("expected", {}),
+            )
 
     # Update session status
     session.status = "published"
@@ -216,7 +250,8 @@ def publish_skill(request, session_id):
     data = {
         "skill_id": skill.pk,
         "name": skill.name,
-        "eval_count": len(eval_cases),
+        "version": skill.version,
+        "eval_count": len(session.proposed_eval_cases or []),
     }
 
     return JsonResponse(success_response(data), status=201)

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -48,6 +48,7 @@ INSTALLED_APPS = [
     "rest_framework",
     "corsheaders",
     # Local apps
+    "apps.common",
     "apps.collections",
     "apps.workspace",
     "apps.skills",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       DATABASE_URL: postgres://canopy:canopy@db:5432/canopy_web
       AI_BACKEND: ${AI_BACKEND:-cli}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      CLAUDE_CODE_OAUTH_TOKEN: ${CLAUDE_CODE_OAUTH_TOKEN:-}
       DEBUG: "true"
     depends_on:
       - db

--- a/docs/walkthroughs/canopy-web-demo.yaml
+++ b/docs/walkthroughs/canopy-web-demo.yaml
@@ -1,0 +1,80 @@
+name: "Canopy Web — Skill Builder Demo"
+narrative: "Turn messy conversations into tested, reusable AI skills — from paste to publish in minutes"
+base_url: "http://localhost:9101"
+
+# No auth needed — single-tenant, no login in V1.
+# Requires: docker compose up -d && docker compose exec backend python manage.py seed_demo
+
+personas:
+  maya:
+    name: "Maya Torres"
+    role: "AI Platform Engineer"
+    color: "#2563eb"
+    intro: "Maya builds internal AI tooling. She curates the skill library and tracks quality through evals."
+  ravi:
+    name: "Ravi Sharma"
+    role: "Solutions Engineer"
+    color: "#059669"
+    intro: "Ravi works with clients daily. He captures great conversations and wants to turn them into repeatable workflows anyone can use."
+
+scenes:
+  # Act 1: Discovery — what's already built
+  - persona: maya
+    title: "The skill library"
+    show: "Skills feed at / showing published skills with names, descriptions, eval scores, and usage counts"
+    impressive_because: "Dense, scannable table — not flashy cards. Shows which skills are actually used and how well they score."
+
+  - persona: maya
+    title: "Inside a skill"
+    show: "Click into a skill to see its full definition — steps, tools, inputs/outputs — plus eval history"
+    impressive_because: "Complete skill anatomy at a glance. Eval runs show quality trending over time."
+
+  - persona: maya
+    title: "Who's shipping quality"
+    show: "Leaderboard page showing skills ranked by eval scores and usage"
+    impressive_because: "Surfaces which skills are battle-tested vs. freshly published. Creates healthy competition."
+
+  # Act 2: Creation — building a new skill from scratch
+  - persona: ravi
+    title: "Start from a conversation"
+    show: "Click New, create a collection named 'Customer Onboarding Workflow', add a description"
+    impressive_because: "Zero friction — name it, describe it, start pasting."
+
+  - persona: ravi
+    title: "Paste the source material"
+    show: "Add a source with type 'transcript' containing a real onboarding conversation — the AI session where an agent walked a customer through setup"
+    impressive_because: "Accepts raw messy transcripts. No reformatting needed."
+
+  - persona: ravi
+    title: "AI extracts the skill"
+    show: "Start workspace analysis — streaming response shows AI reading the sources and proposing a skill definition with eval cases"
+    impressive_because: "Streams the analysis in real-time. Proposes concrete steps, tools, and testable eval cases — not just a summary."
+    ai_quality: "Proposed skill should have specific, actionable steps with clear inputs/outputs. Eval cases should test real scenarios from the source, not generic placeholders."
+
+  - persona: ravi
+    title: "Review the proposal"
+    show: "Workspace page showing the proposed approach (skill definition) and eval cases side by side"
+    impressive_because: "Everything is editable. You can see exactly what the AI extracted and fix anything before publishing."
+
+  - persona: ravi
+    title: "Publish the skill"
+    show: "Click publish — skill appears in the library with eval suite auto-created"
+    impressive_because: "One click from draft to published. Eval cases ship with the skill — quality is built in from day one."
+
+  # Act 3: Evaluation — measuring quality
+  - persona: maya
+    title: "Run the eval suite"
+    show: "Navigate to the newly published skill, run its eval suite, see pass/fail results per case"
+    impressive_because: "Evals run against the actual AI backend. Each case shows what passed, what failed, and why."
+    ai_quality: "Eval results should show meaningful pass/fail with specific output. Failures should explain what was expected vs what was produced."
+
+  - persona: maya
+    title: "Eval history over time"
+    show: "View eval history showing scores across multiple runs"
+    impressive_because: "Track quality over time. Catch regressions before they hit production."
+
+  # Act 4: Settings — infrastructure
+  - persona: maya
+    title: "Connected to your subscription"
+    show: "Settings page showing AI backend connected via Claude subscription"
+    impressive_because: "Uses your existing Claude subscription — no separate API key billing. Token persists across container restarts."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,4 +25,9 @@ else
     ln -sf "$PERSIST_DIR/.claude.json" /root/.claude.json
 fi
 
+# Load persisted OAuth token for Claude CLI
+if [ -f "$PERSIST_DIR/oauth-token" ]; then
+    export CLAUDE_CODE_OAUTH_TOKEN=$(cat "$PERSIST_DIR/oauth-token")
+fi
+
 exec "$@"

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -28,6 +28,10 @@ export const api = {
   getEvalSuite: (skillId: number) => request(`/evals/${skillId}/`),
   runEval: (skillId: number) => request(`/evals/${skillId}/run/`, { method: 'POST' }),
   getEvalHistory: (skillId: number) => request(`/evals/${skillId}/history/`),
+  updateEvalCase: (skillId: number, caseId: number, data: object) =>
+    request(`/evals/${skillId}/cases/${caseId}/`, { method: 'PATCH', body: JSON.stringify(data) }),
+  deleteEvalCase: (skillId: number, caseId: number) =>
+    request(`/evals/${skillId}/cases/${caseId}/`, { method: 'DELETE' }),
   analyzeWorkspace: (collectionId: number) =>
     request<{ session_id: number; status: string; approach: Record<string, unknown>; eval_cases: Record<string, unknown>[] }>(
       `/workspace/analyze/${collectionId}/`,
@@ -36,6 +40,19 @@ export const api = {
 
   // AI backend
   getAiStatus: () => request<{
-    backend: string; ready: boolean; detail: string; setup_command: string | null;
+    backend: string; ready: boolean; detail: string; setup_hint: string | null;
   }>('/ai/status/'),
+
+  // Auth flow
+  authStart: () => request<{
+    auth_url: string | null; token: string | null; status: string;
+  }>('/ai/auth/start/', { method: 'POST' }),
+
+  authComplete: (code: string) => request<{
+    token_preview: string; status: string;
+  }>('/ai/auth/complete/', { method: 'POST', body: JSON.stringify({ code }) }),
+
+  authPoll: () => request<{
+    active: boolean; authenticated: boolean; elapsed_seconds?: number;
+  }>('/ai/auth/poll/'),
 }

--- a/frontend/src/components/AppLayout/AppLayout.tsx
+++ b/frontend/src/components/AppLayout/AppLayout.tsx
@@ -6,17 +6,16 @@ import { api } from '@/api/client'
 const NAV_ITEMS = [
   { path: '/', label: 'Skills' },
   { path: '/leaderboard', label: 'Leaderboard' },
+  { path: '/settings', label: 'Settings' },
 ]
 
 function AiStatusBadge() {
   const [status, setStatus] = useState<{
-    backend: string; ready: boolean; detail: string; setup_command: string | null
+    backend: string; ready: boolean; detail: string; setup_hint: string | null
   } | null>(null)
-  const [showSetup, setShowSetup] = useState(false)
 
   useEffect(() => {
     api.getAiStatus().then(setStatus).catch(() => {})
-    // Poll every 5s while not ready (in case user runs setup-token in terminal)
     const interval = setInterval(() => {
       api.getAiStatus().then((s) => {
         setStatus(s)
@@ -37,25 +36,12 @@ function AiStatusBadge() {
   }
 
   return (
-    <div className="flex items-center gap-2">
-      <button
-        onClick={() => setShowSetup(!showSetup)}
-        className="text-xs text-amber-600 bg-amber-50 px-2 py-1 rounded hover:bg-amber-100"
-      >
-        AI: Not connected
-      </button>
-      {showSetup && status.setup_command && (
-        <div className="absolute right-6 top-12 bg-white border border-gray-200 rounded-lg shadow-lg p-4 z-50 max-w-md">
-          <p className="text-sm text-gray-700 mb-2">Run this in your terminal:</p>
-          <code className="block bg-gray-50 text-xs p-2 rounded font-mono select-all">
-            {status.setup_command}
-          </code>
-          <p className="text-xs text-gray-500 mt-2">
-            This connects to your Claude subscription (one-time setup). The page will update automatically when done.
-          </p>
-        </div>
-      )}
-    </div>
+    <Link
+      to="/settings"
+      className="text-xs text-amber-600 bg-amber-50 px-2 py-1 rounded hover:bg-amber-100"
+    >
+      AI: Not connected — click to set up
+    </Link>
   )
 }
 

--- a/frontend/src/pages/LeaderboardPage.tsx
+++ b/frontend/src/pages/LeaderboardPage.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { api } from '@/api/client'
 import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
 import {
   Table,
@@ -15,14 +16,110 @@ import {
 interface Skill {
   id: number
   name: string
+  description: string
+  version: number
   usage_count: number
   eval_score: number | null
+  eval_trend: 'improving' | 'declining' | 'stable' | null
+  last_eval_at: string | null
+  created_at: string
   updated_at: string
 }
 
-function formatDate(iso: string): string {
-  const d = new Date(iso)
-  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+type SortField = 'eval_score' | 'usage_count' | 'name' | 'last_eval_at'
+type SortDir = 'asc' | 'desc'
+
+const STALE_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000 // 7 days
+
+function isStale(lastEvalAt: string | null): boolean {
+  if (!lastEvalAt) return true
+  return Date.now() - new Date(lastEvalAt).getTime() > STALE_THRESHOLD_MS
+}
+
+function relativeTime(iso: string | null): string {
+  if (!iso) return 'Never'
+  const diff = Date.now() - new Date(iso).getTime()
+  const seconds = Math.floor(diff / 1000)
+  const minutes = Math.floor(seconds / 60)
+  const hours = Math.floor(minutes / 60)
+  const days = Math.floor(hours / 24)
+  const weeks = Math.floor(days / 7)
+  const months = Math.floor(days / 30)
+
+  if (months > 0) return `${months} month${months > 1 ? 's' : ''} ago`
+  if (weeks > 0) return `${weeks} week${weeks > 1 ? 's' : ''} ago`
+  if (days > 0) return `${days} day${days > 1 ? 's' : ''} ago`
+  if (hours > 0) return `${hours} hour${hours > 1 ? 's' : ''} ago`
+  if (minutes > 0) return `${minutes} min${minutes > 1 ? 's' : ''} ago`
+  return 'Just now'
+}
+
+function TrendIndicator({ trend }: { trend: Skill['eval_trend'] }) {
+  switch (trend) {
+    case 'improving':
+      return <span className="text-green-600 font-medium">▲</span>
+    case 'declining':
+      return <span className="text-red-600 font-medium">▼</span>
+    case 'stable':
+    default:
+      return <span className="text-gray-400">—</span>
+  }
+}
+
+function ScoreBadge({ score }: { score: number | null }) {
+  if (score == null) {
+    return <span className="text-xs text-gray-400">--</span>
+  }
+
+  const pct = Math.round(score * 100)
+  let colorClass: string
+
+  if (score >= 0.8) {
+    colorClass = 'text-green-700 bg-green-50 border-green-200'
+  } else if (score >= 0.5) {
+    colorClass = 'text-amber-700 bg-amber-50 border-amber-200'
+  } else {
+    colorClass = 'text-red-700 bg-red-50 border-red-200'
+  }
+
+  return (
+    <Badge variant="outline" className={colorClass}>
+      {pct}%
+    </Badge>
+  )
+}
+
+function SortableHeader({
+  label,
+  field,
+  sortField,
+  sortDir,
+  onSort,
+  className,
+}: {
+  label: string
+  field: SortField
+  sortField: SortField
+  sortDir: SortDir
+  onSort: (field: SortField) => void
+  className?: string
+}) {
+  const active = sortField === field
+  return (
+    <TableHead className={className}>
+      <Button
+        variant="ghost"
+        size="xs"
+        className={`-ml-2 font-medium ${active ? 'text-foreground' : 'text-muted-foreground'}`}
+        onClick={() => onSort(field)}
+      >
+        {label}
+        {active ? (
+          <span className="ml-1 text-[10px]">{sortDir === 'desc' ? '↓' : '↑'}</span>
+        ) : null}
+      </Button>
+    </TableHead>
+  )
 }
 
 export function LeaderboardPage() {
@@ -30,13 +127,15 @@ export function LeaderboardPage() {
   const [skills, setSkills] = useState<Skill[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [sortField, setSortField] = useState<SortField>('eval_score')
+  const [sortDir, setSortDir] = useState<SortDir>('desc')
 
   useEffect(() => {
     let cancelled = false
 
     async function load() {
       try {
-        const data = (await api.getSkills('-usage_count')) as Skill[]
+        const data = (await api.getSkills()) as Skill[]
         if (!cancelled) setSkills(data)
       } catch (err) {
         if (!cancelled) {
@@ -51,6 +150,60 @@ export function LeaderboardPage() {
     return () => { cancelled = true }
   }, [])
 
+  function handleSort(field: SortField) {
+    if (field === sortField) {
+      setSortDir((prev) => (prev === 'desc' ? 'asc' : 'desc'))
+    } else {
+      setSortField(field)
+      setSortDir('desc')
+    }
+  }
+
+  const sorted = useMemo(() => {
+    const copy = [...skills]
+    const dir = sortDir === 'desc' ? -1 : 1
+
+    copy.sort((a, b) => {
+      let aVal: number | string
+      let bVal: number | string
+
+      switch (sortField) {
+        case 'eval_score':
+          // Nulls always sort to the bottom regardless of direction
+          if (a.eval_score == null && b.eval_score == null) return 0
+          if (a.eval_score == null) return 1
+          if (b.eval_score == null) return -1
+          aVal = a.eval_score
+          bVal = b.eval_score
+          break
+        case 'usage_count':
+          aVal = a.usage_count
+          bVal = b.usage_count
+          break
+        case 'name':
+          aVal = a.name.toLowerCase()
+          bVal = b.name.toLowerCase()
+          break
+        case 'last_eval_at':
+          // Nulls sort to bottom
+          if (!a.last_eval_at && !b.last_eval_at) return 0
+          if (!a.last_eval_at) return 1
+          if (!b.last_eval_at) return -1
+          aVal = new Date(a.last_eval_at).getTime()
+          bVal = new Date(b.last_eval_at).getTime()
+          break
+        default:
+          return 0
+      }
+
+      if (aVal < bVal) return -1 * dir
+      if (aVal > bVal) return 1 * dir
+      return 0
+    })
+
+    return copy
+  }, [skills, sortField, sortDir])
+
   if (error) {
     return (
       <div className="rounded border border-red-200 bg-red-50 p-4 text-sm text-red-700">
@@ -63,7 +216,6 @@ export function LeaderboardPage() {
     <div className="space-y-4">
       <h1 className="text-lg font-semibold text-gray-900">Leaderboard</h1>
 
-      {/* Loading */}
       {loading && (
         <div className="space-y-2">
           <Skeleton className="h-10 w-full" />
@@ -73,54 +225,86 @@ export function LeaderboardPage() {
         </div>
       )}
 
-      {/* Table — always show headers for visual structure */}
       {!loading && (
         <Table>
           <TableHeader>
             <TableRow>
-              <TableHead>Skill</TableHead>
-              <TableHead className="text-right">Eval Score</TableHead>
+              <TableHead className="w-8 text-right text-muted-foreground">#</TableHead>
+              <SortableHeader
+                label="Skill"
+                field="name"
+                sortField={sortField}
+                sortDir={sortDir}
+                onSort={handleSort}
+              />
+              <SortableHeader
+                label="Eval Score"
+                field="eval_score"
+                sortField={sortField}
+                sortDir={sortDir}
+                onSort={handleSort}
+                className="text-right"
+              />
               <TableHead className="text-right">Trend</TableHead>
-              <TableHead className="text-right">Runs</TableHead>
-              <TableHead className="text-right">Last Updated</TableHead>
+              <SortableHeader
+                label="Runs"
+                field="usage_count"
+                sortField={sortField}
+                sortDir={sortDir}
+                onSort={handleSort}
+                className="text-right"
+              />
+              <SortableHeader
+                label="Last Eval"
+                field="last_eval_at"
+                sortField={sortField}
+                sortDir={sortDir}
+                onSort={handleSort}
+                className="text-right"
+              />
             </TableRow>
           </TableHeader>
           <TableBody>
-            {skills.length > 0 ? (
-              skills.map((skill) => (
-                <TableRow
-                  key={skill.id}
-                  className="cursor-pointer"
-                  onClick={() => navigate(`/skills/${skill.id}`)}
-                >
-                  <TableCell className="font-medium text-gray-900">
-                    {skill.name}
-                  </TableCell>
-                  <TableCell className="text-right">
-                    {skill.usage_count < 2 ? (
-                      <span className="text-xs text-gray-400">needs data</span>
-                    ) : skill.eval_score != null ? (
-                      <Badge variant={skill.eval_score >= 7 ? 'default' : 'secondary'}>
-                        {skill.eval_score.toFixed(1)}
-                      </Badge>
-                    ) : (
-                      <span className="text-xs text-gray-400">--</span>
-                    )}
-                  </TableCell>
-                  <TableCell className="text-right text-xs text-gray-400">
-                    --
-                  </TableCell>
-                  <TableCell className="text-right text-sm text-gray-500">
-                    {skill.usage_count}
-                  </TableCell>
-                  <TableCell className="text-right text-xs text-gray-400">
-                    {formatDate(skill.updated_at)}
-                  </TableCell>
-                </TableRow>
-              ))
+            {sorted.length > 0 ? (
+              sorted.map((skill, idx) => {
+                const stale = isStale(skill.last_eval_at)
+                return (
+                  <TableRow
+                    key={skill.id}
+                    className={`cursor-pointer ${stale ? 'bg-amber-50/60' : ''}`}
+                    onClick={() => navigate(`/skills/${skill.id}`)}
+                  >
+                    <TableCell className="text-right text-xs text-gray-400 tabular-nums">
+                      {idx + 1}
+                    </TableCell>
+                    <TableCell className="font-medium text-gray-900">
+                      {skill.name}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <ScoreBadge score={skill.eval_score} />
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <TrendIndicator trend={skill.eval_trend} />
+                    </TableCell>
+                    <TableCell className="text-right text-sm text-gray-500 tabular-nums">
+                      {skill.usage_count}
+                    </TableCell>
+                    <TableCell className="text-right text-xs text-gray-400">
+                      <span className="inline-flex items-center gap-1.5">
+                        {relativeTime(skill.last_eval_at)}
+                        {stale && (
+                          <Badge variant="outline" className="text-amber-600 border-amber-300 bg-amber-50 text-[10px] px-1 py-0">
+                            stale
+                          </Badge>
+                        )}
+                      </span>
+                    </TableCell>
+                  </TableRow>
+                )
+              })
             ) : (
               <TableRow>
-                <TableCell colSpan={5} className="h-32 text-center">
+                <TableCell colSpan={6} className="h-32 text-center">
                   <p className="text-sm font-medium text-gray-900">No eval data yet</p>
                   <p className="mt-1 text-sm text-gray-500">
                     Run some evals to see the leaderboard.

--- a/frontend/src/pages/NewCollectionPage.tsx
+++ b/frontend/src/pages/NewCollectionPage.tsx
@@ -1,117 +1,352 @@
-import { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useState, useCallback } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 import { api } from '@/api/client'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
+import { Badge } from '@/components/ui/badge'
+
+const SOURCE_TYPES = ['transcript', 'slack', 'document', 'text'] as const
+type SourceType = (typeof SOURCE_TYPES)[number]
+
+const TYPE_PLACEHOLDERS: Record<SourceType, string> = {
+  transcript: 'e.g., Customer onboarding call',
+  slack: 'e.g., #eng-support thread',
+  document: 'e.g., Runbook: deploy process',
+  text: 'e.g., Notes on incident response',
+}
+
+type Source = {
+  id: number
+  source_type: SourceType
+  title: string
+  content: string
+}
 
 type CollectionResult = { id: number }
 
 export function NewCollectionPage() {
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const reviseSkillId = searchParams.get('revise')
+    ? Number(searchParams.get('revise'))
+    : null
+
+  // Step tracking: 'name' | 'sources' | 'analysis'
+  const [step, setStep] = useState<'name' | 'sources' | 'analysis'>('name')
+
+  // Step 1: Collection info
   const [name, setName] = useState('')
-  const [sourceText, setSourceText] = useState('')
-  const [submitting, setSubmitting] = useState(false)
+  const [description, setDescription] = useState('')
+
+  // Collection state (set after creation)
+  const [collectionId, setCollectionId] = useState<number | null>(null)
+
+  // Step 2: Sources
+  const [sources, setSources] = useState<Source[]>([])
+  const [sourceType, setSourceType] = useState<SourceType>('transcript')
+  const [sourceTitle, setSourceTitle] = useState('')
+  const [sourceContent, setSourceContent] = useState('')
+  const [addingSource, setAddingSource] = useState(false)
+  const [deletingSourceId, setDeletingSourceId] = useState<number | null>(null)
+
+  // Step 3: Analysis
+  const [analysisStatus, setAnalysisStatus] = useState<string | null>(null)
+
+  // Shared
   const [error, setError] = useState<string | null>(null)
-  const [step, setStep] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
 
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault()
+  // Step 1 → Step 2: Create collection, then move to sources step
+  const handleCreateCollection = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault()
+      const trimmedName = name.trim()
+      if (!trimmedName) {
+        setError('Please enter a collection name.')
+        return
+      }
 
-    const trimmedName = name.trim()
-    const trimmedSource = sourceText.trim()
+      setError(null)
+      setSubmitting(true)
 
-    if (!trimmedName) {
-      setError('Please enter a collection name.')
-      return
-    }
-    if (!trimmedSource) {
-      setError('Please paste source content.')
-      return
-    }
+      try {
+        const collection = (await api.createCollection(
+          trimmedName,
+          description.trim()
+        )) as CollectionResult
+        setCollectionId(collection.id)
+        setStep('sources')
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to create collection.')
+      } finally {
+        setSubmitting(false)
+      }
+    },
+    [name, description]
+  )
+
+  // Add a source to the collection via API
+  const handleAddSource = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault()
+      if (collectionId == null) return
+
+      const trimmedContent = sourceContent.trim()
+      if (!trimmedContent) {
+        setError('Please paste source content.')
+        return
+      }
+
+      setError(null)
+      setAddingSource(true)
+
+      try {
+        const result = (await api.addSource(collectionId, {
+          source_type: sourceType,
+          title: sourceTitle.trim() || undefined,
+          content: trimmedContent,
+        })) as Source
+
+        setSources((prev) => [...prev, result])
+        // Reset the add-source form
+        setSourceTitle('')
+        setSourceContent('')
+        setSourceType('transcript')
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to add source.')
+      } finally {
+        setAddingSource(false)
+      }
+    },
+    [collectionId, sourceType, sourceTitle, sourceContent]
+  )
+
+  // Delete a source (optimistic removal from local list)
+  const handleDeleteSource = useCallback(
+    (sourceId: number) => {
+      setDeletingSourceId(sourceId)
+      setSources((prev) => prev.filter((s) => s.id !== sourceId))
+      setDeletingSourceId(null)
+    },
+    []
+  )
+
+  // Step 2 → Step 3: Start analysis
+  const handleStartAnalysis = useCallback(async () => {
+    if (collectionId == null || sources.length === 0) return
 
     setError(null)
     setSubmitting(true)
+    setStep('analysis')
 
     try {
-      // Step 1: Create collection
-      setStep('Creating collection...')
-      const collection = (await api.createCollection(trimmedName)) as CollectionResult
-
-      // Step 2: Add source
-      setStep('Adding source...')
-      await api.addSource(collection.id, {
-        source_type: 'text',
-        title: trimmedName,
-        content: trimmedSource,
-      })
-
-      // Step 3: Run analysis (synchronous - waits for AI to finish)
-      setStep('Analyzing sources (this may take 30-60 seconds)...')
-      const result = await api.analyzeWorkspace(collection.id)
-
-      // Step 4: Navigate to workspace
-      navigate(`/workspace/${result.session_id}`)
+      setAnalysisStatus('Analyzing sources (this may take 30-60 seconds)...')
+      const result = await api.analyzeWorkspace(collectionId)
+      navigate(`/workspace/${result.session_id}${reviseSkillId ? `?revise=${reviseSkillId}` : ''}`)
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Something went wrong.')
+      setError(err instanceof Error ? err.message : 'Analysis failed.')
       setSubmitting(false)
-      setStep(null)
+      setStep('sources')
+      setAnalysisStatus(null)
     }
+  }, [collectionId, sources.length, navigate, reviseSkillId])
+
+  // First line of content for preview
+  function firstLine(content: string, maxLen = 80): string {
+    const line = content.split('\n')[0] || ''
+    return line.length > maxLen ? line.slice(0, maxLen) + '...' : line
   }
 
   return (
     <div className="mx-auto max-w-2xl space-y-6">
+      {/* Header */}
       <div>
-        <h1 className="text-lg font-semibold text-gray-900">New Skill from Source</h1>
+        <h1 className="text-lg font-semibold text-gray-900">
+          {reviseSkillId ? `Revising: Skill #${reviseSkillId}` : 'New Skill from Sources'}
+        </h1>
         <p className="mt-1 text-sm text-gray-500">
-          Paste a conversation, document, or transcript below. The AI will analyze it and
-          propose a reusable skill with evaluation cases.
+          {step === 'name' && 'Name your collection, then add one or more sources for the AI to analyze.'}
+          {step === 'sources' && 'Add conversations, documents, or transcripts. The AI will analyze all sources together.'}
+          {step === 'analysis' && 'The AI is analyzing your sources...'}
         </p>
       </div>
 
+      {/* Error banner */}
       {error && (
         <div className="rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700">
           {error}
         </div>
       )}
 
-      <form onSubmit={(e) => void handleSubmit(e)} className="space-y-4">
-        <div>
-          <label htmlFor="collection-name" className="mb-1 block text-sm font-medium text-gray-700">
-            Collection Name
-          </label>
-          <Input
-            id="collection-name"
-            placeholder="e.g., Customer Onboarding Flow"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            disabled={submitting}
-          />
-        </div>
+      {/* Step 1: Name the collection */}
+      {step === 'name' && (
+        <form onSubmit={(e) => void handleCreateCollection(e)} className="space-y-4">
+          <div>
+            <label htmlFor="collection-name" className="mb-1 block text-sm font-medium text-gray-700">
+              Collection Name
+            </label>
+            <Input
+              id="collection-name"
+              placeholder="e.g., Customer Onboarding Flow"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              disabled={submitting}
+            />
+          </div>
 
-        <div>
-          <label htmlFor="source-content" className="mb-1 block text-sm font-medium text-gray-700">
-            Source Content
-          </label>
-          <Textarea
-            id="source-content"
-            placeholder="Paste a conversation, transcript, or document here..."
-            value={sourceText}
-            onChange={(e) => setSourceText(e.target.value)}
-            disabled={submitting}
-            className="min-h-[300px]"
-          />
-        </div>
+          <div>
+            <label htmlFor="collection-description" className="mb-1 block text-sm font-medium text-gray-700">
+              Description <span className="text-gray-400">(optional)</span>
+            </label>
+            <Textarea
+              id="collection-description"
+              placeholder="Brief description of what this collection covers..."
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              disabled={submitting}
+              className="min-h-[60px]"
+            />
+          </div>
 
-        <div className="flex items-center gap-3">
           <Button type="submit" disabled={submitting}>
-            {submitting ? 'Working...' : 'Start Analysis'}
+            {submitting ? 'Creating...' : 'Next'}
           </Button>
-          {step && (
-            <span className="text-sm text-gray-500">{step}</span>
+        </form>
+      )}
+
+      {/* Step 2: Add sources */}
+      {step === 'sources' && (
+        <div className="space-y-6">
+          {/* Collection header */}
+          <div className="flex items-center gap-2">
+            <h2 className="text-base font-medium text-gray-900">{name}</h2>
+            {description && (
+              <span className="text-sm text-gray-500">— {description}</span>
+            )}
+          </div>
+
+          {/* Source list */}
+          {sources.length > 0 && (
+            <div className="space-y-2">
+              {sources.map((source) => (
+                <div
+                  key={source.id}
+                  className="flex items-start gap-3 rounded border border-gray-200 bg-gray-50 px-3 py-2"
+                >
+                  <Badge variant="secondary" className="mt-0.5 shrink-0">
+                    {source.source_type}
+                  </Badge>
+                  <div className="min-w-0 flex-1">
+                    {source.title && (
+                      <div className="text-sm font-medium text-gray-800">{source.title}</div>
+                    )}
+                    <div className="truncate text-sm text-gray-500">
+                      {firstLine(source.content)}
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => handleDeleteSource(source.id)}
+                    disabled={deletingSourceId === source.id}
+                    className="shrink-0 text-sm text-gray-400 hover:text-red-500"
+                    title="Remove source"
+                  >
+                    &times;
+                  </button>
+                </div>
+              ))}
+            </div>
           )}
+
+          {/* Source count */}
+          <div className="text-sm text-gray-500">
+            {sources.length === 0
+              ? 'No sources added yet'
+              : `${sources.length} source${sources.length === 1 ? '' : 's'} added`}
+          </div>
+
+          {/* Add source form */}
+          <form onSubmit={(e) => void handleAddSource(e)} className="space-y-3 rounded border border-gray-200 bg-white p-4">
+            <div className="text-sm font-medium text-gray-700">Add Source</div>
+
+            <div className="flex gap-3">
+              <div className="w-36">
+                <label htmlFor="source-type" className="mb-1 block text-xs text-gray-500">
+                  Type
+                </label>
+                <select
+                  id="source-type"
+                  value={sourceType}
+                  onChange={(e) => setSourceType(e.target.value as SourceType)}
+                  disabled={addingSource}
+                  className="h-8 w-full rounded-lg border border-gray-300 bg-white px-2 text-sm text-gray-700 focus:border-gray-400 focus:outline-none"
+                >
+                  {SOURCE_TYPES.map((t) => (
+                    <option key={t} value={t}>
+                      {t}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div className="flex-1">
+                <label htmlFor="source-title" className="mb-1 block text-xs text-gray-500">
+                  Title <span className="text-gray-400">(optional)</span>
+                </label>
+                <Input
+                  id="source-title"
+                  placeholder={TYPE_PLACEHOLDERS[sourceType]}
+                  value={sourceTitle}
+                  onChange={(e) => setSourceTitle(e.target.value)}
+                  disabled={addingSource}
+                />
+              </div>
+            </div>
+
+            <div>
+              <label htmlFor="source-content" className="mb-1 block text-xs text-gray-500">
+                Content
+              </label>
+              <Textarea
+                id="source-content"
+                placeholder="Paste content here..."
+                value={sourceContent}
+                onChange={(e) => setSourceContent(e.target.value)}
+                disabled={addingSource}
+                className="min-h-[200px]"
+              />
+            </div>
+
+            <Button type="submit" variant="secondary" disabled={addingSource || !sourceContent.trim()}>
+              {addingSource ? 'Adding...' : 'Add'}
+            </Button>
+          </form>
+
+          {/* Start Analysis */}
+          <div className="flex items-center gap-3 border-t border-gray-200 pt-4">
+            <Button
+              onClick={() => void handleStartAnalysis()}
+              disabled={sources.length === 0 || submitting}
+            >
+              Start Analysis
+            </Button>
+            {sources.length === 0 && (
+              <span className="text-sm text-gray-400">Add at least 1 source to continue</span>
+            )}
+          </div>
         </div>
-      </form>
+      )}
+
+      {/* Step 3: Analysis in progress */}
+      {step === 'analysis' && (
+        <div className="space-y-4">
+          <div className="flex items-center gap-3">
+            <div className="h-4 w-4 animate-spin rounded-full border-2 border-gray-300 border-t-gray-600" />
+            <span className="text-sm text-gray-600">{analysisStatus}</span>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,0 +1,185 @@
+import { useEffect, useState, useRef, useCallback } from 'react'
+import { api } from '@/api/client'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+
+type Step = 'idle' | 'loading' | 'awaiting_code' | 'submitting' | 'complete' | 'error'
+
+export function SettingsPage() {
+  const [aiStatus, setAiStatus] = useState<{
+    backend: string; ready: boolean; detail: string
+  } | null>(null)
+  const [step, setStep] = useState<Step>('idle')
+  const [authUrl, setAuthUrl] = useState<string | null>(null)
+  const [code, setCode] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [tokenPreview, setTokenPreview] = useState<string | null>(null)
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  const refreshStatus = useCallback(() => {
+    api.getAiStatus().then(setAiStatus).catch(() => {})
+  }, [])
+
+  useEffect(() => {
+    refreshStatus()
+  }, [refreshStatus])
+
+  // Poll for auth completion while awaiting code (browser might complete it)
+  useEffect(() => {
+    if (step !== 'awaiting_code') return
+    pollRef.current = setInterval(async () => {
+      try {
+        const result = await api.authPoll()
+        if (result.authenticated) {
+          setStep('complete')
+          refreshStatus()
+        }
+      } catch { /* ignore */ }
+    }, 2000)
+    return () => { if (pollRef.current) clearInterval(pollRef.current) }
+  }, [step, refreshStatus])
+
+  async function handleStartLogin() {
+    setStep('loading')
+    setError(null)
+    setAuthUrl(null)
+    setCode('')
+    setTokenPreview(null)
+    try {
+      const result = await api.authStart()
+      if (result.status === 'complete') {
+        setStep('complete')
+        refreshStatus()
+      } else {
+        setAuthUrl(result.auth_url)
+        setStep('awaiting_code')
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to start login')
+      setStep('error')
+    }
+  }
+
+  async function handleSubmitCode() {
+    if (!code.trim()) return
+    setStep('submitting')
+    setError(null)
+    try {
+      const result = await api.authComplete(code.trim())
+      setTokenPreview(result.token_preview)
+      setStep('complete')
+      refreshStatus()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to complete login')
+      setStep('awaiting_code')
+    }
+  }
+
+  return (
+    <div className="space-y-6 max-w-xl">
+      <h1 className="text-lg font-semibold text-gray-900">Settings</h1>
+
+      {/* Current status */}
+      <div className="rounded border border-gray-200 bg-white p-4 space-y-2">
+        <h2 className="text-sm font-medium text-gray-900">AI Backend</h2>
+        {aiStatus ? (
+          <div className="flex items-center gap-3">
+            <span className={
+              aiStatus.ready
+                ? 'text-xs text-green-700 bg-green-50 px-2 py-1 rounded'
+                : 'text-xs text-amber-700 bg-amber-50 px-2 py-1 rounded'
+            }>
+              {aiStatus.ready ? 'Connected' : 'Not connected'}
+            </span>
+            <span className="text-sm text-gray-500">{aiStatus.detail}</span>
+          </div>
+        ) : (
+          <span className="text-sm text-gray-400">Loading...</span>
+        )}
+      </div>
+
+      {/* Login flow */}
+      {aiStatus && !aiStatus.ready && (
+        <div className="rounded border border-gray-200 bg-white p-4 space-y-4">
+          <h2 className="text-sm font-medium text-gray-900">Connect Claude Subscription</h2>
+          <p className="text-sm text-gray-500">
+            Sign in with your Anthropic account to use your Claude subscription for AI calls.
+          </p>
+
+          {step === 'idle' || step === 'error' || step === 'loading' ? (
+            <div className="space-y-3">
+              <Button size="sm" onClick={handleStartLogin} disabled={step === 'loading'}>
+                {step === 'loading' ? (
+                  <span className="flex items-center gap-2">
+                    <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24" fill="none">
+                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                    </svg>
+                    Starting login...
+                  </span>
+                ) : 'Start Login'}
+              </Button>
+              {step === 'loading' && (
+                <p className="text-xs text-gray-400">Generating authorization link (a few seconds)...</p>
+              )}
+              {error && (
+                <p className="text-sm text-red-600">{error}</p>
+              )}
+            </div>
+          ) : step === 'awaiting_code' ? (
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <p className="text-sm text-gray-700">
+                  1. Click the link below to authorize:
+                </p>
+                <a
+                  href={authUrl!}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="block text-sm text-blue-600 hover:text-blue-800 underline break-all"
+                >
+                  Open Anthropic Login
+                </a>
+              </div>
+              <div className="space-y-2">
+                <p className="text-sm text-gray-700">
+                  2. After authorizing, paste the code shown on the callback page:
+                </p>
+                <div className="flex gap-2">
+                  <Input
+                    placeholder="Paste authorization code..."
+                    value={code}
+                    onChange={(e) => setCode(e.target.value)}
+                    onKeyDown={(e) => { if (e.key === 'Enter') handleSubmitCode() }}
+                    className="font-mono text-sm"
+                  />
+                  <Button size="sm" onClick={handleSubmitCode} disabled={!code.trim()}>
+                    Submit
+                  </Button>
+                </div>
+              </div>
+              {error && (
+                <p className="text-sm text-red-600">{error}</p>
+              )}
+            </div>
+          ) : step === 'submitting' ? (
+            <p className="text-sm text-gray-500">Completing authentication...</p>
+          ) : null}
+        </div>
+      )}
+
+      {/* Success state */}
+      {(step === 'complete' || aiStatus?.ready) && (
+        <div className="rounded border border-green-200 bg-green-50 p-4 space-y-1">
+          <p className="text-sm font-medium text-green-800">Authenticated</p>
+          {tokenPreview && (
+            <p className="text-xs text-green-600 font-mono">{tokenPreview}</p>
+          )}
+          <p className="text-xs text-green-600">
+            Claude CLI is connected via your subscription. Token persists across container restarts.
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/SkillDetailPage.tsx
+++ b/frontend/src/pages/SkillDetailPage.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from 'react'
-import { useParams } from 'react-router-dom'
+import { useEffect, useState, useCallback } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
 import { api } from '@/api/client'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
+import { Input } from '@/components/ui/input'
 import { Skeleton } from '@/components/ui/skeleton'
 import {
   Table,
@@ -12,6 +13,10 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
 
 interface Step {
   name: string
@@ -23,42 +28,58 @@ interface Skill {
   id: number
   name: string
   description: string
+  definition: { steps?: Step[] }
   version: number
   usage_count: number
   eval_score: number | null
-  steps: Step[]
+  eval_trend: 'improving' | 'declining' | 'stable' | null
+  last_eval_at: string | null
+  created_at: string
   updated_at: string
 }
 
-interface EvalCase {
+interface EvalCaseDef {
+  id: number
   name: string
   input: string
-  expected_output: string
+  expected_output: { contains?: string[] }
 }
 
 interface EvalSuite {
-  cases: EvalCase[]
+  cases: EvalCaseDef[]
   runs_count: number
 }
 
 interface CaseResult {
+  case_id: number
   case_name: string
   passed: boolean
-  reason?: string
+  reasons: string[]
+  output_preview: string
 }
 
 interface EvalRun {
   id: number
-  score: number
+  status: string
+  overall_score: number
+  runtime: string
   created_at: string
-  results: CaseResult[]
+  results: { cases: CaseResult[] }
 }
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
 
 const RUNTIMES = [
   { key: 'web_workflow', label: 'Web Workflow' },
   { key: 'claude_code_skill', label: 'Claude Code Skill' },
   { key: 'open_claw_prompt', label: 'Open Claw Prompt' },
 ] as const
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
 function formatDateTime(iso: string): string {
   const d = new Date(iso)
@@ -70,9 +91,285 @@ function formatDateTime(iso: string): string {
   })
 }
 
+function formatDate(iso: string): string {
+  const d = new Date(iso)
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+}
+
+function scorePercent(score: number): string {
+  return (score * 100).toFixed(0) + '%'
+}
+
+function TrendIndicator({ trend }: { trend: Skill['eval_trend'] }) {
+  if (!trend) return null
+  switch (trend) {
+    case 'improving':
+      return <span className="text-green-600 text-sm font-medium" title="Improving">▲</span>
+    case 'declining':
+      return <span className="text-red-600 text-sm font-medium" title="Declining">▼</span>
+    case 'stable':
+      return <span className="text-gray-400 text-sm font-medium" title="Stable">&mdash;</span>
+  }
+}
+
+function ScoreHistoryBadges({ runs }: { runs: EvalRun[] }) {
+  const last5 = runs.slice(0, 5)
+  if (last5.length === 0) return null
+  return (
+    <div className="flex items-center gap-1">
+      {last5.map((run) => (
+        <span
+          key={run.id}
+          className={`inline-block rounded px-1.5 py-0.5 text-[10px] font-medium ${
+            run.overall_score >= 0.7
+              ? 'bg-green-100 text-green-700'
+              : run.overall_score >= 0.4
+                ? 'bg-yellow-100 text-yellow-700'
+                : 'bg-red-100 text-red-700'
+          }`}
+          title={formatDateTime(run.created_at)}
+        >
+          {scorePercent(run.overall_score)}
+        </span>
+      ))}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function EvalCaseEditor({
+  skillId,
+  cases,
+  onUpdate,
+}: {
+  skillId: number
+  cases: EvalCaseDef[]
+  onUpdate: () => void
+}) {
+  const [expandedId, setExpandedId] = useState<number | null>(null)
+  const [saving, setSaving] = useState(false)
+  const [newTerm, setNewTerm] = useState('')
+
+  function handleExpand(c: EvalCaseDef) {
+    if (expandedId === c.id) {
+      setExpandedId(null)
+      return
+    }
+    setExpandedId(c.id)
+    setNewTerm('')
+  }
+
+  async function handleRemoveTerm(c: EvalCaseDef, term: string) {
+    setSaving(true)
+    try {
+      const currentTerms = (c.expected_output?.contains ?? []).filter((t) => t !== term)
+      await api.updateEvalCase(skillId, c.id, {
+        expected_output: { contains: currentTerms },
+      })
+      onUpdate()
+    } catch {
+      // silent
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleAddTerm(c: EvalCaseDef) {
+    const term = newTerm.trim()
+    if (!term) return
+    setSaving(true)
+    try {
+      const currentTerms = [...(c.expected_output?.contains ?? []), term]
+      await api.updateEvalCase(skillId, c.id, {
+        expected_output: { contains: currentTerms },
+      })
+      setNewTerm('')
+      onUpdate()
+    } catch {
+      // silent
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleDelete(caseId: number) {
+    setSaving(true)
+    try {
+      await api.deleteEvalCase(skillId, caseId)
+      if (expandedId === caseId) setExpandedId(null)
+      onUpdate()
+    } catch {
+      // silent
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="mt-3 space-y-1">
+      {cases.map((c) => {
+        const isExpanded = expandedId === c.id
+        const terms = c.expected_output?.contains ?? []
+        return (
+          <div key={c.id} className="rounded border border-gray-200 bg-white">
+            <button
+              type="button"
+              className="flex w-full items-center justify-between px-3 py-2 text-left hover:bg-gray-50"
+              onClick={() => handleExpand(c)}
+            >
+              <span className="text-sm font-medium text-gray-900">{c.name}</span>
+              <div className="flex items-center gap-1">
+                {terms.map((t) => (
+                  <Badge key={t} variant="outline" className="text-[10px]">
+                    {t}
+                  </Badge>
+                ))}
+                <span className="ml-1 text-xs text-gray-400">{isExpanded ? '−' : '+'}</span>
+              </div>
+            </button>
+            {isExpanded && (
+              <div className="border-t border-gray-100 px-3 py-2 space-y-2">
+                <div className="flex flex-wrap gap-1">
+                  {terms.map((t) => (
+                    <span
+                      key={t}
+                      className="inline-flex items-center gap-1 rounded bg-gray-100 px-2 py-0.5 text-xs text-gray-700"
+                    >
+                      {t}
+                      <button
+                        type="button"
+                        className="ml-0.5 text-gray-400 hover:text-red-500"
+                        onClick={() => void handleRemoveTerm(c, t)}
+                        disabled={saving}
+                      >
+                        x
+                      </button>
+                    </span>
+                  ))}
+                </div>
+                <div className="flex gap-2">
+                  <Input
+                    className="h-7 text-xs"
+                    placeholder="Add expected term..."
+                    value={newTerm}
+                    onChange={(e) => setNewTerm(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        e.preventDefault()
+                        void handleAddTerm(c)
+                      }
+                    }}
+                  />
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="h-7 text-xs"
+                    onClick={() => void handleAddTerm(c)}
+                    disabled={saving || !newTerm.trim()}
+                  >
+                    Add
+                  </Button>
+                </div>
+                <div className="flex justify-end gap-2">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="h-7 text-xs text-red-600 hover:text-red-700"
+                    onClick={() => void handleDelete(c.id)}
+                    disabled={saving}
+                  >
+                    Delete Case
+                  </Button>
+                </div>
+              </div>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+function RunCaseTable({ cases }: { cases: CaseResult[] }) {
+  const [expandedCase, setExpandedCase] = useState<number | null>(null)
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Case</TableHead>
+          <TableHead className="text-right">Result</TableHead>
+          <TableHead>Reason</TableHead>
+          <TableHead className="w-8"></TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {cases.map((r, i) => (
+          <>
+            <TableRow key={i} className="group">
+              <TableCell className="text-sm text-gray-900">{r.case_name}</TableCell>
+              <TableCell className="text-right">
+                <span
+                  className={
+                    r.passed
+                      ? 'text-xs font-medium text-green-700'
+                      : 'text-xs font-medium text-red-700'
+                  }
+                >
+                  {r.passed ? 'PASS' : 'FAIL'}
+                </span>
+              </TableCell>
+              <TableCell className="max-w-xs text-xs">
+                {r.passed ? (
+                  <span className="text-green-600">
+                    {r.reasons.length > 0 ? r.reasons.join('; ') : 'All checks passed'}
+                  </span>
+                ) : (
+                  <span className="text-red-600">
+                    {r.reasons.length > 0 ? r.reasons.join('; ') : 'Failed'}
+                  </span>
+                )}
+              </TableCell>
+              <TableCell className="w-8">
+                {r.output_preview && (
+                  <button
+                    type="button"
+                    className="text-xs text-gray-400 hover:text-gray-600"
+                    onClick={() => setExpandedCase(expandedCase === i ? null : i)}
+                    title="Toggle output preview"
+                  >
+                    {expandedCase === i ? '−' : '+'}
+                  </button>
+                )}
+              </TableCell>
+            </TableRow>
+            {expandedCase === i && r.output_preview && (
+              <TableRow key={`${i}-preview`}>
+                <TableCell colSpan={4} className="bg-gray-50">
+                  <pre className="max-h-32 overflow-auto text-xs text-gray-600 whitespace-pre-wrap">
+                    {r.output_preview}
+                  </pre>
+                </TableCell>
+              </TableRow>
+            )}
+          </>
+        ))}
+      </TableBody>
+    </Table>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Main page
+// ---------------------------------------------------------------------------
+
 export function SkillDetailPage() {
   const { skillId: skillIdParam } = useParams<{ skillId: string }>()
   const skillId = skillIdParam ? Number(skillIdParam) : null
+  const navigate = useNavigate()
 
   const [skill, setSkill] = useState<Skill | null>(null)
   const [evalSuite, setEvalSuite] = useState<EvalSuite | null>(null)
@@ -83,64 +380,87 @@ export function SkillDetailPage() {
   const [generatingAdapter, setGeneratingAdapter] = useState<string | null>(null)
   const [adapterOutput, setAdapterOutput] = useState<string | null>(null)
 
-  useEffect(() => {
+  // Track which eval runs are expanded (latest is expanded by default)
+  const [expandedRuns, setExpandedRuns] = useState<Set<number>>(new Set())
+
+  const loadData = useCallback(async () => {
     if (skillId == null || isNaN(skillId)) {
       setError('Invalid skill ID')
       setLoading(false)
       return
     }
 
-    let cancelled = false
+    try {
+      const [skillData, suiteData, historyData] = await Promise.allSettled([
+        api.getSkill(skillId),
+        api.getEvalSuite(skillId),
+        api.getEvalHistory(skillId),
+      ])
 
-    async function load() {
-      try {
-        const [skillData, suiteData, historyData] = await Promise.allSettled([
-          api.getSkill(skillId!),
-          api.getEvalSuite(skillId!),
-          api.getEvalHistory(skillId!),
-        ])
-
-        if (cancelled) return
-
-        if (skillData.status === 'fulfilled') {
-          setSkill(skillData.value as Skill)
-        } else {
-          setError('Failed to load skill')
-          return
-        }
-
-        if (suiteData.status === 'fulfilled') {
-          setEvalSuite(suiteData.value as EvalSuite)
-        }
-
-        if (historyData.status === 'fulfilled') {
-          const runs = historyData.value as EvalRun[]
-          setEvalRuns(runs.slice(0, 5))
-        }
-      } catch (err) {
-        if (!cancelled) {
-          setError(err instanceof Error ? err.message : 'Failed to load skill')
-        }
-      } finally {
-        if (!cancelled) setLoading(false)
+      if (skillData.status === 'fulfilled') {
+        setSkill(skillData.value as Skill)
+      } else {
+        setError('Failed to load skill')
+        return
       }
-    }
 
-    void load()
-    return () => { cancelled = true }
+      if (suiteData.status === 'fulfilled') {
+        setEvalSuite(suiteData.value as EvalSuite)
+      }
+
+      if (historyData.status === 'fulfilled') {
+        const runs = historyData.value as EvalRun[]
+        setEvalRuns(runs)
+        // Expand the latest run by default
+        if (runs.length > 0) {
+          setExpandedRuns(new Set([runs[0].id]))
+        }
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load skill')
+    } finally {
+      setLoading(false)
+    }
   }, [skillId])
+
+  useEffect(() => {
+    let cancelled = false
+    void loadData().then(() => {
+      if (cancelled) {
+        // reset if unmounted — not strictly necessary but safe
+      }
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [loadData])
+
+  function toggleRunExpanded(runId: number) {
+    setExpandedRuns((prev) => {
+      const next = new Set(prev)
+      if (next.has(runId)) {
+        next.delete(runId)
+      } else {
+        next.add(runId)
+      }
+      return next
+    })
+  }
 
   async function handleRunEval() {
     if (skillId == null) return
     setRunningEval(true)
     try {
       await api.runEval(skillId)
-      // Reload eval history
-      const historyData = (await api.getEvalHistory(skillId)) as EvalRun[]
-      setEvalRuns(historyData.slice(0, 5))
-      // Reload skill for updated eval_score
-      const skillData = (await api.getSkill(skillId)) as Skill
+      const [historyData, skillData] = await Promise.all([
+        api.getEvalHistory(skillId) as Promise<EvalRun[]>,
+        api.getSkill(skillId) as Promise<Skill>,
+      ])
+      setEvalRuns(historyData)
       setSkill(skillData)
+      if (historyData.length > 0) {
+        setExpandedRuns(new Set([historyData[0].id]))
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Eval run failed')
     } finally {
@@ -162,6 +482,20 @@ export function SkillDetailPage() {
     }
   }
 
+  async function handleReloadSuite() {
+    if (skillId == null) return
+    try {
+      const suiteData = (await api.getEvalSuite(skillId)) as EvalSuite
+      setEvalSuite(suiteData)
+    } catch {
+      // silent
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Render
+  // -----------------------------------------------------------------------
+
   if (loading) {
     return (
       <div className="space-y-4">
@@ -182,29 +516,43 @@ export function SkillDetailPage() {
 
   if (!skill) return null
 
+  const latestRun = evalRuns.length > 0 ? evalRuns[0] : null
+  const olderRuns = evalRuns.slice(1)
+
   return (
     <div className="space-y-8">
       {/* Header */}
       <div>
         <div className="flex items-center gap-3">
           <h1 className="text-lg font-semibold text-gray-900">{skill.name}</h1>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => navigate(`/new?revise=${skill.id}`)}
+          >
+            Revise
+          </Button>
           <Badge variant="outline">v{skill.version}</Badge>
           <Badge variant="secondary">{skill.usage_count} runs</Badge>
           {skill.eval_score != null && (
-            <Badge variant={skill.eval_score >= 7 ? 'default' : 'secondary'}>
-              {skill.eval_score.toFixed(1)}
-            </Badge>
+            <div className="flex items-center gap-1">
+              <Badge variant={skill.eval_score >= 0.7 ? 'default' : 'secondary'}>
+                {scorePercent(skill.eval_score)}
+              </Badge>
+              <TrendIndicator trend={skill.eval_trend} />
+            </div>
           )}
+          <ScoreHistoryBadges runs={evalRuns} />
         </div>
         <p className="mt-1 text-sm text-gray-500">{skill.description}</p>
       </div>
 
       {/* Steps */}
-      {skill.steps && skill.steps.length > 0 && (
+      {skill.definition?.steps && skill.definition.steps.length > 0 && (
         <section>
           <h2 className="text-sm font-semibold text-gray-900">Steps</h2>
           <ol className="mt-2 space-y-2">
-            {skill.steps.map((step, i) => (
+            {skill.definition.steps.map((step, i) => (
               <li key={i} className="flex gap-3">
                 <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-gray-100 text-xs font-medium text-gray-500">
                   {i + 1}
@@ -243,70 +591,102 @@ export function SkillDetailPage() {
         </div>
 
         {evalSuite ? (
-          <div className="mt-2 flex gap-4 text-xs text-gray-400">
-            <span>{evalSuite.cases.length} cases</span>
-            <span>{evalSuite.runs_count} runs</span>
-          </div>
+          <>
+            <div className="mt-2 flex gap-4 text-xs text-gray-400">
+              <span>{evalSuite.cases.length} cases</span>
+              <span>&middot;</span>
+              <span>{evalSuite.runs_count} runs</span>
+            </div>
+
+            {/* Eval case editor */}
+            {skillId != null && (
+              <EvalCaseEditor
+                skillId={skillId}
+                cases={evalSuite.cases}
+                onUpdate={() => void handleReloadSuite()}
+              />
+            )}
+          </>
         ) : (
           <p className="mt-2 text-sm text-gray-500">No eval suite configured.</p>
         )}
 
-        {/* Recent runs */}
-        {evalRuns.length > 0 && (
+        {/* Latest run — expanded */}
+        {latestRun && (
           <div className="mt-4 space-y-3">
             <h3 className="text-xs font-medium text-gray-500">Recent Runs</h3>
-            {evalRuns.map((run) => (
-              <div key={run.id} className="rounded border border-gray-200 bg-white p-3">
-                <div className="flex items-center justify-between">
+
+            <div className="rounded border border-gray-200 bg-white">
+              <button
+                type="button"
+                className="flex w-full items-center justify-between px-3 py-2 hover:bg-gray-50"
+                onClick={() => toggleRunExpanded(latestRun.id)}
+              >
+                <div className="flex items-center gap-2">
+                  <Badge variant={latestRun.overall_score >= 0.7 ? 'default' : 'secondary'}>
+                    {scorePercent(latestRun.overall_score)}
+                  </Badge>
+                  <span className="text-xs text-gray-400">
+                    {formatDateTime(latestRun.created_at)}
+                  </span>
+                  {latestRun.runtime != null && (
+                    <span className="text-xs text-gray-300">
+                      {latestRun.runtime}
+                    </span>
+                  )}
+                  <Badge variant="outline" className="text-[10px]">latest</Badge>
+                </div>
+                <span className="text-xs text-gray-400">
+                  {expandedRuns.has(latestRun.id) ? '−' : '+'}
+                </span>
+              </button>
+              {expandedRuns.has(latestRun.id) &&
+                latestRun.results?.cases &&
+                latestRun.results.cases.length > 0 && (
+                  <div className="border-t border-gray-100 p-3">
+                    <RunCaseTable cases={latestRun.results.cases} />
+                  </div>
+                )}
+            </div>
+
+            {/* Older runs — collapsed by default */}
+            {olderRuns.map((run) => (
+              <div key={run.id} className="rounded border border-gray-200 bg-white">
+                <button
+                  type="button"
+                  className="flex w-full items-center justify-between px-3 py-2 hover:bg-gray-50"
+                  onClick={() => toggleRunExpanded(run.id)}
+                >
                   <div className="flex items-center gap-2">
-                    <Badge variant={run.score >= 7 ? 'default' : 'secondary'}>
-                      {run.score.toFixed(1)}
+                    <Badge variant={run.overall_score >= 0.7 ? 'default' : 'secondary'}>
+                      {scorePercent(run.overall_score)}
                     </Badge>
                     <span className="text-xs text-gray-400">
-                      {formatDateTime(run.created_at)}
+                      {formatDate(run.created_at)}
                     </span>
+                    {run.runtime != null && (
+                      <span className="text-xs text-gray-300">
+                        {run.runtime}
+                      </span>
+                    )}
                   </div>
-                </div>
-                {run.results && run.results.length > 0 && (
-                  <Table>
-                    <TableHeader>
-                      <TableRow>
-                        <TableHead>Case</TableHead>
-                        <TableHead className="text-right">Result</TableHead>
-                        <TableHead>Reason</TableHead>
-                      </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                      {run.results.map((r, i) => (
-                        <TableRow key={i}>
-                          <TableCell className="text-sm text-gray-900">
-                            {r.case_name}
-                          </TableCell>
-                          <TableCell className="text-right">
-                            <span
-                              className={
-                                r.passed
-                                  ? 'text-xs font-medium text-green-700'
-                                  : 'text-xs font-medium text-red-700'
-                              }
-                            >
-                              {r.passed ? 'PASS' : 'FAIL'}
-                            </span>
-                          </TableCell>
-                          <TableCell className="max-w-xs truncate text-xs text-gray-400">
-                            {r.reason ?? '--'}
-                          </TableCell>
-                        </TableRow>
-                      ))}
-                    </TableBody>
-                  </Table>
-                )}
+                  <span className="text-xs text-gray-400">
+                    {expandedRuns.has(run.id) ? '−' : '+'}
+                  </span>
+                </button>
+                {expandedRuns.has(run.id) &&
+                  run.results?.cases &&
+                  run.results.cases.length > 0 && (
+                    <div className="border-t border-gray-100 p-3">
+                      <RunCaseTable cases={run.results.cases} />
+                    </div>
+                  )}
               </div>
             ))}
           </div>
         )}
 
-        {evalRuns.length === 0 && !loading && (
+        {evalRuns.length === 0 && (
           <p className="mt-4 text-sm text-gray-500">
             No eval runs yet. Click "Run Eval" to get started.
           </p>

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -5,6 +5,7 @@ import { DiscoveryPage } from './pages/DiscoveryPage'
 import { NewCollectionPage } from './pages/NewCollectionPage'
 import { SkillDetailPage } from './pages/SkillDetailPage'
 import { LeaderboardPage } from './pages/LeaderboardPage'
+import { SettingsPage } from './pages/SettingsPage'
 
 export const router = createBrowserRouter([
   {
@@ -15,6 +16,7 @@ export const router = createBrowserRouter([
       { path: '/workspace/:sessionId', element: <WorkspacePage /> },
       { path: '/skills/:skillId', element: <SkillDetailPage /> },
       { path: '/leaderboard', element: <LeaderboardPage /> },
+      { path: '/settings', element: <SettingsPage /> },
     ],
   },
 ])


### PR DESCRIPTION
## Summary
- **Headless Docker auth** — Web UI login flow at `/settings` that drives `claude setup-token` via PTY inside Docker. Token persists via `CLAUDE_CODE_OAUTH_TOKEN` across container restarts.
- **Walkthrough eval spec** — `docs/walkthroughs/canopy-web-demo.yaml` with `seed_demo` management command (5 skills, varied scores, realistic failure reasons, spread timestamps).
- **7 product improvements** identified from running the walkthrough against the live app:
  1. Eval failures show expected terms vs actual output
  2. Eval trend arrows (improving/declining/stable) on leaderboard + skill detail
  3. Collapsed eval runs — latest expanded, older as compact summaries
  4. Skill revision — "Revise" button reopens workspace, publish bumps version
  5. Multi-source collections — step-by-step flow with type picker
  6. Editable eval cases — inline add/remove expected terms
  7. Leaderboard — ranked, sortable, stale detection, color-coded scores

## Test plan
- [ ] `docker compose up -d && docker compose exec backend python manage.py migrate && docker compose exec backend python manage.py seed_demo`
- [ ] Visit http://localhost:9101/settings — verify auth flow (Start Login → paste code → authenticated)
- [ ] Visit http://localhost:9101/ — 5 skills with varied scores
- [ ] Visit http://localhost:9101/leaderboard — ranked with trend arrows and relative dates
- [ ] Click into a skill — collapsed runs, trend badges, editable eval cases, Revise button
- [ ] Click "New" — multi-step collection flow (name → add sources → analyze)
- [ ] Run `/walkthrough canopy-web-demo` to execute the full walkthrough spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)