### PR TITLE
infra: migrate Cloud Run deployment to canopy-494811 (Cloud Build, no local Docker)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,14 +9,14 @@ name: CI / Deploy
 # Workload Identity Federation (no long-lived service account keys):
 #
 #   gcloud iam service-accounts create canopy-web-deployer \
-#     --project=connect-labs
+#     --project=canopy-494811
 #
 #   gcloud iam workload-identity-pools create github \
-#     --project=connect-labs --location=global \
+#     --project=canopy-494811 --location=global \
 #     --display-name="GitHub Actions"
 #
 #   gcloud iam workload-identity-pools providers create-oidc github \
-#     --project=connect-labs --location=global \
+#     --project=canopy-494811 --location=global \
 #     --workload-identity-pool=github \
 #     --display-name="GitHub" \
 #     --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository,attribute.repository_owner=assertion.repository_owner" \
@@ -24,8 +24,8 @@ name: CI / Deploy
 #     --issuer-uri="https://token.actions.githubusercontent.com"
 #
 #   gcloud iam service-accounts add-iam-policy-binding \
-#     canopy-web-deployer@connect-labs.iam.gserviceaccount.com \
-#     --project=connect-labs \
+#     canopy-web-deployer@canopy-494811.iam.gserviceaccount.com \
+#     --project=canopy-494811 \
 #     --role=roles/iam.workloadIdentityUser \
 #     --member="principalSet://iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/github/attribute.repository/jjackson/canopy-web"
 #
@@ -33,7 +33,7 @@ name: CI / Deploy
 # cloud sql, secret manager accessor) and add these GitHub repo secrets:
 #
 #   GCP_WIF_PROVIDER  →  projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/github/providers/github
-#   GCP_SERVICE_ACCOUNT  →  canopy-web-deployer@connect-labs.iam.gserviceaccount.com
+#   GCP_SERVICE_ACCOUNT  →  canopy-web-deployer@canopy-494811.iam.gserviceaccount.com
 
 on:
   push:

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ node_modules/
 # Claude Code local state (only ignore ephemeral lock files; walkthroughs are tracked)
 .claude/scheduled_tasks.lock
 .claude/tasks/
+.claude/settings.local.json

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,43 +1,28 @@
 steps:
-  # Build backend image
   - name: 'gcr.io/cloud-builders/docker'
     args:
       - 'build'
       - '-t'
-      - 'us-central1-docker.pkg.dev/$PROJECT_ID/canopy-web/backend:$SHORT_SHA'
+      - '${_REPO}/${_SERVICE}:${_TAG}'
       - '-t'
-      - 'us-central1-docker.pkg.dev/$PROJECT_ID/canopy-web/backend:latest'
+      - '${_REPO}/${_SERVICE}:latest'
       - '-f'
       - 'Dockerfile'
       - '.'
-    id: 'build-backend'
+    id: 'build'
 
-  # Build frontend image
   - name: 'gcr.io/cloud-builders/docker'
-    args:
-      - 'build'
-      - '-t'
-      - 'us-central1-docker.pkg.dev/$PROJECT_ID/canopy-web/frontend:$SHORT_SHA'
-      - '-t'
-      - 'us-central1-docker.pkg.dev/$PROJECT_ID/canopy-web/frontend:latest'
-      - '-f'
-      - 'Dockerfile.frontend'
-      - '.'
-    id: 'build-frontend'
+    args: ['push', '--all-tags', '${_REPO}/${_SERVICE}']
+    waitFor: ['build']
 
-  # Push backend image
-  - name: 'gcr.io/cloud-builders/docker'
-    args: ['push', '--all-tags', 'us-central1-docker.pkg.dev/$PROJECT_ID/canopy-web/backend']
-    waitFor: ['build-backend']
-
-  # Push frontend image
-  - name: 'gcr.io/cloud-builders/docker'
-    args: ['push', '--all-tags', 'us-central1-docker.pkg.dev/$PROJECT_ID/canopy-web/frontend']
-    waitFor: ['build-frontend']
+substitutions:
+  _TAG: latest
+  _REPO: us-central1-docker.pkg.dev/${PROJECT_ID}/canopy-web
+  _SERVICE: canopy-web
 
 images:
-  - 'us-central1-docker.pkg.dev/$PROJECT_ID/canopy-web/backend'
-  - 'us-central1-docker.pkg.dev/$PROJECT_ID/canopy-web/frontend'
+  - '${_REPO}/${_SERVICE}'
 
 options:
   logging: CLOUD_LOGGING_ONLY
