### PR TITLE
fix(deploy): bake Drive + auth secrets into deploy.sh

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -48,7 +48,8 @@ gcloud run deploy "${SERVICE_NAME}" \
   --set-env-vars="AI_BACKEND=api" \
   --set-env-vars="^|^AUTH_ALLOWED_EMAIL_DOMAIN=dimagi.com,dimagi-ai.com" \
   --set-env-vars="REQUIRE_AUTH=${REQUIRE_AUTH_FLAG}" \
-  --set-secrets="SECRET_KEY=django-secret-key:latest,ANTHROPIC_API_KEY=anthropic-api-key:latest,DATABASE_URL=canopy-db-url:latest,GOOGLE_OAUTH_CLIENT_ID=google-oauth-client-id:latest,GOOGLE_OAUTH_CLIENT_SECRET=google-oauth-client-secret:latest" \
+  --set-env-vars="CANOPY_DRIVE_ROOT_FOLDER_ID=1cUv7wQXOvVwuZ86PdhkxpFcuB4Lm9fPz" \
+  --set-secrets="SECRET_KEY=django-secret-key:latest,ANTHROPIC_API_KEY=anthropic-api-key:latest,DATABASE_URL=canopy-db-url:latest,GOOGLE_OAUTH_CLIENT_ID=google-oauth-client-id:latest,GOOGLE_OAUTH_CLIENT_SECRET=google-oauth-client-secret:latest,WORKBENCH_WRITE_TOKEN=workbench-write-token:latest,CANOPY_E2E_AUTH_TOKEN=canopy-e2e-auth-token:latest,CANOPY_DRIVE_SA_KEY_JSON=canopy-web-drive-sa:latest" \
   --allow-unauthenticated \
   --quiet
 


### PR DESCRIPTION
## Problem

\`deploy.sh\` uses \`--set-env-vars\` / \`--set-secrets\`, which **replace** the Cloud Run service's env+secret list every deploy (they don't merge). Any env var or secret set out-of-band (console, one-off \`gcloud\` command, manual fix) gets silently nuked on the next CI deploy.

Discovered tonight after wiring up canopy-web's Drive integration:
1. I set \`CANOPY_DRIVE_SA_KEY_JSON\` + \`CANOPY_DRIVE_ROOT_FOLDER_ID\` via \`gcloud run services update --update-env-vars\` — walkthrough sharing went live, smoke-tested end-to-end (HTML + MP4, public + private), four real walkthroughs in Drive.
2. The next CI deploy (PR #47 Range fix, manually triggered) ran fine but produced 500s on every \`/w/<id>/content\` request because the deploy wiped Drive config.
3. Two pre-existing secrets I hadn't set — \`CANOPY_E2E_AUTH_TOKEN\` and \`WORKBENCH_WRITE_TOKEN\` — turned out to be in the same boat (some prior operator had set them via console/CLI).

Restored manually to get prod back; this PR locks the script as the source of truth so it can't drift again.

## Change

Four entries added to the existing \`gcloud run deploy\` invocation:
- \`CANOPY_DRIVE_ROOT_FOLDER_ID\` — env var (folder ID isn't secret).
- \`CANOPY_DRIVE_SA_KEY_JSON\` — secret ref \`canopy-web-drive-sa:latest\`.
- \`CANOPY_E2E_AUTH_TOKEN\` — secret ref \`canopy-e2e-auth-token:latest\`.
- \`WORKBENCH_WRITE_TOKEN\` — secret ref \`workbench-write-token:latest\`.

All four secrets already exist in Secret Manager and the runtime SA (\`270508200508-compute@developer.gserviceaccount.com\`) has \`roles/secretmanager.secretAccessor\` on each.

## Going forward

Any new secret added via the console or a one-off \`gcloud\` command MUST be backfilled into \`deploy.sh\`, or the next CI deploy drops it.

## Test plan

- [x] \`bash -n deploy.sh\` (syntax)
- [ ] CI green on push
- [ ] Next CI deploy preserves Drive config (validated by another roundtrip smoke after merge + deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)