### PR TITLE
fix(walkthroughs): honor HTTP Range on Drive downloads

### DIFF
--- a/apps/walkthroughs/drive_client.py
+++ b/apps/walkthroughs/drive_client.py
@@ -178,16 +178,15 @@ class GoogleDriveClient(DriveClient):
         if end is None:
             end = total - 1
         end = min(end, total - 1)
-        # alt=media + Range header
+        # alt=media + Range header. MediaIoBaseDownload was tempting but
+        # rewrites Range per chunk for progressive downloads, clobbering
+        # our bounds and returning the whole file. req.execute() runs a
+        # single GET that honors the Range we set. 75 MB upper bound on
+        # uploads keeps memory pressure reasonable.
         req = self._service.files().get_media(fileId=file_id)
         req.headers["Range"] = f"bytes={start}-{end}"
-        buf = io.BytesIO()
-        from googleapiclient.http import MediaIoBaseDownload  # noqa: PLC0415
-        downloader = MediaIoBaseDownload(buf, req, chunksize=1024 * 1024)
-        done = False
-        while not done:
-            _, done = downloader.next_chunk()
-        return buf.getvalue(), start, end, total
+        data = req.execute()
+        return data, start, end, total
 
     def delete(self, file_id) -> None:
         self._service.files().delete(


### PR DESCRIPTION
## Problem

The streaming view at \`/w/<id>/content\` set correct 206 + Content-Range headers on Range requests but always shipped the full file body. Discovered during the live roundtrip smoke against production after the Drive SA was wired up.

## Cause

\`drive_client.GoogleDriveClient.download()\` set \`req.headers["Range"] = "bytes=start-end"\` then handed the request to \`MediaIoBaseDownload\`, which rewrites the Range header for each chunk to do progressive downloads (\`bytes=0-1048575\`, \`bytes=1048576-...\`, etc). Our bounds got clobbered every time.

Confirmed live: a 1593-byte test MP4 with \`Range: bytes=0-99\` returned status 206, headers \`content-range: bytes 0-99/1593\`, body length **1593**.

## Fix

Use \`req.execute()\` directly — a single GET that honors the Range header we set. Drops MediaIoBaseDownload (we never needed its chunking since we return the bytes as one blob anyway). 75 MB upload ceiling means memory stays reasonable on Cloud Run.

## Why tests didn't catch it

\`FakeDriveClient.download()\` slices its in-memory dict correctly, so unit tests passed. The bug only surfaced via the real googleapiclient path. A regression test that mocks the HTTP layer would basically just re-state the new implementation; leaving the live smoke as the integration verifier for now.

## Test plan

- [x] Existing unit tests still green (\`pytest apps/walkthroughs/\` → 25 passed)
- [x] Empirically reproduced + verified fix against real Drive (\`MediaIoBaseDownload\` returned 1593 bytes; \`req.execute()\` returned 100)
- [ ] Re-smoke after deploy

## Discovered in

End-to-end roundtrip smoke of the just-deployed walkthrough sharing feature (canopy-web revision \`canopy-web-00008-jg6\`, Drive folder \`Canopy/walkthroughs/<uuid>/...\`). Other gates of the smoke passed (private 404, public viewer, wrong-token 404, Drive folder structure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)