### PR TITLE
feat(insights): bidirectional deep links between feed and projects dashboard

### DIFF
--- a/frontend/src/api/insights.ts
+++ b/frontend/src/api/insights.ts
@@ -32,12 +32,19 @@ export function parseInsightBody(content: string): string {
   return content.replace(/^\[\w+\]\s*/, '')
 }
 
+export interface InsightListParams {
+  category?: string
+  project?: string
+  limit?: number
+}
+
 export const insightsApi = {
-  list: (category?: string, limit?: number) => {
-    const params = new URLSearchParams()
-    if (category) params.set('category', category)
-    if (limit) params.set('limit', String(limit))
-    const qs = params.toString()
+  list: (params: InsightListParams = {}) => {
+    const qp = new URLSearchParams()
+    if (params.category) qp.set('category', params.category)
+    if (params.project) qp.set('project', params.project)
+    if (params.limit) qp.set('limit', String(params.limit))
+    const qs = qp.toString()
     return request<Insight[]>(`/insights/${qs ? `?${qs}` : ''}`)
   },
   dismiss: (id: number) =>

--- a/frontend/src/pages/InsightsPage.tsx
+++ b/frontend/src/pages/InsightsPage.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from 'react'
-import { Link } from 'react-router-dom'
+import { useEffect, useMemo, useState } from 'react'
+import { Link, useSearchParams } from 'react-router-dom'
 import { AnimatePresence, motion } from 'framer-motion'
 import {
   type Insight,
@@ -54,8 +54,9 @@ function InsightCard({ insight, onDismiss }: { insight: Insight; onDismiss: (id:
       <div className="flex items-start justify-between gap-3 mb-2">
         <div className="flex items-center gap-2 min-w-0">
           <Link
-            to="/"
+            to={`/?expand=${encodeURIComponent(insight.project_slug)}`}
             className="text-xs font-medium text-stone-400 hover:text-orange-400 transition-colors shrink-0"
+            title={`Open ${insight.project_name} on the dashboard`}
           >
             {insight.project_name}
           </Link>
@@ -106,14 +107,18 @@ export function InsightsPage() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [activeFilter, setActiveFilter] = useState('all')
+  const [searchParams, setSearchParams] = useSearchParams()
+  const projectFilter = searchParams.get('project') || ''
 
   useEffect(() => {
     let cancelled = false
     setLoading(true)
     void (async () => {
       try {
-        const category = activeFilter === 'all' ? undefined : activeFilter
-        const data = await insightsApi.list(category)
+        const data = await insightsApi.list({
+          category: activeFilter === 'all' ? undefined : activeFilter,
+          project: projectFilter || undefined,
+        })
         if (!cancelled) setInsights(data)
       } catch (err) {
         if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load insights')
@@ -122,7 +127,7 @@ export function InsightsPage() {
       }
     })()
     return () => { cancelled = true }
-  }, [activeFilter])
+  }, [activeFilter, projectFilter])
 
   async function handleDismiss(id: number) {
     try {
@@ -133,6 +138,34 @@ export function InsightsPage() {
     }
   }
 
+  function clearProjectFilter() {
+    const next = new URLSearchParams(searchParams)
+    next.delete('project')
+    setSearchParams(next, { replace: true })
+  }
+
+  // Display name for the active project filter (best-effort: use the first
+  // matching insight's project_name; fall back to the slug). Avoids a separate
+  // API call just to render a chip label.
+  const projectFilterLabel = useMemo(() => {
+    if (!projectFilter) return ''
+    const hit = insights.find((i) => i.project_slug === projectFilter)
+    return hit?.project_name || projectFilter
+  }, [projectFilter, insights])
+
+  const emptyMessage = (() => {
+    if (projectFilter && activeFilter !== 'all') {
+      const catLabel = CATEGORIES.find((c) => c.key === activeFilter)?.label.toLowerCase() ?? activeFilter
+      return `No ${catLabel} insights for ${projectFilterLabel}.`
+    }
+    if (projectFilter) return `No insights for ${projectFilterLabel} yet.`
+    if (activeFilter !== 'all') {
+      const catLabel = CATEGORIES.find((c) => c.key === activeFilter)?.label.toLowerCase() ?? activeFilter
+      return `No ${catLabel} insights yet.`
+    }
+    return 'No insights yet.'
+  })()
+
   return (
     <div className="max-w-3xl mx-auto">
       <div className="flex items-center justify-between mb-6">
@@ -141,6 +174,24 @@ export function InsightsPage() {
           {loading ? 'loading...' : `${insights.length} insights`}
         </span>
       </div>
+
+      {/* Active project filter chip */}
+      {projectFilter && (
+        <div className="mb-3 flex items-center gap-2">
+          <span className="inline-flex items-center gap-1.5 text-[11px] text-stone-300 bg-stone-900 border border-orange-400/30 px-2.5 py-1 rounded">
+            <span className="text-stone-500">Project:</span>
+            <span className="font-medium">{projectFilterLabel}</span>
+            <button
+              onClick={clearProjectFilter}
+              className="text-stone-600 hover:text-stone-300 leading-none ml-0.5"
+              aria-label="Clear project filter"
+              title="Clear project filter"
+            >
+              ✕
+            </button>
+          </span>
+        </div>
+      )}
 
       {/* Category filter tabs */}
       <div className="flex gap-1 mb-6 bg-stone-900 rounded-lg p-1 overflow-x-auto">
@@ -185,7 +236,7 @@ export function InsightsPage() {
           {/* Empty state */}
           {insights.length === 0 && (
             <div className="flex flex-col items-center justify-center h-48 text-center">
-              <p className="text-sm text-stone-500 mb-1">No insights yet.</p>
+              <p className="text-sm text-stone-500 mb-1">{emptyMessage}</p>
               <p className="text-xs text-stone-700">
                 Run <code className="text-orange-400/70 bg-stone-900 px-1.5 py-0.5 rounded">canopy:portfolio-review</code> to generate insights.
               </p>

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import { Link, useSearchParams } from 'react-router-dom'
 import { AnimatePresence, LayoutGroup, motion } from 'framer-motion'
 import { type Project, projectsApi } from '@/api/projects'
 
@@ -90,16 +91,27 @@ function CollapsedTile({ project, onExpand }: { project: Project; onExpand: () =
   )
 }
 
-function ExpandedCard({ project, onClose }: {
+function ExpandedCard({ project, onClose, scrollIntoViewOnMount }: {
   project: Project
   onClose: () => void
+  scrollIntoViewOnMount?: boolean
 }) {
   const [skillsExpanded, setSkillsExpanded] = useState(false)
+  const cardRef = useRef<HTMLDivElement | null>(null)
   const ctx = project.latest_context || {}
   const skills = project.skills || []
 
+  useEffect(() => {
+    if (scrollIntoViewOnMount && cardRef.current) {
+      cardRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    }
+    // Only run on mount; the parent flips this flag exactly once per deep link.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   return (
     <div
+      ref={cardRef}
       className="bg-stone-900 border border-stone-700 rounded-xl overflow-hidden"
       onClick={(e) => e.stopPropagation()}
     >
@@ -110,6 +122,14 @@ function ExpandedCard({ project, onClose }: {
         {project.visibility === 'private' && <PrivateBadge />}
         {project.deploy_url && <DeployBadge url={project.deploy_url} />}
         <div className="ml-auto flex items-center gap-4 text-[11px]">
+          <Link
+            to={`/insights?project=${encodeURIComponent(project.slug)}`}
+            className="text-orange-400/70 hover:text-orange-400 transition-colors"
+            onClick={(e) => e.stopPropagation()}
+            title={`See insights for ${project.name}`}
+          >
+            View insights →
+          </Link>
           {project.repo_url && (
             <a href={project.repo_url} target="_blank" rel="noopener noreferrer"
               className="text-orange-400/70 hover:text-orange-400 transition-colors"
@@ -299,6 +319,10 @@ export function ProjectsPage() {
   const [error, setError] = useState<string | null>(null)
   // Ordered list of slugs that are expanded; first = most-recently clicked (top of stack).
   const [expandedOrder, setExpandedOrder] = useState<string[]>([])
+  const [searchParams, setSearchParams] = useSearchParams()
+  // The slug that the URL asked us to expand; we strip it from the URL once
+  // applied so refreshing the page doesn't keep re-scrolling.
+  const [pendingScrollSlug, setPendingScrollSlug] = useState<string | null>(null)
 
   useEffect(() => {
     let cancelled = false
@@ -316,12 +340,38 @@ export function ProjectsPage() {
     return () => { cancelled = true }
   }, [])
 
+  // Handle ?expand=<slug> deep links from the insights feed (and bookmarks).
+  // Wait until projects load so we only expand a slug that actually exists.
+  useEffect(() => {
+    if (loading) return
+    const target = searchParams.get('expand')
+    if (!target) return
+    if (!projects.some((p) => p.slug === target)) {
+      // Unknown slug — drop the param silently rather than leaving a stale URL.
+      const next = new URLSearchParams(searchParams)
+      next.delete('expand')
+      setSearchParams(next, { replace: true })
+      return
+    }
+    setExpandedOrder((order) => (order.includes(target) ? order : [target, ...order]))
+    setPendingScrollSlug(target)
+    const next = new URLSearchParams(searchParams)
+    next.delete('expand')
+    setSearchParams(next, { replace: true })
+    // Clear the scroll flag after the ExpandedCard has had a chance to mount
+    // and run its scrollIntoView, so a later collapse+re-expand of the same
+    // card doesn't keep auto-scrolling.
+    const t = window.setTimeout(() => setPendingScrollSlug(null), 600)
+    return () => window.clearTimeout(t)
+  }, [loading, projects, searchParams, setSearchParams])
+
   function expand(slug: string) {
     setExpandedOrder((order) => (order.includes(slug) ? order : [slug, ...order]))
   }
 
   function collapse(slug: string) {
     setExpandedOrder((order) => order.filter((s) => s !== slug))
+    if (pendingScrollSlug === slug) setPendingScrollSlug(null)
   }
 
   if (loading) {
@@ -362,6 +412,7 @@ export function ProjectsPage() {
                 <ExpandedCard
                   project={project}
                   onClose={() => collapse(project.slug)}
+                  scrollIntoViewOnMount={pendingScrollSlug === project.slug}
                 />
               </motion.div>
             ))}


### PR DESCRIPTION
## Summary
- Click any insight's project name → projects dashboard opens with that project's card pre-expanded and scrolled into view
- Each expanded project card gains a **View insights** link → insights feed pre-filtered to that project
- Both directions are URL-driven (`/?expand=<slug>` and `/insights?project=<slug>`) so they're shareable / bookmarkable
- Empty-state copy on `/insights` now reflects the active project / category filter instead of the generic "Run canopy:portfolio-review" hint

## Implementation notes
- Backend `/api/insights/?project=<slug>` filter already shipped in #32; this PR is purely the UI wiring.
- Refactored `insightsApi.list` from positional args to a single `{category?, project?, limit?}` options object — only one caller in the tree.
- `ProjectsPage` reads `?expand=<slug>` once on mount, applies it, then strips the param so a refresh doesn't keep re-scrolling. A 600ms timeout clears the `pendingScrollSlug` flag so manual collapse+expand of the same card after the deep-link doesn't re-trigger auto-scroll.

## Test plan
- [x] `uv run pytest -q` — 199 passed
- [x] `cd frontend && tsc -b` — clean
- [ ] After merge + deploy: visit `/insights`, click any project name → dashboard opens with that project expanded
- [ ] After merge + deploy: visit `/`, click a project tile → click "View insights" inside the expanded card → feed pre-filtered

🤖 Sent via /canopy:pm-autonomous