### PR TITLE
feat(dashboard): "Today's top 3" hero + insight freshness chip

### DIFF
--- a/frontend/src/api/insights.ts
+++ b/frontend/src/api/insights.ts
@@ -38,6 +38,45 @@ export interface InsightListParams {
   limit?: number
 }
 
+// Category weight for the dashboard "Today's top 3" hero. Higher = more
+// urgent to surface. Tuned for the morning-triage flow: ship gaps and
+// opportunities are time-sensitive (a release, a CWS review, an upstream PR
+// is about to do something) and warrant jumping the queue. Hygiene and
+// pattern are real but rarely "do today". Stale gets the lowest weight
+// because by definition nothing is racing.
+const CATEGORY_RANK: Record<string, number> = {
+  ship_gap: 4,
+  opportunity: 3,
+  pattern: 2,
+  hygiene: 2,
+  stale: 1,
+}
+
+// Pick the top N insights for the home-dashboard hero. Sort key:
+//   1. Category weight (CATEGORY_RANK; unknown/null -> 0)
+//   2. Recency (newer first)
+export function rankInsights(insights: Insight[], limit = 3): Insight[] {
+  return [...insights]
+    .sort((a, b) => {
+      const aw = CATEGORY_RANK[parseInsightCategory(a.content) ?? ''] ?? 0
+      const bw = CATEGORY_RANK[parseInsightCategory(b.content) ?? ''] ?? 0
+      if (bw !== aw) return bw - aw
+      return new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+    })
+    .slice(0, limit)
+}
+
+// Most recent insight timestamp across the whole feed. Drives the freshness
+// chip on the hero — if this is >24h old the user is triaging stale signals
+// and we should nudge them to re-run the portfolio sweep.
+export function newestInsightTimestamp(insights: Insight[]): string | null {
+  if (!insights.length) return null
+  return insights.reduce(
+    (acc, i) => (acc && acc > i.created_at ? acc : i.created_at),
+    insights[0].created_at,
+  )
+}
+
 export const insightsApi = {
   list: (params: InsightListParams = {}) => {
     const qp = new URLSearchParams()

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -5,8 +5,10 @@ import { type Project, projectsApi } from '@/api/projects'
 import {
   type Insight,
   insightsApi,
+  newestInsightTimestamp,
   parseInsightBody,
   parseInsightCategory,
+  rankInsights,
 } from '@/api/insights'
 import { CategoryBadge } from '@/components/InsightChip'
 
@@ -149,6 +151,89 @@ function PrivateBadge() {
     <span className="text-[9px] text-stone-500 border border-orange-400/15 bg-orange-400/5 px-1.5 py-0.5 rounded uppercase tracking-wide">
       private
     </span>
+  )
+}
+
+// "Today's top 3" hero — top of the dashboard, above the tile grid. Answers
+// the primary user's "what should I do next?" question without scrolling. The
+// ranking lives in `rankInsights`; clicking a row defers to the parent's
+// `expand(slug)` so the relevant project tile pops open inline (same path the
+// `?expand=` deep link uses).
+function TopThreeHero({
+  insights,
+  onActivate,
+}: {
+  insights: Insight[]
+  onActivate: (slug: string) => void
+}) {
+  const top = rankInsights(insights, 3)
+  const newest = newestInsightTimestamp(insights)
+  const newestAgeHours = newest
+    ? (Date.now() - new Date(newest).getTime()) / (1000 * 60 * 60)
+    : null
+  const isStale = newestAgeHours !== null && newestAgeHours > 24
+
+  if (!top.length) {
+    // First-run / empty-feed state: still show the hero shell so the surface
+    // isn't a missing-section gap. The freshness line tells the user how to
+    // populate it.
+    return (
+      <div className="mb-6 bg-stone-900 border border-stone-800 rounded-xl p-5">
+        <div className="text-[9px] uppercase tracking-wider text-stone-600 font-semibold mb-1">
+          Today's top 3
+        </div>
+        <p className="text-sm text-stone-500">
+          No insights yet — run <code className="text-stone-300">canopy:portfolio-review</code> to populate the feed.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mb-6 bg-stone-900 border border-stone-800 rounded-xl p-5">
+      <div className="flex items-center justify-between mb-3">
+        <div className="text-[9px] uppercase tracking-wider text-stone-600 font-semibold">
+          Today's top 3
+        </div>
+        <div className="text-[10px] text-stone-600 flex items-center gap-2">
+          {newest && (
+            <span title={new Date(newest).toLocaleString()}>
+              Refreshed {relativeTime(newest)}
+            </span>
+          )}
+          {isStale && (
+            <span
+              className="text-amber-400/90 bg-amber-400/10 border border-amber-400/25 px-2 py-0.5 rounded"
+              title="Run `canopy:portfolio-review` locally to refresh"
+            >
+              stale · run portfolio-review
+            </span>
+          )}
+        </div>
+      </div>
+      <div className="space-y-2">
+        {top.map((insight) => {
+          const category = parseInsightCategory(insight.content)
+          const body = parseInsightBody(insight.content)
+          return (
+            <button
+              key={insight.id}
+              onClick={() => onActivate(insight.project_slug)}
+              className="w-full flex items-center gap-3 text-left bg-stone-950/40 hover:bg-stone-950/70 border border-stone-800 hover:border-stone-700 rounded-lg px-3 py-2 transition-colors group"
+            >
+              <CategoryBadge category={category} />
+              <span className="text-[11px] text-stone-500 shrink-0 w-32 truncate">
+                {insight.project_name}
+              </span>
+              <span className="text-xs text-stone-300 truncate flex-1">{body}</span>
+              <span className="text-[11px] text-stone-600 group-hover:text-orange-400 transition-colors shrink-0">
+                Open →
+              </span>
+            </button>
+          )
+        })}
+      </div>
+    </div>
   )
 }
 
@@ -542,6 +627,10 @@ export function ProjectsPage() {
     .map((slug) => projects.find((p) => p.slug === slug))
     .filter((p): p is Project => Boolean(p))
   const collapsedAll = projects.filter((p) => !expandedSet.has(p.slug))
+  // Flatten the per-project insight map back into a single list so the hero
+  // can rank across all projects. Cheaper than refetching since the page
+  // already loaded insights once on mount.
+  const allInsights = Object.values(insightsByProject).flat()
   // Hot grid leads; stale grid is hidden behind the toggle. Expanded cards
   // are NOT filtered — if the user expanded a stale card, it stays open.
   const collapsedHot = collapsedAll.filter((p) => !isProjectStale(p))
@@ -555,6 +644,8 @@ export function ProjectsPage() {
           {projects.length} projects
         </span>
       </div>
+
+      <TopThreeHero insights={allInsights} onActivate={expand} />
 
       <LayoutGroup>
         {/* Stack of expanded cards at the top */}


### PR DESCRIPTION
## Summary
- Adds a "Today's top 3" hero strip at the top of the home dashboard. Cross-portfolio insights are ranked by category urgency (ship-gap > opportunity > pattern/hygiene > stale) then recency, so the primary user can act on what matters in seconds without scrolling 13 project tiles.
- Click a row → the corresponding project tile expands inline (same code path as the existing `?expand=` deep link from `/insights`).
- A small "Refreshed <X> ago" chip exposes data freshness. If the newest insight is >24h old, a `stale · run portfolio-review` pill surfaces the next concrete action.

## Why this PR
This was the killer "what should I do next?" surface gap surfaced by the autonomous PM scout (`/canopy:pm-autonomous` with the lens "increasing value for me as the primary user"). The dashboard already has all the data; it just wasn't ranking or surfacing freshness.

Pure additive frontend change — no API surface change, no migration, no model touch. The two helpers (`rankInsights`, `newestInsightTimestamp`) are pure functions in `frontend/src/api/insights.ts` and easy to unit-test once a JS test harness lands.

## Test plan
- [ ] CI green (backend pytest + frontend build)
- [ ] After deploy, `https://canopy-web-ujpz2cuyxq-uc.a.run.app/` shows the "Today's top 3" hero above the tile grid with 3 ranked rows
- [ ] Click a row → the matching project tile expands inline
- [ ] Refreshed-ago timestamp matches the newest `created_at` in `/api/insights/`
- [ ] Existing tile grid + stale toggle + expanded-card flow are unchanged

🤖 Generated by [/canopy:pm-autonomous](https://github.com/jjackson/canopy/blob/main/plugins/canopy/skills/product-management/SKILL.md) with [Claude Code](https://claude.com/claude-code)