### PR TITLE
fix: force linux/amd64 in deploy.sh docker builds

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -19,11 +19,13 @@ else
 fi
 
 echo "==> Building and pushing backend image..."
-docker build -t "${REPO}/backend:${TAG}" -f Dockerfile .
+# --platform linux/amd64 is required because Cloud Run only runs amd64/linux
+# and docker build on Apple Silicon defaults to arm64.
+docker build --platform linux/amd64 -t "${REPO}/backend:${TAG}" -f Dockerfile .
 docker push "${REPO}/backend:${TAG}"
 
 echo "==> Building and pushing frontend image..."
-docker build -t "${REPO}/frontend:${TAG}" -f Dockerfile.frontend .
+docker build --platform linux/amd64 -t "${REPO}/frontend:${TAG}" -f Dockerfile.frontend .
 docker push "${REPO}/frontend:${TAG}"
 
 echo "==> Deploying backend to Cloud Run..."


### PR DESCRIPTION
## Summary

Cloud Run only runs amd64/linux, but `docker build` on Apple Silicon defaults to arm64 and produces an OCI image index that Cloud Run rejects:

```
ERROR: Container manifest type 'application/vnd.oci.image.index.v1+json'
must support amd64/linux.
```

Hit this trying to deploy locally from an M-series Mac today. Adding `--platform linux/amd64` to both the backend and frontend `docker build` invocations in `deploy.sh`. GitHub Actions runners are already amd64 so this is a no-op there — the flag is explicit and correct in both environments.

## Test plan

- [x] `bash -n deploy.sh` — syntax OK
- [ ] `./deploy.sh` from M-series Mac — image accepted by Cloud Run (verified post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)