### PR TITLE
fix(projects): prune curated hygiene list to 4 actual skills

### DIFF
--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -14,11 +14,7 @@ const HYGIENE_ACTIONS: Array<{ key: string; label: string }> = [
   { key: 'code-review', label: 'code-review' },
   { key: 'canopy:doc-regen', label: 'doc-regen' },
   { key: 'canopy:improve', label: 'improve' },
-  { key: 'canopy:brief', label: 'brief' },
-  { key: 'canopy:patterns', label: 'patterns' },
-  { key: 'canopy:walkthrough', label: 'walkthrough' },
-  { key: 'canopy:walkthrough-eval', label: 'walkthrough-eval' },
-  { key: 'canopy:session-review', label: 'session-review' },
+  { key: 'canopy:pm-scout', label: 'pm-scout' },
 ]
 
 function relativeTime(iso: string): string {


### PR DESCRIPTION
## Summary

Shrinks `HYGIENE_ACTIONS` to the four skills actually in Jonathan's hygiene cadence:

- `code-review`
- `canopy:doc-regen` → doc-regen
- `canopy:improve` → improve
- `canopy:pm-scout` → pm-scout

Dropped: `brief`, `patterns`, `walkthrough`, `walkthrough-eval`, `session-review`. Showing them as "never" across 13 projects was noise, not signal.

## Follow-up

`canopy:pm-scout` is in the list but doesn't currently log to the action-tracking API. It'll show "never" until the PM scout skill (in `canopy-skills`) starts POSTing to `/api/projects/{slug}/actions/` at run time. That's a separate change.

## Test plan

- [x] `npm run build` passes
- [ ] Manual: canopy-web card now shows 4 rows, three with checkmarks (code-review, doc-regen) and two "never"

🤖 Generated with [Claude Code](https://claude.com/claude-code)