### PR TITLE
fix(walkthroughs): trash Drive files instead of permanent delete (Content Manager can't delete in Shared Drives)

### DIFF
--- a/apps/walkthroughs/api.py
+++ b/apps/walkthroughs/api.py
@@ -1,10 +1,13 @@
 """Django Ninja v2 router for the walkthroughs surface."""
 from __future__ import annotations
 
+import logging
 from uuid import UUID
 
 from django.conf import settings
 from django.http import Http404, HttpRequest
+
+log = logging.getLogger(__name__)
 from ninja import File, Form, Router, Status
 from ninja.files import UploadedFile
 
@@ -270,9 +273,20 @@ def delete_walkthrough(request: HttpRequest, wid: UUID) -> Status:
         try:
             storage.delete_stored(file_id=w.drive_file_id, folder_id=w.drive_folder_id)
         except DriveNotConfigured:
-            pass
+            # No Drive client means no orphan to clean up — still drop the
+            # row so the UI matches reality.
+            log.warning(
+                "delete_walkthrough: drive not configured; row dropped without "
+                "Drive cleanup (walkthrough_id=%s)", w.id,
+            )
         except Exception:
-            pass
+            # Don't block the row delete on a Drive hiccup — recovering an
+            # orphan Drive file is cheap; an orphan DB row blocks the user
+            # from re-deleting. But log loudly so we can sweep later.
+            log.exception(
+                "delete_walkthrough: drive cleanup failed (walkthrough_id=%s, "
+                "drive_file_id=%s)", w.id, w.drive_file_id,
+            )
 
     w.delete()
     return Status(204, None)

--- a/apps/walkthroughs/drive_client.py
+++ b/apps/walkthroughs/drive_client.py
@@ -189,6 +189,14 @@ class GoogleDriveClient(DriveClient):
         return data, start, end, total
 
     def delete(self, file_id) -> None:
-        self._service.files().delete(
-            fileId=file_id, supportsAllDrives=True
+        # Trash (set trashed=True), not permanent delete. Permanent deletion
+        # in a Shared Drive requires the Manager role; Content Manager — the
+        # role our spec asks operators to grant — can only trash. We
+        # discovered this the hard way when /api/walkthroughs/<id>/ DELETE
+        # left orphan files in Drive. Trash is also safer: items are
+        # recoverable for 30 days.
+        self._service.files().update(
+            fileId=file_id,
+            body={"trashed": True},
+            supportsAllDrives=True,
         ).execute()

--- a/apps/walkthroughs/storage.py
+++ b/apps/walkthroughs/storage.py
@@ -63,8 +63,14 @@ def download(
 
 
 def delete_stored(*, file_id: str, folder_id: str) -> None:
-    """Delete the file. Folder is left in place (Drive trash collects it
-    eventually; cheap and avoids races if two walkthroughs ever share a
-    folder, which they shouldn't but the cost is zero)."""
+    """Trash the file AND its per-walkthrough subfolder.
+
+    Each walkthrough lives in its own subfolder so trashing both makes the
+    Drive listing actually look empty after the user deletes a walkthrough.
+    (Previously we left the folder in place; in practice it accumulated
+    empty UUID-named dirs that an operator had to sweep by hand.)
+    """
     client = get_drive_client()
     client.delete(file_id)
+    if folder_id:
+        client.delete(folder_id)


### PR DESCRIPTION
## Problem

\`DELETE /api/walkthroughs/<id>/\` returned 204 in production but left the actual files in Drive. Discovered while cleaning up smoke-test walkthroughs after the live roundtrip.

Walked through:

1. **\`drive_client.delete()\` called \`files().delete()\`.** In a Shared Drive that requires the **Manager** role — but the spec asks operators to grant the SA only **Content Manager** (which can \`trash\` but not permanently delete). The Drive API returned 404 "File not found" — a misleading permission-error wrapper.
2. **\`api.delete_walkthrough\` swallowed the failure** with \`except Exception: pass\`. User saw 204; Drive folder filled with orphans.
3. **\`storage.delete_stored\` only ever touched the file**, never the per-walkthrough subfolder, so even when files \*were\* removed, the UUID-named dirs would stick around.

## Why tests didn't catch it

\`FakeDriveClient.delete()\` just \`files.pop(file_id, None)\` — its semantics never depended on the real Drive permission model. The contract test passed; production failed.

## Fix (three surgical changes)

- **\`drive_client.delete()\`** → trash (\`update(fileId, {trashed: True})\`). Works for Content Manager. Items recoverable for 30 days. Documented with the why.
- **\`storage.delete_stored()\`** → also trash the parent subfolder, so the walkthroughs/ folder doesn't accumulate empty UUID dirs.
- **\`api.delete_walkthrough()\`** → log on Drive cleanup failure instead of silently swallowing. Row delete still completes (orphan DB row is worse than orphan Drive file).

## Test plan

- [x] \`pytest apps/walkthroughs/\` → 25/25 pass
- [x] Manually trashed the 4 orphans + their subfolders left over from the smoke run
- [ ] CI
- [ ] After deploy: end-to-end DELETE actually clears the Drive folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)