### PR TITLE
docs: regenerate CLAUDE.md (staleness + coverage fixes)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,8 +8,7 @@ Collaborative web workspace for building reusable AI skills from conversations.
 - **Frontend:** React 19 + Vite + Tailwind CSS 4 + shadcn/ui
 - **AI:** Anthropic Claude API via SSE streaming. Dual backend — direct API key (`AI_BACKEND=api`) or Claude Code CLI subscription (`AI_BACKEND=cli`), switchable at runtime via `/api/ai/switch/`.
 - **Runtime adapters:** `apps/skills/adapters/` produces skill artifacts for `web`, `claude_code`, and `open_claw` runtimes.
-- **Canopy:** Integrated as git submodule at `./canopy/`
-- **Deployment:** GCP Cloud Run + Cloud SQL via `./deploy.sh` (see PR #3 for resources). Production settings in `config/settings/production.py`.
+- **Deployment:** GCP Cloud Run + Cloud SQL on the `canopy-494811` project. `./deploy.sh` builds via Cloud Build (`cloudbuild.yaml`) and `gcloud run deploy`s — no local Docker daemon required. Production settings in `config/settings/production.py`.
 
 ## Development
 
@@ -32,9 +31,9 @@ uv run honcho start -f Procfile.dev
 # Docker (backend + frontend + Postgres)
 docker compose up
 
-# Deploy to GCP Cloud Run (local). CI also has a manual deploy job —
-# trigger it from the Actions tab ("CI / Deploy" → Run workflow).
-./deploy.sh                  # runs tests + frontend build first
+# Deploy to GCP Cloud Run. CI also has a manual deploy job — trigger it from
+# the Actions tab ("CI / Deploy" → Run workflow).
+./deploy.sh                  # Cloud Build → push → gcloud run deploy
 SKIP_TESTS=1 ./deploy.sh     # bypass test gate (emergencies only)
 ```
 
@@ -52,25 +51,30 @@ CI (`.github/workflows/ci.yml`) runs both on every PR and on push to main. Deplo
 
 ## Key URLs
 
-- `/` — Project workbench (tile grid dashboard)
+- `/` — Project workbench. Tile grid dashboard with a "Today's top 3" insight hero, freshness chip, inline insights triage, and self-prioritizing tile order by insight count.
 - `/skills` — Skill discovery feed
 - `/workspaces` — Workspace session list (resume in-progress sessions)
 - `/new` — New collection / source ingestion flow
 - `/workspace/:sessionId` — Co-authoring workspace
 - `/skills/:skillId` — Skill detail + eval history
 - `/leaderboard` — Eval improvement leaderboard
-- `/guide` — Interactive walkthrough ("Try It Now" sample flow + adapter reference)
+- `/guide` — Interactive walkthrough using a "Discovery Call Debrief" sample collection (try-it / how-it-works / review / eval / deploy sections)
 - `/insights` — Cross-portfolio AI insights feed
-- `/settings` — AI backend status, switch backends, headless Claude CLI auth
+- `/settings` — AI backend status, switch backends, headless Claude CLI auth, debug-session minting
 - `/api/` — REST API
 - `/admin/` — Django admin
 - `/health/` — Health check
 
 ## API Endpoints
 
+### Auth + session (root)
+- `GET /api/me/` — Current authenticated user
+- `GET /api/csrf/` — CSRF token bootstrap
+
 ### Projects
 - `GET /api/projects/` — List projects with latest context
 - `POST /api/projects/` — Create project
+- `GET /api/projects/slugs/` — Lightweight slug list
 - `GET /api/projects/{slug}/` — Project detail with full context
 - `PATCH /api/projects/{slug}/` — Update project
 - `DELETE /api/projects/{slug}/` — Delete project
@@ -87,6 +91,7 @@ CI (`.github/workflows/ci.yml`) runs both on every PR and on push to main. Deplo
 ### Insights
 - `GET /api/insights/` — List all insights across projects. Filters: `?category=<slug>` (matches `[<slug>]` content prefix), `?source=<producer>` (filters by writer), `?project=<slug>`. Bearer-readable for machine producers (e.g. `canopy:portfolio-review`) so they can dedupe before re-publishing.
 - `DELETE /api/insights/{id}/` — Dismiss an insight (OAuth only — bearer is GET-only here).
+- `POST /api/insights/clear/` — Clear insights (regeneration helper).
 
 ### Collections
 - `POST /api/collections/` — Create collection
@@ -132,14 +137,22 @@ CI (`.github/workflows/ci.yml`) runs both on every PR and on push to main. Deplo
 - Workspace flow: Ingest → AI proposes Approach + Eval → Review/Edit → Test → Publish
 - SSE streaming for AI responses (Scout pattern)
 - Overwrite-with-history versioning
-- No auth in V1 (single-tenant internal tool)
-- PostgreSQL on Cloud SQL (GCP deployment)
+- **Auth:** Google OAuth via django-allauth (allowed-domain restricted via `AUTH_ALLOWED_EMAIL_DOMAIN`, default `dimagi.com`). `LoginRequiredMiddleware` enforces auth at the app layer. Two automation bypasses: `/api/auth/e2e-login/` (token-gated, for headless tools) and `/api/debug/mint-session/` (authenticated user mints a short-lived cookie for an AI assistant). Single-tenant in V1; multi-tenant scaffolding tracked in `TODOS.md`.
+- PostgreSQL on Cloud SQL (GCP `canopy-494811`)
 - Dual AI backend lets users run either against an API key or their own Claude Code subscription
 
 ## Reference Docs
 
 - `docs/superpowers/plans/2026-03-27-canopy-web-implementation.md` — Original implementation plan and file structure
+- `docs/superpowers/plans/2026-04-10-project-workbench.md` — Project workbench dashboard plan
+- `docs/superpowers/plans/2026-04-13-portfolio-insights.md` — Cross-portfolio insights feed plan
+- `docs/superpowers/specs/2026-04-10-project-workbench-design.md` — Workbench design spec
+- `docs/superpowers/specs/2026-04-14-google-oauth-auth-gate-design.md` — OAuth gate design spec
 - `docs/designs/canopy-web-design.md` — Product design + glossary (open claw, skill, collection, eval suite, workspace session)
 - `docs/designs/ceo-plan-conversation-to-agent.md` — CEO review, scope decisions, deferred work
 - `docs/walkthroughs/canopy-web-demo.yaml` — Walkthrough QA spec (5 skills, varied scores)
+- `docs/walkthroughs/project-workbench.yaml` — Project workbench walkthrough spec
+- `docs/case-studies/workbench-self-improvement.md` — Self-improvement case study
+- `docs/personas/jonathan.md` — Primary user persona
+- `docs/e2e-login.md` — Token-gated automation login (`/api/auth/e2e-login/`) usage and contract
 - `TODOS.md` — Deferred V2 work (proactive detection, MCP layer, prompt hardening, OAuth integrations, multi-tenant auth, cowork adapter)


### PR DESCRIPTION
Auto-generated by [/canopy:doc-regen](https://github.com/jjackson/canopy/blob/main/plugins/canopy/skills/doc-regeneration/SKILL.md) `--apply`.

## Review report

### Phase 2 — Staleness (5 fixes)

| Line(s) | Issue | Source | Fix |
|---|---|---|---|
| L11 | "Canopy: Integrated as git submodule at `./canopy/`" | n/a — directory does not exist | Removed. `git submodule status` returns nothing; `test -e canopy` fails. |
| L12 | "see PR #3 for resources" | PR #3 (original GCP setup, connect-labs) | Replaced — the production deployment migrated to `canopy-494811` in PR #37 and the build path switched to Cloud Build. |
| L26 | "Building and pushing combined image" via local `docker build` | deploy.sh changed in PR #37 | Updated to "`gcloud builds submit` → push → `gcloud run deploy`" — no local Docker daemon required. |
| L55 | `/` described as "Project workbench (tile grid dashboard)" | PRs #35, #36, #38 | Expanded — names the "Today's top 3" hero, freshness chip, inline insights triage, and self-prioritizing tile order. |
| L62 | `/guide` described as "Try It Now sample flow + adapter reference" | `frontend/src/pages/GuidePage.tsx` actually serves a Discovery Call Debrief sample | Updated to match the live page's section structure. |
| L135 | "No auth in V1 (single-tenant internal tool)" | PR #19 added Google OAuth gate; `LoginRequiredMiddleware` is active | Replaced — names the OAuth gate, domain allowlist, middleware, and the two automation bypasses (e2e-login, mint-session). |

### Phase 2 — Coverage (4 missing endpoints, 8 missing reference docs)

**Endpoints wired in `config/urls.py` but undocumented:**
- `GET /api/me/`
- `GET /api/csrf/`
- `GET /api/projects/slugs/`
- `POST /api/insights/clear/`

**Reference docs on disk but not linked:**
- `docs/superpowers/plans/2026-04-10-project-workbench.md`
- `docs/superpowers/plans/2026-04-13-portfolio-insights.md`
- `docs/superpowers/specs/2026-04-10-project-workbench-design.md`
- `docs/superpowers/specs/2026-04-14-google-oauth-auth-gate-design.md`
- `docs/walkthroughs/project-workbench.yaml`
- `docs/case-studies/workbench-self-improvement.md`
- `docs/personas/jonathan.md`
- `docs/e2e-login.md`

### Phase 2 — Checklist drift
n/a — CLAUDE.md has no checklist or rules section.

### Phase 2 — Size
145 → 158 lines (+13 net). Stayed under the 200-line target. The growth is entirely net-new content (4 endpoints + 8 reference doc links + auth model elaboration); no previously-correct content was rewritten. Section order preserved exactly.

### Phase 2 — Reference integrity
- 23 references checked, 1 broken (`./canopy/`) — removed from the regenerated doc rather than copied forward.
- All 8 newly-added reference docs verified to exist via `test -e` this session.
- No file-count claims in CLAUDE.md (so no transcribed-stale-counts to worry about).

### Opinionated assessment

If I were a fresh agent starting today on this repo, the four things that would have actively misled me from the old CLAUDE.md were:
1. **`./canopy/` submodule** — I'd waste time looking for it before realizing it isn't there.
2. **"No auth in V1"** — I'd push assuming no auth gate, then trip over `LoginRequiredMiddleware` redirecting all my requests.
3. **PR #3 deploy reference** — I'd look at PR #3 for current deploy infra and miss that we just migrated GCP projects.
4. **`/api/me/` and `/api/csrf/` not documented** — I'd reinvent these or assume they're not there.

Two coverage gaps that aren't strictly *wrong* but make the doc thinner than it should be:
- The dashboard's recent UX evolution (Top 3 hero, freshness, inline triage) is not summarized; an agent reading "tile grid dashboard" wouldn't know what's on the page.
- The OAuth + e2e-login + mint-session triple is the most under-documented production surface relative to its operational importance — I gave it a clear paragraph in Design Decisions.

### Recommended changes — applied
All findings above are reflected in the diff. No new learnings authored (no `docs/learnings/` exists in this repo and no patterns from PRs surfaced that warranted starting one).

## Test plan
- [ ] CI green
- [ ] Reviewer reads through CLAUDE.md and confirms each fact still matches the code
- [ ] No stale references reintroduced

🤖 Generated by `/canopy:doc-regen --apply` with [Claude Code](https://claude.com/claude-code)