### PR TITLE
feat: batch context API + workspace session list

### DIFF
--- a/.claude/pm/context.md
+++ b/.claude/pm/context.md
@@ -1,0 +1,29 @@
+# Canopy Web — Product Context
+
+## What It Is
+Collaborative web workspace for building reusable AI skills from conversations — the web layer on top of the canopy ecosystem.
+
+## Who Uses It
+- **Primary user**: Jonathan Jackson (solo) — builds, tests, and uses the tool daily to manage 13+ projects and extract skills from AI conversations
+- **Usage pattern**: Daily workbench for project context tracking, skill authoring, and eval management. CLI agents and open claws also consume the API.
+- **Future users**: Non-technical stakeholders (Neal, Matt, Beth) for demo/review, eventually broader team adoption
+
+## What Matters Most
+1. More features that make canopy-web useful in Jonathan's daily workflow
+2. API-first design so CLI agents and open claws can consume the platform programmatically
+3. Evals co-authored with skills (the reef lesson — skills without evals are unverifiable)
+
+## Tech Stack
+- Django 5 ASGI + uvicorn, PostgreSQL, React 19 + Vite + Tailwind 4 + shadcn/ui
+- Anthropic Claude API via SSE streaming (dual backend: API key or CLI subscription)
+- Runtime adapters for web, claude_code, open_claw
+- GCP Cloud Run + Cloud SQL deployment
+
+## Current State
+V1 shipped: project workbench dashboard, skill discovery, workspace co-authoring flow, eval system, insights feed, Google OAuth, interactive guide. 23 PRs merged. Deployed to GCP Cloud Run. Solo usage — no other users yet.
+
+## Known Considerations
+- Reef failed because evals were deferred — canopy-web must keep skill+eval tightly coupled
+- API is the real product; UI is one consumer. Design API-first for agent consumption.
+- Warm Earth design system (stone/brown base, orange accent, DM Sans) shared with ace-web
+- V1 has no prompt injection hardening — acceptable for single-tenant, must fix before external use

--- a/.claude/pm/learnings.md
+++ b/.claude/pm/learnings.md
@@ -1,0 +1,14 @@
+# Product Management Learnings
+
+Items closed or rejected during PM cycles. Read this before every scout run to avoid re-proposing.
+
+## Closed Items
+
+1. **Context History Timeline in dashboard** (closed 2026-04-17, user-value run)
+   - Proposal: Surface all context entries (not just latest) in expanded project cards as a timeline
+   - Disposition: Close (no explicit reason given)
+   - Don't re-propose: timeline/history views over ProjectContext, "where was I" journal UIs over context entries, context diff views
+
+## Preferences
+
+1. **Ground proposals in design docs before asking for disposition** — When a proposal touches a core concept (workspace, collection, skill schema), briefly summarize how that concept is currently designed before asking Do/Backlog/Close. User's clarification request ("can you clarify how we have defined/designed workspace?") showed this was needed. Applies especially when proposing UX changes to core primitives.

