### PR TITLE
fix(reviews): allow per-token review links through the auth middleware

### DIFF
--- a/apps/common/middleware.py
+++ b/apps/common/middleware.py
@@ -33,6 +33,16 @@ def _is_walkthrough_content(path: str) -> bool:
     return path.startswith("/w/") and path.endswith("/content")
 
 
+def _is_review_link(path: str) -> bool:
+    # /review/<uuid>/  (SPA shell) and the per-review API read/submit endpoints
+    # self-enforce token-or-session auth, so let the per-token public link
+    # through the middleware without a session. The bare collection POST
+    # (/api/reviews/) is NOT included — creating a review still requires auth.
+    if path.startswith("/review/"):
+        return True
+    return path.startswith("/api/reviews/") and path != "/api/reviews/"
+
+
 class LoginRequiredMiddleware:
     """Require authentication for every request except the allowlist.
 
@@ -58,6 +68,7 @@ class LoginRequiredMiddleware:
             request.user.is_authenticated
             or _is_public(request.path)
             or _is_walkthrough_content(request.path)
+            or _is_review_link(request.path)
         ):
             return self.get_response(request)
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -203,3 +203,66 @@ def test_post_without_csrf_rejected(db):
     client.force_login(user)
     resp = client.post("/api/projects/", data={}, content_type="application/json")
     assert resp.status_code == 403
+
+
+# ──────────────────────────────────────────────────────────────────────
+# _is_review_link: per-token review public links bypass the middleware
+# ──────────────────────────────────────────────────────────────────────
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_review_spa_page_is_accessible_unauthenticated(db):
+    """Unauthenticated request to /review/<uuid>/ passes through the middleware
+    (the SPA shell is served; the endpoint itself handles ?t= token auth)."""
+    import uuid
+
+    rid = uuid.uuid4()
+    client = Client()
+    resp = client.get(f"/review/{rid}/")
+    # Must NOT redirect to login — the middleware must let it through.
+    # The SPA catch-all returns 200; any non-302/non-401 confirms the gate is open.
+    assert resp.status_code != 302
+    assert resp.status_code != 401
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_review_api_detail_is_accessible_unauthenticated(db):
+    """Unauthenticated GET /api/reviews/<uuid>/ passes through the middleware
+    and reaches the endpoint (which does its own token/auth check)."""
+    import uuid
+
+    rid = uuid.uuid4()
+    client = Client()
+    resp = client.get(f"/api/reviews/{rid}/")
+    # The endpoint returns 404 (review not found), not 401 from middleware.
+    assert resp.status_code == 404
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_review_api_submit_is_accessible_unauthenticated(db):
+    """Unauthenticated POST /api/reviews/<uuid>/submit/ passes through the middleware
+    and reaches the endpoint (which does its own token/auth check)."""
+    import uuid
+
+    rid = uuid.uuid4()
+    client = Client()
+    resp = client.post(
+        f"/api/reviews/{rid}/submit/",
+        data={"response_json": {}},
+        content_type="application/json",
+    )
+    # The endpoint returns 404 (review not found), not 401 from middleware.
+    assert resp.status_code == 404
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_review_api_create_still_requires_auth(db):
+    """Unauthenticated POST /api/reviews/ (bare create) is still blocked by
+    the middleware — creating a review requires a session or PAT."""
+    client = Client()
+    resp = client.post(
+        "/api/reviews/",
+        data={"request_json": {}, "visibility": "link"},
+        content_type="application/json",
+    )
+    assert resp.status_code == 401


### PR DESCRIPTION
## Product Description

Share links for DDD (demo-driven development) review gates — URLs in the form `/review/<id>/?t=<token>` — now work for unauthenticated recipients. Previously, clicking a share URL posted to Slack redirected you to the Google OAuth login page instead of showing the review. The fix makes the middleware aware of review share links, matching the existing walkthrough content allowlist behaviour.

## Technical Summary

Found by dogfooding: `LoginRequiredMiddleware` was blocking requests to `/review/<uuid>/` (the SPA shell) and `/api/reviews/<uuid>/` (the API detail/submit endpoints) before they reached the endpoint's own `?t=` share-token auth check. The walkthrough content route (`/w/<uuid>/content`) already had a carve-out; review routes were never added.

**Fix:** Added `_is_review_link(path)` in `apps/common/middleware.py`, mirroring `_is_walkthrough_content`:

```python
def _is_review_link(path: str) -> bool:
    # /review/<uuid>/  (SPA shell) and the per-review API read/submit endpoints
    # self-enforce token-or-session auth, so let the per-token public link
    # through the middleware without a session. The bare collection POST
    # (/api/reviews/) is NOT included — creating a review still requires auth.
    if path.startswith("/review/"):
        return True
    return path.startswith("/api/reviews/") and path != "/api/reviews/"
```

Verified against `apps/reviews/api.py`:
- `GET /api/reviews/{rid}/` — `auth=None`, gates via `_can_read()` (owner-or-`?t=`), returns 404 (not leak) when neither matches ✓
- `POST /api/reviews/{rid}/submit/` — `auth=None`, gates via `_can_write()` (owner-or-`?t=`) ✓  
- `POST /api/reviews/` (create) — uses default `session_auth`, correctly excluded from allowlist ✓

No migration needed (middleware-only change).

## Safety Assurance

- Added 4 middleware tests to `tests/test_auth.py`:
  - `test_review_spa_page_is_accessible_unauthenticated` — SPA `/review/<uuid>/` not redirected
  - `test_review_api_detail_is_accessible_unauthenticated` — API detail passes through to endpoint (404, not 401)
  - `test_review_api_submit_is_accessible_unauthenticated` — submit endpoint passes through (404, not 401)
  - `test_review_api_create_still_requires_auth` — bare `POST /api/reviews/` still 401
- `uv run pytest apps/reviews/ apps/common/ tests/test_auth.py -q` → **61 passed**