### PR TITLE
feat(auth): /api/auth/e2e-login/ — token-gated login for headless agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,9 @@ CI (`.github/workflows/ci.yml`) runs both on every PR and on push to main. Deplo
 - `POST /api/ai/auth/complete/` — Submit OAuth code
 - `GET /api/ai/auth/poll/` — Poll auth status
 
+### Automated-tool login (`apps/common/views_auth_e2e`)
+- `POST /api/auth/e2e-login/` — token-gated login for automated tools (gstack walkthroughs, autonomous PM cycles, AI-driven QA). Body: `{email, token}`. Disabled by default — returns 404 unless `CANOPY_E2E_AUTH_TOKEN` is set. Email must be in `AUTH_ALLOWED_EMAIL_DOMAIN`. Sessions carry `_canopy_e2e_session` marker for audit. See `docs/e2e-login.md`.
+
 ### Debug access (`apps/common/views_debug`)
 - `POST /api/debug/mint-session/` — authenticated user mints a short-lived Django session cookie (body: `{ttl_seconds: int}`, clamped to 60s–1w). Returns cookie + curl example. Used to hand access to an AI assistant without going through OAuth. UI lives at `/settings` → "Debug access".
 

--- a/apps/common/middleware.py
+++ b/apps/common/middleware.py
@@ -4,11 +4,12 @@ from django.http import JsonResponse
 from django.shortcuts import redirect
 
 PUBLIC_PATH_PREFIXES = (
-    "/accounts/",        # allauth login/logout/callback
-    "/admin/",           # Django admin has its own auth
-    "/health/",          # health check for Cloud Run
-    "/static/",          # static assets
-    "/api/csrf/",        # bootstraps CSRF cookie before login
+    "/accounts/",            # allauth login/logout/callback
+    "/admin/",               # Django admin has its own auth
+    "/health/",              # health check for Cloud Run
+    "/static/",              # static assets
+    "/api/csrf/",            # bootstraps CSRF cookie before login
+    "/api/auth/e2e-login/",  # token-gated login for automated tools
 )
 
 # Write endpoints callable with a Bearer token (machine writes like the

