### PR TITLE
fix(auth): drop X-Debug-* leak headers from 401 responses

### DIFF
--- a/apps/common/middleware.py
+++ b/apps/common/middleware.py
@@ -3,7 +3,6 @@ from django.conf import settings
 from django.http import JsonResponse
 from django.shortcuts import redirect
 
-
 PUBLIC_PATH_PREFIXES = (
     "/accounts/",        # allauth login/logout/callback
     "/admin/",           # Django admin has its own auth
@@ -79,14 +78,6 @@ class LoginRequiredMiddleware:
                 return self.get_response(request)
 
         if request.path.startswith("/api/"):
-            # Temporary diagnostic header (safe — only length + prefix, never the value)
-            token_len = len(expected_token) if expected_token else 0
-            provided_len = len(provided) if provided else 0
-            resp = JsonResponse({"detail": "Authentication required"}, status=401)
-            resp["X-Debug-Writable"] = str(writable)
-            resp["X-Debug-Expected-Len"] = str(token_len)
-            resp["X-Debug-Provided-Len"] = str(provided_len)
-            resp["X-Debug-Match"] = str(bool(expected_token and provided and provided == expected_token))
-            return resp
+            return JsonResponse({"detail": "Authentication required"}, status=401)
 
         return redirect(f"{settings.LOGIN_URL}?next={request.path}")

--- a/tests/test_auth_token.py
+++ b/tests/test_auth_token.py
@@ -12,7 +12,6 @@ from django.test import Client, override_settings
 
 from apps.projects.models import Project
 
-
 TEST_TOKEN = "test-token-123"
 
 
@@ -165,3 +164,23 @@ def test_bearer_does_not_bypass_non_projects_api(project):
     client = Client()
     resp = client.get("/api/skills/", **_bearer(TEST_TOKEN))
     assert resp.status_code == 401
+
+
+@override_settings(REQUIRE_AUTH=True, WORKBENCH_WRITE_TOKEN=TEST_TOKEN)
+@pytest.mark.parametrize(
+    "method,path",
+    [
+        ("get", "/api/projects/"),
+        ("post", "/api/projects/some-slug/actions/"),
+        ("get", "/api/skills/"),
+    ],
+)
+def test_401_response_does_not_leak_debug_headers(method, path, project):
+    """401 responses must not carry X-Debug-* headers that disclose auth
+    metadata (token length, per-request match oracle). PR #21 added these
+    as 'temporary diagnostic'; they were never removed until now."""
+    client = Client()
+    resp = getattr(client, method)(path)
+    assert resp.status_code == 401
+    leaked = [h for h in resp.headers.keys() if h.lower().startswith("x-debug-")]
+    assert leaked == [], f"401 leaked debug headers: {leaked}"


### PR DESCRIPTION
## Summary

The LoginRequiredMiddleware tags `Authentication required` 401 responses with four `X-Debug-*` headers. PR #21 added them as "Temporary diagnostic"; the cleanup PR (#22) didn't actually land in `apps/common/middleware.py` and they've been leaking on every unauthenticated `/api/` call ever since.

`X-Debug-Match: True/False` is the load-bearing concern — a per-request boolean oracle telling the caller whether their bearer token matched. That's exactly the signal a token-guessing attacker wants. The length headers are minor metadata; the match oracle is what makes this worth fixing.

## What changed

- Removed the four `X-Debug-*` headers from the 401 path.
- Added a parametrized regression test that asserts absence across three representative endpoints (token-eligible POST, non-eligible GET, plain `/api/projects/`).

## Try it

```bash
curl -i https://canopy-web-hhhi4yut3q-uc.a.run.app/api/projects/ | grep -i x-debug
# → empty (no X-Debug-* headers)
```

## Test plan

- [x] `uv run pytest -q tests/test_auth_token.py` — 13 passed (incl. 3 new param cases)
- [x] `uv run pytest -q` — 192 passed full suite
- [x] `uv run ruff check apps/common/middleware.py tests/test_auth_token.py` — clean
- [x] `cd frontend && npm run build` — clean
- [x] `git grep "X-Debug-(Match|Writable|Expected-Len|Provided-Len)"` — zero consumers

This PR was opened by `/canopy:pm-autonomous`. Cycle log: `.claude/pm/runs/2026-04-29-tighter-machine-api.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)