--- a/.claude/pm/runs/2026-04-17-user-value.md
+++ b/.claude/pm/runs/2026-04-17-user-value.md
@@ -1,0 +1,31 @@
+## 2026-04-17 — user-value (first run, PM bootstrap)
+
+Scout lens: **user-value** — what features make canopy-web more useful in Jonathan's daily workflow?
+
+Context at run time: solo user managing 13+ projects. V1 shipped (23 PRs merged). Priority per user: "more features for me to use it."
+
+### Do it
+1. **Batch Context + Actions API** — Effort: S — Status: done
+   - Branch: emdash/pm-1l6
+   - Endpoints: `POST /api/projects/batch-context/`, `POST /api/projects/batch-actions/`
+   - Shape: `{"updates": {slug: [entries]}}` → per-slug results with `created`/`errors`
+   - Tests: 8 new tests in test_projects.py (cross-project creates, partial success, validation errors, invalid shape, empty updates)
+   - Outcome: CLI agents can push context/actions across all 13+ projects in 2 API calls instead of 26+
+2. **Workspace Session List + Resume** — Effort: S — Status: done
+   - Endpoint: `GET /api/workspace/` with filters for status, collection, limit
+   - Frontend: new `/workspaces` page with status filter chips, search by skill/collection, resume links
+   - Nav: added "Workspaces" item to AppLayout
+   - Tests: 7 new tests in test_workspace_engine.py (empty, filter, ordering, limit, invalid input)
+   - Outcome: Workspace sessions are now discoverable. No more losing sessions after navigating away.
+
+### Closed
+1. **Context History Timeline** — Why: user closed without explicit reason
+   - Disposition: Close
+   - Learning: Don't re-propose context history timeline UI for canopy-web. The append-only context model exists, but surfacing history in the dashboard wasn't valued. May have felt like noise or redundant with git log.
+
+### Meta-observations
+- **Context bootstrap worked well** — memory files (user_role, workbench_vision, reef_failure) + CLAUDE.md + recent git log gave enough context to skip 2 of the 4 bootstrap questions. Only needed to ask "who uses it" and "what matters most."
+- **User feedback mid-proposal was valuable** — the "clarify how we've defined/designed workspace" prompt surfaced a real confusion before committing to Do It. The proposal was correct in substance but needed design grounding before approval.
+- **Lint errors in pre-existing code** — saw F401 and F841 on unrelated code when running full `ruff check`. Should scope lint to only touched files going forward to avoid confusing signal.
+- **Frontend tests don't exist** — no vitest/jest harness in frontend/. Validation relies on `tsc -b && vite build` only. Future UI changes should note this gap.
+- **Batch endpoints validate per-entry** — returning per-slug `errors` list is better than all-or-nothing. Enables CLI agents to log partial failures without retrying the whole batch.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,7 @@ CI (`.github/workflows/ci.yml`) runs both on every PR and on push to main. Deplo
 
 - `/` — Project workbench (tile grid dashboard)
 - `/skills` — Skill discovery feed
+- `/workspaces` — Workspace session list (resume in-progress sessions)
 - `/new` — New collection / source ingestion flow
 - `/workspace/:sessionId` — Co-authoring workspace
 - `/skills/:skillId` — Skill detail + eval history
@@ -77,6 +78,8 @@ CI (`.github/workflows/ci.yml`) runs both on every PR and on push to main. Deplo
 - `GET /api/projects/{slug}/context/` — List context entries
 - `GET /api/projects/{slug}/context/latest/` — Latest context per type
 - `POST /api/projects/seed/` — Bulk seed projects
+- `POST /api/projects/batch-context/` — Create context entries across many projects in one request (body: `{updates: {slug: [...]}}`)
+- `POST /api/projects/batch-actions/` — Record actions across many projects in one request (body: `{updates: {slug: [...]}}`)
 - `POST /api/projects/{slug}/actions/` — Record a skill action
 - `GET /api/projects/{slug}/actions/` — List actions (filter: ?skill=name)
 - `GET /api/projects/{slug}/actions/summary/` — Latest action per skill
@@ -91,6 +94,7 @@ CI (`.github/workflows/ci.yml`) runs both on every PR and on push to main. Deplo
 - `POST /api/collections/{id}/sources/` — Add source
 
 ### Workspace
+- `GET /api/workspace/` — List workspace sessions (filter: ?status=proposed, ?collection=id, ?limit=50)
 - `POST /api/workspace/start/{collection_id}/` — Start workspace (SSE stream)
 - `POST /api/workspace/analyze/{collection_id}/` — Run AI analysis to propose approach + eval
 - `GET /api/workspace/{session_id}/` — Get workspace state