--- a/apps/common/views_auth_e2e.py
+++ b/apps/common/views_auth_e2e.py
@@ -1,0 +1,96 @@
+"""Token-gated login for automated tools (gstack walkthroughs, autonomous
+PM cycles, AI-driven QA).
+
+Unlike `mint-session` (which requires an already-authenticated browser),
+this endpoint takes a pre-shared secret and logs in a service user with
+no human in the loop. It exists so headless agents can drive every
+OAuth-gated UI surface the same way humans can.
+
+SECURITY:
+- Disabled by default (CANOPY_E2E_AUTH_TOKEN defaults to empty string).
+- The view returns 404 when the token is unset; the URL is registered
+  unconditionally (the in-view check is the gate).
+- Email is restricted to settings.AUTH_ALLOWED_EMAIL_DOMAIN.
+- Sessions carry a `_canopy_e2e_session` marker so they can be audited
+  or bulk-revoked.
+"""
+from __future__ import annotations
+
+import json
+import logging
+
+from django.conf import settings
+from django.contrib.auth import get_user_model, login
+from django.http import HttpRequest, HttpResponse, JsonResponse
+from django.utils import timezone
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_http_methods
+
+logger = logging.getLogger(__name__)
+
+E2E_SESSION_MARKER = "_canopy_e2e_session"
+
+
+def _is_allowed_domain(email: str) -> bool:
+    allowed = (getattr(settings, "AUTH_ALLOWED_EMAIL_DOMAIN", "") or "").lower()
+    if not allowed:
+        return True
+    _, _, domain = email.rpartition("@")
+    return domain.lower() == allowed
+
+
+@csrf_exempt
+@require_http_methods(["POST"])
+def e2e_login(request: HttpRequest) -> HttpResponse:
+    """POST /api/auth/e2e-login/
+
+    Body (JSON): {"email": "ace@dimagi.com", "token": "<secret>"}
+    Response: 200 with {"user_id": int, "email": str, "created": bool}
+    On success, the response sets the Django session cookie so subsequent
+    requests on the same client are authenticated.
+    """
+    expected_token = (getattr(settings, "CANOPY_E2E_AUTH_TOKEN", "") or "").strip()
+    if not expected_token:
+        return JsonResponse({"error": "e2e login is disabled"}, status=404)
+
+    try:
+        body = json.loads(request.body or b"{}")
+    except json.JSONDecodeError:
+        return JsonResponse({"error": "invalid JSON"}, status=400)
+
+    token = (body.get("token") or "").strip()
+    if not token or token != expected_token:
+        logger.warning("e2e_login: invalid token attempt")
+        return JsonResponse({"error": "invalid token"}, status=403)
+
+    email = (body.get("email") or "").strip().lower()
+    if not email:
+        return JsonResponse({"error": "email is required"}, status=400)
+
+    if not _is_allowed_domain(email):
+        allowed = getattr(settings, "AUTH_ALLOWED_EMAIL_DOMAIN", "")
+        return JsonResponse(
+            {"error": f"email must be from: @{allowed}"},
+            status=400,
+        )
+
+    user_model = get_user_model()
+    user = user_model.objects.filter(email__iexact=email).first()
+    created = False
+    if user is None:
+        user = user_model.objects.create_user(username=email, email=email)
+        created = True
+
+    login(request, user, backend="django.contrib.auth.backends.ModelBackend")
+    request.session[E2E_SESSION_MARKER] = {
+        "email": email,
+        "logged_in_at": timezone.now().isoformat(),
+    }
+    request.session.save()
+    logger.info("e2e_login: authenticated %s (created=%s)", email, created)
+
+    return JsonResponse({
+        "user_id": user.pk,
+        "email": user.email,
+        "created": created,
+    })

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -165,6 +165,12 @@ REQUIRE_AUTH = env.bool("REQUIRE_AUTH", default=True)
 # disables the bypass entirely.
 WORKBENCH_WRITE_TOKEN = os.environ.get("WORKBENCH_WRITE_TOKEN", "")
 
+# Pre-shared secret for /api/auth/e2e-login/ — token-gated login for
+# automated tools (gstack walkthroughs, autonomous PM cycles, AI-driven
+# QA) so they can drive OAuth-gated UI surfaces without a human in the
+# loop. Empty disables the endpoint (404).
+CANOPY_E2E_AUTH_TOKEN = os.environ.get("CANOPY_E2E_AUTH_TOKEN", "")
+
 # AI Backend: "api" (direct Anthropic SDK) or "cli" (claude code CLI)
 AI_BACKEND = env("AI_BACKEND", default="api")
 ANTHROPIC_API_KEY = env("ANTHROPIC_API_KEY", default="")

--- a/config/urls.py
+++ b/config/urls.py
@@ -4,6 +4,7 @@ URL configuration for canopy-web project.
 from django.contrib import admin
 from django.urls import include, path, re_path
 
+from apps.common import views_auth_e2e
 from apps.projects import views_insights
 from config.views import csrf_view, health_check, me_view, spa_view
 
