### PR TITLE
feat(auth): clearer rejection page for non-allowlisted domains

### DIFF
--- a/.claude/pm/learnings.md
+++ b/.claude/pm/learnings.md
@@ -9,6 +9,17 @@ Items closed or rejected during PM cycles. Read this before every scout run to a
    - Disposition: Close (no explicit reason given)
    - Don't re-propose: timeline/history views over ProjectContext, "where was I" journal UIs over context entries, context diff views
 
+2. **First-run / onboarding polish** (closed 2026-04-17, adoption-blockers run)
+   - Proposals: Empty-state hero on `/` with CTAs; Retry UI + human-readable errors in workspace analysis; Guide tab reorder + inline glossary
+   - Disposition: Close (all three)
+   - Don't re-propose: first-run empty state UIs, onboarding heroes, user-friendly error recovery UX, guide reorganization, glossary/concept-introduction work. Adoption polish is out of scope until user explicitly signals that stakeholder onboarding is the priority.
+
 ## Preferences
 
 1. **Ground proposals in design docs before asking for disposition** — When a proposal touches a core concept (workspace, collection, skill schema), briefly summarize how that concept is currently designed before asking Do/Backlog/Close. User's clarification request ("can you clarify how we have defined/designed workspace?") showed this was needed. Applies especially when proposing UX changes to core primitives.
+
+2. **Favor narrow, verifiable fixes over broad UX improvement** — User approves specific edge-case fixes with clear repro and test coverage. He closes broad UX polish proposals (empty states, onboarding, error messages, documentation reorgs). Pattern observed: user-value run shipped 2/3 narrow API improvements; adoption-blockers run shipped only 1/4 — the narrow OAuth fix, not the three UX polish proposals.
+   - **Why:** Current phase is "more features for me to use it" (solo user). Stakeholder adoption isn't the current priority despite the presence of adoption-capable infrastructure (OAuth, deploy, etc.).
+   - **How to apply:** Future scouts should weight proposals toward narrow, verifiable, high-signal fixes. Avoid proposing broad UX/polish/onboarding work until the user explicitly signals a phase change. If multiple proposals are tempting, drop the broad-polish ones and keep the specific-fix ones.
+
+3. **Verify scout claims before proposing** — Adoption-blockers scout claimed "no feedback after non-Dimagi OAuth" but the server-side adapter + template already existed. Future scouts should grep for existing adapters/templates/middleware before claiming absence of behavior.

--- a/.claude/pm/runs/2026-04-17-adoption-blockers.md
+++ b/.claude/pm/runs/2026-04-17-adoption-blockers.md
@@ -1,0 +1,28 @@
+## 2026-04-17 — adoption-blockers
+
+Scout lens: **adoption-blockers** — what would make a new user (Neal, Matt, Beth) walk away from the deployed app?
+
+Context at run time: deploy of user-value cycle just succeeded. Stakeholders could open canopy.dimagi-ai.com at any time.
+
+### Do it
+1. **Non-Dimagi OAuth failure message** — Effort: S — Status: done
+   - Branch: emdash/pm-1l6
+   - The scout claimed there was NO feedback after non-Dimagi login. That was wrong — a server-side adapter (`apps/common/auth_adapter.py`) + template (`templates/auth/domain_rejected.html`) already existed.
+   - Actual fix: improved the template copy — clearer explanation of why they're rejected, instructions to sign out of Google first (links to accounts.google.com/Logout), and a mailto:jjackson@dimagi.com contact for access requests.
+   - Test added: `test_rejection_page_shows_email_domain_and_contact` asserts the rendered HTML contains all four elements.
+
+### Closed
+1. **First-run homepage + onboarding hero** — Why: user declined
+   - Disposition: Close
+   - Learning: Don't propose broad first-run/empty-state/onboarding polish work for canopy-web right now. User is still building for himself; stakeholder adoption isn't the current phase.
+2. **Retry + human-readable errors in workspace analysis** — Why: user declined
+   - Disposition: Close
+   - Learning: Don't propose general error-handling UX polish. Specific bug fixes with clear repro are OK; speculative error-path improvements aren't.
+3. **Guide reorder + inline glossary** — Why: user declined
+   - Disposition: Close
+   - Learning: Don't propose documentation/glossary/tab-reorder changes to canopy-web's Guide page.
+
+### Meta-observations
+- **User approves narrow, specific, verifiable fixes; closes broad UX polish.** Of 4 adoption-blocker proposals, 3 closures and 1 do-it. The one he took was the narrow edge-case (non-Dimagi OAuth). The three closures were all "improve UX for hypothetical new users." This is consistent with his self-declared priority: "more features for me to use it" (user-value run). Adoption polish is premature — adjust future scouts to focus on narrow, verifiable fixes until the user signals broader adoption is in scope.
+- **Scout claims should be verified.** Scout said "no feedback after non-Dimagi OAuth" but the adapter + template already existed. Always grep for adapter patterns and templates before claiming absence of behavior.
+- **Adoption-blockers lens may be too early** — might want to skip this lens in rotation until stakeholder adoption is prioritized. Next rotation should go to integration-depth.

