### PR TITLE
feat(debug): mint session cookie endpoint + settings UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,9 @@ CI (`.github/workflows/ci.yml`) runs both on every PR and on push to main. Deplo
 - `POST /api/ai/auth/complete/` — Submit OAuth code
 - `GET /api/ai/auth/poll/` — Poll auth status
 
+### Debug access (`apps/common/views_debug`)
+- `POST /api/debug/mint-session/` — authenticated user mints a short-lived Django session cookie (body: `{ttl_seconds: int}`, clamped to 60s–1w). Returns cookie + curl example. Used to hand access to an AI assistant without going through OAuth. UI lives at `/settings` → "Debug access".
+
 ## Design Decisions
 
 - APP UI: dense, readable, tables not cards

--- a/apps/common/urls_debug.py
+++ b/apps/common/urls_debug.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from . import views_debug
+
+urlpatterns = [
+    path("mint-session/", views_debug.mint_session, name="debug-mint-session"),
+]

--- a/apps/common/views_debug.py
+++ b/apps/common/views_debug.py
@@ -1,0 +1,88 @@
+"""Debug access endpoints.
+
+Lets an authenticated user mint a short-lived Django session cookie they can
+hand to an AI assistant (or any HTTP client) to access the app on their
+behalf. Rationale: the app is gated by Google OAuth, so agents can't hit
+anything except public endpoints. A minted session cookie gives them the
+caller's exact permissions for a bounded TTL.
+"""
+import json
+
+from django.conf import settings
+from django.contrib.sessions.backends.db import SessionStore
+from django.http import JsonResponse
+from django.utils import timezone
+from django.views.decorators.http import require_POST
+
+from .envelope import error_response, start_timing, success_response
+
+DEFAULT_TTL_SECONDS = 24 * 3600  # 24 hours
+MAX_TTL_SECONDS = 7 * 24 * 3600  # 1 week
+DEBUG_SESSION_MARKER = "_canopy_debug_session"
+
+
+def _cookie_name() -> str:
+    return getattr(settings, "SESSION_COOKIE_NAME", "sessionid")
+
+
+@require_POST
+def mint_session(request):
+    """POST /api/debug/mint-session/
+
+    Creates a new Django session authenticated as the caller. Returns the
+    session key, a curl example, and the expiry timestamp.
+
+    Body (optional): {"ttl_seconds": int} — clamped to MAX_TTL_SECONDS.
+    """
+    start_timing()
+
+    if not request.user.is_authenticated:
+        return JsonResponse(
+            error_response("UNAUTHORIZED", "Sign in required."),
+            status=401,
+        )
+
+    try:
+        body = json.loads(request.body) if request.body else {}
+    except json.JSONDecodeError:
+        body = {}
+
+    try:
+        ttl = int(body.get("ttl_seconds", DEFAULT_TTL_SECONDS))
+    except (TypeError, ValueError):
+        ttl = DEFAULT_TTL_SECONDS
+    ttl = max(60, min(ttl, MAX_TTL_SECONDS))
+
+    user = request.user
+    session = SessionStore()
+    session["_auth_user_id"] = str(user.pk)
+    session["_auth_user_backend"] = (
+        getattr(user, "backend", None)
+        or settings.AUTHENTICATION_BACKENDS[0]
+    )
+    session["_auth_user_hash"] = user.get_session_auth_hash()
+    session[DEBUG_SESSION_MARKER] = {
+        "minted_at": timezone.now().isoformat(),
+        "minted_for_email": user.email,
+    }
+    session.set_expiry(ttl)
+    session.save()
+
+    cookie_name = _cookie_name()
+    origin = f"{request.scheme}://{request.get_host()}"
+    curl_example = (
+        f'curl -H "Cookie: {cookie_name}={session.session_key}" '
+        f'{origin}/api/projects/'
+    )
+
+    return JsonResponse(success_response({
+        "cookie_name": cookie_name,
+        "cookie_value": session.session_key,
+        "origin": origin,
+        "expires_at": (
+            timezone.now() + timezone.timedelta(seconds=ttl)
+        ).isoformat(),
+        "ttl_seconds": ttl,
+        "email": user.email,
+        "curl_example": curl_example,
+    }))

--- a/config/urls.py
+++ b/config/urls.py
@@ -22,6 +22,7 @@ urlpatterns = [
     path("api/insights/<int:pk>/", views_insights.insight_dismiss, name="insight-dismiss"),
     path("api/projects/", include("apps.projects.urls")),
     path("api/ai/", include("apps.common.urls")),
+    path("api/debug/", include("apps.common.urls_debug")),
     # Catch-all: serve the SPA for any non-API route (last).
     re_path(r"^(?!api/|admin/|accounts/|health/|static/).*$", spa_view, name="spa"),
 ]

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -130,4 +130,19 @@ export const api = {
   authPoll: () => request<{
     active: boolean; authenticated: boolean; elapsed_seconds?: number;
   }>('/ai/auth/poll/'),
+
+  // Debug access — mints a session cookie an agent can use on your behalf.
+  mintDebugSession: (ttlSeconds?: number) =>
+    request<{
+      cookie_name: string
+      cookie_value: string
+      origin: string
+      expires_at: string
+      ttl_seconds: number
+      email: string
+      curl_example: string
+    }>('/debug/mint-session/', {
+      method: 'POST',
+      body: JSON.stringify(ttlSeconds ? { ttl_seconds: ttlSeconds } : {}),
+    }),
 }

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -188,6 +188,152 @@ export function SettingsPage() {
           </p>
         </div>
       )}
