### PR TITLE
chore: drop dead WORKBENCH_WRITE_TOKEN + CANOPY_E2E_AUTH_TOKEN from deploy.sh

### DIFF
--- a/apps/api/mcp_server.py
+++ b/apps/api/mcp_server.py
@@ -9,9 +9,12 @@ Each tool invokes the same endpoint via an HTTP loopback call with a
 Bearer token for authentication — reuses every middleware (auth,
 CSRF, throttling) and behaves identically to a frontend caller.
 
-Auth model: machine callers present `Authorization: Bearer <WORKBENCH_WRITE_TOKEN>`
-(the existing canopy-web Bearer-bypass mechanism). MCP tools include
-this header automatically via env-var `CANOPY_MCP_BEARER`.
+Auth model: machine callers present `Authorization: Bearer <PAT>` where
+PAT is a Personal Access Token minted via apps.tokens (manage.py
+create_token, or the /canopy:canopy-web-pat-mint flow on the client
+side). `apps.tokens.middleware.BearerTokenAuthMiddleware` resolves it to
+a Django user. MCP tools include this header automatically via env-var
+`CANOPY_MCP_BEARER`.
 
 Mounting: This module exposes `mcp_starlette_app`, a Starlette ASGI app
 (SSE transport) that is mounted at /api/mcp/ in config/asgi.py via a

--- a/deploy.sh
+++ b/deploy.sh
@@ -49,7 +49,7 @@ gcloud run deploy "${SERVICE_NAME}" \
   --set-env-vars="^|^AUTH_ALLOWED_EMAIL_DOMAIN=dimagi.com,dimagi-ai.com" \
   --set-env-vars="REQUIRE_AUTH=${REQUIRE_AUTH_FLAG}" \
   --set-env-vars="CANOPY_DRIVE_ROOT_FOLDER_ID=1cUv7wQXOvVwuZ86PdhkxpFcuB4Lm9fPz" \
-  --set-secrets="SECRET_KEY=django-secret-key:latest,ANTHROPIC_API_KEY=anthropic-api-key:latest,DATABASE_URL=canopy-db-url:latest,GOOGLE_OAUTH_CLIENT_ID=google-oauth-client-id:latest,GOOGLE_OAUTH_CLIENT_SECRET=google-oauth-client-secret:latest,WORKBENCH_WRITE_TOKEN=workbench-write-token:latest,CANOPY_E2E_AUTH_TOKEN=canopy-e2e-auth-token:latest,CANOPY_DRIVE_SA_KEY_JSON=canopy-web-drive-sa:latest" \
+  --set-secrets="SECRET_KEY=django-secret-key:latest,ANTHROPIC_API_KEY=anthropic-api-key:latest,DATABASE_URL=canopy-db-url:latest,GOOGLE_OAUTH_CLIENT_ID=google-oauth-client-id:latest,GOOGLE_OAUTH_CLIENT_SECRET=google-oauth-client-secret:latest,CANOPY_DRIVE_SA_KEY_JSON=canopy-web-drive-sa:latest" \
   --allow-unauthenticated \
   --quiet
 


### PR DESCRIPTION
## Summary

Hygiene cleanup. Both env vars were retired by the PAT refactor (\`apps/tokens/\`). The view, route, settings binding, and middleware bypass were already removed by previous PRs; the entries in \`deploy.sh\`'s \`--set-secrets\` list were the last surface still injecting them into the running container.

Verified via \`grep -rn\` that no Python code reads either name at runtime — only docstrings reference them as historical context.

## Changes

- \`deploy.sh\`: drop \`WORKBENCH_WRITE_TOKEN=workbench-write-token:latest\` and \`CANOPY_E2E_AUTH_TOKEN=canopy-e2e-auth-token:latest\` from \`--set-secrets\`.
- \`apps/api/mcp_server.py\`: update module docstring — was describing the long-gone WORKBENCH_WRITE_TOKEN Bearer-bypass; now describes the current PAT model via \`apps.tokens.middleware.BearerTokenAuthMiddleware\`.

## Left alone (out of scope for this PR)

- \`CLAUDE.md:142\` mentions both names in a "Replaces the retired..." sentence — that's useful context for anyone reading PAT code wondering why it exists.
- Secret Manager secrets \`canopy-e2e-auth-token\` and \`workbench-write-token\` are still in GCP. Cost nothing dormant. An operator can sweep them via the console when convenient.
- Historical references in \`docs/superpowers/plans/*\` and \`apps/tokens/models.py\` docstring — left because they're explicitly past-tense.

## Test plan

- [x] \`pytest apps/walkthroughs apps/common apps/tokens\` → 88/88 pass
- [x] \`bash -n deploy.sh\` syntax clean
- [ ] CI
- [ ] Next deploy: env list contains only \`SECRET_KEY\`, \`ANTHROPIC_API_KEY\`, \`DATABASE_URL\`, \`GOOGLE_OAUTH_*\`, \`CANOPY_DRIVE_SA_KEY_JSON\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)