+  machineType: E2_HIGHCPU_8

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-PROJECT_ID="connect-labs"
+PROJECT_ID="canopy-494811"
 REGION="us-central1"
 REPO="us-central1-docker.pkg.dev/${PROJECT_ID}/canopy-web"
 SQL_INSTANCE="${PROJECT_ID}:${REGION}:canopy-web-db"
@@ -20,11 +20,15 @@ else
   (cd frontend && npm run build)
 fi
 
-echo "==> Building and pushing combined image..."
-# --platform linux/amd64 is required because Cloud Run only runs amd64/linux
-# and docker build on Apple Silicon defaults to arm64.
-docker build --platform linux/amd64 -t "${REPO}/${SERVICE_NAME}:${TAG}" -f Dockerfile .
-docker push "${REPO}/${SERVICE_NAME}:${TAG}"
+echo "==> Building and pushing combined image via Cloud Build..."
+# Cloud Build runs on linux/amd64 in GCP, so no local Docker required and no
+# cross-arch headache from Apple Silicon. cloudbuild.yaml drives the build and
+# tags both :${TAG} and :latest.
+gcloud builds submit \
+  --project="${PROJECT_ID}" \
+  --config=cloudbuild.yaml \
+  --substitutions="_TAG=${TAG},_REPO=${REPO},_SERVICE=${SERVICE_NAME}" \
+  .
 
 echo "==> Deploying to Cloud Run..."
 # Single service serves Django API + built React SPA (via WhiteNoise).

--- a/docs/e2e-login.md
+++ b/docs/e2e-login.md
@@ -15,10 +15,10 @@ Manager (`canopy-e2e-auth-token:latest`). Mint a new value with:
 ```bash
 TOKEN=$(openssl rand -hex 32)
 echo -n "$TOKEN" | gcloud secrets create canopy-e2e-auth-token \
-  --project=connect-labs --data-file=-
+  --project=canopy-494811 --data-file=-
 # or, for a new version:
 echo -n "$TOKEN" | gcloud secrets versions add canopy-e2e-auth-token \
-  --project=connect-labs --data-file=-
+  --project=canopy-494811 --data-file=-
 ```
 
 ## Use


### PR DESCRIPTION
## Summary
- Move the canopy-web GCP deployment off the shared `connect-labs` project and onto a dedicated `canopy-494811` project.
- Switch the image build step from local `docker build && docker push` to `gcloud builds submit`, so deploys (and CI) no longer need a Docker daemon. This also avoids the linux/amd64 cross-arch workaround on Apple Silicon.
- Fix the stale `cloudbuild.yaml` (it referenced a `Dockerfile.frontend` that doesn't exist in this repo) and rewrite it as a single-image build matching the actual `Dockerfile`, parameterised via `_TAG / _REPO / _SERVICE` so `deploy.sh` drives it.
- Refresh the WIF setup comment in `ci.yml` and the example `gcloud secrets` invocations in `docs/e2e-login.md` to point at `canopy-494811`.

## Out-of-band changes already applied
- `canopy-494811`: APIs enabled (run, sqladmin, artifactregistry, secretmanager, cloudbuild, iamcredentials, servicenetworking); Cloud SQL `canopy-web-db` + `canopy_web` DB; Artifact Registry repo `canopy-web`; 7 secrets in Secret Manager; deployer SA `canopy-web-deployer@canopy-494811` with run/cloudbuild/sql/secret/AR/SA-user roles; WIF pool `github` + provider bound to `jjackson/canopy-web`.
- GitHub repo secrets `GCP_WIF_PROVIDER` and `GCP_SERVICE_ACCOUNT` rotated to the new project values.
- Production data dumped from connect-labs Cloud SQL → imported into canopy-494811 (13 projects, 20 insights, user accounts preserved).
- Old `connect-labs` Cloud Run service `canopy-web` has been deleted; the rest of the connect-labs canopy-web resources (Cloud SQL, AR repo, secrets, deployer SA) are kept for a few days as a rollback safety net.
- 1Password `AI-Agents` vault has a consolidated item ("Canopy Web - GCP (canopy-494811)") with all secret values + Service URL.

## Test plan
- [ ] Backend tests pass in CI (`pytest`).
- [ ] Frontend build passes in CI.
- [ ] Manual `workflow_dispatch` of the Deploy job succeeds end-to-end against `canopy-494811` (auth via WIF, Cloud Build image build, `gcloud run deploy` to the new service).
- [ ] After deploy, `https://canopy-web-ujpz2cuyxq-uc.a.run.app/health/` returns 200 and Google OAuth login works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)