### PR TITLE
feat(walkthroughs): streaming view, frontend pages, docs (Tasks 8-13)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,8 @@ CI (`.github/workflows/ci.yml`) runs both on every PR and on push to main. Deplo
 - `/leaderboard` — Eval improvement leaderboard
 - `/guide` — Interactive walkthrough using a "Discovery Call Debrief" sample collection (try-it / how-it-works / review / eval / deploy sections)
 - `/insights` — Cross-portfolio AI insights feed
+- `/walkthroughs` — Sharable demos uploaded from `/canopy:walkthrough`
+- `/w/:id` — Single walkthrough viewer (HTML iframe or video player)
 - `/settings` — AI backend status, switch backends, headless Claude CLI auth, debug-session minting
 - `/api/` — REST API
 - `/admin/` — Django admin
@@ -127,6 +129,21 @@ CI (`.github/workflows/ci.yml`) runs both on every PR and on push to main. Deplo
 
 ### Automated-tool login (`apps/common/views_auth_e2e`)
 - `POST /api/auth/e2e-login/` — token-gated login for automated tools (gstack walkthroughs, autonomous PM cycles, AI-driven QA). Body: `{email, token}`. Disabled by default — returns 404 unless `CANOPY_E2E_AUTH_TOKEN` is set. Email must be in `AUTH_ALLOWED_EMAIL_DOMAIN`. Sessions carry `_canopy_e2e_session` marker for audit. See `docs/e2e-login.md`.
+
+### Walkthroughs
+- `GET /api/walkthroughs/` — List. Filters: `?project=<slug>`, `?kind=html|video`, `?mine=true`
+- `POST /api/walkthroughs/` — Upload (multipart). Fields: `file`, `title`, `kind` (html|video), optional `description`, `project_slug`, `visibility` (private|link)
+- `GET /api/walkthroughs/<uuid>/` — Detail. Returns `share_token` only to owner; `is_owner` flag tells the UI which toolbar to render
+- `PATCH /api/walkthroughs/<uuid>/` — Owner-only update of title/description/project_slug/visibility. Switching to `visibility=link` auto-mints `share_token`
+- `DELETE /api/walkthroughs/<uuid>/` — Owner-only. Deletes Drive file and the row
+- `POST /api/walkthroughs/<uuid>/rotate-token/` — Owner-only. Mints a fresh `share_token`, invalidating the old one
+- `GET /w/<uuid>/content?t=<token>` — Streams file bytes. Session-auth OR valid token. Range-aware (supports `<video>` scrubbing)
+
+Settings:
+- `WALKTHROUGHS_ENABLED` (default `True`) — `/api/walkthroughs/` and `/w/<id>/content` 404 when off
+- `CANOPY_DRIVE_SA_KEY_JSON` — Google Drive service-account key (JSON string). Empty disables uploads/streams (500 with `code=drive-not-configured`)
+- `CANOPY_DRIVE_ROOT_FOLDER_ID` — Shared-drive folder ID. `walkthroughs/<uuid>/` subfolders are created under it
+- `WALKTHROUGH_MAX_UPLOAD_BYTES` (default 75 MB)
 
 ### Debug access (`apps/common/views_debug`)
 - `POST /api/debug/mint-session/` — authenticated user mints a short-lived Django session cookie (body: `{ttl_seconds: int}`, clamped to 60s–1w). Returns cookie + curl example. Used to hand access to an AI assistant without going through OAuth. UI lives at `/settings` → "Debug access".

--- a/TODOS.md
+++ b/TODOS.md
@@ -86,4 +86,21 @@
 **Priority:** P3
 **Depends on:** Cowork API documentation available
 
+### Walkthrough sharing — deferred (V2)
+
+**What:** Items deferred from the V1 walkthrough sharing slice (spec `docs/superpowers/specs/2026-05-26-walkthrough-sharing-design.md`):
+- View analytics (who viewed, when, where from)
+- Multi-link / per-audience tokens (promote `share_token` to its own table)
+- Comments / reactions on walkthroughs
+- Embed support (oEmbed-style)
+- Video poster frames, chapter markers, thumbnails
+- Signed Drive URLs for video (approach B in the spec) — only if Cloud Run egress becomes a measurable cost
+- Auto-upload mode from `/canopy:walkthrough`
+- Browser drag-drop upload UI at `/walkthroughs` (currently CLI-only)
+- Multi-tenant scoping of walkthrough list (today: any dimagi user sees all walkthroughs)
+
+**Effort:** Each item is S-M independently.
+**Priority:** P2 (analytics, video signed URLs) / P3 (rest)
+**Depends on:** V1 backend in production, real usage feedback
+
 ## Completed

--- a/apps/common/middleware.py
+++ b/apps/common/middleware.py
@@ -33,6 +33,13 @@ def _is_public(path: str) -> bool:
     return any(path == p or path.startswith(p) for p in PUBLIC_PATH_PREFIXES)
 
 
