### PR TITLE
feat(auth): multi-domain AUTH_ALLOWED_EMAIL_DOMAIN (allow @dimagi-ai.com bots alongside @dimagi.com humans)

### DIFF
--- a/apps/common/auth_adapter.py
+++ b/apps/common/auth_adapter.py
@@ -1,22 +1,22 @@
 """Social account adapter enforcing an email-domain allowlist."""
 from allauth.core.exceptions import ImmediateHttpResponse
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
-from django.conf import settings
 from django.shortcuts import render
+
+from .auth_domains import allowed_email_domains, email_in_allowlist
 
 
 class CustomSocialAccountAdapter(DefaultSocialAccountAdapter):
     def pre_social_login(self, request, sociallogin):
-        allowed_domain = (getattr(settings, "AUTH_ALLOWED_EMAIL_DOMAIN", "") or "").lower()
-        if not allowed_domain:
+        email = (sociallogin.account.extra_data.get("email") or "").lower()
+        if email_in_allowlist(email):
             return
 
-        email = (sociallogin.account.extra_data.get("email") or "").lower()
-        if not email.endswith(f"@{allowed_domain}"):
-            response = render(
-                request,
-                "auth/domain_rejected.html",
-                {"email": email, "allowed_domain": allowed_domain},
-                status=403,
-            )
-            raise ImmediateHttpResponse(response)
+        allowed = ", ".join(allowed_email_domains())
+        response = render(
+            request,
+            "auth/domain_rejected.html",
+            {"email": email, "allowed_domain": allowed},
+            status=403,
+        )
+        raise ImmediateHttpResponse(response)

--- a/apps/common/auth_domains.py
+++ b/apps/common/auth_domains.py
@@ -1,0 +1,30 @@
+"""Allowed-email-domain helpers.
+
+`AUTH_ALLOWED_EMAIL_DOMAIN` is a comma-separated list of allowed domains.
+Single-value usage continues to work (no commas → list of 1). Empty value
+disables the check (allow any domain).
+"""
+from __future__ import annotations
+
+from django.conf import settings
+
+
+def allowed_email_domains() -> list[str]:
+    """Return the parsed list of allowed email domains, lowercased."""
+    raw = (getattr(settings, "AUTH_ALLOWED_EMAIL_DOMAIN", "") or "").strip().lower()
+    if not raw:
+        return []
+    return [d.strip() for d in raw.split(",") if d.strip()]
+
+
+def email_in_allowlist(email: str) -> bool:
+    """True if `email`'s domain matches one of the allowed entries.
+
+    An empty allowlist short-circuits to True (matches the prior behavior
+    when AUTH_ALLOWED_EMAIL_DOMAIN was unset or empty).
+    """
+    allowed = allowed_email_domains()
+    if not allowed:
+        return True
+    _, _, domain = email.rpartition("@")
+    return domain.lower() in allowed

--- a/apps/common/tests/test_auth_domains.py
+++ b/apps/common/tests/test_auth_domains.py
@@ -1,0 +1,49 @@
+"""Tests for the multi-domain email allowlist helper."""
+from __future__ import annotations
+
+import pytest
+
+from apps.common.auth_domains import allowed_email_domains, email_in_allowlist
+
+
+def test_single_domain(settings):
+    settings.AUTH_ALLOWED_EMAIL_DOMAIN = "dimagi.com"
+    assert allowed_email_domains() == ["dimagi.com"]
+    assert email_in_allowlist("ace@dimagi.com")
+    assert not email_in_allowlist("ace@dimagi-ai.com")
+
+
+def test_multi_domain_comma_separated(settings):
+    settings.AUTH_ALLOWED_EMAIL_DOMAIN = "dimagi.com,dimagi-ai.com"
+    assert allowed_email_domains() == ["dimagi.com", "dimagi-ai.com"]
+    assert email_in_allowlist("ace@dimagi.com")
+    assert email_in_allowlist("ace@dimagi-ai.com")
+    assert not email_in_allowlist("outsider@example.com")
+
+
+def test_whitespace_tolerance(settings):
+    settings.AUTH_ALLOWED_EMAIL_DOMAIN = " dimagi.com , dimagi-ai.com "
+    assert allowed_email_domains() == ["dimagi.com", "dimagi-ai.com"]
+    assert email_in_allowlist("ace@dimagi-ai.com")
+
+
+def test_case_insensitive(settings):
+    settings.AUTH_ALLOWED_EMAIL_DOMAIN = "Dimagi.com"
+    assert email_in_allowlist("ACE@DIMAGI.COM")
+
+
+def test_empty_allowlist_admits_anything(settings):
+    settings.AUTH_ALLOWED_EMAIL_DOMAIN = ""
+    assert allowed_email_domains() == []
+    assert email_in_allowlist("anyone@anywhere.com")
+
+
+def test_unset_allowlist_admits_anything(settings):
+    delattr(settings, "AUTH_ALLOWED_EMAIL_DOMAIN")
+    assert allowed_email_domains() == []
+    assert email_in_allowlist("anyone@anywhere.com")
+
+
+def test_drops_empty_segments(settings):
+    settings.AUTH_ALLOWED_EMAIL_DOMAIN = "dimagi.com,,dimagi-ai.com,"
+    assert allowed_email_domains() == ["dimagi.com", "dimagi-ai.com"]

--- a/apps/common/views_auth_e2e.py
+++ b/apps/common/views_auth_e2e.py
@@ -32,11 +32,8 @@ E2E_SESSION_MARKER = "_canopy_e2e_session"
 
 
 def _is_allowed_domain(email: str) -> bool:
-    allowed = (getattr(settings, "AUTH_ALLOWED_EMAIL_DOMAIN", "") or "").lower()
-    if not allowed:
-        return True
-    _, _, domain = email.rpartition("@")
-    return domain.lower() == allowed
+    from .auth_domains import email_in_allowlist
+    return email_in_allowlist(email)
 
 
 @csrf_exempt
@@ -68,9 +65,11 @@ def e2e_login(request: HttpRequest) -> HttpResponse:
         return JsonResponse({"error": "email is required"}, status=400)
 
     if not _is_allowed_domain(email):
-        allowed = getattr(settings, "AUTH_ALLOWED_EMAIL_DOMAIN", "")
+        from .auth_domains import allowed_email_domains
+
+        allowed = ", ".join(f"@{d}" for d in allowed_email_domains())
         return JsonResponse(
-            {"error": f"email must be from: @{allowed}"},
+            {"error": f"email must be from: {allowed}"},
             status=400,
         )
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -46,7 +46,7 @@ gcloud run deploy "${SERVICE_NAME}" \
   --add-cloudsql-instances="${SQL_INSTANCE}" \
   --set-env-vars="DJANGO_SETTINGS_MODULE=config.settings.production" \
   --set-env-vars="AI_BACKEND=api" \
-  --set-env-vars="AUTH_ALLOWED_EMAIL_DOMAIN=dimagi.com" \
+  --set-env-vars="^|^AUTH_ALLOWED_EMAIL_DOMAIN=dimagi.com,dimagi-ai.com" \
   --set-env-vars="REQUIRE_AUTH=${REQUIRE_AUTH_FLAG}" \
   --set-secrets="SECRET_KEY=django-secret-key:latest,ANTHROPIC_API_KEY=anthropic-api-key:latest,DATABASE_URL=canopy-db-url:latest,GOOGLE_OAUTH_CLIENT_ID=google-oauth-client-id:latest,GOOGLE_OAUTH_CLIENT_SECRET=google-oauth-client-secret:latest,WORKBENCH_WRITE_TOKEN=workbench-write-token:latest,CANOPY_E2E_AUTH_TOKEN=canopy-e2e-auth-token:latest" \
   --allow-unauthenticated \


### PR DESCRIPTION
## Summary

Lets \`AUTH_ALLOWED_EMAIL_DOMAIN\` be a comma-separated list of allowed domains instead of exactly one. Production env value becomes \`dimagi.com,dimagi-ai.com\` so the \`ace@dimagi-ai.com\` bot identity can:

- Sign in via Google OAuth (CustomSocialAccountAdapter)
- Authenticate via \`/api/auth/e2e-login/\` (currently the e2e flow used by automation tools)

Single-value usage continues to work without any change (no commas → list of 1).

## Why

Right now \`AUTH_ALLOWED_EMAIL_DOMAIN=dimagi.com\` rejects \`ace@dimagi-ai.com\` at both gates. Headless testing / autonomous agents can't reach the OAuth-gated UI; the e2e-login endpoint also refuses with \`{"error": "email must be from: @dimagi.com"}\`. Unblocking this is the prerequisite for browser-driven smoke tests against the deployed canopy-web (Playwright with cookie injection or OAuth dance).

## Changes

- **New helper \`apps/common/auth_domains.py\`** — \`allowed_email_domains()\` + \`email_in_allowlist(email)\`. Single source of truth for parsing + matching.
- **\`apps/common/auth_adapter.py\`** — \`CustomSocialAccountAdapter.pre_social_login\` delegates to the helper. The 403 template now receives a comma-joined string in \`allowed_domain\`.
- **\`apps/common/views_auth_e2e.py\`** — \`_is_allowed_domain\` is now a thin wrapper; the 400 error body lists every allowed domain.
- **\`deploy.sh\`** — \`gcloud run deploy\` uses the \`^|^\` delimiter syntax (\`--set-env-vars="^|^AUTH_ALLOWED_EMAIL_DOMAIN=dimagi.com,dimagi-ai.com"\`) so the comma in the *value* isn't parsed as a \`KEY=VALUE\` separator.

## Tests

\`apps/common/tests/test_auth_domains.py\` — **7 tests, all pass**:

- \`test_single_domain\` — legacy behavior preserved
- \`test_multi_domain_comma_separated\` — both \`@dimagi.com\` and \`@dimagi-ai.com\` admitted
- \`test_whitespace_tolerance\` — \`" dimagi.com , dimagi-ai.com "\` parses correctly
- \`test_case_insensitive\` — \`Dimagi.com\` matches \`ACE@DIMAGI.COM\`
- \`test_empty_allowlist_admits_anything\`
- \`test_unset_allowlist_admits_anything\`
- \`test_drops_empty_segments\` — \`"a,,b,"\` → \`["a", "b"]\`

Full backend regression: **260 passed, 1 skipped** (schemathesis baseline; live in CI).

## Follow-up (separate PR)

\`/api/auth/e2e-login/\` is still a shared-secret token-gated flow. Replacing it with a first-class Personal Access Token system (modeled on ace-web's \`apps/service_accounts/\`) is tracked separately — see the next PR.

## Test plan

- [ ] CI green (backend tests, frontend build, contract tests)
- [ ] After merge + deploy, verify \`POST /api/auth/e2e-login/\` with \`ace@dimagi-ai.com\` returns 200 (was 400)
- [ ] Verify a real \`@dimagi.com\` user can still OAuth-login (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)