+
+      <DebugAccessPanel />
     </div>
   )
+}
+
+type Mint = Awaited<ReturnType<typeof api.mintDebugSession>>
+
+const TTL_OPTIONS: Array<{ label: string; seconds: number }> = [
+  { label: '1 hour', seconds: 60 * 60 },
+  { label: '24 hours', seconds: 24 * 60 * 60 },
+  { label: '1 week', seconds: 7 * 24 * 60 * 60 },
+]
+
+function DebugAccessPanel() {
+  const [mint, setMint] = useState<Mint | null>(null)
+  const [minting, setMinting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [ttl, setTtl] = useState<number>(24 * 60 * 60)
+  const [copied, setCopied] = useState<string | null>(null)
+
+  async function handleMint() {
+    setMinting(true)
+    setError(null)
+    setCopied(null)
+    try {
+      const result = await api.mintDebugSession(ttl)
+      setMint(result)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to mint session')
+    } finally {
+      setMinting(false)
+    }
+  }
+
+  async function copy(text: string, key: string) {
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopied(key)
+      setTimeout(() => setCopied((c) => (c === key ? null : c)), 1500)
+    } catch {
+      // ignore
+    }
+  }
+
+  const expiresRelative = mint
+    ? formatExpiry(new Date(mint.expires_at))
+    : null
+
+  return (
+    <div className="rounded-xl border border-stone-800 bg-stone-900 p-5 space-y-4">
+      <div>
+        <h2 className="text-sm font-semibold text-stone-100">Debug access</h2>
+        <p className="mt-1 text-sm text-stone-500">
+          Mint a short-lived session cookie you can hand to an AI assistant
+          (or any HTTP client). It authenticates as you, for the TTL you pick.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-xs text-stone-500">Valid for:</span>
+        <div className="flex gap-1">
+          {TTL_OPTIONS.map((opt) => (
+            <button
+              key={opt.seconds}
+              type="button"
+              onClick={() => setTtl(opt.seconds)}
+              className={`text-xs px-2.5 py-1 rounded border transition-colors ${
+                ttl === opt.seconds
+                  ? 'bg-orange-400/10 border-orange-400/30 text-orange-400'
+                  : 'bg-stone-950 border-stone-800 text-stone-500 hover:text-stone-300 hover:border-stone-700'
+              }`}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+        <div className="ml-auto">
+          <Button size="sm" onClick={handleMint} disabled={minting}>
+            {minting ? 'Minting…' : mint ? 'Mint another' : 'Mint session cookie'}
+          </Button>
+        </div>
+      </div>
+
+      {error && <p className="text-sm text-red-400">{error}</p>}
+
+      {mint && (
+        <div className="space-y-3">
+          <div className="rounded-lg border border-amber-400/20 bg-amber-400/5 p-3 text-xs text-amber-300/80">
+            <strong className="text-amber-300">Treat this like a password.</strong>{' '}
+            Anyone with this cookie has your access until {expiresRelative}.
+          </div>
+
+          <CopyBlock
+            label="Cookie"
+            value={`${mint.cookie_name}=${mint.cookie_value}`}
+            copied={copied === 'cookie'}
+            onCopy={() =>
+              copy(`${mint.cookie_name}=${mint.cookie_value}`, 'cookie')
+            }
+          />
+
+          <CopyBlock
+            label="curl example"
+            value={mint.curl_example}
+            copied={copied === 'curl'}
+            onCopy={() => copy(mint.curl_example, 'curl')}
+          />
+
+          <div className="text-[11px] text-stone-600">
+            Minted for {mint.email} · expires {expiresRelative} ({new Date(mint.expires_at).toLocaleString()})
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function CopyBlock({
+  label, value, copied, onCopy,
+}: { label: string; value: string; copied: boolean; onCopy: () => void }) {
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-1">
+        <span className="text-[10px] uppercase tracking-wider text-stone-600 font-semibold">{label}</span>
+        <button
+          type="button"
+          onClick={onCopy}
+          className="text-xs text-orange-400 hover:text-orange-300 transition-colors"
+        >
+          {copied ? 'Copied' : 'Copy'}
+        </button>
+      </div>
+      <pre className="bg-stone-950 border border-stone-800 rounded-lg p-3 text-xs text-stone-300 font-mono overflow-x-auto whitespace-pre-wrap break-all">
+        {value}
+      </pre>
+    </div>
+  )
+}
+
+function formatExpiry(date: Date): string {
+  const diffMs = date.getTime() - Date.now()
+  if (diffMs <= 0) return 'expired'
+  const hours = Math.round(diffMs / (1000 * 60 * 60))
+  if (hours < 1) return 'in <1 hour'
+  if (hours < 48) return `in ${hours}h`
+  const days = Math.round(hours / 24)
+  return `in ${days}d`
 }

--- a/tests/test_debug_session.py
+++ b/tests/test_debug_session.py
@@ -1,0 +1,99 @@
+"""Tests for the debug-session mint endpoint."""
+import json
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import Client, override_settings
+
+
+@pytest.fixture
+def auth_client(db):
+    user_model = get_user_model()
+    user = user_model.objects.create_user(
+        username="tester",
+        email="tester@dimagi.com",
+        password="irrelevant",
+    )
+    client = Client()
+    client.force_login(user)
+    return client
+
+
+@pytest.fixture
+def anon_client(db):
+    return Client()
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_mint_requires_auth(anon_client):
+    resp = anon_client.post("/api/debug/mint-session/")
+    assert resp.status_code == 401
+
+
+def test_mint_returns_cookie_shape(auth_client):
+    resp = auth_client.post("/api/debug/mint-session/")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["success"] is True
+    data = body["data"]
+    assert data["cookie_name"] == "sessionid"
+    assert data["cookie_value"]
+    assert len(data["cookie_value"]) >= 16
+    assert data["email"] == "tester@dimagi.com"
+    assert data["ttl_seconds"] == 24 * 3600
+    assert "curl" in data["curl_example"]
+    assert data["cookie_value"] in data["curl_example"]
+
+
+def test_mint_custom_ttl(auth_client):
+    resp = auth_client.post(
+        "/api/debug/mint-session/",
+        data=json.dumps({"ttl_seconds": 3600}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    assert resp.json()["data"]["ttl_seconds"] == 3600
+
+
+def test_mint_ttl_clamped_upper(auth_client):
+    resp = auth_client.post(
+        "/api/debug/mint-session/",
+        data=json.dumps({"ttl_seconds": 10_000_000}),
+        content_type="application/json",
+    )
+    # Max is 1 week
+    assert resp.json()["data"]["ttl_seconds"] == 7 * 24 * 3600
+
+
+def test_mint_ttl_clamped_lower(auth_client):
+    resp = auth_client.post(
+        "/api/debug/mint-session/",
+        data=json.dumps({"ttl_seconds": 1}),
+        content_type="application/json",
+    )
+    # Min is 60 seconds
+    assert resp.json()["data"]["ttl_seconds"] == 60
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_minted_cookie_authorizes_api(auth_client, db):
+    """End-to-end: mint a cookie, then use it on a fresh client to hit a
+    normally-gated endpoint. This is the whole point of the endpoint —
+    if this doesn't work, the feature is broken."""
+    mint = auth_client.post("/api/debug/mint-session/").json()["data"]
+
+    fresh = Client()
+    fresh.cookies["sessionid"] = mint["cookie_value"]
+    resp = fresh.get("/api/projects/")
+    assert resp.status_code == 200
+
+
+def test_mint_session_is_marked_for_audit(auth_client):
+    """Minted sessions carry a marker so they can be audited or bulk-revoked later."""
+    from django.contrib.sessions.models import Session
+
+    mint = auth_client.post("/api/debug/mint-session/").json()["data"]
+    session = Session.objects.get(session_key=mint["cookie_value"])
+    data = session.get_decoded()
+    assert "_canopy_debug_session" in data
+    assert data["_canopy_debug_session"]["minted_for_email"] == "tester@dimagi.com"


### PR DESCRIPTION
## Summary

Lets an authenticated user hand a time-limited session cookie to an AI agent (or any HTTP client) that needs to call the app on their behalf without going through Google OAuth.

- `POST /api/debug/mint-session/` — auth-required, accepts `{ttl_seconds}` clamped to 60s–7d (default 24h). Returns cookie value, expiry, and a ready-to-paste curl example.
- `/settings` → new **Debug access** panel: pick TTL chip, click Mint, copy cookie or curl.
- Minted sessions carry a `_canopy_debug_session` marker for future auditing/bulk-revoke.

## Why

The app is gated by Google OAuth @dimagi.com, so an agent can't see the rendered UI or authenticated API state to debug issues. The existing bearer token (`WORKBENCH_WRITE_TOKEN`) only covers `/actions/` and `/context/` writes — not reads, not the UI. A minted session covers the full authenticated surface, bounded by TTL.

## Security notes

- Only authenticated users can mint (session flows through `LoginRequiredMiddleware` like any other protected endpoint)
- Session is on behalf of the caller only — you can't mint for another user
- TTL capped at 1 week; default 24h
- Session survives via Django's normal session store, so clearing sessions revokes access

## Test plan

- [x] 7 tests pass in `tests/test_debug_session.py` including end-to-end (minted cookie actually authorizes `GET /api/projects/`)
- [x] Full backend: 194 pass
- [x] Frontend: `npm run build` passes
- [x] Ruff clean on touched files
- [ ] Manual: `/settings` → click Mint → copy cookie → `curl -H 'Cookie: sessionid=<val>' https://.../api/projects/` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)