+def _is_walkthrough_content(path: str) -> bool:
+    # /w/<uuid>/content — the view itself enforces token-or-session auth.
+    # We let it through the middleware so the per-token public link can
+    # be served without a session cookie.
+    return path.startswith("/w/") and path.endswith("/content")
+
+
 def _is_token_writable_path(path: str) -> bool:
     if not path.startswith("/api/projects/"):
         return False
@@ -68,7 +75,11 @@ class LoginRequiredMiddleware:
         if not getattr(settings, "REQUIRE_AUTH", True):
             return self.get_response(request)
 
-        if request.user.is_authenticated or _is_public(request.path):
+        if (
+            request.user.is_authenticated
+            or _is_public(request.path)
+            or _is_walkthrough_content(request.path)
+        ):
             return self.get_response(request)
 
         # Bearer-token bypass for a narrow set of machine endpoints.

--- a/apps/projects/serializers.py
+++ b/apps/projects/serializers.py
@@ -12,6 +12,7 @@ class ProjectListSerializer(serializers.ModelSerializer):
     latest_context = serializers.SerializerMethodField()
     latest_actions = serializers.SerializerMethodField()
     insight_count = serializers.SerializerMethodField()
+    walkthrough_count = serializers.SerializerMethodField()
 
     class Meta:
         model = Project
@@ -19,6 +20,7 @@ class ProjectListSerializer(serializers.ModelSerializer):
             "id", "name", "slug", "repo_url", "deploy_url",
             "visibility", "status", "skills",
             "latest_context", "latest_actions", "insight_count",
+            "walkthrough_count",
             "created_at", "updated_at",
         ]
 
@@ -71,6 +73,10 @@ class ProjectListSerializer(serializers.ModelSerializer):
         else:
             contexts = obj.contexts.all()
         return sum(1 for ctx in contexts if ctx.context_type == "insight")
+
+    def get_walkthrough_count(self, obj):
+        from apps.walkthroughs.models import Walkthrough  # noqa: PLC0415
+        return Walkthrough.objects.filter(project_slug=obj.slug).count()
 
 
 class ProjectDetailSerializer(serializers.ModelSerializer):

--- a/apps/projects/views.py
+++ b/apps/projects/views.py
@@ -85,8 +85,11 @@ def project_detail(request, slug):
         )
 
     if request.method == "GET":
+        from apps.walkthroughs.models import Walkthrough  # noqa: PLC0415
         serializer = ProjectDetailSerializer(project)
-        return Response(success_response(serializer.data))
+        data = dict(serializer.data)
+        data["walkthrough_count"] = Walkthrough.objects.filter(project_slug=project.slug).count()
+        return Response(success_response(data))
 
     if request.method == "PATCH":
         serializer = ProjectCreateSerializer(project, data=request.data, partial=True)

--- a/apps/walkthroughs/views.py
+++ b/apps/walkthroughs/views.py
@@ -1,8 +1,10 @@
 """REST endpoints for walkthroughs."""
 from __future__ import annotations
 
+import re
+
 from django.conf import settings
-from django.http import Http404
+from django.http import Http404, HttpResponse, StreamingHttpResponse
 from rest_framework import status
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
@@ -222,3 +224,88 @@ def walkthrough_rotate_token(request, wid):
         )
     new_token = w.rotate_share_token()
     return Response(success_response({"share_token": new_token}))
+
+
+# ---- Content streaming ----
+
+_RANGE_RE = re.compile(r"bytes=(\d+)-(\d*)$")
+
+
+def _parse_range(header: str, total: int) -> tuple[int, int] | None:
+    """Parse a single-range HTTP Range header. Multi-range not supported."""
+    if not header:
+        return None
+    m = _RANGE_RE.match(header.strip())
+    if not m:
+        return None
+    start = int(m.group(1))
+    end_raw = m.group(2)
+    end = int(end_raw) if end_raw else total - 1
+    if start > end or start >= total:
+        return None
+    return start, min(end, total - 1)
+
+
+def walkthrough_content(request, wid):
+    """GET /w/<id>/content — stream the file bytes from Drive.
+
+    Auth: caller is the authenticated owner OR visibility=link with a
+    valid ?t=<share_token>. Mismatch returns 404 (don't leak existence
+    of private walkthroughs).
+    """
+    if not getattr(settings, "WALKTHROUGHS_ENABLED", True):
+        raise Http404("walkthroughs disabled")
+
+    w = _get_or_404(wid)
+    if w is None:
+        raise Http404("walkthrough not found")
+
+    token = request.GET.get("t", "")
+    is_authed = request.user.is_authenticated
+    token_ok = (
+        w.visibility == Walkthrough.VISIBILITY_LINK
+        and bool(w.share_token)
+        and token == w.share_token
+    )
+    if not (is_authed or token_ok):
+        raise Http404("walkthrough not found")
+
+    range_hdr = request.META.get("HTTP_RANGE", "")
+    try:
+        if range_hdr:
+            # We need the total to clamp the range — do a tiny head download.
+            _, _, _, total = storage.download(
+                file_id=w.drive_file_id, start=0, end=0,
+            )
+            parsed = _parse_range(range_hdr, total)
+            if parsed is None:
+                resp = HttpResponse(status=416)
+                resp["Content-Range"] = f"bytes */{total}"
+                return resp
+            start, end = parsed
+            data, s, e, t = storage.download(
+                file_id=w.drive_file_id, start=start, end=end,
+            )
+            resp = StreamingHttpResponse(
+                iter([data]),
+                status=206,
+                content_type=w.content_type,
+            )
+            resp["Content-Range"] = f"bytes {s}-{e}/{t}"
+            resp["Content-Length"] = str(len(data))
+            resp["Accept-Ranges"] = "bytes"
+            return resp
+
+        data, s, e, t = storage.download(file_id=w.drive_file_id)
+        resp = StreamingHttpResponse(
+            iter([data]),
+            status=200,
+            content_type=w.content_type,
+        )
+        resp["Content-Length"] = str(len(data))
+        resp["Accept-Ranges"] = "bytes"
+        return resp
+    except DriveNotConfigured:
+        return HttpResponse(status=500)
+    except Exception:
+        return HttpResponse(status=502)

