### PR TITLE
feat(insights): bearer-readable /api/insights/ with source+project filters

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,8 +85,8 @@ CI (`.github/workflows/ci.yml`) runs both on every PR and on push to main. Deplo
 - `GET /api/projects/{slug}/actions/summary/` — Latest action per skill
 
 ### Insights
-- `GET /api/insights/` — List all insights across projects (filter: ?category=ship_gap)
-- `DELETE /api/insights/{id}/` — Dismiss an insight
+- `GET /api/insights/` — List all insights across projects. Filters: `?category=<slug>` (matches `[<slug>]` content prefix), `?source=<producer>` (filters by writer), `?project=<slug>`. Bearer-readable for machine producers (e.g. `canopy:portfolio-review`) so they can dedupe before re-publishing.
+- `DELETE /api/insights/{id}/` — Dismiss an insight (OAuth only — bearer is GET-only here).
 
 ### Collections
 - `POST /api/collections/` — Create collection

--- a/apps/common/middleware.py
+++ b/apps/common/middleware.py
@@ -17,11 +17,15 @@ PUBLIC_PATH_PREFIXES = (
 WORKBENCH_TOKEN_WRITE_SUFFIXES = ("/actions/", "/context/")
 
 # Read endpoints callable with a Bearer token. Exact-match paths only —
-# scoped tightly to slim "what projects exist?" lookups so machine clients
-# (like the canopy portfolio-guide skill) can iterate without a session
-# cookie. Anything richer (full project list, contexts, guides) still
+# scoped tightly to slim machine lookups (what projects exist?, what
+# insights have I already published?) so producer skills like
+# canopy:portfolio-review can iterate without a session cookie. Anything
+# richer (full project list, contexts, raw context entries) still
 # requires OAuth.
-WORKBENCH_TOKEN_READABLE_PATHS = ("/api/projects/slugs/",)
+WORKBENCH_TOKEN_READABLE_PATHS = (
+    "/api/projects/slugs/",
+    "/api/insights/",
+)
 
 
 def _is_public(path: str) -> bool:

--- a/apps/projects/views_insights.py
+++ b/apps/projects/views_insights.py
@@ -19,6 +19,14 @@ def insights_list(request):
     if category:
         insights = insights.filter(content__startswith=f"[{category}]")
 
+    source = request.query_params.get("source")
+    if source:
+        insights = insights.filter(source=source)
+
+    project_slug = request.query_params.get("project")
+    if project_slug:
+        insights = insights.filter(project__slug=project_slug)
+
     limit = int(request.query_params.get("limit", 20))
     limit = min(limit, 100)
 

--- a/tests/test_auth_token.py
+++ b/tests/test_auth_token.py
@@ -128,6 +128,61 @@ def test_slugs_get_without_bearer_is_rejected(project):
 
 
 @override_settings(REQUIRE_AUTH=True, WORKBENCH_WRITE_TOKEN=TEST_TOKEN)
+def test_insights_get_with_valid_bearer_succeeds(project):
+    """Producer skills like canopy:portfolio-review can GET their own
+    insights via Bearer token to dedupe before re-publishing."""
+    client = Client()
+    resp = client.get("/api/insights/", **_bearer(TEST_TOKEN))
+    assert resp.status_code == 200, resp.content
+    body = resp.json()
+    assert body["success"] is True
+
+
+@override_settings(REQUIRE_AUTH=True, WORKBENCH_WRITE_TOKEN=TEST_TOKEN)
+def test_insights_get_with_filter_via_bearer(project):
+    """Bearer GET preserves source/project query filters end-to-end."""
+    from apps.projects.models import ProjectContext
+    ProjectContext.objects.create(
+        project=project, context_type="insight",
+        content="[ship_gap] x", source="canopy:portfolio-review",
+    )
+    ProjectContext.objects.create(
+        project=project, context_type="insight",
+        content="[hygiene] y", source="canopy:doctor",
+    )
+    client = Client()
+    resp = client.get(
+        "/api/insights/?source=canopy:portfolio-review", **_bearer(TEST_TOKEN)
+    )
+    assert resp.status_code == 200, resp.content
+    body = resp.json()
+    assert len(body["data"]) == 1
+    assert body["data"][0]["source"] == "canopy:portfolio-review"
+
+
+@override_settings(REQUIRE_AUTH=True, WORKBENCH_WRITE_TOKEN=TEST_TOKEN)
+def test_insights_get_without_bearer_is_rejected(project):
+    client = Client()
+    resp = client.get("/api/insights/")
+    assert resp.status_code == 401
+
+
+@override_settings(REQUIRE_AUTH=True, WORKBENCH_WRITE_TOKEN=TEST_TOKEN)
+def test_insight_dismiss_with_bearer_is_rejected(project):
+    """Bearer is GET-only on /api/insights/. DELETE (dismiss) still
+    requires OAuth — producers shouldn't be able to clear the inbox."""
+    from apps.projects.models import ProjectContext
+    ctx = ProjectContext.objects.create(
+        project=project, context_type="insight",
+        content="x", source="t",
+    )
+    client = Client()
+    resp = client.delete(f"/api/insights/{ctx.id}/", **_bearer(TEST_TOKEN))
+    assert resp.status_code == 401
+    assert ProjectContext.objects.filter(id=ctx.id).exists()
+
+
+@override_settings(REQUIRE_AUTH=True, WORKBENCH_WRITE_TOKEN=TEST_TOKEN)
 def test_actions_summary_with_bearer_is_rejected(project):
     """The Bearer bypass is scoped to exact /actions/ and /context/ suffixes —
     nested read endpoints like /actions/summary/ should still require OAuth."""

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -1,7 +1,8 @@
 import pytest
-from django.utils import timezone
-from apps.projects.models import Project, ProjectAction, ProjectContext
 from django.test import Client
+from django.utils import timezone
+
+from apps.projects.models import Project, ProjectAction, ProjectContext
 
 
 @pytest.fixture
@@ -261,7 +262,6 @@ class TestProjectSkillsField:
             content_type="application/json",
         )
         assert response.status_code == 200
