### PR TITLE
docs: regenerate CLAUDE.md (staleness + coverage fixes)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,16 +6,19 @@ Collaborative web workspace for building reusable AI skills from conversations.
 
 - **Backend:** Django 5 ASGI + uvicorn, PostgreSQL
 - **Frontend:** React 19 + Vite + Tailwind CSS 4 + shadcn/ui
-- **AI:** Anthropic Claude API via SSE streaming
+- **AI:** Anthropic Claude API via SSE streaming. Dual backend — direct API key (`AI_BACKEND=api`) or Claude Code CLI subscription (`AI_BACKEND=cli`), switchable at runtime via `/api/ai/switch/`.
+- **Runtime adapters:** `apps/skills/adapters/` produces skill artifacts for `web`, `claude_code`, and `open_claw` runtimes.
 - **Canopy:** Integrated as git submodule at `./canopy/`
+- **Deployment:** GCP Cloud Run + Cloud SQL via `./deploy.sh` (see PR #3 for resources). Production settings in `config/settings/production.py`.
 
 ## Development
 
 ```bash
 # Backend
-cp .env.example .env  # Add ANTHROPIC_API_KEY
+cp .env.example .env  # Set AI_BACKEND=api + ANTHROPIC_API_KEY, or AI_BACKEND=cli
 pip install -e ".[dev]"
 python manage.py migrate
+python manage.py seed_demo   # optional: 5 demo skills with eval history
 python manage.py runserver
 
 # Frontend
@@ -24,24 +27,34 @@ cd frontend && npm install && npm run dev
 # Both (via honcho)
 honcho start -f Procfile.dev
 
-# Docker
+# Docker (backend + frontend + Postgres)
 docker compose up
+
+# Deploy to GCP Cloud Run
+./deploy.sh
 ```
+
+When `AI_BACKEND=cli`, the `claude` binary must be on PATH and authenticated. In Docker, use the headless auth flow at `/settings` (drives `claude setup-token` via PTY; token persists in `CLAUDE_CODE_OAUTH_TOKEN`).
 
 ## Testing
 
 ```bash
-pytest                           # All backend tests
+pytest                                    # All backend tests
 pytest tests/test_workspace_engine.py -v  # Specific
-cd frontend && npm run build     # Frontend type check + build
+cd frontend && npm run build              # Frontend type check + build
 ```
+
+Walkthrough QA spec at `docs/walkthroughs/canopy-web-demo.yaml` (run via `/walkthrough canopy-web-demo`).
 
 ## Key URLs
 
 - `/` — Skill discovery feed
-- `/workspace/:id` — Co-authoring workspace
-- `/skills/:id` — Skill detail + eval history
+- `/new` — New collection / source ingestion flow
+- `/workspace/:sessionId` — Co-authoring workspace
+- `/skills/:skillId` — Skill detail + eval history
 - `/leaderboard` — Eval improvement leaderboard
+- `/guide` — Interactive walkthrough ("Try It Now" sample flow + adapter reference)
+- `/settings` — AI backend status, switch backends, headless Claude CLI auth
 - `/api/` — REST API
 - `/admin/` — Django admin
 - `/health/` — Health check
@@ -55,6 +68,7 @@ cd frontend && npm run build     # Frontend type check + build
 
 ### Workspace
 - `POST /api/workspace/start/{collection_id}/` — Start workspace (SSE stream)
+- `POST /api/workspace/analyze/{collection_id}/` — Run AI analysis to propose approach + eval
 - `GET /api/workspace/{session_id}/` — Get workspace state
 - `PATCH /api/workspace/{session_id}/edit/` — Edit skill draft
 - `POST /api/workspace/{session_id}/publish/` — Publish skill
@@ -69,6 +83,14 @@ cd frontend && npm run build     # Frontend type check + build
 - `POST /api/evals/{skill_id}/run/` — Run eval
 - `GET /api/evals/{skill_id}/history/` — Eval history
 - `POST /api/evals/{skill_id}/cases/` — Add eval case
+- `PATCH /api/evals/{skill_id}/cases/{case_id}/` — Edit / remove eval case
+
+### AI backend (`apps/common`)
+- `GET /api/ai/status/` — Current backend + auth state
+- `POST /api/ai/switch/` — Switch between `api` and `cli` at runtime
+- `POST /api/ai/auth/start/` — Begin headless Claude CLI login
+- `POST /api/ai/auth/complete/` — Submit OAuth code
+- `GET /api/ai/auth/poll/` — Poll auth status
 
 ## Design Decisions
 
@@ -78,3 +100,12 @@ cd frontend && npm run build     # Frontend type check + build
 - Overwrite-with-history versioning
 - No auth in V1 (single-tenant internal tool)
 - PostgreSQL on Cloud SQL (GCP deployment)
+- Dual AI backend lets users run either against an API key or their own Claude Code subscription
+
+## Reference Docs
+
+- `docs/superpowers/plans/2026-03-27-canopy-web-implementation.md` — Original implementation plan and file structure
+- `docs/designs/canopy-web-design.md` — Product design + glossary (open claw, skill, collection, eval suite, workspace session)
+- `docs/designs/ceo-plan-conversation-to-agent.md` — CEO review, scope decisions, deferred work
+- `docs/walkthroughs/canopy-web-demo.yaml` — Walkthrough QA spec (5 skills, varied scores)
+- `TODOS.md` — Deferred V2 work (proactive detection, MCP layer, prompt hardening, OAuth integrations, multi-tenant auth, cowork adapter)


### PR DESCRIPTION
## Summary

CLAUDE.md regeneration audit found drift across PRs #2-#4. The regenerated version corrects stale routes/endpoints and adds missing context so a fresh agent has accurate ground truth without grepping the repo.

## Findings

**Staleness — fixed**
- Routes table missing `/new`, `/guide`, `/settings`; `:id` placeholders didn't match the router (`:sessionId`, `:skillId`).
- Workspace API was missing `POST /api/workspace/analyze/{collection_id}/`.
- Evals API was missing `PATCH /api/evals/{skill_id}/cases/{case_id}/` (added in PR #2).
- The entire `/api/ai/*` group (`status`, `switch`, `auth/start`, `auth/complete`, `auth/poll`) was missing — added across PRs #2 and #4.

**Coverage — added**
- Dual AI backend (`AI_BACKEND=api` vs `cli`) now noted in Architecture (PRs #1, #4).
- Headless Docker auth flow at `/settings` documented (PR #2).
- GCP Cloud Run deployment via `./deploy.sh` documented (PR #3).
- `python manage.py seed_demo` added to bootstrap (PR #2).
- Walkthrough QA spec at `docs/walkthroughs/canopy-web-demo.yaml` referenced (PR #2).
- New **Reference Docs** section links the implementation plan, design docs, walkthrough spec, and `TODOS.md`.

**Structure**
- Section order preserved exactly. One new section (`Reference Docs`) added at the end.
- File grew from 81 → 111 lines, still well under the 200-line target.

**No `docs/learnings/` directory exists** — coverage check against learnings was skipped. No new learning files were created (no patterns from PRs warranted standalone learnings beyond what now lives in CLAUDE.md).

## Test plan

- [ ] `cat CLAUDE.md` — verify regenerated content reads cleanly
- [ ] Cross-check routes against `frontend/src/router.tsx`
- [ ] Cross-check API endpoints against `apps/*/urls.py` and `config/urls.py`
- [ ] Confirm referenced files exist (`./deploy.sh`, `seed_demo`, `docs/walkthroughs/canopy-web-demo.yaml`, `TODOS.md`, plan + design docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)