--- a/config/urls.py
+++ b/config/urls.py
@@ -6,6 +6,7 @@ from django.urls import include, path, re_path
 
 from apps.common import views_auth_e2e
 from apps.projects import views_insights
+from apps.walkthroughs.views import walkthrough_content as views_walkthrough_content
 from config.views import csrf_view, health_check, me_view, spa_view
 
 urlpatterns = [
@@ -26,6 +27,7 @@ urlpatterns = [
     path("api/ai/", include("apps.common.urls")),
     path("api/debug/", include("apps.common.urls_debug")),
     path("api/walkthroughs/", include("apps.walkthroughs.urls")),
+    path("w/<uuid:wid>/content", views_walkthrough_content, name="walkthrough-content"),
     # Catch-all: serve the SPA for any non-API route (last).
     re_path(r"^(?!api/|admin/|accounts/|health/|static/).*$", spa_view, name="spa"),
 ]

--- a/frontend/src/api/projects.ts
+++ b/frontend/src/api/projects.ts
@@ -36,6 +36,7 @@ export interface Project {
   skills: Array<{ name: string; path?: string; description?: string }>
   latest_actions: Record<string, { status: string; started_at: string; completed_at: string | null }>
   insight_count: number
+  walkthrough_count?: number
   created_at: string
   updated_at: string
 }

--- a/frontend/src/api/walkthroughs.ts
+++ b/frontend/src/api/walkthroughs.ts
@@ -1,0 +1,120 @@
+const BASE = '/api'
+
+function getCsrfToken(): string {
+  const match = document.cookie.match(/(?:^|;\s*)csrftoken=([^;]+)/)
+  return match ? decodeURIComponent(match[1]) : ''
+}
+
+function redirectToLogin(): never {
+  const next = encodeURIComponent(window.location.pathname + window.location.search)
+  window.location.href = `/accounts/google/login/?next=${next}`
+  throw new Error('Redirecting to login')
+}
+
+async function request<T>(path: string, options?: RequestInit): Promise<T> {
+  const method = (options?.method || 'GET').toUpperCase()
+  const headers: Record<string, string> = {
+    ...(options?.headers as Record<string, string> | undefined),
+  }
+  // Don't force Content-Type for FormData — the browser sets it with boundary.
+  const isForm = options?.body instanceof FormData
+  if (!isForm && method !== 'GET' && method !== 'HEAD') {
+    headers['Content-Type'] = 'application/json'
+  }
+  if (method !== 'GET' && method !== 'HEAD' && method !== 'OPTIONS') {
+    const token = getCsrfToken()
+    if (token) headers['X-CSRFToken'] = token
+  }
+  const resp = await fetch(`${BASE}${path}`, {
+    credentials: 'same-origin',
+    ...options,
+    headers,
+  })
+  if (resp.status === 401) redirectToLogin()
+  if (resp.status === 204) return undefined as T
+  const data = await resp.json()
+  if (!data.success) throw new Error(data.error?.message || 'Request failed')
+  return data.data as T
+}
+
+export type WalkthroughKind = 'html' | 'video'
+export type WalkthroughVisibility = 'private' | 'link'
+
+export interface WalkthroughListItem {
+  id: string
+  title: string
+  description: string
+  kind: WalkthroughKind
+  project_slug: string | null
+  visibility: WalkthroughVisibility
+  owner_email: string
+  size_bytes: number
+  duration_sec: number | null
+  created_at: string
+  updated_at: string
+}
+
+export interface WalkthroughDetail extends WalkthroughListItem {
+  share_token: string | null
+  content_type: string
+  is_owner: boolean
+}
+
+export interface WalkthroughListFilters {
+  project?: string
+  kind?: WalkthroughKind
+  mine?: boolean
+}
+
+export async function listWalkthroughs(
+  filters: WalkthroughListFilters = {},
+): Promise<WalkthroughListItem[]> {
+  const params = new URLSearchParams()
+  if (filters.project) params.set('project', filters.project)
+  if (filters.kind) params.set('kind', filters.kind)
+  if (filters.mine) params.set('mine', 'true')
+  const qs = params.toString()
+  return request<WalkthroughListItem[]>(`/walkthroughs/${qs ? `?${qs}` : ''}`)
+}
+
+export async function getWalkthrough(id: string): Promise<WalkthroughDetail> {
+  return request<WalkthroughDetail>(`/walkthroughs/${id}/`)
+}
+
+export interface PatchWalkthroughInput {
+  title?: string
+  description?: string
+  project_slug?: string | null
+  visibility?: WalkthroughVisibility
+}
+
+export async function patchWalkthrough(
+  id: string,
+  patch: PatchWalkthroughInput,
+): Promise<WalkthroughDetail> {
+  return request<WalkthroughDetail>(`/walkthroughs/${id}/`, {
+    method: 'PATCH',
+    body: JSON.stringify(patch),
+  })
+}
+
+export async function deleteWalkthrough(id: string): Promise<void> {
+  await request<void>(`/walkthroughs/${id}/`, { method: 'DELETE' })
+}
+
+export async function rotateWalkthroughToken(
+  id: string,
+): Promise<{ share_token: string }> {
+  return request<{ share_token: string }>(
+    `/walkthroughs/${id}/rotate-token/`,
+    { method: 'POST' },
+  )
+}
+
+export function walkthroughContentUrl(
+  id: string,
+  shareToken: string | null,
+): string {
+  const t = shareToken ? `?t=${encodeURIComponent(shareToken)}` : ''
+  return `/w/${id}/content${t}`
+}

--- a/frontend/src/components/AppLayout/AppLayout.tsx
+++ b/frontend/src/components/AppLayout/AppLayout.tsx
@@ -8,6 +8,7 @@ const NAV_ITEMS = [
   { path: '/', label: 'Projects' },
   { path: '/insights', label: 'Insights' },
   { path: '/skills', label: 'Skills' },
+  { path: '/walkthroughs', label: 'Walkthroughs' },
   { path: '/workspaces', label: 'Workspaces' },
   { path: '/leaderboard', label: 'Leaderboard' },
   { path: '/guide', label: 'Guide' },

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -434,6 +434,19 @@ function ExpandedCard({ project, onClose, scrollIntoViewOnMount, insights, onDis
             </div>
           )}
 
+          {/* Walkthroughs link */}
+          {project.walkthrough_count && project.walkthrough_count > 0 ? (
+            <div className="mb-3">
+              <Link
+                to={`/walkthroughs?project=${project.slug}`}
+                onClick={(e) => e.stopPropagation()}
+                className="text-[11px] text-stone-300 hover:text-stone-100"
+              >
+                Walkthroughs · {project.walkthrough_count}
+              </Link>
+            </div>
+          ) : null}
+
           {/* Skills (collapsible) */}
           <div>
             <button

--- a/frontend/src/pages/WalkthroughViewerPage.tsx
+++ b/frontend/src/pages/WalkthroughViewerPage.tsx
@@ -1,0 +1,169 @@
+import { useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import {
+  deleteWalkthrough,
+  getWalkthrough,
+  patchWalkthrough,
+  rotateWalkthroughToken,
+  walkthroughContentUrl,
+  type WalkthroughDetail,
+} from '../api/walkthroughs'
+
+export function WalkthroughViewerPage() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const [w, setW] = useState<WalkthroughDetail | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  useEffect(() => {
+    if (!id) return
+    let cancelled = false
+    getWalkthrough(id)
+      .then((d) => !cancelled && setW(d))
+      .catch((e) => !cancelled && setError(String(e.message || e)))
+    return () => {
+      cancelled = true
+    }
+  }, [id])
+
+  async function toggleVisibility() {
+    if (!w) return
+    setBusy(true)
+    try {
+      const next = w.visibility === 'link' ? 'private' : 'link'
+      const updated = await patchWalkthrough(w.id, { visibility: next })
+      setW(updated)
+    } catch (e: any) {
+      setError(String(e?.message || e))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function copyShareLink() {
+    if (!w) return
+    let token = w.share_token
+    if (!token || w.visibility !== 'link') {
+      const updated = await patchWalkthrough(w.id, { visibility: 'link' })
+      setW(updated)
+      token = updated.share_token
+    }
+    const url = `${window.location.origin}/w/${w.id}?t=${encodeURIComponent(token!)}`
+    await navigator.clipboard.writeText(url)
+  }
+
+  async function rotate() {
+    if (!w) return
+    setBusy(true)
+    try {
+      const { share_token } = await rotateWalkthroughToken(w.id)
+      setW({ ...w, share_token })
+      const url = `${window.location.origin}/w/${w.id}?t=${encodeURIComponent(share_token)}`
+      await navigator.clipboard.writeText(url)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function destroy() {
+    if (!w) return
+    if (!confirm(`Delete "${w.title}"? This cannot be undone.`)) return
+    setBusy(true)
+    try {
+      await deleteWalkthrough(w.id)
+      navigate('/walkthroughs')
+    } catch (e: any) {
+      setError(String(e?.message || e))
+      setBusy(false)
+    }
+  }
+
+  if (error) {
+    return (
+      <div className="max-w-4xl mx-auto p-6 text-red-600">Error: {error}</div>
+    )
+  }
+  if (!w) {
+    return <div className="max-w-4xl mx-auto p-6 text-slate-500">Loading…</div>
+  }
+
+  const params = new URLSearchParams(window.location.search)
+  const viewerToken = params.get('t') ?? w.share_token ?? null
+  const contentSrc = walkthroughContentUrl(w.id, viewerToken)
+
+  return (
+    <div className="max-w-5xl mx-auto p-6">
+      <header className="mb-4 flex items-baseline justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold">{w.title}</h1>
+          <p className="text-sm text-slate-500">
+            {w.kind === 'video' ? 'Video' : 'HTML slideshow'} · {w.owner_email}
+            {w.project_slug ? ` · ${w.project_slug}` : ''}
+          </p>
+        </div>
+        <span
+          className={`px-2 py-0.5 text-xs rounded ${
+            w.visibility === 'link'
+              ? 'bg-emerald-100 text-emerald-800'
+              : 'bg-slate-100 text-slate-700'
+          }`}
+        >
+          {w.visibility === 'link' ? 'Shareable link' : 'Private (dimagi)'}
+        </span>
+      </header>
+
+      {w.is_owner && (
+        <div className="mb-4 flex flex-wrap gap-2 text-sm">
+          <button
+            className="px-3 py-1 rounded border hover:bg-slate-50"
+            onClick={toggleVisibility}
+            disabled={busy}
+          >
+            {w.visibility === 'link' ? 'Make private' : 'Enable link'}
+          </button>
+          <button
+            className="px-3 py-1 rounded border hover:bg-slate-50"
+            onClick={copyShareLink}
+            disabled={busy}
+          >
+            Copy share link
+          </button>
+          {w.visibility === 'link' && (
+            <button
+              className="px-3 py-1 rounded border hover:bg-slate-50"
+              onClick={rotate}
+              disabled={busy}
+            >
+              Rotate token
+            </button>
+          )}
+          <button
+            className="px-3 py-1 rounded border border-red-300 text-red-700 hover:bg-red-50 ml-auto"
+            onClick={destroy}
+            disabled={busy}
+          >
+            Delete
+          </button>
+        </div>
+      )}
+
+      <div className="rounded border bg-white overflow-hidden">
+        {w.kind === 'video' ? (
+          <video
+            src={contentSrc}
+            controls
+            className="w-full max-h-[80vh] bg-black"
+          />
+        ) : (
+          <iframe
+            src={contentSrc}
+            title={w.title}
+            sandbox="allow-scripts allow-same-origin"
+            className="w-full h-[80vh]"
+          />
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/WalkthroughsPage.tsx
+++ b/frontend/src/pages/WalkthroughsPage.tsx
@@ -1,0 +1,166 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Link, useSearchParams } from 'react-router-dom'
+import {
+  listWalkthroughs,
+  type WalkthroughListItem,
+  type WalkthroughKind,
+} from '../api/walkthroughs'
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`
+}
+
+function VisibilityChip({ v }: { v: 'private' | 'link' }) {
+  const cls =
+    v === 'link'
+      ? 'bg-emerald-100 text-emerald-800'
+      : 'bg-slate-100 text-slate-700'
+  return (
+    <span className={`px-2 py-0.5 text-xs rounded ${cls}`}>
+      {v === 'link' ? 'Link' : 'Private'}
+    </span>
+  )
+}
+
+export function WalkthroughsPage() {
+  const [params, setParams] = useSearchParams()
+  const project = params.get('project') ?? ''
+  const kind = (params.get('kind') as WalkthroughKind | null) ?? null
+  const mine = params.get('mine') === 'true'
+
+  const [items, setItems] = useState<WalkthroughListItem[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setItems(null)
+    setError(null)
+    listWalkthroughs({
+      project: project || undefined,
+      kind: kind ?? undefined,
+      mine: mine || undefined,
+    })
+      .then((data) => {
+        if (!cancelled) setItems(data)
+      })
+      .catch((e) => {
+        if (!cancelled) setError(String(e.message || e))
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [project, kind, mine])
+
+  const distinctProjects = useMemo(() => {
+    if (!items) return []
+    const s = new Set<string>()
+    for (const w of items) if (w.project_slug) s.add(w.project_slug)
+    return [...s].sort()
+  }, [items])
+
+  function update(key: string, value: string | null) {
+    const next = new URLSearchParams(params)
+    if (value == null || value === '') next.delete(key)
+    else next.set(key, value)
+    setParams(next, { replace: true })
+  }
+
+  return (
+    <div className="max-w-6xl mx-auto p-6">
+      <header className="flex items-baseline justify-between mb-6">
+        <h1 className="text-2xl font-semibold">Walkthroughs</h1>
+        <p className="text-sm text-slate-500">
+          Sharable demos uploaded from <code>/canopy:walkthrough</code>
+        </p>
+      </header>
+
+      <div className="flex gap-3 mb-4 text-sm">
+        <select
+          className="border rounded px-2 py-1"
+          value={project}
+          onChange={(e) => update('project', e.target.value)}
+        >
+          <option value="">All projects</option>
+          {distinctProjects.map((p) => (
+            <option key={p} value={p}>
+              {p}
+            </option>
+          ))}
+        </select>
+        <select
+          className="border rounded px-2 py-1"
+          value={kind ?? ''}
+          onChange={(e) => update('kind', e.target.value || null)}
+        >
+          <option value="">All kinds</option>
+          <option value="html">HTML</option>
+          <option value="video">Video</option>
+        </select>
+        <label className="flex items-center gap-1">
+          <input
+            type="checkbox"
+            checked={mine}
+            onChange={(e) => update('mine', e.target.checked ? 'true' : null)}
+          />
+          Mine only
+        </label>
+      </div>
+
+      {error && (
+        <div className="text-red-600 text-sm mb-3">Failed: {error}</div>
+      )}
+      {items === null && !error && (
+        <div className="text-slate-500 text-sm">Loading…</div>
+      )}
+      {items && items.length === 0 && (
+        <div className="text-slate-500 text-sm">No walkthroughs match.</div>
+      )}
+      {items && items.length > 0 && (
+        <table className="w-full text-sm">
+          <thead className="text-left text-xs text-slate-500 border-b">
+            <tr>
+              <th className="py-2 pr-3">Title</th>
+              <th className="py-2 pr-3">Project</th>
+              <th className="py-2 pr-3">Kind</th>
+              <th className="py-2 pr-3">Owner</th>
+              <th className="py-2 pr-3">Visibility</th>
+              <th className="py-2 pr-3">Size</th>
+              <th className="py-2 pr-3">Created</th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.map((w) => (
+              <tr key={w.id} className="border-b hover:bg-slate-50">
+                <td className="py-2 pr-3">
+                  <Link to={`/w/${w.id}`} className="text-blue-700 hover:underline">
+                    {w.title}
+                  </Link>
+                </td>
+                <td className="py-2 pr-3">
+                  {w.project_slug ? (
+                    <Link to={`/?project=${w.project_slug}`} className="text-slate-700 hover:underline">
+                      {w.project_slug}
+                    </Link>
+                  ) : (
+                    <span className="text-slate-400">—</span>
+                  )}
+                </td>
+                <td className="py-2 pr-3 capitalize">{w.kind}</td>
+                <td className="py-2 pr-3">{w.owner_email}</td>
+                <td className="py-2 pr-3">
+                  <VisibilityChip v={w.visibility} />
+                </td>
+                <td className="py-2 pr-3">{formatBytes(w.size_bytes)}</td>
+                <td className="py-2 pr-3 text-slate-500">
+                  {new Date(w.created_at).toLocaleDateString()}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -10,6 +10,7 @@ import { SkillDetailPage } from './pages/SkillDetailPage'
 import { LeaderboardPage } from './pages/LeaderboardPage'
 import { SettingsPage } from './pages/SettingsPage'
 import { GuidePage } from './pages/GuidePage'
+import { WalkthroughsPage } from './pages/WalkthroughsPage'
 
 export const router = createBrowserRouter([
   {
@@ -18,6 +19,7 @@ export const router = createBrowserRouter([
       { path: '/', element: <ProjectsPage /> },
       { path: '/insights', element: <InsightsPage /> },
       { path: '/skills', element: <DiscoveryPage /> },
+      { path: '/walkthroughs', element: <WalkthroughsPage /> },
       { path: '/new', element: <NewCollectionPage /> },
       { path: '/workspaces', element: <WorkspacesPage /> },
       { path: '/workspace/:sessionId', element: <WorkspacePage /> },

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -11,6 +11,7 @@ import { LeaderboardPage } from './pages/LeaderboardPage'
 import { SettingsPage } from './pages/SettingsPage'
 import { GuidePage } from './pages/GuidePage'
 import { WalkthroughsPage } from './pages/WalkthroughsPage'
+import { WalkthroughViewerPage } from './pages/WalkthroughViewerPage'
 
 export const router = createBrowserRouter([
   {
@@ -20,6 +21,7 @@ export const router = createBrowserRouter([
       { path: '/insights', element: <InsightsPage /> },
       { path: '/skills', element: <DiscoveryPage /> },
       { path: '/walkthroughs', element: <WalkthroughsPage /> },
+      { path: '/w/:id', element: <WalkthroughViewerPage /> },
       { path: '/new', element: <NewCollectionPage /> },
       { path: '/workspaces', element: <WorkspacesPage /> },
       { path: '/workspace/:sessionId', element: <WorkspacePage /> },

--- a/tests/test_walkthroughs_views.py
+++ b/tests/test_walkthroughs_views.py
@@ -363,3 +363,30 @@ def test_content_range_request_serves_partial(client, db, owner, fake_drive):
     assert b"".join(resp.streaming_content) == b"2345"
     assert resp["Content-Range"] == "bytes 2-5/10"
     assert resp["Accept-Ranges"] == "bytes"
+
+
+# ---- Project tile integration ----
+
+@override_settings(WALKTHROUGHS_ENABLED=True)
+def test_project_detail_includes_walkthrough_count(auth_client, db, owner):
+    from apps.projects.models import Project
+    p = Project.objects.create(name="Canopy", slug="canopy-web")
+    Walkthrough.objects.create(
+        title="a", kind="html", owner=owner, project_slug="canopy-web",
+        drive_file_id="f", drive_folder_id="d",
+        content_type="text/html", size_bytes=1,
+    )
+    Walkthrough.objects.create(
+        title="b", kind="html", owner=owner, project_slug="canopy-web",
+        drive_file_id="f2", drive_folder_id="d2",
+        content_type="text/html", size_bytes=1,
+    )
+    Walkthrough.objects.create(
+        title="other", kind="html", owner=owner, project_slug="ace-web",
+        drive_file_id="f3", drive_folder_id="d3",
+        content_type="text/html", size_bytes=1,
+    )
+    resp = auth_client.get(f"/api/projects/{p.slug}/")
+    assert resp.status_code == 200
+    body = resp.json()["data"]
+    assert body["walkthrough_count"] == 2

--- a/tests/test_walkthroughs_views.py
+++ b/tests/test_walkthroughs_views.py
@@ -270,3 +270,96 @@ def test_rotate_token(auth_client, db, owner):
     assert resp.status_code == 200
     new_token = resp.json()["data"]["share_token"]
     assert new_token and new_token != old
+
+
+# ---- Content streaming ----
+
+@override_settings(
+    WALKTHROUGHS_ENABLED=True,
+    CANOPY_DRIVE_SA_KEY_JSON='{"x":"y"}',
+    CANOPY_DRIVE_ROOT_FOLDER_ID="root",
+)
+def test_content_private_requires_session(client, db, owner, fake_drive):
+    stored = storage.store_upload(
+        walkthrough_id="abc", filename="slideshow.html",
+        content_type="text/html", data=b"<html>x</html>",
+    )
+    w = Walkthrough.objects.create(
+        title="t", kind="html", owner=owner,
+        drive_file_id=stored.file_id, drive_folder_id=stored.folder_id,
+        content_type="text/html", size_bytes=12,
+    )
+    # Anonymous → middleware redirects or 401
+    resp = client.get(f"/w/{w.id}/content")
+    assert resp.status_code in (302, 401, 404)
+
+
+@override_settings(
+    WALKTHROUGHS_ENABLED=True,
+    CANOPY_DRIVE_SA_KEY_JSON='{"x":"y"}',
+    CANOPY_DRIVE_ROOT_FOLDER_ID="root",
+)
+def test_content_link_visibility_serves_with_token(client, db, owner, fake_drive):
+    stored = storage.store_upload(
+        walkthrough_id="abc", filename="slideshow.html",
+        content_type="text/html", data=b"<html>linked</html>",
+    )
+    w = Walkthrough.objects.create(
+        title="t", kind="html", owner=owner,
+        drive_file_id=stored.file_id, drive_folder_id=stored.folder_id,
+        content_type="text/html", size_bytes=17,
+        visibility="link",
+    )
+    w.ensure_share_token()
+    resp = client.get(f"/w/{w.id}/content?t={w.share_token}")
+    assert resp.status_code == 200
+    assert b"".join(resp.streaming_content) == b"<html>linked</html>"
+    assert resp["Content-Type"].startswith("text/html")
+
+
+@override_settings(
+    WALKTHROUGHS_ENABLED=True,
+    CANOPY_DRIVE_SA_KEY_JSON='{"x":"y"}',
+    CANOPY_DRIVE_ROOT_FOLDER_ID="root",
+)
+def test_content_wrong_token_returns_404_not_403(client, db, owner, fake_drive):
+    stored = storage.store_upload(
+        walkthrough_id="abc", filename="slideshow.html",
+        content_type="text/html", data=b"x",
+    )
+    w = Walkthrough.objects.create(
+        title="t", kind="html", owner=owner,
+        drive_file_id=stored.file_id, drive_folder_id=stored.folder_id,
+        content_type="text/html", size_bytes=1,
+        visibility="link",
+    )
+    w.ensure_share_token()
+    resp = client.get(f"/w/{w.id}/content?t=wrongtoken")
+    assert resp.status_code == 404
+
+
+@override_settings(
+    WALKTHROUGHS_ENABLED=True,
+    CANOPY_DRIVE_SA_KEY_JSON='{"x":"y"}',
+    CANOPY_DRIVE_ROOT_FOLDER_ID="root",
+)
+def test_content_range_request_serves_partial(client, db, owner, fake_drive):
+    stored = storage.store_upload(
+        walkthrough_id="abc", filename="video.mp4",
+        content_type="video/mp4", data=b"0123456789",
+    )
+    w = Walkthrough.objects.create(
+        title="t", kind="video", owner=owner,
+        drive_file_id=stored.file_id, drive_folder_id=stored.folder_id,
+        content_type="video/mp4", size_bytes=10,
+        visibility="link",
+    )
+    w.ensure_share_token()
+    resp = client.get(
+        f"/w/{w.id}/content?t={w.share_token}",
+        HTTP_RANGE="bytes=2-5",
+    )
+    assert resp.status_code == 206
+    assert b"".join(resp.streaming_content) == b"2345"
+    assert resp["Content-Range"] == "bytes 2-5/10"
+    assert resp["Accept-Ranges"] == "bytes"


### PR DESCRIPTION
## Summary

Completes the walkthrough sharing feature on top of #40 (Tasks 1-7). Adds the streaming view + middleware allowlist, the entire frontend, and project-tile integration + docs. After this merges the feature is end-to-end usable (browser + CLI) — only deployment prereqs (Drive folder + SA key + Cloud Run env) remain.

## What ships

- **Task 8** — `GET /w/<uuid>/content` streaming view (Django proxy), HTTP Range support for video scrubbing, 416 on bad ranges, 404 on token mismatch (don't leak existence). Middleware allowlist for `/w/.../content` so anonymous viewers can hit a public-link URL without the OAuth gate; the view itself enforces session OR valid `?t=<token>`.
- **Task 9** — `walkthrough_count` on `GET /api/projects/<slug>/` (detail).
- **Task 10** — `frontend/src/api/walkthroughs.ts` API client + TS types (list/get/patch/delete/rotate + `walkthroughContentUrl()` helper).
- **Task 11** — \`/walkthroughs\` list page (\`WalkthroughsPage.tsx\`) with URL-param filters (project / kind / mine-only) + nav-link entry + router wiring.
- **Task 12** — \`/w/:id\` viewer (\`WalkthroughViewerPage.tsx\`) with owner toolbar (toggle visibility, copy share link, rotate token, delete) and \`<iframe sandbox>\` / \`<video controls>\` body.
- **Task 13** — Walkthrough count link on the expanded project tile (and on \`ProjectListSerializer\` so the list endpoint returns it too), CLAUDE.md endpoint + URL + env-var docs, \`TODOS.md\` deferred-V2 entries.

## Verification

- \`uv run pytest -q\` → **241 passed** (full backend suite)
- \`cd frontend && npm run build\` → clean (chunk-size warning is pre-existing)
- \`uv run python manage.py check\` → 0 issues
- Lint findings on new code (N818 \`DriveNotConfigured\`, E501 in generated migration, I001 in migration import order) are present in sibling apps too — matched the inherited convention rather than introducing a stricter one for new code only.

## How to enable in production

Pre-merge: nothing — the feature is opt-in via env vars and 500s safely if Drive isn't configured.

Post-merge (deployment prereqs, not in any PR):
1. Create a Shared Drive folder ("canopy-web walkthroughs"), invite the SA email as Content Manager.
2. Generate (or reuse) a Google service-account JSON, store in 1Password.
3. Cloud Run env vars: \`CANOPY_DRIVE_SA_KEY_JSON\`, \`CANOPY_DRIVE_ROOT_FOLDER_ID\` (optional: \`WALKTHROUGH_MAX_UPLOAD_BYTES\`).
4. Manual deploy via Actions tab → CI / Deploy → Run workflow.

## Out of repo (canopy plugin work, deferred)

The CLI upload skill lives in the canopy plugin repo (\`~/.claude/plugins/marketplaces/canopy/\`):
- New \`/canopy:walkthrough-share <path>\` skill — auto-detects html/mp4, inlines screenshot \`<img>\` refs as base64 data URIs for HTML, POSTs multipart to \`/api/walkthroughs/\`. Auth via existing \`/api/auth/e2e-login/\` (no new secret).
- Edit existing \`/canopy:walkthrough\` to add an opt-in upload prompt after a run.
- Extend \`/canopy:setup\` to write \`canopy_web_url\` to \`~/.canopy/config\`.

## Test plan

- [x] Backend test suite green
- [x] Frontend build green
- [x] manage.py check clean
- [ ] CI green on push (will check)
- [ ] Manual smoke after Drive prereqs are provisioned

## Related

- Spec: \`docs/superpowers/specs/2026-05-26-walkthrough-sharing-design.md\` (merged in #40)
- Plan: \`docs/superpowers/plans/2026-05-26-walkthrough-sharing.md\` (merged in #40)
- Prior PR: #40 — backend foundation (Tasks 1-7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)