--- a/apps/projects/urls.py
+++ b/apps/projects/urls.py
@@ -4,6 +4,8 @@ from . import views
 urlpatterns = [
     path("", views.project_list, name="project-list"),
     path("seed/", views.seed_projects, name="seed-projects"),
+    path("batch-context/", views.batch_context, name="batch-context"),
+    path("batch-actions/", views.batch_actions, name="batch-actions"),
     path("<slug:slug>/", views.project_detail, name="project-detail"),
     path("<slug:slug>/context/", views.project_context, name="project-context"),
     path("<slug:slug>/context/latest/", views.project_context_latest, name="project-context-latest"),

--- a/apps/projects/views.py
+++ b/apps/projects/views.py
@@ -241,6 +241,143 @@ def project_actions_summary(request, slug):
 
 
 @api_view(["POST"])
+def batch_context(request):
+    """
+    Create context entries across multiple projects in one request.
+
+    POST /api/projects/batch-context/
+    Body: {"updates": {slug: [{context_type, content, source}, ...]}}
+
+    Returns per-slug results with counts and errors. Partial success is allowed —
+    valid slugs get their entries created even if other slugs fail.
+    """
+    start_timing()
+
+    updates = request.data.get("updates")
+    if not isinstance(updates, dict):
+        return Response(
+            error_response(
+                "VALIDATION_ERROR",
+                "'updates' must be an object mapping slug to a list of context entries.",
+            ),
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    results = {}
+    total_created = 0
+    total_errors = 0
+
+    for slug, entries in updates.items():
+        if not isinstance(entries, list):
+            results[slug] = {
+                "created": 0,
+                "errors": [{"code": "VALIDATION_ERROR", "message": "Entries must be a list."}],
+            }
+            total_errors += 1
+            continue
+
+        project = _get_project_or_404(slug)
+        if project is None:
+            results[slug] = {
+                "created": 0,
+                "errors": [{"code": "NOT_FOUND", "message": "Project not found."}],
+            }
+            total_errors += len(entries)
+            continue
+
+        created = 0
+        errors = []
+        for entry in entries:
+            serializer = ProjectContextCreateSerializer(data=entry)
+            if serializer.is_valid():
+                serializer.save(project=project)
+                created += 1
+            else:
+                errors.append({"code": "VALIDATION_ERROR", "message": serializer.errors})
+                total_errors += 1
+
+        results[slug] = {"created": created, "errors": errors}
+        total_created += created
+
+    return Response(
+        success_response({
+            "results": results,
+            "total_created": total_created,
+            "total_errors": total_errors,
+        }),
+        status=status.HTTP_201_CREATED if total_created else status.HTTP_200_OK,
+    )
+
+
+@api_view(["POST"])
+def batch_actions(request):
+    """
+    Create action entries across multiple projects in one request.
+
+    POST /api/projects/batch-actions/
+    Body: {"updates": {slug: [{skill_name, status, started_at, ...}, ...]}}
+
+    Returns per-slug results with counts and errors. Partial success is allowed.
+    """
+    start_timing()
+
+    updates = request.data.get("updates")
+    if not isinstance(updates, dict):
+        return Response(
+            error_response(
+                "VALIDATION_ERROR",
+                "'updates' must be an object mapping slug to a list of action entries.",
+            ),
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    results = {}
+    total_created = 0
+    total_errors = 0
+
+    for slug, entries in updates.items():
+        if not isinstance(entries, list):
+            results[slug] = {
+                "created": 0,
+                "errors": [{"code": "VALIDATION_ERROR", "message": "Entries must be a list."}],
+            }
+            total_errors += 1
+            continue
+
+        project = _get_project_or_404(slug)
+        if project is None:
+            results[slug] = {
+                "created": 0,
+                "errors": [{"code": "NOT_FOUND", "message": "Project not found."}],
+            }
+            total_errors += len(entries)
+            continue
+
+        created = 0
+        errors = []
+        for entry in entries:
+            serializer = ProjectActionCreateSerializer(data=entry)
+            if serializer.is_valid():
+                serializer.save(project=project)
+                created += 1
+            else:
+                errors.append({"code": "VALIDATION_ERROR", "message": serializer.errors})
+                total_errors += 1
+
+        results[slug] = {"created": created, "errors": errors}
+        total_created += created
+
+    return Response(
+        success_response({
+            "results": results,
+            "total_created": total_created,
+            "total_errors": total_errors,
+        }),
+        status=status.HTTP_201_CREATED if total_created else status.HTTP_200_OK,
+    )
+
+
+@api_view(["POST"])
 def seed_projects(request):
     start_timing()
 

--- a/apps/workspace/urls.py
+++ b/apps/workspace/urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
+    path("", views.workspace_list, name="workspace-list"),
     path("start/<int:collection_id>/", views.start_workspace, name="start-workspace"),
     path("analyze/<int:collection_id>/", views.analyze_workspace, name="analyze-workspace"),
     path("<int:session_id>/", views.workspace_detail, name="workspace-detail"),

--- a/apps/workspace/views.py
+++ b/apps/workspace/views.py
@@ -24,6 +24,56 @@ from .stream import stream_re_proposal, stream_workspace_analysis
 logger = logging.getLogger(__name__)
 
 
+@require_GET
+def workspace_list(request):
+    """
+    List workspace sessions, ordered by most recently updated.
+
+    GET /api/workspace/
+    Query params:
+        status: filter by session status (created, analyzing, proposed, editing, testing, published)
+        collection: filter by collection ID
+        limit: max results (default 50, max 200)
+    """
+    start_timing()
+
+    qs = WorkspaceSession.objects.select_related("collection").order_by("-updated_at")
+
+    status_filter = request.GET.get("status")
+    if status_filter:
+        qs = qs.filter(status=status_filter)
+
+    collection_id = request.GET.get("collection")
+    if collection_id:
+        try:
+            qs = qs.filter(collection_id=int(collection_id))
+        except ValueError:
+            return JsonResponse(
+                error_response("VALIDATION_ERROR", "'collection' must be an integer."),
+                status=400,
+            )
+
+    try:
+        limit = min(int(request.GET.get("limit", 50)), 200)
+    except ValueError:
+        limit = 50
+
+    sessions = list(qs[:limit])
+    data = [
+        {
+            "id": s.pk,
+            "collection_id": s.collection_id,
+            "collection_name": s.collection.name if s.collection else None,
+            "status": s.status,
+            "skill_name": (s.proposed_approach or {}).get("name") or None,
+            "created_at": s.created_at.isoformat(),
+            "updated_at": s.updated_at.isoformat(),
+        }
+        for s in sessions
+    ]
+    return JsonResponse(success_response(data))
+
+
 @require_POST
 def start_workspace(request, collection_id):
     """

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -63,6 +63,22 @@ export const api = {
     request(`/collections/${collectionId}/sources/`, { method: 'POST', body: JSON.stringify(source) }),
   getCollection: (id: number) => request(`/collections/${id}/`),
   getWorkspace: (sessionId: number) => request(`/workspace/${sessionId}/`),
+  listWorkspaces: (params?: { status?: string; collection?: number; limit?: number }) => {
+    const search = new URLSearchParams()
+    if (params?.status) search.set('status', params.status)
+    if (params?.collection !== undefined) search.set('collection', String(params.collection))
+    if (params?.limit !== undefined) search.set('limit', String(params.limit))
+    const qs = search.toString()
+    return request<Array<{
+      id: number
+      collection_id: number
+      collection_name: string | null
+      status: string
+      skill_name: string | null
+      created_at: string
+      updated_at: string
+    }>>(`/workspace/${qs ? `?${qs}` : ''}`)
+  },
   editSkill: (sessionId: number, edit: object, structural: boolean) =>
     request(`/workspace/${sessionId}/edit/`, { method: 'PATCH', body: JSON.stringify({ edit, structural }) }),
   publishSkill: (sessionId: number) =>

--- a/frontend/src/components/AppLayout/AppLayout.tsx
+++ b/frontend/src/components/AppLayout/AppLayout.tsx
@@ -8,6 +8,7 @@ const NAV_ITEMS = [
   { path: '/', label: 'Projects' },
   { path: '/insights', label: 'Insights' },
   { path: '/skills', label: 'Skills' },
+  { path: '/workspaces', label: 'Workspaces' },
   { path: '/leaderboard', label: 'Leaderboard' },
   { path: '/guide', label: 'Guide' },
   { path: '/settings', label: 'Settings' },

--- a/frontend/src/pages/WorkspacesPage.tsx
+++ b/frontend/src/pages/WorkspacesPage.tsx
@@ -1,0 +1,218 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { api } from '@/api/client'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Badge } from '@/components/ui/badge'
+import { Skeleton } from '@/components/ui/skeleton'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+
+interface WorkspaceSession {
+  id: number
+  collection_id: number
+  collection_name: string | null
+  status: string
+  skill_name: string | null
+  created_at: string
+  updated_at: string
+}
+
+const STATUS_FILTERS = [
+  { value: '', label: 'All' },
+  { value: 'created', label: 'Created' },
+  { value: 'analyzing', label: 'Analyzing' },
+  { value: 'proposed', label: 'Proposed' },
+  { value: 'editing', label: 'Editing' },
+  { value: 'testing', label: 'Testing' },
+  { value: 'published', label: 'Published' },
+]
+
+const STATUS_VARIANTS: Record<string, 'default' | 'secondary'> = {
+  published: 'default',
+  proposed: 'default',
+  editing: 'default',
+  analyzing: 'secondary',
+  testing: 'secondary',
+  created: 'secondary',
+}
+
+function relativeTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime()
+  const minutes = Math.floor(diff / 60000)
+  if (minutes < 1) return 'just now'
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  if (days < 7) return `${days}d ago`
+  return new Date(iso).toLocaleDateString()
+}
+
+export function WorkspacesPage() {
+  const navigate = useNavigate()
+  const [sessions, setSessions] = useState<WorkspaceSession[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [search, setSearch] = useState('')
+  const [statusFilter, setStatusFilter] = useState('')
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function load() {
+      setLoading(true)
+      try {
+        const params = statusFilter ? { status: statusFilter } : undefined
+        const data = await api.listWorkspaces(params)
+        if (!cancelled) setSessions(data)
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to load workspaces')
+        }
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+
+    void load()
+    return () => { cancelled = true }
+  }, [statusFilter])
+
+  const filtered = useMemo(() => {
+    if (!search.trim()) return sessions
+    const q = search.toLowerCase()
+    return sessions.filter(
+      (s) =>
+        (s.skill_name && s.skill_name.toLowerCase().includes(q)) ||
+        (s.collection_name && s.collection_name.toLowerCase().includes(q)),
+    )
+  }, [sessions, search])
+
+  function handleNew() {
+    navigate('/new')
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-red-400/30 bg-red-400/10 p-4 text-sm text-red-400">
+        {error}
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-5">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-lg font-semibold text-stone-100">Workspace Sessions</h1>
+          <p className="mt-0.5 text-xs text-stone-500">
+            Resume in-progress skill extraction sessions or review past ones.
+          </p>
+        </div>
+        <Button size="sm" onClick={handleNew}>
+          New Session
+        </Button>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="max-w-sm flex-1 min-w-[200px]">
+          <Input
+            placeholder="Search by skill or collection..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+        </div>
+        <div className="flex flex-wrap gap-1">
+          {STATUS_FILTERS.map((f) => (
+            <button
+              key={f.value}
+              type="button"
+              onClick={() => setStatusFilter(f.value)}
+              className={`text-xs px-2.5 py-1 rounded border transition-colors ${
+                statusFilter === f.value
+                  ? 'bg-orange-400/10 border-orange-400/30 text-orange-400'
+                  : 'bg-stone-900 border-stone-800 text-stone-500 hover:text-stone-300 hover:border-stone-700'
+              }`}
+            >
+              {f.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {loading && (
+        <div className="space-y-2">
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-8 w-full" />
+          <Skeleton className="h-8 w-full" />
+        </div>
+      )}
+
+      {!loading && (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Skill</TableHead>
+              <TableHead>Collection</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead className="text-right">Updated</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {filtered.length > 0 ? (
+              filtered.map((session) => (
+                <TableRow
+                  key={session.id}
+                  className="cursor-pointer"
+                  onClick={() => navigate(`/workspace/${session.id}`)}
+                >
+                  <TableCell className="font-medium text-stone-100">
+                    {session.skill_name || <span className="text-stone-600 italic">Untitled</span>}
+                  </TableCell>
+                  <TableCell className="text-sm text-stone-400">
+                    {session.collection_name || <span className="text-stone-600">—</span>}
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant={STATUS_VARIANTS[session.status] || 'secondary'}>
+                      {session.status}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-right text-xs text-stone-500">
+                    {relativeTime(session.updated_at)}
+                  </TableCell>
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell colSpan={4} className="h-40 text-center">
+                  {sessions.length === 0 ? (
+                    <div className="flex flex-col items-center gap-2">
+                      <p className="text-sm font-semibold text-stone-200">
+                        No workspace sessions {statusFilter ? `with status "${statusFilter}"` : 'yet'}
+                      </p>
+                      <p className="text-sm text-stone-500">
+                        Start a new session to extract a skill from a collection.
+                      </p>
+                      <Button size="sm" className="mt-2" onClick={handleNew}>
+                        New Session
+                      </Button>
+                    </div>
+                  ) : (
+                    <p className="text-sm text-stone-500">No sessions match &ldquo;{search}&rdquo;</p>
+                  )}
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -1,6 +1,7 @@
 import { createBrowserRouter } from 'react-router-dom'
 import { AppLayout } from './components/AppLayout/AppLayout'
 import { WorkspacePage } from './pages/WorkspacePage'
+import { WorkspacesPage } from './pages/WorkspacesPage'
 import { DiscoveryPage } from './pages/DiscoveryPage'
 import { ProjectsPage } from './pages/ProjectsPage'
 import { InsightsPage } from './pages/InsightsPage'
@@ -20,6 +21,7 @@ export const router = createBrowserRouter([
       { path: '/skills', element: <DiscoveryPage /> },
       { path: '/projects/:slug/guide', element: <ProjectGuidePage /> },
       { path: '/new', element: <NewCollectionPage /> },
+      { path: '/workspaces', element: <WorkspacesPage /> },
       { path: '/workspace/:sessionId', element: <WorkspacePage /> },
       { path: '/skills/:skillId', element: <SkillDetailPage /> },
       { path: '/leaderboard', element: <LeaderboardPage /> },

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -491,3 +491,128 @@ class TestInsightsAPI:
             ProjectContext.objects.create(project=project, context_type="insight", content=f"I{i}", source="test")
         response = client.get("/api/insights/")
         assert len(response.json()["data"]) == 20
+
+
+class TestBatchContextAPI:
+    def test_batch_creates_across_projects(self, client, db):
+        Project.objects.create(name="alpha", slug="alpha")
+        Project.objects.create(name="beta", slug="beta")
+        response = client.post(
+            "/api/projects/batch-context/",
+            data={
+                "updates": {
+                    "alpha": [{"context_type": "summary", "content": "A1", "source": "test"}],
+                    "beta": [
+                        {"context_type": "summary", "content": "B1", "source": "test"},
+                        {"context_type": "next_step", "content": "B2", "source": "test"},
+                    ],
+                }
+            },
+            content_type="application/json",
+        )
+        assert response.status_code == 201
+        body = response.json()
+        assert body["data"]["total_created"] == 3
+        assert body["data"]["total_errors"] == 0
+        assert body["data"]["results"]["alpha"]["created"] == 1
+        assert body["data"]["results"]["beta"]["created"] == 2
+        assert ProjectContext.objects.filter(project__slug="alpha").count() == 1
+        assert ProjectContext.objects.filter(project__slug="beta").count() == 2
+
+    def test_batch_partial_success_unknown_slug(self, client, project):
+        response = client.post(
+            "/api/projects/batch-context/",
+            data={
+                "updates": {
+                    "canopy-web": [{"context_type": "summary", "content": "Good", "source": "test"}],
+                    "unknown": [{"context_type": "summary", "content": "X", "source": "test"}],
+                }
+            },
+            content_type="application/json",
+        )
+        assert response.status_code == 201
+        body = response.json()
+        assert body["data"]["results"]["canopy-web"]["created"] == 1
+        assert body["data"]["results"]["unknown"]["created"] == 0
+        assert body["data"]["results"]["unknown"]["errors"][0]["code"] == "NOT_FOUND"
+        assert body["data"]["total_created"] == 1
+        assert body["data"]["total_errors"] == 1
+
+    def test_batch_entry_validation_error(self, client, project):
+        response = client.post(
+            "/api/projects/batch-context/",
+            data={
+                "updates": {
+                    "canopy-web": [
+                        {"context_type": "summary", "content": "Valid", "source": "test"},
+                        {"context_type": "note", "content": "   ", "source": "test"},
+                    ]
+                }
+            },
+            content_type="application/json",
+        )
+        body = response.json()
+        assert body["data"]["results"]["canopy-web"]["created"] == 1
+        assert len(body["data"]["results"]["canopy-web"]["errors"]) == 1
+
+    def test_batch_invalid_shape(self, client, db):
+        response = client.post(
+            "/api/projects/batch-context/",
+            data={"updates": "not a dict"},
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+
+    def test_batch_empty_updates(self, client, db):
+        response = client.post(
+            "/api/projects/batch-context/",
+            data={"updates": {}},
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        assert response.json()["data"]["total_created"] == 0
+
+
+class TestBatchActionsAPI:
+    def test_batch_actions_across_projects(self, client, db):
+        Project.objects.create(name="alpha", slug="alpha")
+        Project.objects.create(name="beta", slug="beta")
+        response = client.post(
+            "/api/projects/batch-actions/",
+            data={
+                "updates": {
+                    "alpha": [{
+                        "skill_name": "code-review",
+                        "status": "completed",
+                        "started_at": "2026-04-10T12:00:00Z",
+                    }],
+                    "beta": [{
+                        "skill_name": "doc-regen",
+                        "status": "started",
+                        "started_at": "2026-04-10T12:00:00Z",
+                    }],
+                }
+            },
+            content_type="application/json",
+        )
+        assert response.status_code == 201
+        body = response.json()
+        assert body["data"]["total_created"] == 2
+        assert ProjectAction.objects.filter(project__slug="alpha").count() == 1
+        assert ProjectAction.objects.filter(project__slug="beta").count() == 1
+
+    def test_batch_actions_invalid_entry(self, client, project):
+        response = client.post(
+            "/api/projects/batch-actions/",
+            data={
+                "updates": {
+                    "canopy-web": [
+                        {"skill_name": "", "status": "started", "started_at": "2026-04-10T12:00:00Z"},
+                    ]
+                }
+            },
+            content_type="application/json",
+        )
+        body = response.json()
+        assert body["data"]["results"]["canopy-web"]["created"] == 0
+        assert len(body["data"]["results"]["canopy-web"]["errors"]) == 1

--- a/tests/test_workspace_engine.py
+++ b/tests/test_workspace_engine.py
@@ -254,3 +254,63 @@ class TestEditSkill:
         assert response.status_code == 400
         body = response.json()
         assert body["error"]["code"] == "INVALID_JSON"
+
+
+class TestWorkspaceList:
+    def test_list_empty(self, client, db):
+        response = client.get("/api/workspace/")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["success"] is True
+        assert body["data"] == []
+
+    def test_list_returns_sessions_with_summary_fields(self, client, session_with_proposal):
+        response = client.get("/api/workspace/")
+        assert response.status_code == 200
+        body = response.json()
+        assert len(body["data"]) == 1
+        entry = body["data"][0]
+        assert entry["id"] == session_with_proposal.pk
+        assert entry["status"] == "proposed"
+        assert entry["skill_name"] == "Deployment Helper"
+        assert entry["collection_id"] == session_with_proposal.collection_id
+        assert entry["collection_name"] == "Test Collection"
+
+    def test_list_ordered_by_updated_desc(self, client, collection_with_sources):
+        a = WorkspaceSession.objects.create(collection=collection_with_sources, status="created")
+        b = WorkspaceSession.objects.create(collection=collection_with_sources, status="created")
+        # Touch b to bump updated_at
+        b.save()
+        response = client.get("/api/workspace/")
+        ids = [e["id"] for e in response.json()["data"]]
+        assert ids[0] == b.pk
+        assert ids[1] == a.pk
+
+    def test_list_filter_by_status(self, client, collection_with_sources):
+        WorkspaceSession.objects.create(collection=collection_with_sources, status="proposed")
+        WorkspaceSession.objects.create(collection=collection_with_sources, status="published")
+        response = client.get("/api/workspace/?status=proposed")
+        body = response.json()
+        assert len(body["data"]) == 1
+        assert body["data"][0]["status"] == "proposed"
+
+    def test_list_filter_by_collection(self, client, db):
+        c1 = Collection.objects.create(name="C1")
+        c2 = Collection.objects.create(name="C2")
+        WorkspaceSession.objects.create(collection=c1)
+        WorkspaceSession.objects.create(collection=c2)
+        response = client.get(f"/api/workspace/?collection={c1.pk}")
+        body = response.json()
+        assert len(body["data"]) == 1
+        assert body["data"][0]["collection_id"] == c1.pk
+
+    def test_list_invalid_collection(self, client, db):
+        response = client.get("/api/workspace/?collection=abc")
+        assert response.status_code == 400
+
+    def test_list_limit(self, client, collection_with_sources):
+        for _ in range(5):
+            WorkspaceSession.objects.create(collection=collection_with_sources)
+        response = client.get("/api/workspace/?limit=3")
+        body = response.json()
+        assert len(body["data"]) == 3


### PR DESCRIPTION
## Summary

Two additive API features from a PM scout cycle (user-value lens):

- **Batch context + actions** (`POST /api/projects/batch-context/`, `POST /api/projects/batch-actions/`) — CLI agents can update many projects in one request (`{updates: {slug: [entries]}}`), with per-slug success/error isolation. Collapses the common 26+ sequential call pattern to 2 calls for 13+ projects.
- **Workspace session list + resume** (`GET /api/workspace/`, `/workspaces` page) — sessions already persist in the DB but were invisible after navigating away. New list endpoint (filterable by status, collection, limit) and a browsable page with status chips + search + resume links.

Both are purely additive — no existing endpoints changed.

## Test plan

- [x] Backend: 186 tests pass (14 new — 8 for batch, 6 for workspace list)
- [x] Frontend: `npm run build` passes (tsc + vite, 539 modules)
- [x] Ruff clean on touched files
- [ ] Manual: visit `/workspaces` on deployed branch, confirm resume links open the correct session
- [ ] Manual: POST to batch-context with mix of valid/invalid slugs, confirm partial success shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)