### PR TITLE
fix(walkthroughs): allow same-origin iframe for /w/<id>/content (HTML viewer was blocked by X-Frame-Options: DENY)

### DIFF
--- a/apps/walkthroughs/streaming.py
+++ b/apps/walkthroughs/streaming.py
@@ -11,6 +11,7 @@ import re
 
 from django.conf import settings
 from django.http import Http404, HttpResponse, StreamingHttpResponse
+from django.views.decorators.clickjacking import xframe_options_sameorigin
 
 from . import storage
 from .drive_client import DriveNotConfigured
@@ -41,12 +42,18 @@ def _get_or_404(wid):
         return None
 
 
+@xframe_options_sameorigin
 def walkthrough_content(request, wid):
     """GET /w/<id>/content — stream the file bytes from Drive.
 
     Auth: caller is the authenticated owner OR visibility=link with a
     valid ?t=<share_token>. Mismatch returns 404 (don't leak existence
     of private walkthroughs).
+
+    Django's SecurityMiddleware sets ``X-Frame-Options: DENY`` globally,
+    which breaks our own viewer page (``/w/<id>``) when it tries to embed
+    this endpoint via ``<iframe src=...>``. Override to ``SAMEORIGIN`` —
+    the viewer is the only intended embedder and lives on the same host.
     """
     if not getattr(settings, "WALKTHROUGHS_ENABLED", True):
         raise Http404("walkthroughs disabled")


### PR DESCRIPTION
## Problem

HTML walkthrough viewer page (\`/w/<id>\`) renders the toolbar + chrome but the iframe body shows the browser's broken-resource icon. The content endpoint returns 200 with the correct \`text/html\` body (9 MB in the reported case), so the bytes are fine — but \`X-Frame-Options: DENY\` (set by Django's \`SecurityMiddleware\` for the whole app) prevents the iframe from rendering, even though the iframe is on the same origin.

Reported live: \"Program Admin Report — Manager Flow + Drill-Through\" upload, 9 MB HTML deck.

## Fix

\`@xframe_options_sameorigin\` on \`walkthrough_content\`. Overrides the header to \`SAMEORIGIN\` for this one view; \`DENY\` stays the default everywhere else in the app. Narrowly scoped to the surface that has a legitimate same-origin embedder (the viewer page itself).

Video walkthroughs weren't affected — the viewer uses \`<video controls>\` directly for video kind, not iframe, so this bug only manifested for HTML kind.

## Test plan

- [x] \`manage.py check\` → 0 issues
- [x] \`pytest apps/walkthroughs/\` → 25/25
- [ ] CI
- [ ] Post-deploy: re-open the reported walkthrough and confirm the iframe renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)