--- a/templates/auth/domain_rejected.html
+++ b/templates/auth/domain_rejected.html
@@ -9,6 +9,7 @@
       --stone-50: #fafaf9;
       --stone-100: #f5f5f4;
       --stone-200: #e7e5e4;
+      --stone-500: #78716c;
       --stone-700: #44403c;
       --stone-900: #1c1917;
       --orange: #ea580c;
@@ -33,13 +34,15 @@
       box-shadow: 0 1px 2px rgba(0,0,0,0.04);
     }
     h1 { margin: 0 0 0.5rem; font-size: 1.5rem; }
-    p { color: var(--stone-700); line-height: 1.5; margin: 0 0 1.25rem; }
+    p { color: var(--stone-700); line-height: 1.5; margin: 0 0 1rem; }
+    p.muted { color: var(--stone-500); font-size: 0.875rem; }
     code {
       background: var(--stone-100);
       padding: 1px 6px;
       border-radius: 4px;
       font-size: 0.95em;
     }
+    a { color: var(--orange); }
     a.btn {
       display: inline-block;
       background: var(--orange);
@@ -48,21 +51,35 @@
       padding: 0.625rem 1.125rem;
       border-radius: 8px;
       font-weight: 500;
+      margin-top: 0.5rem;
     }
     a.btn:hover { filter: brightness(0.95); }
+    .contact {
+      margin-top: 1.5rem;
+      padding-top: 1.25rem;
+      border-top: 1px solid var(--stone-200);
+    }
   </style>
 </head>
 <body>
   <div class="card">
-    <h1>Access denied</h1>
+    <h1>Access restricted</h1>
     <p>
-      Canopy is restricted to <code>@{{ allowed_domain }}</code> accounts.
-      {% if email %}You signed in as <code>{{ email }}</code>.{% endif %}
+      Canopy is currently limited to <code>@{{ allowed_domain }}</code> accounts.
+      {% if email %}You signed in as <code>{{ email }}</code>, which isn't on the allowlist.{% endif %}
     </p>
-    <p>
-      Sign in with a <code>@{{ allowed_domain }}</code> Google account to continue.
+    <p class="muted">
+      To retry with a different account, sign out of Google first
+      (<a href="https://accounts.google.com/Logout" target="_blank" rel="noopener">accounts.google.com/Logout</a>),
+      then click below.
     </p>
     <a class="btn" href="/accounts/google/login/">Try another account</a>
+    <div class="contact">
+      <p class="muted">
+        Need access? Email
+        <a href="mailto:jjackson@dimagi.com?subject=Canopy%20access%20request">jjackson@dimagi.com</a>.
+      </p>
+    </div>
   </div>
 </body>
 </html>

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -165,6 +165,22 @@ def test_adapter_case_insensitive(rf):
     adapter.pre_social_login(request, sociallogin)
 
 
+@override_settings(AUTH_ALLOWED_EMAIL_DOMAIN="dimagi.com")
+def test_rejection_page_shows_email_domain_and_contact(rf):
+    """The rejection response must tell the user their email, the allowed
+    domain, and a way to request access — otherwise it's a dead end."""
+    adapter = CustomSocialAccountAdapter()
+    request = rf.get("/accounts/google/login/callback/")
+    sociallogin = _make_social_login("mallory@gmail.com")
+    with pytest.raises(ImmediateHttpResponse) as exc:
+        adapter.pre_social_login(request, sociallogin)
+    body = exc.value.response.content.decode()
+    assert "mallory@gmail.com" in body
+    assert "dimagi.com" in body
+    assert "mailto:jjackson@dimagi.com" in body
+    assert "accounts.google.com/Logout" in body
+
+
 # ──────────────────────────────────────────────────────────────────────
 # CSRF enforcement on state-mutating endpoints
 # ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

From a PM scout cycle (adoption-blockers lens): the post-OAuth rejection page was a dead-end for users whose Google account wasn't in `AUTH_ALLOWED_EMAIL_DOMAIN`. Clicking "Try another account" sent them to the Google login, which auto-reused their already-signed-in Google account, looping back to rejection.

## Changes

- Template copy explains the rejection in plain language and names the rejected email
- Muted note with an `accounts.google.com/Logout` link so users can actually switch Google accounts
- `mailto:jjackson@dimagi.com` contact for access requests
- Test asserts the rendered HTML contains the email, allowed domain, mailto link, and Google logout URL

No server-side adapter changes — the existing allowlist enforcement in `apps/common/auth_adapter.py` is unchanged.

## Test plan

- [x] `uv run pytest tests/test_auth.py` — 17 tests pass (1 new)
- [x] Full backend suite: 187 pass
- [ ] Manual: sign in with a non-Dimagi Google account → see new page with all four elements (email, domain, logout link, mailto)

🤖 Generated with [Claude Code](https://claude.com/claude-code)