-        body = response.json()
         # The skills field should round-trip
         canopy = client.get("/api/projects/canopy-web/").json()["data"]
         assert canopy["skills"][0]["name"] == "new"
@@ -418,6 +418,48 @@ class TestInsightsAPI:
             ProjectContext.objects.create(project=project, context_type="insight", content=f"I{i}", source="test")
         response = client.get("/api/insights/")
         assert len(response.json()["data"]) == 20
+
+    def test_filter_by_source(self, client, project):
+        ProjectContext.objects.create(
+            project=project, context_type="insight",
+            content="[ship_gap] from review", source="canopy:portfolio-review",
+        )
+        ProjectContext.objects.create(
+            project=project, context_type="insight",
+            content="[hygiene] from doctor", source="canopy:doctor",
+        )
+        response = client.get("/api/insights/?source=canopy:portfolio-review")
+        body = response.json()
+        assert len(body["data"]) == 1
+        assert body["data"][0]["source"] == "canopy:portfolio-review"
+
+    def test_filter_by_project(self, client, db):
+        a = Project.objects.create(name="alpha", slug="alpha")
+        b = Project.objects.create(name="beta", slug="beta")
+        ProjectContext.objects.create(project=a, context_type="insight", content="A", source="x")
+        ProjectContext.objects.create(project=b, context_type="insight", content="B", source="x")
+        response = client.get("/api/insights/?project=alpha")
+        body = response.json()
+        assert len(body["data"]) == 1
+        assert body["data"][0]["project_slug"] == "alpha"
+
+    def test_filter_source_and_project_compose(self, client, db):
+        a = Project.objects.create(name="alpha", slug="alpha")
+        b = Project.objects.create(name="beta", slug="beta")
+        # Two producers x two projects = 4 insights
+        for proj in (a, b):
+            for src in ("canopy:portfolio-review", "canopy:doctor"):
+                ProjectContext.objects.create(
+                    project=proj, context_type="insight",
+                    content=f"{proj.slug}/{src}", source=src,
+                )
+        response = client.get(
+            "/api/insights/?project=alpha&source=canopy:portfolio-review"
+        )
+        body = response.json()
+        assert len(body["data"]) == 1
+        assert body["data"][0]["project_slug"] == "alpha"
+        assert body["data"][0]["source"] == "canopy:portfolio-review"
 
 
 class TestBatchContextAPI:


### PR DESCRIPTION
## Summary

Producer skills like `canopy:portfolio-review` can WRITE insights via Bearer token (since #29) but still need OAuth to READ what they last wrote. That forces every run to either over-publish or pre-clear, churning the user's inbox.

This PR closes the gap by:

1. Making `/api/insights/` GET bearer-readable (DELETE/dismiss still OAuth-only — covered by regression test).
2. Adding `?source=<producer>` and `?project=<slug>` query filters that match the existing `?category=` idiom, so a producer can ask "what did I push to project X?" in one round-trip.

## Try it

```bash
TOKEN=$WORKBENCH_WRITE_TOKEN  # or any minted bearer
curl -H "Authorization: Bearer $TOKEN" \
  'https://canopy-web-hhhi4yut3q-uc.a.run.app/api/insights/?source=canopy:portfolio-review&project=canopy-web' \
  | jq '.data | length, .[].content'
```

## Test plan

- [x] `uv run pytest -q tests/test_auth_token.py tests/test_projects.py` — 66/66 (incl. 7 new — 4 bearer/auth, 3 view-level filter)
- [x] `uv run pytest -q` — 199/199 full suite
- [x] `uv run ruff check` (scoped to staged files) — clean (drive-by removed one pre-existing F841 dead variable)
- [x] `cd frontend && npm run build` — clean
- [x] DELETE on `/api/insights/<id>/` with bearer still rejected (regression test)

This PR was opened by `/canopy:pm-autonomous`. Cycle log: `.claude/pm/runs/2026-04-29-tighter-machine-api.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)