### PR TITLE
fix(ci): grant regen-openapi contents:write + check in PAT types

### DIFF
--- a/.github/workflows/regen-openapi.yml
+++ b/.github/workflows/regen-openapi.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   regen:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # push the regenerated generated.ts back to the PR branch
     steps:
       - uses: actions/checkout@v4
         with:

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -783,6 +783,41 @@ export interface paths {
         readonly patch?: never;
         readonly trace?: never;
     };
+    readonly "/api/tokens/": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        /** List my tokens */
+        readonly get: operations["apps_tokens_api_list_tokens"];
+        readonly put?: never;
+        /** Mint a token */
+        readonly post: operations["apps_tokens_api_create_token"];
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
+    readonly "/api/tokens/{pk}/": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly get?: never;
+        readonly put?: never;
+        readonly post?: never;
+        /** Revoke a token (mine only) */
+        readonly delete: operations["apps_tokens_api_revoke_token"];
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -1783,6 +1818,51 @@ export interface components {
         readonly WalkthroughRotateTokenOut: {
             /** Share Token */
             readonly share_token: string;
+        };
+        /**
+         * PersonalTokenOut
+         * @description A token as listed to its owner. Never contains the raw value.
+         */
+        readonly PersonalTokenOut: {
+            /** Id */
+            readonly id: number;
+            /** Label */
+            readonly label: string;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            readonly created_at: string;
+            /** Last Used At */
+            readonly last_used_at?: string | null;
+            /** Revoked At */
+            readonly revoked_at?: string | null;
+        };
+        /**
+         * PersonalTokenCreatedOut
+         * @description Returned exactly once at creation — includes the raw token.
+         */
+        readonly PersonalTokenCreatedOut: {
+            /** Id */
+            readonly id: number;
+            /** Label */
+            readonly label: string;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            readonly created_at: string;
+            /** Last Used At */
+            readonly last_used_at?: string | null;
+            /** Revoked At */
+            readonly revoked_at?: string | null;
+            /** Raw */
+            readonly raw: string;
+        };
+        /** PersonalTokenCreateIn */
+        readonly PersonalTokenCreateIn: {
+            /** Label */
+            readonly label: string;
         };
     };
     responses: never;
@@ -2993,6 +3073,70 @@ export interface operations {
                 content: {
                     readonly "application/json": components["schemas"]["WalkthroughRotateTokenOut"];
                 };
+            };
+        };
+    };
+    readonly apps_tokens_api_list_tokens: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description OK */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": readonly components["schemas"]["PersonalTokenOut"][];
+                };
+            };
+        };
+    };
+    readonly apps_tokens_api_create_token: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly requestBody: {
+            readonly content: {
+                readonly "application/json": components["schemas"]["PersonalTokenCreateIn"];
+            };
+        };
+        readonly responses: {
+            /** @description Created */
+            readonly 201: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["PersonalTokenCreatedOut"];
+                };
+            };
+        };
+    };
+    readonly apps_tokens_api_revoke_token: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path: {
+                readonly pk: number;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description No Content */
+            readonly 204: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };


### PR DESCRIPTION
## Summary

Two small fixes from PR #45's CI fallout:

1. **Workflow permission gap.** The \`regen-openapi\` workflow runs on every PR touching \`apps/**/api.py\` etc. and tries to commit the regenerated \`frontend/src/api/generated.ts\` back to the PR branch. PR #45 surfaced that \`GITHUB_TOKEN\` lacks \`contents:write\` by default for forked-PR / cross-actor workflows — the auto-commit step got a 403 (\"Permission to jjackson/canopy-web.git denied to github-actions[bot]\"). Adding \`permissions: contents: write\` to the regen job grants the token push rights on same-repo PRs (this fix doesn't help with fork PRs, but canopy-web doesn't have those today).

2. **Manually-regenerated types from PR #45.** Since the workflow couldn't push, I regenerated \`generated.ts\` locally and committed the diff here. 144 net-new lines covering the three new \`/api/tokens/\` operations + their \`PersonalToken*\` schemas. Without this, frontend's typed client would lack the new endpoints (the frontend doesn't *use* them yet — no consumer is broken — but the contract drift is real).

## Verification

- \`npm run build\` clean on the regenerated \`generated.ts\` (542 modules, 148ms, no type errors)
- Next push to \`feat/personal-access-tokens\` or any future schema-touching PR will validate the new permissions

## Auto-merge

Setting \`gh pr merge --auto\` so this lands as soon as CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)