### PR TITLE
fix(reviews): don't 401-redirect anonymous /review token links

### DIFF
--- a/frontend/src/api/client.v2.ts
+++ b/frontend/src/api/client.v2.ts
@@ -12,6 +12,13 @@ function redirectToLogin(): never {
   throw new Error("Redirecting to login");
 }
 
+// Per-token public-link routes (e.g. /review/<id>?t=…) self-gate on their share
+// token, so a 401 from an incidental authenticated call (e.g. /api/me) must NOT
+// bounce an anonymous visitor to login. Keep in sync with AuthProvider.
+function isPublicLinkRoute(): boolean {
+  return window.location.pathname.startsWith("/review/");
+}
+
 export const apiV2 = createClient<paths>({
   baseUrl: "",
   credentials: "same-origin",
@@ -27,7 +34,7 @@ apiV2.use({
     return request;
   },
   async onResponse({ response }) {
-    if (response.status === 401) {
+    if (response.status === 401 && !isPublicLinkRoute()) {
       redirectToLogin();
     }
     return response;


### PR DESCRIPTION
Third client-side auth gate on the review token-link: the global 401 handler in client.v2.ts redirected anonymous /review visitors to Google login (via the incidental /api/me 401). Exempt /review/ — the page self-gates on ?t=. Completes PR #54 (middleware) + #55 (AuthProvider).