### PR TITLE
feat(reviews): scene/feature editor (op-buffer) — add/delete, edit features, feedback

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -41,7 +41,8 @@
         "openapi-typescript": "^7.13.0",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.57.0",
-        "vite": "^8.0.1"
+        "vite": "^8.0.1",
+        "vitest": "^4.1.7"
       }
     },
     "node_modules/@ai-sdk/gateway": {
@@ -2119,6 +2120,24 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2505,6 +2524,119 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
+      "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
+      "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
+      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
+      "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.7",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
+      "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
+      "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
+      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -2666,6 +2798,16 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/ast-types": {
       "version": "0.16.1",
@@ -2859,6 +3001,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -3439,6 +3591,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -3666,6 +3825,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3730,6 +3899,16 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -5527,6 +5706,17 @@
         "node": ">= 10"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -5836,6 +6026,13 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
       "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -6538,6 +6735,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -6574,6 +6778,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -6582,6 +6793,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stdin-discarder": {
       "version": "0.2.2",
@@ -6776,6 +6994,23 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.2.tgz",
+      "integrity": "sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -6791,6 +7026,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tldts": {
@@ -7180,6 +7425,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
+      "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.7",
+        "@vitest/mocker": "4.1.7",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/runner": "4.1.7",
+        "@vitest/snapshot": "4.1.7",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.7",
+        "@vitest/browser-preview": "4.1.7",
+        "@vitest/browser-webdriverio": "4.1.7",
+        "@vitest/coverage-istanbul": "4.1.7",
+        "@vitest/coverage-v8": "4.1.7",
+        "@vitest/ui": "4.1.7",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -7202,6 +7537,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,8 @@
     "gen:api": "openapi-typescript http://localhost:8000/api/openapi.json --output src/api/generated.ts --immutable",
     "gen:api:local": "openapi-typescript openapi.json --output src/api/generated.ts --immutable",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@ai-sdk/react": "^3.0.143",
@@ -45,6 +46,7 @@
     "openapi-typescript": "^7.13.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.57.0",
-    "vite": "^8.0.1"
+    "vite": "^8.0.1",
+    "vitest": "^4.1.7"
   }
 }

--- a/frontend/src/api/reviews.ts
+++ b/frontend/src/api/reviews.ts
@@ -69,9 +69,32 @@ export interface ReviewRequestJson {
   actionability?: ReviewActionability | null
 }
 
+// ---------------------------------------------------------------------------
+// Submit payload — new "edited_scenes" contract
+// ---------------------------------------------------------------------------
+
+export interface ReviewSubmittedFeature {
+  id: string
+  description: string
+  verify: string
+  feedback: string
+}
+
+export interface ReviewSubmittedScene {
+  id: string
+  title: string
+  narration: string
+  deleted: boolean
+  features: ReviewSubmittedFeature[]
+  feedback: string
+}
+
 export interface ReviewSubmitPayload {
   decisions: Record<string, string>
-  narration_edits: Record<string, string>
+  /** Legacy field — kept for backwards-compat read; send is now edited_scenes */
+  narration_edits?: Record<string, string>
+  edited_scenes?: ReviewSubmittedScene[]
+  overall_feedback?: string
 }
 
 export interface ReviewDetail {

--- a/frontend/src/components/reviews/ReviewEditorContext.tsx
+++ b/frontend/src/components/reviews/ReviewEditorContext.tsx
@@ -1,0 +1,95 @@
+/**
+ * Context + provider for the review scene/feature editor.
+ *
+ * Pattern mirrors ace-web's videos/BeatEditorContext.tsx.
+ * Consumers call useReviewEditor() to get:
+ *   - state.buffer         (pending ops)
+ *   - effectiveScenes      (applyReviewOps projection — pure, no mutation)
+ *   - overallFeedback      (derived from the buffer's set-overall-feedback op)
+ *   - isDirty              (buffer.length > 0)
+ *   - dispatch             (append ops, undo, etc.)
+ */
+
+import {
+  createContext,
+  useContext,
+  useMemo,
+  useReducer,
+  type ReactNode,
+} from 'react'
+import { applyReviewOps, type EffectiveScene } from './reviewApplyOps'
+import {
+  reviewEditorReducer,
+  initialReviewEditorState,
+  type ReviewEditorAction,
+} from './reviewEditorReducer'
+import type { ReviewEditorState, PendingReviewOp } from './reviewEditorTypes'
+import type { ReviewNarrationItem } from '../../api/reviews'
+
+// ---------------------------------------------------------------------------
+// Context shape
+// ---------------------------------------------------------------------------
+
+interface ReviewEditorContextValue {
+  state: ReviewEditorState
+  effectiveScenes: EffectiveScene[]
+  /** Current value of the overall_feedback field (from buffer or ''). */
+  overallFeedback: string
+  isDirty: boolean
+  dispatch: (a: ReviewEditorAction) => void
+}
+
+const Ctx = createContext<ReviewEditorContextValue | null>(null)
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+interface Props {
+  original: ReviewNarrationItem[]
+  children: ReactNode
+}
+
+export function ReviewEditorProvider({ original, children }: Props) {
+  const [state, dispatch] = useReducer(
+    reviewEditorReducer,
+    original,
+    initialReviewEditorState,
+  )
+
+  const effectiveScenes = useMemo(
+    () => applyReviewOps(state.original, state.buffer),
+    [state.original, state.buffer],
+  )
+
+  const overallFeedback = useMemo(() => {
+    // Last set-overall-feedback op in buffer wins.
+    for (let i = state.buffer.length - 1; i >= 0; i--) {
+      const op = state.buffer[i] as PendingReviewOp
+      if (op.op === 'set-overall-feedback') return op.text
+    }
+    return ''
+  }, [state.buffer])
+
+  const isDirty = state.buffer.length > 0
+
+  const value: ReviewEditorContextValue = {
+    state,
+    effectiveScenes,
+    overallFeedback,
+    isDirty,
+    dispatch,
+  }
+
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useReviewEditor(): ReviewEditorContextValue {
+  const v = useContext(Ctx)
+  if (!v) throw new Error('useReviewEditor must be used inside <ReviewEditorProvider>')
+  return v
+}

--- a/frontend/src/components/reviews/reviewApplyOps.test.ts
+++ b/frontend/src/components/reviews/reviewApplyOps.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from 'vitest'
+import { applyReviewOps } from './reviewApplyOps'
+import type { ReviewNarrationItem } from '../../api/reviews'
+import type { PendingReviewOp } from './reviewEditorTypes'
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const ORIGINAL: ReviewNarrationItem[] = [
+  {
+    scene: 1,
+    id: 'scene-1',
+    text: 'Original narration one',
+    features: [
+      { id: 'feat-a', description: 'Feature A', verify: 'check A' },
+    ],
+  },
+  {
+    scene: 2,
+    id: 'scene-2',
+    text: 'Original narration two',
+    features: [],
+  },
+]
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('applyReviewOps', () => {
+  it('returns effective scenes with no ops (identity)', () => {
+    const scenes = applyReviewOps(ORIGINAL, [])
+    expect(scenes).toHaveLength(2)
+    expect(scenes[0].id).toBe('scene-1')
+    expect(scenes[0].narration).toBe('Original narration one')
+    expect(scenes[0].deleted).toBe(false)
+    expect(scenes[0].features[0].id).toBe('feat-a')
+    expect(scenes[0].features[0].feedback).toBe('')
+  })
+
+  it('edit-narration updates the narration text', () => {
+    const ops: PendingReviewOp[] = [
+      { op: 'edit-narration', sceneId: 'scene-1', text: 'Edited narration' },
+    ]
+    const scenes = applyReviewOps(ORIGINAL, ops)
+    expect(scenes[0].narration).toBe('Edited narration')
+    // other scene unchanged
+    expect(scenes[1].narration).toBe('Original narration two')
+  })
+
+  it('edit-feature updates description and verify', () => {
+    const ops: PendingReviewOp[] = [
+      { op: 'edit-feature', sceneId: 'scene-1', featureId: 'feat-a', field: 'description', value: 'New desc' },
+      { op: 'edit-feature', sceneId: 'scene-1', featureId: 'feat-a', field: 'verify', value: 'new verify' },
+    ]
+    const scenes = applyReviewOps(ORIGINAL, ops)
+    const feat = scenes[0].features[0]
+    expect(feat.description).toBe('New desc')
+    expect(feat.verify).toBe('new verify')
+  })
+
+  it('set-feature-feedback sets feedback', () => {
+    const ops: PendingReviewOp[] = [
+      { op: 'set-feature-feedback', sceneId: 'scene-1', featureId: 'feat-a', text: 'nice feature' },
+    ]
+    const scenes = applyReviewOps(ORIGINAL, ops)
+    expect(scenes[0].features[0].feedback).toBe('nice feature')
+  })
+
+  it('add-feature appends a new empty feature', () => {
+    const ops: PendingReviewOp[] = [
+      { op: 'add-feature', sceneId: 'scene-2', featureId: 'new-1' },
+    ]
+    const scenes = applyReviewOps(ORIGINAL, ops)
+    const scene2 = scenes.find((s) => s.id === 'scene-2')!
+    expect(scene2.features).toHaveLength(1)
+    expect(scene2.features[0].id).toBe('new-1')
+    expect(scene2.features[0].description).toBe('')
+    expect(scene2.features[0].deleted).toBe(false)
+  })
+
+  it('delete-feature marks feature as deleted', () => {
+    const ops: PendingReviewOp[] = [
+      { op: 'delete-feature', sceneId: 'scene-1', featureId: 'feat-a' },
+    ]
+    const scenes = applyReviewOps(ORIGINAL, ops)
+    expect(scenes[0].features[0].deleted).toBe(true)
+  })
+
+  it('add-scene appends a new empty scene', () => {
+    const ops: PendingReviewOp[] = [
+      { op: 'add-scene', sceneId: 'new-1', title: 'Brand New Scene' },
+    ]
+    const scenes = applyReviewOps(ORIGINAL, ops)
+    expect(scenes).toHaveLength(3)
+    const newScene = scenes[2]
+    expect(newScene.id).toBe('new-1')
+    expect(newScene.title).toBe('Brand New Scene')
+    expect(newScene.narration).toBe('')
+    expect(newScene.features).toHaveLength(0)
+    expect(newScene.deleted).toBe(false)
+  })
+
+  it('delete-scene marks scene as deleted', () => {
+    const ops: PendingReviewOp[] = [
+      { op: 'delete-scene', sceneId: 'scene-1' },
+    ]
+    const scenes = applyReviewOps(ORIGINAL, ops)
+    expect(scenes[0].deleted).toBe(true)
+    expect(scenes[1].deleted).toBe(false)
+  })
+
+  it('set-scene-feedback sets scene feedback', () => {
+    const ops: PendingReviewOp[] = [
+      { op: 'set-scene-feedback', sceneId: 'scene-2', text: 'great scene' },
+    ]
+    const scenes = applyReviewOps(ORIGINAL, ops)
+    expect(scenes[1].feedback).toBe('great scene')
+  })
+
+  it('set-overall-feedback is a noop in applyReviewOps (handled by caller)', () => {
+    const ops: PendingReviewOp[] = [
+      { op: 'set-overall-feedback', text: 'global feedback' },
+    ]
+    const scenes = applyReviewOps(ORIGINAL, ops)
+    // Scenes unchanged
+    expect(scenes).toHaveLength(2)
+    expect(scenes[0].narration).toBe('Original narration one')
+  })
+
+  it('multiple ops applied in order — edit then delete', () => {
+    const ops: PendingReviewOp[] = [
+      { op: 'edit-narration', sceneId: 'scene-1', text: 'Changed' },
+      { op: 'delete-scene', sceneId: 'scene-1' },
+    ]
+    const scenes = applyReviewOps(ORIGINAL, ops)
+    // narration was edited, then scene deleted — deleted wins at render time
+    expect(scenes[0].narration).toBe('Changed')
+    expect(scenes[0].deleted).toBe(true)
+  })
+
+  it('does not mutate the original items', () => {
+    const orig = JSON.parse(JSON.stringify(ORIGINAL)) as ReviewNarrationItem[]
+    const ops: PendingReviewOp[] = [
+      { op: 'edit-narration', sceneId: 'scene-1', text: 'Mutated?' },
+      { op: 'add-scene', sceneId: 'new-1', title: 'Extra' },
+    ]
+    applyReviewOps(orig, ops)
+    // original should be unchanged
+    expect(orig[0].text).toBe('Original narration one')
+    expect(orig).toHaveLength(2)
+  })
+})

--- a/frontend/src/components/reviews/reviewApplyOps.ts
+++ b/frontend/src/components/reviews/reviewApplyOps.ts
@@ -1,0 +1,161 @@
+/**
+ * Pure projection: given the original narration items + a buffer of ops,
+ * returns a new array of EffectiveScene objects.
+ *
+ * - Deep-clones via JSON.parse/stringify (scenes are small).
+ * - Never mutates the original.
+ * - Ops are applied in buffer order; same-key ops already coalesced by
+ *   the reducer, so each key appears at most once.
+ */
+
+import type { ReviewNarrationItem, ReviewFeature } from '../../api/reviews'
+import type { PendingReviewOp } from './reviewEditorTypes'
+
+// ---------------------------------------------------------------------------
+// Output shape — what the editor renders and the submit payload is built from.
+// ---------------------------------------------------------------------------
+
+export interface EffectiveFeature {
+  id: string
+  description: string
+  verify: string
+  feedback: string
+  deleted: boolean
+}
+
+export interface EffectiveScene {
+  id: string
+  /** 'new' scenes carry a user-editable title; original scenes use "Scene N". */
+  title: string
+  narration: string
+  deleted: boolean
+  features: EffectiveFeature[]
+  feedback: string
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function applyReviewOps(
+  original: ReviewNarrationItem[],
+  ops: PendingReviewOp[],
+): EffectiveScene[] {
+  if (ops.length === 0) return originalToEffective(original)
+
+  // Start from a deep clone of the original as EffectiveScene[]
+  const scenes: EffectiveScene[] = JSON.parse(
+    JSON.stringify(originalToEffective(original)),
+  ) as EffectiveScene[]
+
+  // Index for O(1) lookup
+  const byId = new Map<string, EffectiveScene>()
+  for (const s of scenes) byId.set(s.id, s)
+
+  // Track insertion order for new scenes (append to end)
+  let newSceneCounter = 0
+
+  for (const op of ops) {
+    switch (op.op) {
+      case 'edit-narration': {
+        const s = byId.get(op.sceneId)
+        if (s) s.narration = op.text
+        break
+      }
+      case 'edit-feature': {
+        const s = byId.get(op.sceneId)
+        if (!s) break
+        const f = s.features.find((x) => x.id === op.featureId)
+        if (f) {
+          if (op.field === 'description') f.description = op.value
+          else f.verify = op.value
+        }
+        break
+      }
+      case 'set-feature-feedback': {
+        const s = byId.get(op.sceneId)
+        if (!s) break
+        const f = s.features.find((x) => x.id === op.featureId)
+        if (f) f.feedback = op.text
+        break
+      }
+      case 'add-feature': {
+        const s = byId.get(op.sceneId)
+        if (!s) break
+        // Idempotent: only add if not already in list
+        if (!s.features.find((x) => x.id === op.featureId)) {
+          s.features.push({
+            id: op.featureId,
+            description: '',
+            verify: '',
+            feedback: '',
+            deleted: false,
+          })
+        }
+        break
+      }
+      case 'delete-feature': {
+        const s = byId.get(op.sceneId)
+        if (!s) break
+        const f = s.features.find((x) => x.id === op.featureId)
+        if (f) f.deleted = true
+        break
+      }
+      case 'add-scene': {
+        if (!byId.has(op.sceneId)) {
+          newSceneCounter++
+          const newScene: EffectiveScene = {
+            id: op.sceneId,
+            title: op.title,
+            narration: '',
+            deleted: false,
+            features: [],
+            feedback: '',
+          }
+          scenes.push(newScene)
+          byId.set(op.sceneId, newScene)
+        }
+        break
+      }
+      case 'delete-scene': {
+        const s = byId.get(op.sceneId)
+        if (s) s.deleted = true
+        break
+      }
+      case 'set-scene-feedback': {
+        const s = byId.get(op.sceneId)
+        if (s) s.feedback = op.text
+        break
+      }
+      case 'set-overall-feedback':
+        // overall_feedback is handled separately by the caller; noop here.
+        break
+    }
+  }
+
+  // Suppress TS unused warning on counter (used for ordering new scenes)
+  void newSceneCounter
+
+  return scenes
+}
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+function originalToEffective(items: ReviewNarrationItem[]): EffectiveScene[] {
+  return items.map((item) => ({
+    id: item.id,
+    title: `Scene ${item.scene}`,
+    narration: item.text,
+    deleted: false,
+    features: (item.features ?? []).map((f: ReviewFeature) => ({
+      id: f.id,
+      description: f.description,
+      verify: f.verify ?? '',
+      feedback: '',
+      deleted: false,
+    })),
+    feedback: '',
+  }))
+}

--- a/frontend/src/components/reviews/reviewEditorReducer.ts
+++ b/frontend/src/components/reviews/reviewEditorReducer.ts
@@ -1,0 +1,68 @@
+/**
+ * Reducer for the review scene/feature editor op-buffer.
+ *
+ * Pattern mirrors ace-web's videos/editorReducer.ts.
+ */
+
+import type { ReviewNarrationItem } from '../../api/reviews'
+import type { PendingReviewOp, ReviewEditorState } from './reviewEditorTypes'
+import { opCoalesceKey } from './reviewEditorTypes'
+
+// ---------------------------------------------------------------------------
+// Actions
+// ---------------------------------------------------------------------------
+
+export type ReviewEditorAction =
+  | { type: 'APPEND_OP'; op: PendingReviewOp }
+  | { type: 'UNDO_LAST_OP' }
+  | { type: 'CLEAR_BUFFER' }
+  | { type: 'SAVE_START' }
+  | { type: 'SAVE_OK' }
+  | { type: 'SAVE_ERROR'; message: string }
+  | { type: 'SAVE_IDLE' }
+
+// ---------------------------------------------------------------------------
+// Init
+// ---------------------------------------------------------------------------
+
+export function initialReviewEditorState(
+  original: ReviewNarrationItem[],
+): ReviewEditorState {
+  return { original, buffer: [], saveState: { status: 'idle' } }
+}
+
+// ---------------------------------------------------------------------------
+// Reducer
+// ---------------------------------------------------------------------------
+
+export function reviewEditorReducer(
+  state: ReviewEditorState,
+  action: ReviewEditorAction,
+): ReviewEditorState {
+  switch (action.type) {
+    case 'APPEND_OP': {
+      const key = opCoalesceKey(action.op)
+      const existingIdx = state.buffer.findIndex((o) => opCoalesceKey(o) === key)
+      if (existingIdx >= 0) {
+        const next = state.buffer.slice()
+        next[existingIdx] = action.op
+        return { ...state, buffer: next }
+      }
+      return { ...state, buffer: [...state.buffer, action.op] }
+    }
+    case 'UNDO_LAST_OP': {
+      if (state.buffer.length === 0) return state
+      return { ...state, buffer: state.buffer.slice(0, -1) }
+    }
+    case 'CLEAR_BUFFER':
+      return { ...state, buffer: [] }
+    case 'SAVE_START':
+      return { ...state, saveState: { status: 'saving' } }
+    case 'SAVE_OK':
+      return { ...state, saveState: { status: 'saved' } }
+    case 'SAVE_ERROR':
+      return { ...state, saveState: { status: 'error', message: action.message } }
+    case 'SAVE_IDLE':
+      return { ...state, saveState: { status: 'idle' } }
+  }
+}

--- a/frontend/src/components/reviews/reviewEditorTypes.ts
+++ b/frontend/src/components/reviews/reviewEditorTypes.ts
@@ -1,0 +1,67 @@
+/**
+ * Op-buffer types for the review scene/feature editor.
+ *
+ * Pattern mirrors ace-web's videos/types.ts:
+ *  - PendingReviewOp = one typed edit that has not yet been saved
+ *  - opCoalesceKey   = last-write-wins key per field (edit-narration per scene,
+ *                      edit-feature per scene+feature+field, etc.)
+ *  - ReviewEditorState  = original review + buffer + save status
+ */
+
+import type { ReviewNarrationItem } from '../../api/reviews'
+
+// ---------------------------------------------------------------------------
+// Op types
+// ---------------------------------------------------------------------------
+
+export type PendingReviewOp =
+  | { op: 'edit-narration'; sceneId: string; text: string }
+  | { op: 'edit-feature'; sceneId: string; featureId: string; field: 'description' | 'verify'; value: string }
+  | { op: 'set-feature-feedback'; sceneId: string; featureId: string; text: string }
+  | { op: 'add-feature'; sceneId: string; featureId: string }   // featureId = 'new-<n>'
+  | { op: 'delete-feature'; sceneId: string; featureId: string }
+  | { op: 'add-scene'; sceneId: string; title: string }          // sceneId = 'new-<n>'
+  | { op: 'delete-scene'; sceneId: string }
+  | { op: 'set-scene-feedback'; sceneId: string; text: string }
+  | { op: 'set-overall-feedback'; text: string }
+
+/** Coalescing key: same key → last op wins (in-place replacement in buffer). */
+export function opCoalesceKey(op: PendingReviewOp): string {
+  switch (op.op) {
+    case 'edit-narration':
+      return `edit-narration:${op.sceneId}`
+    case 'edit-feature':
+      return `edit-feature:${op.sceneId}:${op.featureId}:${op.field}`
+    case 'set-feature-feedback':
+      return `set-feature-feedback:${op.sceneId}:${op.featureId}`
+    case 'add-feature':
+      // Each add-feature is unique (different featureId), so key by featureId.
+      return `add-feature:${op.sceneId}:${op.featureId}`
+    case 'delete-feature':
+      return `delete-feature:${op.sceneId}:${op.featureId}`
+    case 'add-scene':
+      return `add-scene:${op.sceneId}`
+    case 'delete-scene':
+      return `delete-scene:${op.sceneId}`
+    case 'set-scene-feedback':
+      return `set-scene-feedback:${op.sceneId}`
+    case 'set-overall-feedback':
+      return 'set-overall-feedback'
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Editor state
+// ---------------------------------------------------------------------------
+
+export interface ReviewEditorState {
+  /** The original review request narration (never mutated). */
+  original: ReviewNarrationItem[]
+  /** Buffer of pending ops — applied in order by applyReviewOps(). */
+  buffer: PendingReviewOp[]
+  saveState:
+    | { status: 'idle' }
+    | { status: 'saving' }
+    | { status: 'saved' }
+    | { status: 'error'; message: string }
+}

--- a/frontend/src/pages/ReviewPage.tsx
+++ b/frontend/src/pages/ReviewPage.tsx
@@ -1,22 +1,24 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import {
   getReview,
   submitReview,
   type ReviewDetail,
   type ReviewDecision,
-  type ReviewNarrationItem,
-  type ReviewFeature,
   type ReviewSceneActionability,
   type ReviewSubmitPayload,
+  type ReviewSubmittedScene,
 } from '../api/reviews'
 import { walkthroughContentUrl } from '../api/walkthroughs'
+import {
+  ReviewEditorProvider,
+  useReviewEditor,
+} from '../components/reviews/ReviewEditorContext'
 
 // ---------------------------------------------------------------------------
-// Sub-components
+// Small utility components
 // ---------------------------------------------------------------------------
 
-/** Small badge for numeric scores (e.g. "4.2 / 5") */
 function ScoreBadge({
   score,
   total = 5,
@@ -38,115 +40,19 @@ function ScoreBadge({
   )
 }
 
-/** List of features for one narration chunk */
-function FeatureList({
-  features,
-  sceneActionability,
-}: {
-  features: ReviewFeature[]
-  sceneActionability?: ReviewSceneActionability
-}) {
-  if (features.length === 0) return null
-
-  const missedIds = new Set(sceneActionability?.missed ?? [])
-
+function DirtyBadge({ isDirty }: { isDirty: boolean }) {
+  if (!isDirty) return null
   return (
-    <div className="mt-3 space-y-2">
-      <p className="text-[11px] font-semibold uppercase tracking-wider text-stone-500">
-        Features this scene commits to
-      </p>
-      <ul className="space-y-2">
-        {features.map((f) => {
-          const isMissed = missedIds.has(f.id)
-          return (
-            <li
-              key={f.id}
-              className={[
-                'rounded border px-3 py-2 text-sm',
-                isMissed
-                  ? 'border-amber-500/30 bg-amber-500/5'
-                  : 'border-stone-800 bg-stone-900/60',
-              ].join(' ')}
-            >
-              <p className="text-stone-200 leading-snug">{f.description}</p>
-              {f.verify && (
-                <p className="mt-1 font-mono text-[11px] text-stone-500 leading-snug">
-                  verify: {f.verify}
-                </p>
-              )}
-              {isMissed && (
-                <p className="mt-1.5 text-[11px] text-amber-400/80">
-                  ⚠ eval flagged as under-specified
-                </p>
-              )}
-            </li>
-          )
-        })}
-      </ul>
-    </div>
+    <span className="inline-flex items-center gap-1 rounded px-2 py-0.5 text-xs font-semibold bg-amber-500/20 text-amber-300 border border-amber-500/30">
+      Edited
+    </span>
   )
 }
 
-/** One narration chunk: editable textarea + features list + optional scene score */
-interface NarrationCardProps {
-  item: ReviewNarrationItem
-  value: string
-  onChange: (value: string) => void
-  readOnly: boolean
-  sceneActionability?: ReviewSceneActionability
-}
+// ---------------------------------------------------------------------------
+// Decision tiles
+// ---------------------------------------------------------------------------
 
-function NarrationCard({
-  item,
-  value,
-  onChange,
-  readOnly,
-  sceneActionability,
-}: NarrationCardProps) {
-  const features: ReviewFeature[] = item.features ?? []
-
-  return (
-    <div className="rounded-lg border border-stone-700 bg-stone-950 p-4 space-y-3">
-      {/* Scene header row */}
-      <div className="flex items-center justify-between gap-2">
-        <span className="text-xs font-semibold text-stone-500 uppercase tracking-wider">
-          Scene {item.scene}
-        </span>
-        {sceneActionability != null && (
-          <ScoreBadge score={sceneActionability.score} tooltip="Scene actionability score (AI buildability estimate)" />
-        )}
-      </div>
-
-      {/* Editable narration text */}
-      <textarea
-        className={[
-          'w-full rounded border bg-stone-900 px-3 py-2 text-sm text-stone-200 resize-y min-h-[4rem]',
-          'border-stone-700 focus:border-stone-500 focus:outline-none transition-colors',
-          readOnly ? 'opacity-70 cursor-default' : '',
-        ].join(' ')}
-        value={value}
-        onChange={(e) => !readOnly && onChange(e.target.value)}
-        readOnly={readOnly}
-        rows={3}
-      />
-
-      {/* Features */}
-      {features.length > 0 && (
-        <FeatureList
-          features={features}
-          sceneActionability={sceneActionability}
-        />
-      )}
-    </div>
-  )
-}
-
-/**
- * The approve / redraft decision block.
- *
- * Replaces the old generic DecisionGroup for the "narrative-verdict" decision.
- * Two clearly-labeled action buttons, each with a one-line explanation.
- */
 interface NarrativeVerdictProps {
   decision: ReviewDecision
   chosen: string
@@ -228,7 +134,6 @@ function NarrativeVerdictControl({
   )
 }
 
-/** Generic radio-button decision group for non-narrative-verdict decisions */
 interface DecisionGroupProps {
   decision: ReviewDecision
   chosen: string
@@ -289,112 +194,335 @@ function DecisionGroup({ decision, chosen, onChange, readOnly }: DecisionGroupPr
 }
 
 // ---------------------------------------------------------------------------
-// Main page
+// Feature row — editable description + verify + optional feedback
 // ---------------------------------------------------------------------------
 
-export function ReviewPage() {
-  const { id } = useParams<{ id: string }>()
+interface FeatureRowProps {
+  feature: {
+    id: string
+    description: string
+    verify: string
+    feedback: string
+    deleted: boolean
+  }
+  readOnly: boolean
+  isMissed: boolean
+  onEdit: (field: 'description' | 'verify', value: string) => void
+  onFeedback: (text: string) => void
+  onDelete: () => void
+}
 
-  // Read ?t= from query string — same pattern as WalkthroughViewerPage
-  const params = new URLSearchParams(window.location.search)
-  const shareToken = params.get('t') ?? null
+function FeatureRow({
+  feature,
+  readOnly,
+  isMissed,
+  onEdit,
+  onFeedback,
+  onDelete,
+}: FeatureRowProps) {
+  if (feature.deleted) return null
 
-  const [review, setReview] = useState<ReviewDetail | null>(null)
-  const [error, setError] = useState<string | null>(null)
+  return (
+    <li
+      className={[
+        'rounded border px-3 py-2 space-y-2',
+        isMissed
+          ? 'border-amber-500/30 bg-amber-500/5'
+          : 'border-stone-800 bg-stone-900/60',
+      ].join(' ')}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <p className="text-[11px] font-semibold uppercase tracking-wider text-stone-500">
+          Feature
+        </p>
+        {!readOnly && (
+          <button
+            type="button"
+            onClick={onDelete}
+            title="Delete feature"
+            className="text-stone-600 hover:text-red-400 transition-colors text-xs"
+          >
+            ✕
+          </button>
+        )}
+      </div>
+
+      {/* description */}
+      <textarea
+        className={[
+          'w-full rounded border bg-stone-900 px-2 py-1.5 text-sm text-stone-200 resize-y min-h-[2.5rem]',
+          'border-stone-700 focus:border-stone-500 focus:outline-none transition-colors',
+          readOnly ? 'opacity-70 cursor-default' : '',
+        ].join(' ')}
+        value={feature.description}
+        onChange={(e) => !readOnly && onEdit('description', e.target.value)}
+        readOnly={readOnly}
+        placeholder="Description"
+        rows={2}
+      />
+
+      {/* verify */}
+      <input
+        type="text"
+        className={[
+          'w-full rounded border bg-stone-900 px-2 py-1.5 font-mono text-[11px] text-stone-400',
+          'border-stone-700 focus:border-stone-500 focus:outline-none transition-colors',
+          readOnly ? 'opacity-70 cursor-default' : '',
+        ].join(' ')}
+        value={feature.verify}
+        onChange={(e) => !readOnly && onEdit('verify', e.target.value)}
+        readOnly={readOnly}
+        placeholder="verify: how to confirm"
+      />
+
+      {isMissed && (
+        <p className="text-[11px] text-amber-400/80">⚠ eval flagged as under-specified</p>
+      )}
+
+      {/* optional feedback */}
+      {!readOnly && (
+        <input
+          type="text"
+          className="w-full rounded border bg-stone-900 px-2 py-1.5 text-[11px] text-stone-400 border-stone-700 focus:border-stone-500 focus:outline-none transition-colors"
+          value={feature.feedback}
+          onChange={(e) => onFeedback(e.target.value)}
+          placeholder="Feedback on this feature (optional)"
+        />
+      )}
+      {readOnly && feature.feedback && (
+        <p className="text-[11px] text-stone-500 italic">Feedback: {feature.feedback}</p>
+      )}
+    </li>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Scene card — narration + features + add-feature + delete-scene + per-scene feedback
+// ---------------------------------------------------------------------------
+
+interface SceneCardProps {
+  scene: {
+    id: string
+    title: string
+    narration: string
+    deleted: boolean
+    features: Array<{
+      id: string
+      description: string
+      verify: string
+      feedback: string
+      deleted: boolean
+    }>
+    feedback: string
+  }
+  readOnly: boolean
+  sceneActionability?: ReviewSceneActionability
+  onEditNarration: (text: string) => void
+  onEditFeature: (featureId: string, field: 'description' | 'verify', value: string) => void
+  onFeatureFeedback: (featureId: string, text: string) => void
+  onDeleteFeature: (featureId: string) => void
+  onAddFeature: () => void
+  onDeleteScene: () => void
+  onSceneFeedback: (text: string) => void
+}
+
+function SceneCard({
+  scene,
+  readOnly,
+  sceneActionability,
+  onEditNarration,
+  onEditFeature,
+  onFeatureFeedback,
+  onDeleteFeature,
+  onAddFeature,
+  onDeleteScene,
+  onSceneFeedback,
+}: SceneCardProps) {
+  if (scene.deleted) return null
+
+  const missedIds = new Set(sceneActionability?.missed ?? [])
+  const activeFeatures = scene.features.filter((f) => !f.deleted)
+
+  return (
+    <div className="rounded-lg border border-stone-700 bg-stone-950 p-4 space-y-3">
+      {/* Scene header */}
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-xs font-semibold text-stone-500 uppercase tracking-wider">
+          {scene.title}
+        </span>
+        <div className="flex items-center gap-2">
+          {sceneActionability != null && (
+            <ScoreBadge
+              score={sceneActionability.score}
+              tooltip="Scene actionability score (AI buildability estimate)"
+            />
+          )}
+          {!readOnly && (
+            <button
+              type="button"
+              onClick={onDeleteScene}
+              title="Delete scene"
+              className="text-stone-600 hover:text-red-400 transition-colors text-xs px-2 py-0.5 rounded border border-stone-700 hover:border-red-500/40"
+            >
+              Delete scene
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Editable narration */}
+      <textarea
+        className={[
+          'w-full rounded border bg-stone-900 px-3 py-2 text-sm text-stone-200 resize-y min-h-[4rem]',
+          'border-stone-700 focus:border-stone-500 focus:outline-none transition-colors',
+          readOnly ? 'opacity-70 cursor-default' : '',
+        ].join(' ')}
+        value={scene.narration}
+        onChange={(e) => !readOnly && onEditNarration(e.target.value)}
+        readOnly={readOnly}
+        rows={3}
+        placeholder="Scene narration…"
+      />
+
+      {/* Features list */}
+      {(activeFeatures.length > 0 || !readOnly) && (
+        <div className="space-y-2">
+          {activeFeatures.length > 0 && (
+            <>
+              <p className="text-[11px] font-semibold uppercase tracking-wider text-stone-500">
+                Features this scene commits to
+              </p>
+              <ul className="space-y-2">
+                {scene.features.map((f) => (
+                  <FeatureRow
+                    key={f.id}
+                    feature={f}
+                    readOnly={readOnly}
+                    isMissed={missedIds.has(f.id)}
+                    onEdit={(field, value) => onEditFeature(f.id, field, value)}
+                    onFeedback={(text) => onFeatureFeedback(f.id, text)}
+                    onDelete={() => onDeleteFeature(f.id)}
+                  />
+                ))}
+              </ul>
+            </>
+          )}
+          {!readOnly && (
+            <button
+              type="button"
+              onClick={onAddFeature}
+              className="mt-1 text-xs text-stone-500 hover:text-stone-300 border border-dashed border-stone-700 hover:border-stone-500 rounded px-3 py-1.5 transition-colors"
+            >
+              + Add feature
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Per-scene feedback */}
+      {!readOnly && (
+        <input
+          type="text"
+          className="w-full rounded border bg-stone-900 px-3 py-1.5 text-xs text-stone-400 border-stone-700 focus:border-stone-500 focus:outline-none transition-colors"
+          value={scene.feedback}
+          onChange={(e) => onSceneFeedback(e.target.value)}
+          placeholder="Scene-level feedback (optional)"
+        />
+      )}
+      {readOnly && scene.feedback && (
+        <p className="text-xs text-stone-500 italic">Feedback: {scene.feedback}</p>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Inner editor — has access to the ReviewEditor context
+// Owns all user interaction + submit logic.
+// ---------------------------------------------------------------------------
+
+interface ReviewEditorInnerProps {
+  review: ReviewDetail
+  readOnly: boolean
+  /** Called after a successful submit with the updated review */
+  onResolved: (updated: ReviewDetail) => void
+}
+
+function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerProps) {
+  const { effectiveScenes, overallFeedback, isDirty, dispatch } = useReviewEditor()
+
+  const shareToken = useRef(new URLSearchParams(window.location.search).get('t')).current
+
+  const newFeatureCounterRef = useRef(0)
+  const newSceneCounterRef = useRef(0)
+
+  const [choices, setChoices] = useState<Record<string, string>>(() => {
+    const initial: Record<string, string> = {}
+    for (const dec of review.request_json.decisions ?? []) {
+      initial[dec.id] = dec.recommended ?? dec.options[0] ?? ''
+    }
+    return initial
+  })
   const [busy, setBusy] = useState(false)
-  const [submitted, setSubmitted] = useState(false)
-
-  // Local state for decision choices (keyed by decision.id)
-  const [choices, setChoices] = useState<Record<string, string>>({})
-  // Local state for narration edits (keyed by narration item id)
-  const [narrationEdits, setNarrationEdits] = useState<Record<string, string>>({})
-
-  // Collapsed/expanded state for the autonomous audit section
+  const [error, setError] = useState<string | null>(null)
   const [auditOpen, setAuditOpen] = useState(false)
 
-  useEffect(() => {
-    if (!id) return
-    let cancelled = false
-    getReview(id, shareToken)
-      .then((d) => {
-        if (cancelled) return
-        setReview(d)
-        // Initialise local decision choices from recommended values
-        const initialChoices: Record<string, string> = {}
-        for (const dec of d.request_json.decisions ?? []) {
-          initialChoices[dec.id] = dec.recommended ?? dec.options[0] ?? ''
-        }
-        setChoices(initialChoices)
-        // Initialise narration edits from existing text
-        const initialNarration: Record<string, string> = {}
-        for (const n of d.request_json.narration ?? []) {
-          initialNarration[n.id] = n.text
-        }
-        setNarrationEdits(initialNarration)
-        // If already resolved, show the read-only resolved state immediately
-        if (d.status === 'resolved') setSubmitted(true)
-      })
-      .catch((e) => !cancelled && setError(String(e?.message ?? e)))
-    return () => {
-      cancelled = true
-    }
-  }, [id]) // eslint-disable-line react-hooks/exhaustive-deps
-  // (shareToken is stable for the page lifetime — intentionally omitted from deps)
-
-  async function handleSubmit() {
-    if (!id || !review) return
-    setBusy(true)
-    setError(null)
-    try {
-      const payload: ReviewSubmitPayload = {
-        decisions: choices,
-        narration_edits: narrationEdits,
-      }
-      const updated = await submitReview(id, payload, shareToken)
-      setReview(updated)
-      setSubmitted(true)
-    } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : String(e)
-      setError(msg)
-    } finally {
-      setBusy(false)
-    }
-  }
-
-  // -------------------------------------------------------------------
-  // Loading / error states
-  // -------------------------------------------------------------------
-
-  if (error && !review) {
-    return (
-      <div className="max-w-4xl mx-auto p-6 text-red-500">
-        <p className="font-semibold">Error loading review</p>
-        <p className="text-sm mt-1 text-red-400">{error}</p>
-      </div>
-    )
-  }
-
-  if (!review) {
-    return <div className="max-w-4xl mx-auto p-6 text-stone-500">Loading…</div>
-  }
-
   const req = review.request_json
-  const isResolved = review.status === 'resolved' || submitted
   const decisions: ReviewDecision[] = req.decisions ?? []
-  const narration: ReviewNarrationItem[] = req.narration ?? []
   const autonomousAudit: string[] = req.autonomous_audit ?? []
   const actionability = req.actionability ?? null
   const overallScore = actionability?.overall_score ?? null
   const perScene = actionability?.per_scene ?? {}
 
-  // Separate narrative-verdict decision from other decisions
   const narrativeVerdictDecision = decisions.find((d) => d.id === 'narrative-verdict') ?? null
   const otherDecisions = decisions.filter((d) => d.id !== 'narrative-verdict')
 
-  // -------------------------------------------------------------------
-  // Video / iframe embed — mirrors WalkthroughViewerPage mechanism
-  // -------------------------------------------------------------------
+  // Resolved display: prefer submitted response_json values over local choices
+  function resolvedChoice(decId: string): string {
+    if (readOnly && review.response_json?.decisions) {
+      return review.response_json.decisions[decId] ?? choices[decId] ?? ''
+    }
+    return choices[decId] ?? ''
+  }
 
+  // Submit — builds payload from op-buffer projection
+  const handleSubmit = useCallback(async () => {
+    setBusy(true)
+    setError(null)
+    try {
+      // Build edited_scenes from effectiveScenes (op-buffer projection)
+      const editedScenes: ReviewSubmittedScene[] = effectiveScenes.map((scene) => ({
+        id: scene.id,
+        title: scene.title,
+        narration: scene.narration,
+        deleted: scene.deleted,
+        features: scene.features.map((f) => ({
+          id: f.id,
+          description: f.description,
+          verify: f.verify,
+          feedback: f.feedback,
+        })),
+        feedback: scene.feedback,
+      }))
+
+      const payload: ReviewSubmitPayload = {
+        decisions: choices,
+        edited_scenes: editedScenes,
+        overall_feedback: overallFeedback,
+      }
+
+      const updated = await submitReview(review.id, payload, shareToken)
+      onResolved(updated)
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setBusy(false)
+    }
+  }, [effectiveScenes, overallFeedback, choices, review.id, shareToken, onResolved])
+
+  const canSubmit = !busy && decisions.every((d) => !!choices[d.id])
+
+  // Video embed
   let videoElement: React.ReactNode = null
   if (req.video?.walkthrough_id) {
     const contentSrc = walkthroughContentUrl(req.video.walkthrough_id, shareToken)
@@ -408,11 +536,7 @@ export function ReviewPage() {
     )
   } else if (req.video?.url) {
     videoElement = (
-      <video
-        src={req.video.url}
-        controls
-        className="w-full max-h-[60vh] bg-black"
-      />
+      <video src={req.video.url} controls className="w-full max-h-[60vh] bg-black" />
     )
   } else {
     videoElement = (
@@ -421,18 +545,6 @@ export function ReviewPage() {
       </div>
     )
   }
-
-  // Helper to get the resolved decision value for a decision id
-  function resolvedChoice(decId: string): string {
-    if (isResolved && review?.response_json?.decisions) {
-      return review.response_json.decisions[decId] ?? choices[decId] ?? ''
-    }
-    return choices[decId] ?? ''
-  }
-
-  // -------------------------------------------------------------------
-  // Render
-  // -------------------------------------------------------------------
 
   return (
     <div className="max-w-4xl mx-auto py-8 px-4 space-y-8">
@@ -453,17 +565,33 @@ export function ReviewPage() {
             </div>
           )}
         </div>
-        <span
-          className={[
-            'shrink-0 rounded px-2 py-0.5 text-xs font-medium',
-            isResolved
-              ? 'bg-emerald-500/20 text-emerald-300 border border-emerald-500/30'
-              : 'bg-amber-500/20 text-amber-300 border border-amber-500/30',
-          ].join(' ')}
-        >
-          {isResolved ? 'Resolved' : 'Needs your input'}
-        </span>
+        <div className="flex items-center gap-2">
+          <DirtyBadge isDirty={isDirty} />
+          <span
+            className={[
+              'shrink-0 rounded px-2 py-0.5 text-xs font-medium',
+              readOnly
+                ? 'bg-emerald-500/20 text-emerald-300 border border-emerald-500/30'
+                : 'bg-amber-500/20 text-amber-300 border border-amber-500/30',
+            ].join(' ')}
+          >
+            {readOnly ? 'Resolved' : 'Needs your input'}
+          </span>
+        </div>
       </header>
+
+      {/* Undo bar */}
+      {isDirty && !readOnly && (
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => dispatch({ type: 'UNDO_LAST_OP' })}
+            className="text-xs text-stone-400 hover:text-stone-200 border border-stone-700 hover:border-stone-500 rounded px-3 py-1 transition-colors"
+          >
+            ↩ Undo last edit
+          </button>
+        </div>
+      )}
 
       {/* Current cut */}
       <section>
@@ -475,26 +603,26 @@ export function ReviewPage() {
         </div>
       </section>
 
-      {/* Narrative verdict — the primary decision, shown before narration */}
+      {/* Narrative verdict decision tile */}
       {narrativeVerdictDecision && (
         <section>
           <h2 className="text-sm font-semibold text-stone-400 uppercase tracking-wider mb-3">
-            {isResolved ? 'Decision (submitted)' : 'Your decision'}
+            {readOnly ? 'Decision (submitted)' : 'Your decision'}
           </h2>
           <NarrativeVerdictControl
             decision={narrativeVerdictDecision}
             chosen={resolvedChoice('narrative-verdict')}
             onChange={(val) => setChoices((prev) => ({ ...prev, 'narrative-verdict': val }))}
-            readOnly={isResolved}
+            readOnly={readOnly}
           />
         </section>
       )}
 
-      {/* Other decisions (non-narrative-verdict) */}
+      {/* Other decisions */}
       {otherDecisions.length > 0 && (
         <section>
           <h2 className="text-sm font-semibold text-stone-400 uppercase tracking-wider mb-3">
-            {isResolved ? 'Additional decisions (submitted)' : 'Additional decisions'}
+            {readOnly ? 'Additional decisions (submitted)' : 'Additional decisions'}
           </h2>
           <div className="space-y-3">
             {otherDecisions.map((dec) => (
@@ -503,39 +631,102 @@ export function ReviewPage() {
                 decision={dec}
                 chosen={resolvedChoice(dec.id)}
                 onChange={(val) => setChoices((prev) => ({ ...prev, [dec.id]: val }))}
-                readOnly={isResolved}
+                readOnly={readOnly}
               />
             ))}
           </div>
         </section>
       )}
 
-      {/* Narration cards — editable text + features + per-scene scores */}
-      {narration.length > 0 && (
+      {/* Scene cards — driven by op-buffer projection */}
+      {(effectiveScenes.length > 0 || !readOnly) && (
         <section>
           <h2 className="text-sm font-semibold text-stone-400 uppercase tracking-wider mb-3">
-            {isResolved ? 'Narration (submitted)' : 'Narration — edit inline'}
+            {readOnly ? 'Narration (submitted)' : 'Narration — edit inline'}
           </h2>
           <div className="space-y-4">
-            {narration.map((item) => {
-              const editedValue = isResolved && review.response_json?.narration_edits
-                ? (review.response_json.narration_edits[item.id] ?? narrationEdits[item.id] ?? item.text)
-                : (narrationEdits[item.id] ?? item.text)
-              const sceneScore = perScene[item.id] ?? undefined
-              return (
-                <NarrationCard
-                  key={item.id}
-                  item={item}
-                  value={editedValue}
-                  onChange={(val) =>
-                    setNarrationEdits((prev) => ({ ...prev, [item.id]: val }))
-                  }
-                  readOnly={isResolved}
-                  sceneActionability={sceneScore}
-                />
-              )
-            })}
+            {effectiveScenes.map((scene) => (
+              <SceneCard
+                key={scene.id}
+                scene={scene}
+                readOnly={readOnly}
+                sceneActionability={perScene[scene.id] ?? undefined}
+                onEditNarration={(text) =>
+                  dispatch({ type: 'APPEND_OP', op: { op: 'edit-narration', sceneId: scene.id, text } })
+                }
+                onEditFeature={(featureId, field, value) =>
+                  dispatch({
+                    type: 'APPEND_OP',
+                    op: { op: 'edit-feature', sceneId: scene.id, featureId, field, value },
+                  })
+                }
+                onFeatureFeedback={(featureId, text) =>
+                  dispatch({
+                    type: 'APPEND_OP',
+                    op: { op: 'set-feature-feedback', sceneId: scene.id, featureId, text },
+                  })
+                }
+                onDeleteFeature={(featureId) =>
+                  dispatch({ type: 'APPEND_OP', op: { op: 'delete-feature', sceneId: scene.id, featureId } })
+                }
+                onAddFeature={() => {
+                  newFeatureCounterRef.current += 1
+                  const featureId = `new-${newFeatureCounterRef.current}`
+                  dispatch({ type: 'APPEND_OP', op: { op: 'add-feature', sceneId: scene.id, featureId } })
+                }}
+                onDeleteScene={() =>
+                  dispatch({ type: 'APPEND_OP', op: { op: 'delete-scene', sceneId: scene.id } })
+                }
+                onSceneFeedback={(text) =>
+                  dispatch({ type: 'APPEND_OP', op: { op: 'set-scene-feedback', sceneId: scene.id, text } })
+                }
+              />
+            ))}
+
+            {/* Add scene */}
+            {!readOnly && (
+              <button
+                type="button"
+                onClick={() => {
+                  newSceneCounterRef.current += 1
+                  const sceneId = `new-${newSceneCounterRef.current}`
+                  dispatch({
+                    type: 'APPEND_OP',
+                    op: { op: 'add-scene', sceneId, title: `New Scene ${newSceneCounterRef.current}` },
+                  })
+                }}
+                className="w-full rounded-lg border border-dashed border-stone-700 hover:border-stone-500 text-stone-500 hover:text-stone-300 py-3 text-sm transition-colors"
+              >
+                + Add scene
+              </button>
+            )}
           </div>
+        </section>
+      )}
+
+      {/* Overall feedback */}
+      {!readOnly && (
+        <section>
+          <h2 className="text-sm font-semibold text-stone-400 uppercase tracking-wider mb-2">
+            Overall feedback
+          </h2>
+          <textarea
+            className="w-full rounded border bg-stone-900 px-3 py-2 text-sm text-stone-200 resize-y min-h-[3rem] border-stone-700 focus:border-stone-500 focus:outline-none transition-colors"
+            value={overallFeedback}
+            onChange={(e) =>
+              dispatch({ type: 'APPEND_OP', op: { op: 'set-overall-feedback', text: e.target.value } })
+            }
+            rows={2}
+            placeholder="Any overall feedback for the re-draft (optional)"
+          />
+        </section>
+      )}
+      {readOnly && review.response_json?.overall_feedback && (
+        <section>
+          <h2 className="text-sm font-semibold text-stone-400 uppercase tracking-wider mb-2">
+            Overall feedback (submitted)
+          </h2>
+          <p className="text-sm text-stone-400 italic">{review.response_json.overall_feedback}</p>
         </section>
       )}
 
@@ -548,10 +739,7 @@ export function ReviewPage() {
             className="flex items-center gap-2 text-sm text-stone-500 hover:text-stone-300 transition-colors"
           >
             <svg
-              className={[
-                'h-4 w-4 transition-transform',
-                auditOpen ? 'rotate-90' : '',
-              ].join(' ')}
+              className={['h-4 w-4 transition-transform', auditOpen ? 'rotate-90' : ''].join(' ')}
               viewBox="0 0 12 12"
               fill="none"
             >
@@ -578,14 +766,15 @@ export function ReviewPage() {
         </section>
       )}
 
-      {/* Action / resolved state */}
+      {/* Error */}
       {error && (
         <p className="text-sm text-red-400 rounded border border-red-500/30 bg-red-500/10 px-3 py-2">
           {error}
         </p>
       )}
 
-      {isResolved ? (
+      {/* Submit / resolved state */}
+      {readOnly ? (
         <div className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-4 py-3">
           <p className="text-sm text-emerald-300 font-medium">
             Review resolved — the loop will continue.
@@ -601,10 +790,10 @@ export function ReviewPage() {
           <button
             type="button"
             onClick={() => void handleSubmit()}
-            disabled={busy || decisions.some((d) => !choices[d.id])}
+            disabled={!canSubmit}
             className={[
               'px-6 py-2 rounded font-medium text-sm transition-colors',
-              busy
+              !canSubmit
                 ? 'bg-stone-700 text-stone-400 cursor-not-allowed'
                 : 'bg-orange-500 hover:bg-orange-400 text-white',
             ].join(' ')}
@@ -614,5 +803,57 @@ export function ReviewPage() {
         </div>
       )}
     </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Outer page shell — fetches data, owns resolved state, wraps provider
+// ---------------------------------------------------------------------------
+
+export function ReviewPage() {
+  const { id } = useParams<{ id: string }>()
+
+  // ?t= share-token (stable for page lifetime — intentionally not in deps)
+  const shareToken = useRef(new URLSearchParams(window.location.search).get('t')).current
+
+  const [review, setReview] = useState<ReviewDetail | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!id) return
+    let cancelled = false
+    getReview(id, shareToken)
+      .then((d) => { if (!cancelled) setReview(d) })
+      .catch((e) => { if (!cancelled) setError(String(e?.message ?? e)) })
+    return () => { cancelled = true }
+  }, [id]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // -------------------------------------------------------------------
+  // Loading / error states
+  // -------------------------------------------------------------------
+
+  if (error && !review) {
+    return (
+      <div className="max-w-4xl mx-auto p-6 text-red-500">
+        <p className="font-semibold">Error loading review</p>
+        <p className="text-sm mt-1 text-red-400">{error}</p>
+      </div>
+    )
+  }
+
+  if (!review) {
+    return <div className="max-w-4xl mx-auto p-6 text-stone-500">Loading…</div>
+  }
+
+  const isResolved = review.status === 'resolved'
+
+  return (
+    <ReviewEditorProvider original={review.request_json.narration ?? []}>
+      <ReviewEditorInner
+        review={review}
+        readOnly={isResolved}
+        onResolved={(updated) => setReview(updated)}
+      />
+    </ReviewEditorProvider>
   )
 }


### PR DESCRIPTION
## Product Description

The review gate page now has a full scene and feature editor. Reviewers can:

- Edit narration text for any scene inline
- Edit each feature's description and verify fields
- Add optional per-feature and per-scene feedback
- Add new scenes (assigned sequential `new-<n>` ids)
- Delete scenes or individual features
- Undo the last edit with a single button
- See an "Edited" badge when the buffer has uncommitted edits
- Leave overall feedback for the re-draft
- Choose Approve & continue or Send back to re-draft via the decision tiles

All scenes (including deleted ones with `deleted: true`) are included in the submit payload, which matches the `apply_narrative_edits` contract exactly.

## Technical Summary

Implements the op-buffer / applyOps pattern (mirrors ace-web's videos editor):

- `reviewEditorTypes.ts` — `PendingReviewOp` union + `opCoalesceKey` (last-write-wins coalescing per field)
- `reviewEditorReducer.ts` — `APPEND_OP` / `UNDO_LAST_OP` / `CLEAR_BUFFER` / `SAVE_*` actions
- `reviewApplyOps.ts` — pure projection of original narration + op-buffer → `EffectiveScene[]`; never mutates original
- `ReviewEditorContext.tsx` — `ReviewEditorProvider` + `useReviewEditor()` hook; exposes `effectiveScenes`, `overallFeedback`, `isDirty`, `dispatch`
- `ReviewPage.tsx` — fully rewritten: outer shell fetches data + wraps provider; inner `ReviewEditorInner` reads context, owns all user interaction and submit logic
- `reviews.ts` — adds `ReviewSubmittedFeature`, `ReviewSubmittedScene`; updates `ReviewSubmitPayload` to include `edited_scenes` + `overall_feedback`; legacy `narration_edits` kept optional for read compatibility

Submit payload contract:
```json
{
  "decisions": {"narrative-verdict": "approve"|"redraft"},
  "edited_scenes": [
    {
      "id": "<narration id or 'new-<n>'>",
      "title": "...",
      "narration": "...",
      "deleted": false,
      "features": [{"id": "...", "description": "...", "verify": "...", "feedback": ""}],
      "feedback": ""
    }
  ],
  "overall_feedback": ""
}
```

## Safety Assurance

- `npm run build` passes with 0 TypeScript errors
- 12 unit tests added in `reviewApplyOps.test.ts` (vitest): edit, add-scene, delete-scene, add-feature, delete-feature, feedback, set-overall-feedback noop, mutation guard — all pass
- No mutations to original narration data (deep-clone via JSON.parse/stringify in applyReviewOps)
- Anonymous / `?t=` link-token access preserved — token passed through to all API calls and video embed
- Read-only / resolved state preserved — all controls lock when `status === 'resolved'`