@@ -13,6 +14,7 @@ urlpatterns = [
     path("health/", health_check, name="health-check"),
     path("api/me/", me_view, name="me"),
     path("api/csrf/", csrf_view, name="csrf"),
+    path("api/auth/e2e-login/", views_auth_e2e.e2e_login, name="auth-e2e-login"),
     path("api/collections/", include("apps.collections.urls")),
     path("api/workspace/", include("apps.workspace.urls")),
     path("api/skills/", include("apps.skills.urls")),

--- a/deploy.sh
+++ b/deploy.sh
@@ -44,7 +44,7 @@ gcloud run deploy "${SERVICE_NAME}" \
   --set-env-vars="AI_BACKEND=api" \
   --set-env-vars="AUTH_ALLOWED_EMAIL_DOMAIN=dimagi.com" \
   --set-env-vars="REQUIRE_AUTH=${REQUIRE_AUTH_FLAG}" \
-  --set-secrets="SECRET_KEY=django-secret-key:latest,ANTHROPIC_API_KEY=anthropic-api-key:latest,DATABASE_URL=canopy-db-url:latest,GOOGLE_OAUTH_CLIENT_ID=google-oauth-client-id:latest,GOOGLE_OAUTH_CLIENT_SECRET=google-oauth-client-secret:latest,WORKBENCH_WRITE_TOKEN=workbench-write-token:latest" \
+  --set-secrets="SECRET_KEY=django-secret-key:latest,ANTHROPIC_API_KEY=anthropic-api-key:latest,DATABASE_URL=canopy-db-url:latest,GOOGLE_OAUTH_CLIENT_ID=google-oauth-client-id:latest,GOOGLE_OAUTH_CLIENT_SECRET=google-oauth-client-secret:latest,WORKBENCH_WRITE_TOKEN=workbench-write-token:latest,CANOPY_E2E_AUTH_TOKEN=canopy-e2e-auth-token:latest" \
   --allow-unauthenticated \
   --quiet
 

--- a/docs/e2e-login.md
+++ b/docs/e2e-login.md
@@ -1,0 +1,51 @@
+# Token-gated E2E login
+
+`POST /api/auth/e2e-login/` lets automated tools (gstack walkthroughs,
+autonomous PM cycles, AI-driven QA) sign in without going through Google
+OAuth. Same surfaces a human gets, no human in the loop.
+
+## Enable
+
+Set `CANOPY_E2E_AUTH_TOKEN` to a long random string. Empty (default)
+means the endpoint returns 404 — no exposure unless explicitly enabled.
+
+In Cloud Run prod, the secret is wired in `deploy.sh` from Secret
+Manager (`canopy-e2e-auth-token:latest`). Mint a new value with:
+
+```bash
+TOKEN=$(openssl rand -hex 32)
+echo -n "$TOKEN" | gcloud secrets create canopy-e2e-auth-token \
+  --project=connect-labs --data-file=-
+# or, for a new version:
+echo -n "$TOKEN" | gcloud secrets versions add canopy-e2e-auth-token \
+  --project=connect-labs --data-file=-
+```
+
+## Use
+
+```bash
+curl -c cookies.txt -X POST \
+  https://canopy-web-hhhi4yut3q-uc.a.run.app/api/auth/e2e-login/ \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"ace@dimagi.com","token":"<CANOPY_E2E_AUTH_TOKEN>"}'
+
+# Now the cookie jar carries `sessionid`; reuse it on any gated route:
+curl -b cookies.txt https://canopy-web-hhhi4yut3q-uc.a.run.app/api/projects/
+```
+
+For headless browsers (gstack, Playwright): hit the endpoint, then drive
+the SPA — the response sets the `sessionid` cookie on the same client.
+
+## Contract
+
+- **Method:** `POST` only (`GET` returns 405).
+- **Body:** JSON `{"email": "<addr>", "token": "<secret>"}`.
+- **Email gate:** must match `AUTH_ALLOWED_EMAIL_DOMAIN` (defaults to
+  `dimagi.com`); other domains return 400.
+- **Token gate:** must equal `CANOPY_E2E_AUTH_TOKEN` exactly; mismatch
+  returns 403.
+- **User:** an `auth.User` is created on first call (`username == email`),
+  reused on subsequent calls.
+- **Audit marker:** the session blob carries `_canopy_e2e_session = {email,
+  logged_in_at}` so e2e sessions can be filtered/revoked separately from
+  human OAuth sessions or `mint-session` cookies.

--- a/tests/test_auth_e2e.py
+++ b/tests/test_auth_e2e.py
@@ -1,0 +1,145 @@
+"""Tests for the token-gated e2e-login endpoint.
+
+Mirrors the pattern in ace-web's apps/auth/e2e_login_views.py: a pre-shared
+token in CANOPY_E2E_AUTH_TOKEN lets automated tools (gstack walkthroughs,
+autonomous PM cycles) sign in without going through Google OAuth.
+"""
+import json
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import Client, override_settings
+
+
+@pytest.fixture
+def anon_client(db):
+    return Client()
+
+
+@override_settings(CANOPY_E2E_AUTH_TOKEN="")
+def test_endpoint_disabled_when_token_unset(anon_client):
+    resp = anon_client.post(
+        "/api/auth/e2e-login/",
+        data=json.dumps({"email": "ace@dimagi.com", "token": "anything"}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 404
+
+
+@override_settings(CANOPY_E2E_AUTH_TOKEN="s3cret")
+def test_invalid_token_rejected(anon_client):
+    resp = anon_client.post(
+        "/api/auth/e2e-login/",
+        data=json.dumps({"email": "ace@dimagi.com", "token": "wrong"}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 403
+
+
+@override_settings(CANOPY_E2E_AUTH_TOKEN="s3cret")
+def test_missing_email_rejected(anon_client):
+    resp = anon_client.post(
+        "/api/auth/e2e-login/",
+        data=json.dumps({"token": "s3cret"}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+
+
+@override_settings(CANOPY_E2E_AUTH_TOKEN="s3cret", AUTH_ALLOWED_EMAIL_DOMAIN="dimagi.com")
+def test_disallowed_domain_rejected(anon_client):
+    resp = anon_client.post(
+        "/api/auth/e2e-login/",
+        data=json.dumps({"email": "outsider@example.com", "token": "s3cret"}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+
+
+@override_settings(CANOPY_E2E_AUTH_TOKEN="s3cret", AUTH_ALLOWED_EMAIL_DOMAIN="dimagi.com")
+def test_invalid_json_rejected(anon_client):
+    resp = anon_client.post(
+        "/api/auth/e2e-login/",
+        data="not-json",
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+
+
+@override_settings(CANOPY_E2E_AUTH_TOKEN="s3cret", AUTH_ALLOWED_EMAIL_DOMAIN="dimagi.com")
+def test_valid_token_creates_and_logs_in(anon_client, db):
+    user_model = get_user_model()
+    assert not user_model.objects.filter(email="ace@dimagi.com").exists()
+
+    resp = anon_client.post(
+        "/api/auth/e2e-login/",
+        data=json.dumps({"email": "ace@dimagi.com", "token": "s3cret"}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["email"] == "ace@dimagi.com"
+    assert body["created"] is True
+    assert isinstance(body["user_id"], int)
+    assert user_model.objects.filter(email="ace@dimagi.com").count() == 1
+
+
+@override_settings(CANOPY_E2E_AUTH_TOKEN="s3cret", AUTH_ALLOWED_EMAIL_DOMAIN="dimagi.com")
+def test_valid_token_reuses_existing_user(anon_client, db):
+    user_model = get_user_model()
+    user_model.objects.create_user(username="ace@dimagi.com", email="ace@dimagi.com")
+
+    resp = anon_client.post(
+        "/api/auth/e2e-login/",
+        data=json.dumps({"email": "ace@dimagi.com", "token": "s3cret"}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["created"] is False
+    assert user_model.objects.filter(email="ace@dimagi.com").count() == 1
+
+
+@override_settings(
+    CANOPY_E2E_AUTH_TOKEN="s3cret",
+    AUTH_ALLOWED_EMAIL_DOMAIN="dimagi.com",
+    REQUIRE_AUTH=True,
+)
+def test_session_cookie_authorizes_gated_api(db):
+    """End-to-end: e2e-login, then use the session cookie to hit a
+    normally-OAuth-gated endpoint. Same client carries the cookie set by
+    the login response."""
+    client = Client()
+    resp = client.post(
+        "/api/auth/e2e-login/",
+        data=json.dumps({"email": "ace@dimagi.com", "token": "s3cret"}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    # Reuse the same client (it now carries sessionid).
+    gated = client.get("/api/projects/")
+    assert gated.status_code == 200
+
+
+@override_settings(CANOPY_E2E_AUTH_TOKEN="s3cret", AUTH_ALLOWED_EMAIL_DOMAIN="dimagi.com")
+def test_session_marker_set_for_audit(db):
+    from django.contrib.sessions.models import Session
+
+    client = Client()
+    resp = client.post(
+        "/api/auth/e2e-login/",
+        data=json.dumps({"email": "ace@dimagi.com", "token": "s3cret"}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    sessionid = client.cookies["sessionid"].value
+    blob = Session.objects.get(session_key=sessionid).get_decoded()
+    assert "_canopy_e2e_session" in blob
+    assert blob["_canopy_e2e_session"]["email"] == "ace@dimagi.com"
+
+
+@override_settings(CANOPY_E2E_AUTH_TOKEN="s3cret", AUTH_ALLOWED_EMAIL_DOMAIN="dimagi.com")
+def test_get_method_rejected(anon_client):
+    """Only POST is allowed — GET should 405."""
+    resp = anon_client.get("/api/auth/e2e-login/")
+    assert resp.status_code == 405


### PR DESCRIPTION
## Summary

Adds `POST /api/auth/e2e-login/` — a token-gated login endpoint for automated
tools (gstack walkthroughs, autonomous PM cycles, AI-driven QA) that mints a
Django session cookie without going through Google OAuth.

This closes the #1 follow-up from the 2026-04-29 autonomous PM E.5 self-review:
without an automation login, every autonomous email on canopy-web ships
screenshot-less. With it, the email's hero blocks become real prod shots
captured by `gstack` driving the deployed app.

## What's in the diff

- `apps/common/views_auth_e2e.py` — the view (csrf_exempt, POST-only, JSON body)
- `apps/common/middleware.py` — adds `/api/auth/e2e-login/` to `PUBLIC_PATH_PREFIXES`
- `config/urls.py` — mounts at `/api/auth/e2e-login/` (top-level, not nested under `/api/ai/`)
- `config/settings/base.py` — reads `CANOPY_E2E_AUTH_TOKEN` from env (empty default = endpoint 404s)
- `deploy.sh` — wires `CANOPY_E2E_AUTH_TOKEN` from `canopy-e2e-auth-token:latest` Secret Manager secret
- `tests/test_auth_e2e.py` — 10 tests covering disabled / invalid-token / bad-domain / end-to-end / GET-405 / audit-marker / reuse-existing-user
- `docs/e2e-login.md` — flow doc with curl example
- `CLAUDE.md` — API-listing entry under "Automated-tool login"

## Security

- Disabled by default (`CANOPY_E2E_AUTH_TOKEN` defaults to empty → 404).
- Email must match `AUTH_ALLOWED_EMAIL_DOMAIN` (defaults to `dimagi.com`).
- Sessions carry `_canopy_e2e_session = {email, logged_in_at}` so e2e sessions can be filtered/revoked separately from human OAuth sessions or `mint-session` cookies.
- Secret minted in `connect-labs` Secret Manager (`canopy-e2e-auth-token`, version 1) and bound to the Cloud Run runtime SA pre-merge.

## Test plan

- [x] `uv run pytest -q tests/test_auth_e2e.py` — 10/10 pass
- [x] `uv run pytest -q` — full suite: 209/209 pass
- [x] `cd frontend && tsc -b` — exit 0
- [x] Ruff scoped to staged Python files — clean
- [x] Secret-leak scan — clean
- [x] Diff-size cap (1500 lines) — 310 lines, well under
- [ ] Post-deploy: `curl -X POST .../api/auth/e2e-login/` returns 200 + sets `sessionid`
- [ ] Post-deploy: `gstack` drives prod via the cookie, captures `/` for the release-notes email

🤖 Generated with [Claude Code](https://claude.com/claude-code)