### PR TITLE
ci: GitHub Actions test + deploy pipeline, fix stale eval tests, document uv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
 name: CI / Deploy
 
 # Runs backend tests + frontend build on every PR and push to main.
-# On push to main (and on manual workflow_dispatch), the deploy job
-# runs after both test jobs pass and ships images to Cloud Run.
+# Deploy is manual-only: trigger via the "Run workflow" button on the
+# Actions tab (workflow_dispatch). When triggered, the deploy job waits
+# for both test jobs to pass before shipping images to Cloud Run.
 #
 # One-time GCP setup required for the deploy job to authenticate via
 # Workload Identity Federation (no long-lived service account keys):
@@ -88,7 +89,9 @@ jobs:
   deploy:
     name: Deploy to Cloud Run
     needs: [test-backend, test-frontend]
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
+    # Manual-only: must be triggered from the Actions tab via "Run workflow".
+    # Tests still gate the deploy because of `needs:` above.
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,114 @@
+name: CI / Deploy
+
+# Runs backend tests + frontend build on every PR and push to main.
+# On push to main (and on manual workflow_dispatch), the deploy job
+# runs after both test jobs pass and ships images to Cloud Run.
+#
+# One-time GCP setup required for the deploy job to authenticate via
+# Workload Identity Federation (no long-lived service account keys):
+#
+#   gcloud iam service-accounts create canopy-web-deployer \
+#     --project=connect-labs
+#
+#   gcloud iam workload-identity-pools create github \
+#     --project=connect-labs --location=global \
+#     --display-name="GitHub Actions"
+#
+#   gcloud iam workload-identity-pools providers create-oidc github \
+#     --project=connect-labs --location=global \
+#     --workload-identity-pool=github \
+#     --display-name="GitHub" \
+#     --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository,attribute.repository_owner=assertion.repository_owner" \
+#     --attribute-condition="assertion.repository_owner=='jjackson'" \
+#     --issuer-uri="https://token.actions.githubusercontent.com"
+#
+#   gcloud iam service-accounts add-iam-policy-binding \
+#     canopy-web-deployer@connect-labs.iam.gserviceaccount.com \
+#     --project=connect-labs \
+#     --role=roles/iam.workloadIdentityUser \
+#     --member="principalSet://iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/github/attribute.repository/jjackson/canopy-web"
+#
+# Then grant the deployer SA the roles it needs (run, artifact registry,
+# cloud sql, secret manager accessor) and add these GitHub repo secrets:
+#
+#   GCP_WIF_PROVIDER  →  projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/github/providers/github
+#   GCP_SERVICE_ACCOUNT  →  canopy-web-deployer@connect-labs.iam.gserviceaccount.com
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  test-backend:
+    name: Backend tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Sync dependencies
+        run: uv sync --extra dev
+
+      - name: Run pytest
+        run: uv run pytest
+
+  test-frontend:
+    name: Frontend build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Build
+        working-directory: frontend
+        run: npm run build
+
+  deploy:
+    name: Deploy to Cloud Run
+    needs: [test-backend, test-frontend]
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write  # Required for Workload Identity Federation
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
+
+      - name: Deploy
+        env:
+          SKIP_TESTS: '1'  # Already verified in test-backend / test-frontend jobs
+        run: ./deploy.sh ${{ github.sha }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,8 @@ uv run honcho start -f Procfile.dev
 # Docker (backend + frontend + Postgres)
 docker compose up
 
-# Deploy to GCP Cloud Run (local; CI also deploys on push to main)
+# Deploy to GCP Cloud Run (local). CI also has a manual deploy job —
+# trigger it from the Actions tab ("CI / Deploy" → Run workflow).
 ./deploy.sh                  # runs tests + frontend build first
 SKIP_TESTS=1 ./deploy.sh     # bypass test gate (emergencies only)
 ```
@@ -47,7 +48,7 @@ uv run pytest tests/test_workspace_engine.py -v  # Specific
 cd frontend && npm run build                     # Frontend type check + build
 ```
 
-CI (`.github/workflows/ci.yml`) runs both on every PR and on push to main, and gates auto-deploy. Walkthrough QA spec at `docs/walkthroughs/canopy-web-demo.yaml` (run via `/walkthrough canopy-web-demo`).
+CI (`.github/workflows/ci.yml`) runs both on every PR and on push to main. Deploy is a separate manual job in the same workflow — trigger it from the Actions tab via "Run workflow"; the deploy step waits for the test jobs to pass before shipping. Walkthrough QA spec at `docs/walkthroughs/canopy-web-demo.yaml` (run via `/walkthrough canopy-web-demo`).
 
 ## Key URLs
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,25 +13,28 @@ Collaborative web workspace for building reusable AI skills from conversations.
 
 ## Development
 
+Backend uses [`uv`](https://docs.astral.sh/uv/) for dependency management (uv.lock is committed). Install uv first if you don't have it: `curl -LsSf https://astral.sh/uv/install.sh | sh`.
+
 ```bash
 # Backend
 cp .env.example .env  # Set AI_BACKEND=api + ANTHROPIC_API_KEY, or AI_BACKEND=cli
-pip install -e ".[dev]"
-python manage.py migrate
-python manage.py seed_demo   # optional: 5 demo skills with eval history
-python manage.py runserver
+uv sync --extra dev
+uv run python manage.py migrate
+uv run python manage.py seed_demo   # optional: 5 demo skills with eval history
+uv run python manage.py runserver
 
 # Frontend
 cd frontend && npm install && npm run dev
 
 # Both (via honcho)
-honcho start -f Procfile.dev
+uv run honcho start -f Procfile.dev
 
 # Docker (backend + frontend + Postgres)
 docker compose up
 
-# Deploy to GCP Cloud Run
-./deploy.sh
+# Deploy to GCP Cloud Run (local; CI also deploys on push to main)
+./deploy.sh                  # runs tests + frontend build first
+SKIP_TESTS=1 ./deploy.sh     # bypass test gate (emergencies only)
 ```
 
 When `AI_BACKEND=cli`, the `claude` binary must be on PATH and authenticated. In Docker, use the headless auth flow at `/settings` (drives `claude setup-token` via PTY; token persists in `CLAUDE_CODE_OAUTH_TOKEN`).
@@ -39,12 +42,12 @@ When `AI_BACKEND=cli`, the `claude` binary must be on PATH and authenticated. In
 ## Testing
 
 ```bash
-pytest                                    # All backend tests
-pytest tests/test_workspace_engine.py -v  # Specific
-cd frontend && npm run build              # Frontend type check + build
+uv run pytest                                    # All backend tests
+uv run pytest tests/test_workspace_engine.py -v  # Specific
+cd frontend && npm run build                     # Frontend type check + build
 ```
 
-Walkthrough QA spec at `docs/walkthroughs/canopy-web-demo.yaml` (run via `/walkthrough canopy-web-demo`).
+CI (`.github/workflows/ci.yml`) runs both on every PR and on push to main, and gates auto-deploy. Walkthrough QA spec at `docs/walkthroughs/canopy-web-demo.yaml` (run via `/walkthrough canopy-web-demo`).
 
 ## Key URLs
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -6,6 +6,17 @@ REGION="us-central1"
 REPO="us-central1-docker.pkg.dev/${PROJECT_ID}/canopy-web"
 SQL_INSTANCE="${PROJECT_ID}:${REGION}:canopy-web-db"
 TAG="${1:-latest}"
+SKIP_TESTS="${SKIP_TESTS:-0}"
+
+if [ "${SKIP_TESTS}" = "1" ]; then
+  echo "==> SKIP_TESTS=1, skipping pre-deploy verification"
+else
+  echo "==> Running backend tests..."
+  uv run pytest
+
+  echo "==> Building frontend (type check + bundle)..."
+  (cd frontend && npm run build)
+fi
 
 echo "==> Building and pushing backend image..."
 docker build -t "${REPO}/backend:${TAG}" -f Dockerfile .

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -62,8 +62,8 @@ class TestCheckExpectedContains:
         passed, reasons = check_expected(output, expected)
         assert passed is False
         assert len(reasons) == 2
-        assert "Missing expected term: 'climate'" in reasons
-        assert "Missing expected term: 'temperature'" in reasons
+        assert any("Expected 'climate' in output but not found" in r for r in reasons)
+        assert any("Expected 'temperature' in output but not found" in r for r in reasons)
 
     def test_case_insensitive_match(self):
         output = "CLIMATE and TEMPERATURE are related."
@@ -92,7 +92,7 @@ class TestCheckExpectedContains:
         passed, reasons = check_expected(output, expected)
         assert passed is False
         assert len(reasons) == 1
-        assert "Missing expected term: 'temperature'" in reasons
+        assert any("Expected 'temperature' in output but not found" in r for r in reasons)
 
 
 class TestRunEvalAllPass:


### PR DESCRIPTION
## Summary

- Adds the project's first CI workflow (`.github/workflows/ci.yml`): backend pytest + frontend build run on every PR and push to main. A separate **manual** deploy job ships to Cloud Run via `workflow_dispatch` (Actions tab → Run workflow). No auto-deploy.
- Fixes 2 stale `test_evals.py` assertions that have been failing on `main` since #2 (the runner's error message format was improved but the tests weren't updated).
- Documents that this project uses `uv` (uv.lock is committed) — `CLAUDE.md` previously said `pip install` / `pytest`, which doesn't work on a fresh clone.
- Adds a `SKIP_TESTS`-bypassable test gate to `deploy.sh` so local `./deploy.sh` runs catch breakage before shipping.

## Why now

While trying to deploy `main` we hit:
1. CLAUDE.md docs were wrong about Python tooling (`pip` vs `uv`).
2. No CI runs anywhere — `cloudbuild.yaml` only builds/pushes images, no `.github/workflows/`. That's how the 2 stale tests slipped through #2 → #5 unnoticed.
3. `deploy.sh` is a pure 'trust me' script with no test gate.

This PR closes those three gaps in one shot.

## Deploy is manual

The deploy job's trigger is `workflow_dispatch` only — there's no auto-deploy on push to main. To ship, go to the Actions tab, pick "CI / Deploy", click "Run workflow". The deploy step waits for the test jobs (`needs:`) before running, so a manual trigger still gets a test gate.

## One-time GCP setup before deploy job will work

The deploy job authenticates to GCP via Workload Identity Federation (no long-lived SA keys). The full setup commands are documented as comments at the top of `ci.yml`. Net steps:

1. Create a `canopy-web-deployer` service account in `connect-labs`
2. Create a workload identity pool + GitHub OIDC provider
3. Bind the SA so this repo can impersonate it
4. Grant the SA roles: `roles/run.admin`, `roles/artifactregistry.writer`, `roles/cloudsql.client`, `roles/secretmanager.secretAccessor`, `roles/iam.serviceAccountUser`
5. Add two repo secrets: `GCP_WIF_PROVIDER` and `GCP_SERVICE_ACCOUNT`

Until those secrets exist, the test jobs still run on every PR; only manual deploy will fail at the auth step.

## Test plan

- [x] `uv run pytest` — 102 passed (was 100 + 2 failing)
- [x] `cd frontend && npm run build` — clean
- [x] `bash -n deploy.sh` — syntax OK
- [ ] After merge: confirm CI workflow runs on the next PR
- [ ] After GCP setup + secrets: confirm manual deploy ships images and rolls Cloud Run

🤖 Generated with [Claude Code](https://claude.com/claude-code)