### PR TITLE
feat(reviews): per-sentence tints on the narrative banner + click-to-scroll to scene

### DIFF
--- a/frontend/src/api/insights.ts
+++ b/frontend/src/api/insights.ts
@@ -3,7 +3,7 @@ import type { components } from "./generated";
 
 export type Insight = components["schemas"]["InsightOut"];
 
-export type InsightCategory = 'ship_gap' | 'hygiene' | 'pattern' | 'stale' | 'opportunity'
+export type InsightCategory = 'ship_gap' | 'hygiene' | 'pattern' | 'stale' | 'opportunity' | 'alignment'
 
 export function parseInsightCategory(content: string): InsightCategory | null {
   const match = content.match(/^\[(\w+)\]/)
@@ -30,6 +30,7 @@ export interface InsightListParams {
 const CATEGORY_RANK: Record<string, number> = {
   ship_gap: 4,
   opportunity: 3,
+  alignment: 3,
   pattern: 2,
   hygiene: 2,
   stale: 1,

--- a/frontend/src/api/reviews.ts
+++ b/frontend/src/api/reviews.ts
@@ -43,6 +43,8 @@ export interface ReviewNarrationItem {
   title?: string
   /** Persona key on screen for this beat (DDD v3). Maps into request_json.personas. */
   persona?: string
+  /** Spine id this beat grounds — joins the scene to its why-brief grounding. */
+  provenance?: string
   text: string
   features?: ReviewFeature[]
 }

--- a/frontend/src/api/reviews.ts
+++ b/frontend/src/api/reviews.ts
@@ -59,11 +59,17 @@ export interface ReviewPersona {
 }
 
 // Why-brief (the grounding doc), shown + edited alongside the narrative.
+export interface ReviewWhyEvidence {
+  kind?: string
+  ref: string
+}
+
 export interface ReviewWhySpineItem {
   id: string
   claim: string
   rationale?: string
   status?: string
+  evidence?: ReviewWhyEvidence[]
 }
 
 export interface ReviewWhyGap {

--- a/frontend/src/api/reviews.ts
+++ b/frontend/src/api/reviews.ts
@@ -52,6 +52,30 @@ export interface ReviewPersona {
   role: string
   color: string
   intro: string
+  /** The organization this individual belongs to (e.g. "Dimagi", "LLO"). */
+  org?: string
+}
+
+// Why-brief (the grounding doc), shown + edited alongside the narrative.
+export interface ReviewWhySpineItem {
+  id: string
+  claim: string
+  rationale?: string
+  status?: string
+}
+
+export interface ReviewWhyGap {
+  id: string
+  type?: string
+  claim_ref?: string
+  detail: string
+  proposed_action: string
+}
+
+export interface ReviewWhyBrief {
+  problem?: string
+  spine?: ReviewWhySpineItem[]
+  gaps?: ReviewWhyGap[]
 }
 
 export interface ReviewVideo {
@@ -80,6 +104,8 @@ export interface ReviewRequestJson {
   narrative?: string
   /** Persona key -> details, so the surface can show who is on screen each beat. */
   personas?: Record<string, ReviewPersona>
+  /** The resolved why-brief (problem/spine/gaps), shown + edited on the surface. */
+  why_brief?: ReviewWhyBrief
   autonomous_audit: string[]
   actionability?: ReviewActionability | null
   /**
@@ -110,11 +136,23 @@ export interface ReviewSubmittedScene {
   feedback: string
 }
 
+/** Partial persona edit — only changed fields are sent, keyed by persona key. */
+export type ReviewSubmittedPersonas = Record<string, Partial<Omit<ReviewPersona, 'color'>>>
+
+/** Why-brief edits — prose fields only, keyed by spine/gap id. */
+export interface ReviewSubmittedWhyBrief {
+  problem?: string
+  spine?: Record<string, { claim?: string; rationale?: string }>
+  gaps?: Record<string, { detail?: string; proposed_action?: string }>
+}
+
 export interface ReviewSubmitPayload {
   decisions: Record<string, string>
   /** Legacy field — kept for backwards-compat read; send is now edited_scenes */
   narration_edits?: Record<string, string>
   edited_scenes?: ReviewSubmittedScene[]
+  edited_personas?: ReviewSubmittedPersonas
+  edited_why_brief?: ReviewSubmittedWhyBrief
   overall_feedback?: string
   /**
    * The reviewer's chosen build sequence — an ordered list of scene ids

--- a/frontend/src/api/reviews.ts
+++ b/frontend/src/api/reviews.ts
@@ -39,8 +39,19 @@ export interface ReviewFeature {
 export interface ReviewNarrationItem {
   scene: number
   id: string
+  /** Story-beat title (DDD v3). Falls back to "Scene N" when absent. */
+  title?: string
+  /** Persona key on screen for this beat (DDD v3). Maps into request_json.personas. */
+  persona?: string
   text: string
   features?: ReviewFeature[]
+}
+
+export interface ReviewPersona {
+  name: string
+  role: string
+  color: string
+  intro: string
 }
 
 export interface ReviewVideo {
@@ -65,6 +76,10 @@ export interface ReviewRequestJson {
   video?: ReviewVideo
   decisions: ReviewDecision[]
   narration: ReviewNarrationItem[]
+  /** The cohesive demo narrative — the whole story the scenes decompose (DDD v3). */
+  narrative?: string
+  /** Persona key -> details, so the surface can show who is on screen each beat. */
+  personas?: Record<string, ReviewPersona>
   autonomous_audit: string[]
   actionability?: ReviewActionability | null
   /**

--- a/frontend/src/components/InsightChip.tsx
+++ b/frontend/src/components/InsightChip.tsx
@@ -6,6 +6,7 @@ export const CATEGORY_STYLES: Record<string, { bg: string; border: string; text:
   pattern: { bg: 'bg-violet-400/5', border: 'border-violet-400/20', text: 'text-violet-400', label: 'Pattern' },
   stale: { bg: 'bg-stone-400/5', border: 'border-stone-400/20', text: 'text-stone-500', label: 'Stale' },
   opportunity: { bg: 'bg-emerald-400/5', border: 'border-emerald-400/20', text: 'text-emerald-400', label: 'Opportunity' },
+  alignment: { bg: 'bg-sky-400/5', border: 'border-sky-400/20', text: 'text-sky-400', label: 'Alignment' },
 }
 
 export function CategoryBadge({ category }: { category: InsightCategory | null }) {

--- a/frontend/src/components/reviews/ReviewEditorContext.tsx
+++ b/frontend/src/components/reviews/ReviewEditorContext.tsx
@@ -17,14 +17,21 @@ import {
   useReducer,
   type ReactNode,
 } from 'react'
-import { applyReviewOps, projectBuildOrder, type EffectiveScene } from './reviewApplyOps'
+import {
+  applyReviewOps,
+  projectBuildOrder,
+  projectPersonas,
+  projectWhyBrief,
+  type EffectiveScene,
+  type EffectivePersonas,
+} from './reviewApplyOps'
 import {
   reviewEditorReducer,
   initialReviewEditorState,
   type ReviewEditorAction,
 } from './reviewEditorReducer'
 import type { ReviewEditorState, PendingReviewOp } from './reviewEditorTypes'
-import type { ReviewNarrationItem } from '../../api/reviews'
+import type { ReviewNarrationItem, ReviewPersona, ReviewWhyBrief } from '../../api/reviews'
 
 // ---------------------------------------------------------------------------
 // Context shape
@@ -33,6 +40,10 @@ import type { ReviewNarrationItem } from '../../api/reviews'
 interface ReviewEditorContextValue {
   state: ReviewEditorState
   effectiveScenes: EffectiveScene[]
+  /** Personas with edit-persona ops applied (pure projection). */
+  effectivePersonas: EffectivePersonas
+  /** Why-brief with edit-why-* ops applied (pure projection). */
+  effectiveWhyBrief: ReviewWhyBrief
   /** Current value of the overall_feedback field (from buffer or ''). */
   overallFeedback: string
   /**
@@ -56,19 +67,45 @@ interface Props {
   original: ReviewNarrationItem[]
   /** From request_json.build_order — null/undefined = absent, fall back to narration order. */
   initialBuildOrder?: string[] | null
+  /** From request_json.personas — the cast, editable on the surface. */
+  personas?: Record<string, ReviewPersona>
+  /** From request_json.why_brief — the grounding doc, editable on the surface. */
+  whyBrief?: ReviewWhyBrief | null
   children: ReactNode
 }
 
-export function ReviewEditorProvider({ original, initialBuildOrder, children }: Props) {
+export function ReviewEditorProvider({
+  original,
+  initialBuildOrder,
+  personas,
+  whyBrief,
+  children,
+}: Props) {
   const [state, dispatch] = useReducer(
     reviewEditorReducer,
     undefined,
-    () => initialReviewEditorState(original, initialBuildOrder ?? null),
+    () =>
+      initialReviewEditorState(
+        original,
+        initialBuildOrder ?? null,
+        personas ?? {},
+        whyBrief ?? null,
+      ),
   )
 
   const effectiveScenes = useMemo(
     () => applyReviewOps(state.original, state.buffer),
     [state.original, state.buffer],
+  )
+
+  const effectivePersonas = useMemo(
+    () => projectPersonas(state.originalPersonas, state.buffer),
+    [state.originalPersonas, state.buffer],
+  )
+
+  const effectiveWhyBrief = useMemo(
+    () => projectWhyBrief(state.originalWhyBrief, state.buffer),
+    [state.originalWhyBrief, state.buffer],
   )
 
   const overallFeedback = useMemo(() => {
@@ -90,6 +127,8 @@ export function ReviewEditorProvider({ original, initialBuildOrder, children }: 
   const value: ReviewEditorContextValue = {
     state,
     effectiveScenes,
+    effectivePersonas,
+    effectiveWhyBrief,
     overallFeedback,
     buildOrder,
     isDirty,

--- a/frontend/src/components/reviews/reviewApplyOps.test.ts
+++ b/frontend/src/components/reviews/reviewApplyOps.test.ts
@@ -255,3 +255,63 @@ describe('projectBuildOrder', () => {
     expect(order).toEqual(['scene-1', 'new-42'])
   })
 })
+
+import { projectPersonas, projectWhyBrief } from './reviewApplyOps'
+import type { ReviewPersona, ReviewWhyBrief } from '../../api/reviews'
+
+describe('projectPersonas', () => {
+  const PERSONAS: Record<string, ReviewPersona> = {
+    maya: { name: 'Maya', role: 'Lead', color: '#3B82F6', intro: 'designs', org: 'Dimagi' },
+    sam: { name: 'Sam', role: 'Partner', color: '#10B981', intro: 'runs field', org: 'LLO' },
+  }
+
+  it('returns a clone with no ops (no mutation of original)', () => {
+    const out = projectPersonas(PERSONAS, [])
+    expect(out.maya.name).toBe('Maya')
+    out.maya.name = 'X'
+    expect(PERSONAS.maya.name).toBe('Maya')
+  })
+
+  it('applies edit-persona ops by key+field', () => {
+    const out = projectPersonas(PERSONAS, [
+      { op: 'edit-persona', key: 'maya', field: 'org', value: 'Dimagi Inc' },
+      { op: 'edit-persona', key: 'sam', field: 'name', value: 'Samir' },
+    ])
+    expect(out.maya.org).toBe('Dimagi Inc')
+    expect(out.sam.name).toBe('Samir')
+    expect(out.maya.name).toBe('Maya')
+  })
+
+  it('ignores edits to unknown persona keys', () => {
+    const out = projectPersonas(PERSONAS, [
+      { op: 'edit-persona', key: 'ghost', field: 'name', value: 'Nobody' },
+    ])
+    expect(out.ghost).toBeUndefined()
+  })
+})
+
+describe('projectWhyBrief', () => {
+  const WB: ReviewWhyBrief = {
+    problem: 'old problem',
+    spine: [{ id: 'S1', claim: 'old claim', rationale: 'old rat', status: 'grounded' }],
+    gaps: [{ id: 'g1', type: 'CAPABILITY', claim_ref: 'S1', detail: 'old detail', proposed_action: 'old action' }],
+  }
+
+  it('applies problem / spine / gap edits, leaving others intact', () => {
+    const out = projectWhyBrief(WB, [
+      { op: 'edit-why-problem', value: 'new problem' },
+      { op: 'edit-why-spine', id: 'S1', field: 'claim', value: 'new claim' },
+      { op: 'edit-why-gap', id: 'g1', field: 'proposed_action', value: 'new action' },
+    ])
+    expect(out.problem).toBe('new problem')
+    expect(out.spine![0].claim).toBe('new claim')
+    expect(out.spine![0].rationale).toBe('old rat')
+    expect(out.gaps![0].proposed_action).toBe('new action')
+    expect(out.gaps![0].detail).toBe('old detail')
+  })
+
+  it('does not mutate the original', () => {
+    projectWhyBrief(WB, [{ op: 'edit-why-problem', value: 'x' }])
+    expect(WB.problem).toBe('old problem')
+  })
+})

--- a/frontend/src/components/reviews/reviewApplyOps.test.ts
+++ b/frontend/src/components/reviews/reviewApplyOps.test.ts
@@ -39,6 +39,22 @@ describe('applyReviewOps', () => {
     expect(scenes[0].features[0].feedback).toBe('')
   })
 
+  it('carries the real story-beat title and persona when present', () => {
+    const withTitles: ReviewNarrationItem[] = [
+      { scene: 1, id: 'scene-1', title: 'Maya picks the district', persona: 'lead', text: 'one', features: [] },
+    ]
+    const scenes = applyReviewOps(withTitles, [])
+    expect(scenes[0].title).toBe('Maya picks the district')
+    expect(scenes[0].persona).toBe('lead')
+  })
+
+  it('falls back to "Scene N" when no title is provided', () => {
+    const scenes = applyReviewOps(ORIGINAL, [])
+    expect(scenes[0].title).toBe('Scene 1')
+    expect(scenes[1].title).toBe('Scene 2')
+    expect(scenes[0].persona).toBe('')
+  })
+
   it('edit-narration updates the narration text', () => {
     const ops: PendingReviewOp[] = [
       { op: 'edit-narration', sceneId: 'scene-1', text: 'Edited narration' },

--- a/frontend/src/components/reviews/reviewApplyOps.ts
+++ b/frontend/src/components/reviews/reviewApplyOps.ts
@@ -29,8 +29,12 @@ export interface EffectiveFeature {
 
 export interface EffectiveScene {
   id: string
-  /** 'new' scenes carry a user-editable title; original scenes use "Scene N". */
+  /** Story-beat title. Original scenes carry the spec title; falls back to
+   * "Scene N" only when the backend sent no title. New scenes carry the
+   * user-entered title. */
   title: string
+  /** Persona key on screen this beat (DDD v3). Empty for new/unassigned scenes. */
+  persona: string
   narration: string
   deleted: boolean
   features: EffectiveFeature[]
@@ -111,6 +115,7 @@ export function applyReviewOps(
           const newScene: EffectiveScene = {
             id: op.sceneId,
             title: op.title,
+            persona: '',
             narration: '',
             deleted: false,
             features: [],
@@ -212,7 +217,8 @@ export function projectBuildOrder(
 function originalToEffective(items: ReviewNarrationItem[]): EffectiveScene[] {
   return items.map((item) => ({
     id: item.id,
-    title: `Scene ${item.scene}`,
+    title: item.title && item.title.trim() ? item.title : `Scene ${item.scene}`,
+    persona: item.persona ?? '',
     narration: item.text,
     deleted: false,
     features: (item.features ?? []).map((f: ReviewFeature) => ({

--- a/frontend/src/components/reviews/reviewApplyOps.ts
+++ b/frontend/src/components/reviews/reviewApplyOps.ts
@@ -40,6 +40,8 @@ export interface EffectiveScene {
   title: string
   /** Persona key on screen this beat (DDD v3). Empty for new/unassigned scenes. */
   persona: string
+  /** Spine id this beat grounds — joins to the why-brief grounding. Empty for new scenes. */
+  provenance: string
   narration: string
   deleted: boolean
   features: EffectiveFeature[]
@@ -121,6 +123,7 @@ export function applyReviewOps(
             id: op.sceneId,
             title: op.title,
             persona: '',
+            provenance: '',
             narration: '',
             deleted: false,
             features: [],
@@ -224,6 +227,7 @@ function originalToEffective(items: ReviewNarrationItem[]): EffectiveScene[] {
     id: item.id,
     title: item.title && item.title.trim() ? item.title : `Scene ${item.scene}`,
     persona: item.persona ?? '',
+    provenance: item.provenance ?? '',
     narration: item.text,
     deleted: false,
     features: (item.features ?? []).map((f: ReviewFeature) => ({

--- a/frontend/src/components/reviews/reviewApplyOps.ts
+++ b/frontend/src/components/reviews/reviewApplyOps.ts
@@ -12,7 +12,12 @@
  *   the reducer, so each key appears at most once.
  */
 
-import type { ReviewNarrationItem, ReviewFeature } from '../../api/reviews'
+import type {
+  ReviewNarrationItem,
+  ReviewFeature,
+  ReviewPersona,
+  ReviewWhyBrief,
+} from '../../api/reviews'
 import type { PendingReviewOp } from './reviewEditorTypes'
 
 // ---------------------------------------------------------------------------
@@ -230,4 +235,49 @@ function originalToEffective(items: ReviewNarrationItem[]): EffectiveScene[] {
     })),
     feedback: '',
   }))
+}
+
+// ---------------------------------------------------------------------------
+// Persona projection — apply edit-persona ops over the original personas dict.
+// ---------------------------------------------------------------------------
+
+export type EffectivePersonas = Record<string, ReviewPersona>
+
+export function projectPersonas(
+  original: Record<string, ReviewPersona> | undefined,
+  ops: PendingReviewOp[],
+): EffectivePersonas {
+  const personas: EffectivePersonas = JSON.parse(JSON.stringify(original ?? {}))
+  for (const op of ops) {
+    if (op.op !== 'edit-persona') continue
+    const p = personas[op.key]
+    if (!p) continue
+    p[op.field] = op.value
+  }
+  return personas
+}
+
+// ---------------------------------------------------------------------------
+// Why-brief projection — apply edit-why-* ops over the original why-brief.
+// ---------------------------------------------------------------------------
+
+export function projectWhyBrief(
+  original: ReviewWhyBrief | undefined | null,
+  ops: PendingReviewOp[],
+): ReviewWhyBrief {
+  const wb: ReviewWhyBrief = JSON.parse(
+    JSON.stringify(original ?? { problem: '', spine: [], gaps: [] }),
+  )
+  for (const op of ops) {
+    if (op.op === 'edit-why-problem') {
+      wb.problem = op.value
+    } else if (op.op === 'edit-why-spine') {
+      const item = (wb.spine ?? []).find((s) => s.id === op.id)
+      if (item) item[op.field] = op.value
+    } else if (op.op === 'edit-why-gap') {
+      const gap = (wb.gaps ?? []).find((g) => g.id === op.id)
+      if (gap) gap[op.field] = op.value
+    }
+  }
+  return wb
 }

--- a/frontend/src/components/reviews/reviewEditorReducer.ts
+++ b/frontend/src/components/reviews/reviewEditorReducer.ts
@@ -4,7 +4,7 @@
  * Pattern mirrors ace-web's videos/editorReducer.ts.
  */
 
-import type { ReviewNarrationItem } from '../../api/reviews'
+import type { ReviewNarrationItem, ReviewPersona, ReviewWhyBrief } from '../../api/reviews'
 import type { PendingReviewOp, ReviewEditorState } from './reviewEditorTypes'
 import { opCoalesceKey } from './reviewEditorTypes'
 
@@ -28,8 +28,17 @@ export type ReviewEditorAction =
 export function initialReviewEditorState(
   original: ReviewNarrationItem[],
   initialBuildOrder: string[] | null = null,
+  originalPersonas: Record<string, ReviewPersona> = {},
+  originalWhyBrief: ReviewWhyBrief | null = null,
 ): ReviewEditorState {
-  return { original, initialBuildOrder, buffer: [], saveState: { status: 'idle' } }
+  return {
+    original,
+    originalPersonas,
+    originalWhyBrief,
+    initialBuildOrder,
+    buffer: [],
+    saveState: { status: 'idle' },
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/components/reviews/reviewEditorTypes.ts
+++ b/frontend/src/components/reviews/reviewEditorTypes.ts
@@ -8,11 +8,15 @@
  *  - ReviewEditorState  = original review + buffer + save status
  */
 
-import type { ReviewNarrationItem } from '../../api/reviews'
+import type { ReviewNarrationItem, ReviewPersona, ReviewWhyBrief } from '../../api/reviews'
 
 // ---------------------------------------------------------------------------
 // Op types
 // ---------------------------------------------------------------------------
+
+export type PersonaField = 'name' | 'org' | 'role' | 'intro'
+export type WhySpineField = 'claim' | 'rationale'
+export type WhyGapField = 'detail' | 'proposed_action'
 
 export type PendingReviewOp =
   | { op: 'edit-narration'; sceneId: string; text: string }
@@ -24,6 +28,12 @@ export type PendingReviewOp =
   | { op: 'delete-scene'; sceneId: string }
   | { op: 'set-scene-feedback'; sceneId: string; text: string }
   | { op: 'set-overall-feedback'; text: string }
+  // Persona edits — key is the persona's stable dict key (never renamed here).
+  | { op: 'edit-persona'; key: string; field: PersonaField; value: string }
+  // Why-brief edits — prose fields only; ids/status/type are structural.
+  | { op: 'edit-why-problem'; value: string }
+  | { op: 'edit-why-spine'; id: string; field: WhySpineField; value: string }
+  | { op: 'edit-why-gap'; id: string; field: WhyGapField; value: string }
   /**
    * Replaces the entire build order with the given sequence of scene ids.
    * last-write-wins: the reducer coalesces all set-build-order ops into one.
@@ -52,6 +62,14 @@ export function opCoalesceKey(op: PendingReviewOp): string {
       return `set-scene-feedback:${op.sceneId}`
     case 'set-overall-feedback':
       return 'set-overall-feedback'
+    case 'edit-persona':
+      return `edit-persona:${op.key}:${op.field}`
+    case 'edit-why-problem':
+      return 'edit-why-problem'
+    case 'edit-why-spine':
+      return `edit-why-spine:${op.id}:${op.field}`
+    case 'edit-why-gap':
+      return `edit-why-gap:${op.id}:${op.field}`
     case 'set-build-order':
       // All set-build-order ops coalesce into one slot — last write wins.
       return 'set-build-order'
@@ -65,6 +83,10 @@ export function opCoalesceKey(op: PendingReviewOp): string {
 export interface ReviewEditorState {
   /** The original review request narration (never mutated). */
   original: ReviewNarrationItem[]
+  /** The original personas dict (never mutated); projection applies edit-persona ops. */
+  originalPersonas: Record<string, ReviewPersona>
+  /** The original why-brief (never mutated); projection applies edit-why-* ops. */
+  originalWhyBrief: ReviewWhyBrief | null
   /**
    * The initial build order from request_json.build_order, if provided.
    * When absent, the reducer falls back to the narration order.

--- a/frontend/src/pages/ReviewPage.tsx
+++ b/frontend/src/pages/ReviewPage.tsx
@@ -8,6 +8,7 @@ import {
   type ReviewSceneActionability,
   type ReviewSubmitPayload,
   type ReviewSubmittedScene,
+  type ReviewPersona,
 } from '../api/reviews'
 import { walkthroughContentUrl } from '../api/walkthroughs'
 import {
@@ -45,6 +46,24 @@ function DirtyBadge({ isDirty }: { isDirty: boolean }) {
   return (
     <span className="inline-flex items-center gap-1 rounded px-2 py-0.5 text-xs font-semibold bg-amber-500/20 text-amber-300 border border-amber-500/30">
       Edited
+    </span>
+  )
+}
+
+function PersonaChip({ persona, dim = false }: { persona: ReviewPersona; dim?: boolean }) {
+  return (
+    <span
+      title={`${persona.name} — ${persona.role}`}
+      className={[
+        'inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-xs font-medium select-none',
+        dim ? 'border-stone-700 text-stone-400' : 'border-stone-600 text-stone-200',
+      ].join(' ')}
+    >
+      <span
+        className="inline-block h-2 w-2 rounded-full shrink-0"
+        style={{ backgroundColor: persona.color || '#78716c' }}
+      />
+      {persona.name}
     </span>
   )
 }
@@ -304,6 +323,7 @@ interface SceneCardProps {
   scene: {
     id: string
     title: string
+    persona: string
     narration: string
     deleted: boolean
     features: Array<{
@@ -315,6 +335,8 @@ interface SceneCardProps {
     }>
     feedback: string
   }
+  sceneNumber?: number
+  persona?: ReviewPersona
   readOnly: boolean
   sceneActionability?: ReviewSceneActionability
   onEditNarration: (text: string) => void
@@ -328,6 +350,8 @@ interface SceneCardProps {
 
 function SceneCard({
   scene,
+  sceneNumber,
+  persona,
   readOnly,
   sceneActionability,
   onEditNarration,
@@ -346,11 +370,17 @@ function SceneCard({
   return (
     <div className="rounded-lg border border-stone-700 bg-stone-950 p-4 space-y-3">
       {/* Scene header */}
-      <div className="flex items-center justify-between gap-2">
-        <span className="text-xs font-semibold text-stone-500 uppercase tracking-wider">
-          {scene.title}
-        </span>
-        <div className="flex items-center gap-2">
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex items-center gap-2 flex-wrap min-w-0">
+          {sceneNumber != null && (
+            <span className="text-[11px] font-semibold text-stone-500 tabular-nums shrink-0">
+              Scene {sceneNumber}
+            </span>
+          )}
+          {persona && <PersonaChip persona={persona} />}
+          <span className="text-sm font-medium text-stone-100">{scene.title}</span>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
           {sceneActionability != null && (
             <ScoreBadge
               score={sceneActionability.score}
@@ -599,6 +629,13 @@ function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerPr
   const actionability = req.actionability ?? null
   const overallScore = actionability?.overall_score ?? null
   const perScene = actionability?.per_scene ?? {}
+  const personas = req.personas ?? {}
+
+  // 1-based scene numbers among non-deleted scenes (renumbers as scenes are added/deleted).
+  const sceneNumberById = new Map<string, number>()
+  effectiveScenes
+    .filter((s) => !s.deleted)
+    .forEach((s, i) => sceneNumberById.set(s.id, i + 1))
 
   const narrativeVerdictDecision = decisions.find((d) => d.id === 'narrative-verdict') ?? null
   const otherDecisions = decisions.filter((d) => d.id !== 'narrative-verdict')
@@ -720,6 +757,26 @@ function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerPr
         </div>
       )}
 
+      {/* The demo narrative — the cohesive story the scenes decompose */}
+      {req.narrative && req.narrative.trim() && (
+        <section className="rounded-lg border border-stone-700 bg-stone-900/60 p-5 space-y-3">
+          <h2 className="text-sm font-semibold text-stone-400 uppercase tracking-wider">
+            The demo
+          </h2>
+          <p className="text-[15px] leading-relaxed text-stone-200 whitespace-pre-line">
+            {req.narrative}
+          </p>
+          {Object.keys(personas).length > 0 && (
+            <div className="flex items-center gap-2 flex-wrap pt-1">
+              <span className="text-[11px] uppercase tracking-wider text-stone-600">Cast</span>
+              {Object.values(personas).map((p) => (
+                <PersonaChip key={p.name} persona={p} dim />
+              ))}
+            </div>
+          )}
+        </section>
+      )}
+
       {/* Current cut */}
       <section>
         <h2 className="text-sm font-semibold text-stone-400 uppercase tracking-wider mb-2">
@@ -776,6 +833,8 @@ function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerPr
               <SceneCard
                 key={scene.id}
                 scene={scene}
+                sceneNumber={sceneNumberById.get(scene.id)}
+                persona={scene.persona ? personas[scene.persona] : undefined}
                 readOnly={readOnly}
                 sceneActionability={perScene[scene.id] ?? undefined}
                 onEditNarration={(text) =>

--- a/frontend/src/pages/ReviewPage.tsx
+++ b/frontend/src/pages/ReviewPage.tsx
@@ -730,7 +730,8 @@ function PersonasSection({
                   className="inline-block h-3 w-3 rounded-full shrink-0"
                   style={{ backgroundColor: p.color || '#78716c' }}
                 />
-                <span className="text-xs text-stone-600">persona: {key}</span>
+                <span className="text-sm font-medium text-stone-100">{p.name || key}</span>
+                {p.org && <span className="text-xs text-stone-500">· {p.org}</span>}
               </div>
               <div className="grid grid-cols-2 gap-2">
                 <div>
@@ -1059,6 +1060,12 @@ function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerPr
       {/* Narrative tab — the story, personas, why-brief, scenes, decision */}
       {tab === 'narrative' && (
         <>
+      {!readOnly && (
+        <p className="text-xs text-stone-400 rounded border border-stone-700 bg-stone-900/60 px-3 py-2">
+          Every field on this page is editable — click any text to change it, drag the build
+          sequence to reorder, then approve or send back at the bottom.
+        </p>
+      )}
       {/* The demo — the cohesive story + the one problem it all serves */}
       {(req.narrative?.trim() || effectiveWhyBrief.problem || Object.keys(personas).length > 0) && (
         <section className="rounded-lg border border-stone-700 bg-stone-900/60 p-5 space-y-3">
@@ -1066,9 +1073,18 @@ function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerPr
             The demo
           </h2>
           {req.narrative?.trim() && (
-            <p className="text-[15px] leading-relaxed text-stone-200 whitespace-pre-line">
-              {req.narrative}
-            </p>
+            <div className="space-y-1.5">
+              {req.narrative
+                .trim()
+                .split(/(?<=\.)\s+/)
+                .filter((s) => s.trim())
+                .map((sentence, i) => (
+                  <p key={i} className="text-[15px] leading-relaxed text-stone-200 flex gap-2">
+                    <span className="text-stone-600 tabular-nums shrink-0 select-none">{i + 1}.</span>
+                    <span>{sentence.trim()}</span>
+                  </p>
+                ))}
+            </div>
           )}
           {(effectiveWhyBrief.problem || !readOnly) && (
             <div className="pt-1">

--- a/frontend/src/pages/ReviewPage.tsx
+++ b/frontend/src/pages/ReviewPage.tsx
@@ -412,6 +412,11 @@ function SceneCard({
   // features + grounding hide behind a toggle so the page isn't a wall.
   // defaultOpen (?expand=1) starts expanded so the full substance is captured for judging/print.
   const [open, setOpen] = useState(defaultOpen ?? false)
+  // Top-level trust signal: did this scene's verify actually run green? (kept visible
+  // in the collapsed view so the proof isn't buried behind the details toggle.)
+  const verifiedGreen = (grounding?.evidence ?? []).some((e) =>
+    /verify ran green/i.test(e.ref),
+  )
 
   return (
     <div className="rounded-lg border border-stone-700 bg-stone-950 p-4 space-y-3">
@@ -426,6 +431,14 @@ function SceneCard({
           {persona && <PersonaChip persona={persona} />}
           <span className="text-sm font-medium text-stone-100">{scene.title}</span>
           {grounding?.status && <StatusBadge status={grounding.status} />}
+          {verifiedGreen && (
+            <span
+              title="This scene's verify actually ran and passed"
+              className="shrink-0 rounded px-2 py-0.5 text-[11px] font-medium bg-emerald-500/15 text-emerald-300 border border-emerald-500/30 select-none"
+            >
+              ✓ verify passed
+            </span>
+          )}
         </div>
         <div className="flex items-center gap-2 shrink-0">
           {sceneActionability != null && (
@@ -469,9 +482,7 @@ function SceneCard({
       {!open && activeFeatures.length > 0 && (
         <p className="text-xs text-stone-500">
           <span className="text-stone-600">Builds: </span>
-          {activeFeatures[0].description.length > 90
-            ? activeFeatures[0].description.slice(0, 90).replace(/\s+\S*$/, '') + '…'
-            : activeFeatures[0].description}
+          {activeFeatures[0].description}
           {activeFeatures.length > 1 ? ` +${activeFeatures.length - 1} more` : ''}
         </p>
       )}
@@ -1236,7 +1247,13 @@ function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerPr
                 key={scene.id}
                 scene={scene}
                 sceneNumber={sceneNumberById.get(scene.id)}
-                defaultOpen={expandAll}
+                defaultOpen={
+                  expandAll ||
+                  (scene.provenance
+                    ? (spineById.get(scene.provenance)?.status ?? 'grounded') !== 'grounded'
+                    : false) ||
+                  (perScene[scene.id]?.score ?? 5) < 4
+                }
                 persona={scene.persona ? personas[scene.persona] : undefined}
                 grounding={scene.provenance ? spineById.get(scene.provenance) : undefined}
                 gaps={scene.provenance ? gapsByRef.get(scene.provenance) : undefined}

--- a/frontend/src/pages/ReviewPage.tsx
+++ b/frontend/src/pages/ReviewPage.tsx
@@ -288,16 +288,16 @@ function FeatureRow({
       {/* verify */}
       <div>
         <FieldLabel>Verify — how we'll confirm it's built</FieldLabel>
-        <input
-          type="text"
+        <textarea
           className={[
-            'w-full rounded border bg-stone-900 px-2 py-1.5 font-mono text-[11px] text-stone-400',
+            'w-full rounded border bg-stone-900 px-2 py-1.5 font-mono text-[11px] text-stone-300 resize-y min-h-[2.25rem] whitespace-pre-wrap break-words',
             'border-stone-700 focus:border-stone-500 focus:outline-none transition-colors',
             readOnly ? 'opacity-70 cursor-default' : '',
           ].join(' ')}
           value={feature.verify}
           onChange={(e) => !readOnly && onEdit('verify', e.target.value)}
           readOnly={readOnly}
+          rows={2}
           placeholder="A runnable check — API assertion, UI state, or test command"
         />
       </div>
@@ -991,7 +991,7 @@ function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerPr
                 score={overallScore}
                 tooltip="Actionability score — how confidently an AI could build this narrative as written (out of 5)"
               />
-              <p className="text-[10px] text-stone-600 mt-0.5 text-center">Actionability</p>
+              <p className="text-[10px] text-stone-600 mt-0.5 text-center">Actionability · AI eval</p>
             </div>
           )}
         </div>
@@ -1159,9 +1159,13 @@ function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerPr
       {/* Scene cards — driven by op-buffer projection */}
       {(effectiveScenes.length > 0 || !readOnly) && (
         <section>
-          <h2 className="text-sm font-semibold text-stone-400 uppercase tracking-wider mb-3">
-            {readOnly ? 'Narration (submitted)' : 'Narration — edit inline'}
+          <h2 className="text-sm font-semibold text-stone-400 uppercase tracking-wider mb-1">
+            {readOnly ? 'Scenes (submitted)' : 'Scenes — the story, beat by beat'}
           </h2>
+          <p className="text-xs text-stone-600 mb-3">
+            <span className="text-emerald-300">Built</span> = backed by shipped code ·{' '}
+            <span className="text-amber-300">Frontier</span> = intended, not built yet. Each scene = one beat of the demo.
+          </p>
           <div className="space-y-4">
             {effectiveScenes.map((scene) => (
               <SceneCard

--- a/frontend/src/pages/ReviewPage.tsx
+++ b/frontend/src/pages/ReviewPage.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useCallback, useEffect, useLayoutEffect, useRef, useState, type TextareaHTMLAttributes } from 'react'
+import { forwardRef, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type TextareaHTMLAttributes } from 'react'
 import { useParams } from 'react-router-dom'
 import {
   getReview,
@@ -405,6 +405,10 @@ interface SceneCardProps {
   onEditGap?: (gapId: string, field: 'detail' | 'proposed_action', value: string) => void
   /** When true, the scene's details start expanded (e.g. ?expand=1 / print/judge view). */
   defaultOpen?: boolean
+  /** When true, the scene has pending edits in the current session — drives the
+   *  "Edited" badge + a sky-tinted border so the reviewer sees at a glance which
+   *  beats they've touched. */
+  isEdited?: boolean
 }
 
 function StatusBadge({ status }: { status?: string }) {
@@ -443,6 +447,7 @@ function SceneCard({
   onEditRationale,
   onEditGap,
   defaultOpen,
+  isEdited,
 }: SceneCardProps) {
   if (scene.deleted) return null
 
@@ -460,7 +465,14 @@ function SceneCard({
   )
 
   return (
-    <div className="rounded-lg border border-stone-700 bg-stone-950 p-4 space-y-3">
+    <div
+      className={[
+        'rounded-lg border p-4 space-y-3 transition-colors',
+        isEdited
+          ? 'border-sky-500/60 bg-sky-500/5 ring-1 ring-sky-500/20'
+          : 'border-stone-700 bg-stone-950',
+      ].join(' ')}
+    >
       {/* Scene header */}
       <div className="flex items-start justify-between gap-2">
         <div className="flex items-center gap-2 flex-wrap min-w-0">
@@ -472,6 +484,14 @@ function SceneCard({
           {persona && <PersonaChip persona={persona} />}
           <span className="text-sm font-medium text-stone-100">{scene.title}</span>
           {grounding?.status && <StatusBadge status={grounding.status} />}
+          {isEdited && (
+            <span
+              title="This scene has pending edits in your current session"
+              className="shrink-0 rounded px-2 py-0.5 text-[11px] font-medium bg-sky-500/15 text-sky-300 border border-sky-500/30 select-none"
+            >
+              Edited
+            </span>
+          )}
           {verifiedGreen && (
             <span
               title="This scene's verify actually ran and passed"
@@ -894,6 +914,7 @@ interface ReviewEditorInnerProps {
 
 function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerProps) {
   const {
+    state,
     effectiveScenes,
     effectivePersonas,
     effectiveWhyBrief,
@@ -902,6 +923,17 @@ function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerPr
     isDirty,
     dispatch,
   } = useReviewEditor()
+
+  // Scenes that have any pending edit op in the buffer — drives the per-scene
+  // "Edited" badge + border tint so the reviewer can see at a glance which
+  // beats they've touched in this session.
+  const editedSceneIds = useMemo(() => {
+    const ids = new Set<string>()
+    for (const op of state.buffer) {
+      if ('sceneId' in op && op.sceneId) ids.add(op.sceneId)
+    }
+    return ids
+  }, [state.buffer])
 
   const shareToken = useRef(new URLSearchParams(window.location.search).get('t')).current
 
@@ -1266,12 +1298,14 @@ function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerPr
                 key={scene.id}
                 scene={scene}
                 sceneNumber={sceneNumberById.get(scene.id)}
+                isEdited={editedSceneIds.has(scene.id)}
                 defaultOpen={
                   expandAll ||
                   (scene.provenance
                     ? (spineById.get(scene.provenance)?.status ?? 'grounded') !== 'grounded'
                     : false) ||
-                  (perScene[scene.id]?.score ?? 5) < 4
+                  (perScene[scene.id]?.score ?? 5) < 4 ||
+                  editedSceneIds.has(scene.id)
                 }
                 persona={scene.persona ? personas[scene.persona] : undefined}
                 grounding={scene.provenance ? spineById.get(scene.provenance) : undefined}

--- a/frontend/src/pages/ReviewPage.tsx
+++ b/frontend/src/pages/ReviewPage.tsx
@@ -466,7 +466,7 @@ function SceneCard({
         <p className="text-xs text-stone-500">
           <span className="text-stone-600">Builds: </span>
           {activeFeatures[0].description.length > 90
-            ? activeFeatures[0].description.slice(0, 90) + '…'
+            ? activeFeatures[0].description.slice(0, 90).replace(/\s+\S*$/, '') + '…'
             : activeFeatures[0].description}
           {activeFeatures.length > 1 ? ` +${activeFeatures.length - 1} more` : ''}
         </p>
@@ -538,6 +538,20 @@ function SceneCard({
                 placeholder="The reason this capability earns its place in the demo"
                 onChange={(e) => !readOnly && onEditRationale?.(e.target.value)}
               />
+            </div>
+          )}
+          {grounding?.evidence && grounding.evidence.length > 0 && (
+            <div>
+              <FieldLabel>
+                {grounding.status === 'grounded' ? 'Backed by (shipped code/docs)' : 'Evidence'}
+              </FieldLabel>
+              <ul className="space-y-0.5">
+                {grounding.evidence.map((ev, i) => (
+                  <li key={i} className="text-[11px] text-stone-400 font-mono break-words">
+                    <span className="text-stone-600">{ev.kind ?? 'ref'}:</span> {ev.ref}
+                  </li>
+                ))}
+              </ul>
             </div>
           )}
           {(gaps ?? []).map((gap) => (
@@ -892,6 +906,13 @@ function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerPr
   const orphanGaps = (effectiveWhyBrief.gaps ?? []).filter(
     (g) => !g.claim_ref || !usedProvenance.has(g.claim_ref),
   )
+
+  // Honesty flag before approval: how many scenes are Frontier (not built) or below the ≥4 bar.
+  const liveScenes = effectiveScenes.filter((s) => !s.deleted)
+  const frontierCount = liveScenes.filter(
+    (s) => s.provenance && (spineById.get(s.provenance)?.status ?? 'grounded') !== 'grounded',
+  ).length
+  const belowBarCount = liveScenes.filter((s) => (perScene[s.id]?.score ?? 5) < 4).length
 
   const narrativeVerdictDecision = decisions.find((d) => d.id === 'narrative-verdict') ?? null
   const otherDecisions = decisions.filter((d) => d.id !== 'narrative-verdict')
@@ -1414,6 +1435,14 @@ function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerPr
         </div>
       ) : (
         <div className="flex flex-col items-end gap-1">
+          {(frontierCount > 0 || belowBarCount > 0) && resolvedChoice('narrative-verdict') !== 'redraft' && (
+            <p className="text-[11px] text-amber-300/90 max-w-md text-right mb-1">
+              ⚠ {frontierCount > 0 && `${frontierCount} scene${frontierCount === 1 ? ' is' : 's are'} Frontier (not built yet)`}
+              {frontierCount > 0 && belowBarCount > 0 && '; '}
+              {belowBarCount > 0 && `${belowBarCount} below the ≥4 actionability bar`}
+              . Approving commits to building these as intended — they are not yet verified.
+            </p>
+          )}
           <button
             type="button"
             onClick={() => void handleSubmit()}

--- a/frontend/src/pages/ReviewPage.tsx
+++ b/frontend/src/pages/ReviewPage.tsx
@@ -9,7 +9,8 @@ import {
   type ReviewSubmitPayload,
   type ReviewSubmittedScene,
   type ReviewPersona,
-  type ReviewWhyBrief,
+  type ReviewWhySpineItem,
+  type ReviewWhyGap,
 } from '../api/reviews'
 import { walkthroughContentUrl } from '../api/walkthroughs'
 import {
@@ -268,32 +269,38 @@ function FeatureRow({
       </div>
 
       {/* description */}
-      <textarea
-        className={[
-          'w-full rounded border bg-stone-900 px-2 py-1.5 text-sm text-stone-200 resize-y min-h-[2.5rem]',
-          'border-stone-700 focus:border-stone-500 focus:outline-none transition-colors',
-          readOnly ? 'opacity-70 cursor-default' : '',
-        ].join(' ')}
-        value={feature.description}
-        onChange={(e) => !readOnly && onEdit('description', e.target.value)}
-        readOnly={readOnly}
-        placeholder="Description"
-        rows={2}
-      />
+      <div>
+        <FieldLabel>What to build</FieldLabel>
+        <textarea
+          className={[
+            'w-full rounded border bg-stone-900 px-2 py-1.5 text-sm text-stone-200 resize-y min-h-[2.5rem]',
+            'border-stone-700 focus:border-stone-500 focus:outline-none transition-colors',
+            readOnly ? 'opacity-70 cursor-default' : '',
+          ].join(' ')}
+          value={feature.description}
+          onChange={(e) => !readOnly && onEdit('description', e.target.value)}
+          readOnly={readOnly}
+          placeholder="The buildable unit — what an engineer implements"
+          rows={2}
+        />
+      </div>
 
       {/* verify */}
-      <input
-        type="text"
-        className={[
-          'w-full rounded border bg-stone-900 px-2 py-1.5 font-mono text-[11px] text-stone-400',
-          'border-stone-700 focus:border-stone-500 focus:outline-none transition-colors',
-          readOnly ? 'opacity-70 cursor-default' : '',
-        ].join(' ')}
-        value={feature.verify}
-        onChange={(e) => !readOnly && onEdit('verify', e.target.value)}
-        readOnly={readOnly}
-        placeholder="verify: how to confirm"
-      />
+      <div>
+        <FieldLabel>Verify — how we'll confirm it's built</FieldLabel>
+        <input
+          type="text"
+          className={[
+            'w-full rounded border bg-stone-900 px-2 py-1.5 font-mono text-[11px] text-stone-400',
+            'border-stone-700 focus:border-stone-500 focus:outline-none transition-colors',
+            readOnly ? 'opacity-70 cursor-default' : '',
+          ].join(' ')}
+          value={feature.verify}
+          onChange={(e) => !readOnly && onEdit('verify', e.target.value)}
+          readOnly={readOnly}
+          placeholder="A runnable check — API assertion, UI state, or test command"
+        />
+      </div>
 
       {isMissed && (
         <p className="text-[11px] text-amber-400/80">⚠ eval flagged as under-specified</p>
@@ -338,6 +345,10 @@ interface SceneCardProps {
   }
   sceneNumber?: number
   persona?: ReviewPersona
+  /** The spine item this scene grounds (resolved by provenance), if any. */
+  grounding?: ReviewWhySpineItem
+  /** Gaps whose claim_ref points at this scene's spine item. */
+  gaps?: ReviewWhyGap[]
   readOnly: boolean
   sceneActionability?: ReviewSceneActionability
   onEditNarration: (text: string) => void
@@ -347,12 +358,36 @@ interface SceneCardProps {
   onAddFeature: () => void
   onDeleteScene: () => void
   onSceneFeedback: (text: string) => void
+  /** Edit the grounding rationale (persists to the why-brief spine item). */
+  onEditRationale?: (value: string) => void
+  /** Edit a gap field (persists to the why-brief gap). */
+  onEditGap?: (gapId: string, field: 'detail' | 'proposed_action', value: string) => void
+}
+
+function StatusBadge({ status }: { status?: string }) {
+  if (!status) return null
+  const frontier = status !== 'grounded'
+  return (
+    <span
+      title={frontier ? 'Frontier — not yet built; this scene shows intended behavior' : 'Built — backed by shipped code/evidence'}
+      className={[
+        'shrink-0 rounded px-2 py-0.5 text-[11px] font-medium select-none',
+        frontier
+          ? 'bg-amber-500/15 text-amber-300 border border-amber-500/30'
+          : 'bg-emerald-500/15 text-emerald-300 border border-emerald-500/30',
+      ].join(' ')}
+    >
+      {frontier ? 'Frontier' : 'Built'}
+    </span>
+  )
 }
 
 function SceneCard({
   scene,
   sceneNumber,
   persona,
+  grounding,
+  gaps,
   readOnly,
   sceneActionability,
   onEditNarration,
@@ -362,11 +397,14 @@ function SceneCard({
   onAddFeature,
   onDeleteScene,
   onSceneFeedback,
+  onEditRationale,
+  onEditGap,
 }: SceneCardProps) {
   if (scene.deleted) return null
 
   const missedIds = new Set(sceneActionability?.missed ?? [])
   const activeFeatures = scene.features.filter((f) => !f.deleted)
+  const hasGrounding = grounding != null || (gaps != null && gaps.length > 0)
 
   return (
     <div className="rounded-lg border border-stone-700 bg-stone-950 p-4 space-y-3">
@@ -380,6 +418,7 @@ function SceneCard({
           )}
           {persona && <PersonaChip persona={persona} />}
           <span className="text-sm font-medium text-stone-100">{scene.title}</span>
+          {grounding?.status && <StatusBadge status={grounding.status} />}
         </div>
         <div className="flex items-center gap-2 shrink-0">
           {sceneActionability != null && (
@@ -402,18 +441,21 @@ function SceneCard({
       </div>
 
       {/* Editable narration */}
-      <textarea
-        className={[
-          'w-full rounded border bg-stone-900 px-3 py-2 text-sm text-stone-200 resize-y min-h-[4rem]',
-          'border-stone-700 focus:border-stone-500 focus:outline-none transition-colors',
-          readOnly ? 'opacity-70 cursor-default' : '',
-        ].join(' ')}
-        value={scene.narration}
-        onChange={(e) => !readOnly && onEditNarration(e.target.value)}
-        readOnly={readOnly}
-        rows={3}
-        placeholder="Scene narration…"
-      />
+      <div>
+        <FieldLabel>What plays in the demo</FieldLabel>
+        <textarea
+          className={[
+            'w-full rounded border bg-stone-900 px-3 py-2 text-sm text-stone-200 resize-y min-h-[4rem]',
+            'border-stone-700 focus:border-stone-500 focus:outline-none transition-colors',
+            readOnly ? 'opacity-70 cursor-default' : '',
+          ].join(' ')}
+          value={scene.narration}
+          onChange={(e) => !readOnly && onEditNarration(e.target.value)}
+          readOnly={readOnly}
+          rows={3}
+          placeholder="The beat the viewer watches in this scene…"
+        />
+      </div>
 
       {/* Features list */}
       {(activeFeatures.length > 0 || !readOnly) && (
@@ -421,7 +463,7 @@ function SceneCard({
           {activeFeatures.length > 0 && (
             <>
               <p className="text-[11px] font-semibold uppercase tracking-wider text-stone-500">
-                Features this scene commits to
+                Features to build
               </p>
               <ul className="space-y-2">
                 {scene.features.map((f) => (
@@ -447,6 +489,59 @@ function SceneCard({
               + Add feature
             </button>
           )}
+        </div>
+      )}
+
+      {/* Grounding — why this scene matters, co-located with the scene it grounds.
+          Muted + below the demo/features because the narration is what's most
+          important to get right; this is the supporting "why" + build status. */}
+      {hasGrounding && (
+        <div className="rounded border border-stone-800 bg-stone-900/40 p-3 space-y-2">
+          <p className="text-[10px] font-semibold uppercase tracking-wider text-stone-600">
+            Why this matters {grounding?.id ? `· ${grounding.id}` : ''}
+          </p>
+          {grounding != null && (
+            <div>
+              <FieldLabel>Why it matters (rationale)</FieldLabel>
+              <textarea
+                className={inputCls(readOnly) + ' resize-y min-h-[3rem]'}
+                value={grounding.rationale ?? ''}
+                readOnly={readOnly || !onEditRationale}
+                rows={2}
+                placeholder="The reason this capability earns its place in the demo"
+                onChange={(e) => !readOnly && onEditRationale?.(e.target.value)}
+              />
+            </div>
+          )}
+          {(gaps ?? []).map((gap) => (
+            <div key={gap.id} className="rounded border border-amber-500/20 bg-amber-500/5 p-2 space-y-2">
+              <div className="flex items-center gap-2 text-[11px]">
+                {gap.type && (
+                  <span className="rounded bg-amber-500/15 text-amber-300 px-1.5 py-0.5">{gap.type}</span>
+                )}
+                <span className="text-stone-500">what's missing for this scene</span>
+              </div>
+              <textarea
+                className={inputCls(readOnly) + ' resize-y min-h-[2.5rem]'}
+                value={gap.detail}
+                readOnly={readOnly || !onEditGap}
+                rows={2}
+                placeholder="The gap"
+                onChange={(e) => !readOnly && onEditGap?.(gap.id, 'detail', e.target.value)}
+              />
+              <div>
+                <FieldLabel>Proposed action</FieldLabel>
+                <textarea
+                  className={inputCls(readOnly) + ' resize-y min-h-[2.5rem]'}
+                  value={gap.proposed_action}
+                  readOnly={readOnly || !onEditGap}
+                  rows={2}
+                  placeholder="What to do to close it"
+                  onChange={(e) => !readOnly && onEditGap?.(gap.id, 'proposed_action', e.target.value)}
+                />
+              </div>
+            </div>
+          ))}
         </div>
       )}
 
@@ -686,123 +781,6 @@ function PersonasSection({
 }
 
 // ---------------------------------------------------------------------------
-// Why-brief section — the grounding doc, visible + editable
-// ---------------------------------------------------------------------------
-
-function WhyBriefSection({
-  whyBrief,
-  readOnly,
-  onEditProblem,
-  onEditSpine,
-  onEditGap,
-}: {
-  whyBrief: ReviewWhyBrief
-  readOnly: boolean
-  onEditProblem: (value: string) => void
-  onEditSpine: (id: string, field: 'claim' | 'rationale', value: string) => void
-  onEditGap: (id: string, field: 'detail' | 'proposed_action', value: string) => void
-}) {
-  const spine = whyBrief.spine ?? []
-  const gaps = whyBrief.gaps ?? []
-  if (!whyBrief.problem && spine.length === 0 && gaps.length === 0) return null
-  return (
-    <section>
-      <h2 className="text-sm font-semibold text-stone-400 uppercase tracking-wider mb-1">
-        Why this matters (grounding)
-      </h2>
-      <p className="text-xs text-stone-600 mb-3">
-        The why-brief grounds the demo. Editable here; ids / status / type are structural and fixed.
-      </p>
-      <div className="rounded-lg border border-stone-700 bg-stone-950 p-4 space-y-4">
-        <div>
-          <FieldLabel>Problem</FieldLabel>
-          <textarea
-            className={inputCls(readOnly) + ' resize-y min-h-[4rem]'}
-            value={whyBrief.problem ?? ''}
-            readOnly={readOnly}
-            rows={3}
-            onChange={(e) => !readOnly && onEditProblem(e.target.value)}
-          />
-        </div>
-
-        {spine.length > 0 && (
-          <div className="space-y-3">
-            <p className="text-[11px] font-semibold uppercase tracking-wider text-stone-500">Spine</p>
-            {spine.map((item) => (
-              <div key={item.id} className="rounded border border-stone-800 p-3 space-y-2">
-                <div className="flex items-center gap-2 text-xs">
-                  <span className="font-mono text-stone-400">{item.id}</span>
-                  {item.status && (
-                    <span className="rounded bg-stone-800 px-1.5 py-0.5 text-stone-400">{item.status}</span>
-                  )}
-                </div>
-                <div>
-                  <FieldLabel>Claim</FieldLabel>
-                  <textarea
-                    className={inputCls(readOnly) + ' resize-y min-h-[3rem]'}
-                    value={item.claim}
-                    readOnly={readOnly}
-                    rows={2}
-                    onChange={(e) => !readOnly && onEditSpine(item.id, 'claim', e.target.value)}
-                  />
-                </div>
-                <div>
-                  <FieldLabel>Rationale</FieldLabel>
-                  <textarea
-                    className={inputCls(readOnly) + ' resize-y min-h-[3rem]'}
-                    value={item.rationale ?? ''}
-                    readOnly={readOnly}
-                    rows={2}
-                    onChange={(e) => !readOnly && onEditSpine(item.id, 'rationale', e.target.value)}
-                  />
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
-
-        {gaps.length > 0 && (
-          <div className="space-y-3">
-            <p className="text-[11px] font-semibold uppercase tracking-wider text-stone-500">Gaps</p>
-            {gaps.map((gap) => (
-              <div key={gap.id} className="rounded border border-stone-800 p-3 space-y-2">
-                <div className="flex items-center gap-2 text-xs">
-                  <span className="font-mono text-stone-400">{gap.id}</span>
-                  {gap.type && (
-                    <span className="rounded bg-amber-500/15 text-amber-300 px-1.5 py-0.5">{gap.type}</span>
-                  )}
-                  {gap.claim_ref && <span className="text-stone-600">→ {gap.claim_ref}</span>}
-                </div>
-                <div>
-                  <FieldLabel>Detail</FieldLabel>
-                  <textarea
-                    className={inputCls(readOnly) + ' resize-y min-h-[3rem]'}
-                    value={gap.detail}
-                    readOnly={readOnly}
-                    rows={2}
-                    onChange={(e) => !readOnly && onEditGap(gap.id, 'detail', e.target.value)}
-                  />
-                </div>
-                <div>
-                  <FieldLabel>Proposed action</FieldLabel>
-                  <textarea
-                    className={inputCls(readOnly) + ' resize-y min-h-[3rem]'}
-                    value={gap.proposed_action}
-                    readOnly={readOnly}
-                    rows={2}
-                    onChange={(e) => !readOnly && onEditGap(gap.id, 'proposed_action', e.target.value)}
-                  />
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
-      </div>
-    </section>
-  )
-}
-
-// ---------------------------------------------------------------------------
 // Inner editor — has access to the ReviewEditor context
 // Owns all user interaction + submit logic.
 // ---------------------------------------------------------------------------
@@ -866,6 +844,24 @@ function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerPr
   effectiveScenes
     .filter((s) => !s.deleted)
     .forEach((s, i) => sceneNumberById.set(s.id, i + 1))
+
+  // Join each scene to its why-brief grounding (spine item by provenance) + gaps
+  // (by claim_ref), so the "why" lives inside the scene it grounds instead of a
+  // parallel section. Anything not tied to a scene falls through to "other grounding".
+  const spineById = new Map((effectiveWhyBrief.spine ?? []).map((s) => [s.id, s]))
+  const gapsByRef = new Map<string, ReviewWhyGap[]>()
+  for (const g of effectiveWhyBrief.gaps ?? []) {
+    const ref = g.claim_ref ?? ''
+    if (!gapsByRef.has(ref)) gapsByRef.set(ref, [])
+    gapsByRef.get(ref)!.push(g)
+  }
+  const usedProvenance = new Set(
+    effectiveScenes.filter((s) => !s.deleted).map((s) => s.provenance).filter(Boolean),
+  )
+  const orphanSpine = (effectiveWhyBrief.spine ?? []).filter((s) => !usedProvenance.has(s.id))
+  const orphanGaps = (effectiveWhyBrief.gaps ?? []).filter(
+    (g) => !g.claim_ref || !usedProvenance.has(g.claim_ref),
+  )
 
   const narrativeVerdictDecision = decisions.find((d) => d.id === 'narrative-verdict') ?? null
   const otherDecisions = decisions.filter((d) => d.id !== 'narrative-verdict')
@@ -1063,15 +1059,32 @@ function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerPr
       {/* Narrative tab — the story, personas, why-brief, scenes, decision */}
       {tab === 'narrative' && (
         <>
-      {/* The demo narrative — the cohesive story the scenes decompose */}
-      {req.narrative && req.narrative.trim() && (
+      {/* The demo — the cohesive story + the one problem it all serves */}
+      {(req.narrative?.trim() || effectiveWhyBrief.problem || Object.keys(personas).length > 0) && (
         <section className="rounded-lg border border-stone-700 bg-stone-900/60 p-5 space-y-3">
           <h2 className="text-sm font-semibold text-stone-400 uppercase tracking-wider">
             The demo
           </h2>
-          <p className="text-[15px] leading-relaxed text-stone-200 whitespace-pre-line">
-            {req.narrative}
-          </p>
+          {req.narrative?.trim() && (
+            <p className="text-[15px] leading-relaxed text-stone-200 whitespace-pre-line">
+              {req.narrative}
+            </p>
+          )}
+          {(effectiveWhyBrief.problem || !readOnly) && (
+            <div className="pt-1">
+              <FieldLabel>The problem we're solving</FieldLabel>
+              <textarea
+                className={inputCls(readOnly) + ' resize-y min-h-[3rem]'}
+                value={effectiveWhyBrief.problem ?? ''}
+                readOnly={readOnly}
+                rows={3}
+                placeholder="The core problem this whole demo exists to solve"
+                onChange={(e) =>
+                  !readOnly && dispatch({ type: 'APPEND_OP', op: { op: 'edit-why-problem', value: e.target.value } })
+                }
+              />
+            </div>
+          )}
           {Object.keys(personas).length > 0 && (
             <div className="flex items-center gap-2 flex-wrap pt-1">
               <span className="text-[11px] uppercase tracking-wider text-stone-600">Cast</span>
@@ -1089,21 +1102,6 @@ function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerPr
         readOnly={readOnly}
         onEdit={(key, field, value) =>
           dispatch({ type: 'APPEND_OP', op: { op: 'edit-persona', key, field, value } })
-        }
-      />
-
-      {/* Why-brief — visible + editable */}
-      <WhyBriefSection
-        whyBrief={effectiveWhyBrief}
-        readOnly={readOnly}
-        onEditProblem={(value) =>
-          dispatch({ type: 'APPEND_OP', op: { op: 'edit-why-problem', value } })
-        }
-        onEditSpine={(id, field, value) =>
-          dispatch({ type: 'APPEND_OP', op: { op: 'edit-why-spine', id, field, value } })
-        }
-        onEditGap={(id, field, value) =>
-          dispatch({ type: 'APPEND_OP', op: { op: 'edit-why-gap', id, field, value } })
         }
       />
 
@@ -1155,8 +1153,20 @@ function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerPr
                 scene={scene}
                 sceneNumber={sceneNumberById.get(scene.id)}
                 persona={scene.persona ? personas[scene.persona] : undefined}
+                grounding={scene.provenance ? spineById.get(scene.provenance) : undefined}
+                gaps={scene.provenance ? gapsByRef.get(scene.provenance) : undefined}
                 readOnly={readOnly}
                 sceneActionability={perScene[scene.id] ?? undefined}
+                onEditRationale={(value) =>
+                  scene.provenance &&
+                  dispatch({
+                    type: 'APPEND_OP',
+                    op: { op: 'edit-why-spine', id: scene.provenance, field: 'rationale', value },
+                  })
+                }
+                onEditGap={(gapId, field, value) =>
+                  dispatch({ type: 'APPEND_OP', op: { op: 'edit-why-gap', id: gapId, field, value } })
+                }
                 onEditNarration={(text) =>
                   dispatch({ type: 'APPEND_OP', op: { op: 'edit-narration', sceneId: scene.id, text } })
                 }
@@ -1206,6 +1216,44 @@ function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerPr
                 + Add scene
               </button>
             )}
+          </div>
+        </section>
+      )}
+
+      {/* Other grounding — spine claims / gaps not tied to any scene (kept so nothing is lost) */}
+      {(orphanSpine.length > 0 || orphanGaps.length > 0) && (
+        <section>
+          <h2 className="text-sm font-semibold text-stone-400 uppercase tracking-wider mb-1">
+            Other grounding
+          </h2>
+          <p className="text-xs text-stone-600 mb-3">
+            Why-brief items not tied to any scene above. Tie one to a scene by setting that scene's provenance.
+          </p>
+          <div className="rounded-lg border border-stone-800 bg-stone-900/40 p-4 space-y-3">
+            {orphanSpine.map((item) => (
+              <div key={item.id} className="text-sm">
+                <div className="flex items-center gap-2 text-xs mb-1">
+                  <span className="font-mono text-stone-400">{item.id}</span>
+                  <StatusBadge status={item.status} />
+                </div>
+                <p className="text-stone-300">{item.claim}</p>
+                {item.rationale && <p className="text-stone-500 text-xs mt-0.5">{item.rationale}</p>}
+              </div>
+            ))}
+            {orphanGaps.map((gap) => (
+              <div key={gap.id} className="text-sm">
+                <div className="flex items-center gap-2 text-xs mb-1">
+                  <span className="font-mono text-stone-400">{gap.id}</span>
+                  {gap.type && (
+                    <span className="rounded bg-amber-500/15 text-amber-300 px-1.5 py-0.5">{gap.type}</span>
+                  )}
+                </div>
+                <p className="text-stone-300">{gap.detail}</p>
+                {gap.proposed_action && (
+                  <p className="text-stone-500 text-xs mt-0.5">→ {gap.proposed_action}</p>
+                )}
+              </div>
+            ))}
           </div>
         </section>
       )}

--- a/frontend/src/pages/ReviewPage.tsx
+++ b/frontend/src/pages/ReviewPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { forwardRef, useCallback, useEffect, useLayoutEffect, useRef, useState, type TextareaHTMLAttributes } from 'react'
 import { useParams } from 'react-router-dom'
 import {
   getReview,
@@ -17,6 +17,47 @@ import {
   ReviewEditorProvider,
   useReviewEditor,
 } from '../components/reviews/ReviewEditorContext'
+
+// ---------------------------------------------------------------------------
+// AutoTextarea — a textarea that grows to fit its content (never internally
+// scrolls). Re-fits on value changes and window resize; honors any min-height
+// supplied via className.
+// ---------------------------------------------------------------------------
+
+const AutoTextarea = forwardRef<HTMLTextAreaElement, TextareaHTMLAttributes<HTMLTextAreaElement>>(
+  function AutoTextarea(props, fwdRef) {
+    const innerRef = useRef<HTMLTextAreaElement | null>(null)
+    const setRef = (el: HTMLTextAreaElement | null) => {
+      innerRef.current = el
+      if (typeof fwdRef === 'function') fwdRef(el)
+      else if (fwdRef) (fwdRef as React.MutableRefObject<HTMLTextAreaElement | null>).current = el
+    }
+    const resize = useCallback(() => {
+      const el = innerRef.current
+      if (!el) return
+      el.style.height = 'auto'
+      el.style.height = `${el.scrollHeight}px`
+    }, [])
+    useLayoutEffect(() => {
+      resize()
+    }, [resize, props.value])
+    useEffect(() => {
+      window.addEventListener('resize', resize)
+      return () => window.removeEventListener('resize', resize)
+    }, [resize])
+    const userOnInput = props.onInput
+    return (
+      <textarea
+        {...props}
+        ref={setRef}
+        onInput={(e) => {
+          resize()
+          userOnInput?.(e)
+        }}
+      />
+    )
+  },
+)
 
 // ---------------------------------------------------------------------------
 // Small utility components
@@ -271,9 +312,9 @@ function FeatureRow({
       {/* description */}
       <div>
         <FieldLabel>What to build</FieldLabel>
-        <textarea
+        <AutoTextarea
           className={[
-            'w-full rounded border bg-stone-900 px-2 py-1.5 text-sm text-stone-200 resize-y min-h-[2.5rem]',
+            'w-full rounded border bg-stone-900 px-2 py-1.5 text-sm text-stone-200 resize-none min-h-[2.5rem]',
             'border-stone-700 focus:border-stone-500 focus:outline-none transition-colors',
             readOnly ? 'opacity-70 cursor-default' : '',
           ].join(' ')}
@@ -288,9 +329,9 @@ function FeatureRow({
       {/* verify */}
       <div>
         <FieldLabel>Verify — how we'll confirm it's built</FieldLabel>
-        <textarea
+        <AutoTextarea
           className={[
-            'w-full rounded border bg-stone-900 px-2 py-1.5 font-mono text-[11px] text-stone-300 resize-y min-h-[2.25rem] whitespace-pre-wrap break-words',
+            'w-full rounded border bg-stone-900 px-2 py-1.5 font-mono text-[11px] text-stone-300 resize-none min-h-[2.25rem] whitespace-pre-wrap break-words',
             'border-stone-700 focus:border-stone-500 focus:outline-none transition-colors',
             readOnly ? 'opacity-70 cursor-default' : '',
           ].join(' ')}
@@ -371,7 +412,7 @@ function StatusBadge({ status }: { status?: string }) {
   const frontier = status !== 'grounded'
   return (
     <span
-      title={frontier ? 'Frontier — not yet built; this scene shows intended behavior' : 'Grounded — backed by shipped code/evidence (not re-verified live)'}
+      title={frontier ? 'New feature — not yet built; this scene shows intended behavior' : 'Grounded — backed by shipped code/evidence (not re-verified live)'}
       className={[
         'shrink-0 rounded px-2 py-0.5 text-[11px] font-medium select-none',
         frontier
@@ -379,7 +420,7 @@ function StatusBadge({ status }: { status?: string }) {
           : 'bg-emerald-500/15 text-emerald-300 border border-emerald-500/30',
       ].join(' ')}
     >
-      {frontier ? 'Frontier' : 'Grounded'}
+      {frontier ? 'New feature' : 'Grounded'}
     </span>
   )
 }
@@ -463,9 +504,9 @@ function SceneCard({
       {/* Editable narration */}
       <div>
         <FieldLabel>What plays in the demo</FieldLabel>
-        <textarea
+        <AutoTextarea
           className={[
-            'w-full rounded border bg-stone-900 px-3 py-2 text-sm text-stone-200 resize-y min-h-[4rem]',
+            'w-full rounded border bg-stone-900 px-3 py-2 text-sm text-stone-200 resize-none min-h-[4rem]',
             'border-stone-700 focus:border-stone-500 focus:outline-none transition-colors',
             readOnly ? 'opacity-70 cursor-default' : '',
           ].join(' ')}
@@ -545,8 +586,8 @@ function SceneCard({
           {grounding != null && (
             <div>
               <FieldLabel>Why it matters (rationale)</FieldLabel>
-              <textarea
-                className={inputCls(readOnly) + ' resize-y min-h-[3rem]'}
+              <AutoTextarea
+                className={inputCls(readOnly) + ' resize-none min-h-[3rem]'}
                 value={grounding.rationale ?? ''}
                 readOnly={readOnly || !onEditRationale}
                 rows={2}
@@ -577,8 +618,8 @@ function SceneCard({
                 )}
                 <span className="text-stone-500">what's missing for this scene</span>
               </div>
-              <textarea
-                className={inputCls(readOnly) + ' resize-y min-h-[2.5rem]'}
+              <AutoTextarea
+                className={inputCls(readOnly) + ' resize-none min-h-[2.5rem]'}
                 value={gap.detail}
                 readOnly={readOnly || !onEditGap}
                 rows={2}
@@ -587,8 +628,8 @@ function SceneCard({
               />
               <div>
                 <FieldLabel>Proposed action</FieldLabel>
-                <textarea
-                  className={inputCls(readOnly) + ' resize-y min-h-[2.5rem]'}
+                <AutoTextarea
+                  className={inputCls(readOnly) + ' resize-none min-h-[2.5rem]'}
                   value={gap.proposed_action}
                   readOnly={readOnly || !onEditGap}
                   rows={2}
@@ -823,8 +864,8 @@ function PersonasSection({
               </div>
               <div>
                 <FieldLabel>Intro</FieldLabel>
-                <textarea
-                  className={inputCls(readOnly) + ' resize-y min-h-[3rem]'}
+                <AutoTextarea
+                  className={inputCls(readOnly) + ' resize-none min-h-[3rem]'}
                   value={p.intro}
                   readOnly={readOnly}
                   rows={2}
@@ -925,7 +966,7 @@ function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerPr
     (g) => !g.claim_ref || !usedProvenance.has(g.claim_ref),
   )
 
-  // Honesty flag before approval: how many scenes are Frontier (not built) or below the ≥4 bar.
+  // Honesty flag before approval: how many scenes are New features (not built) or below the ≥4 bar.
   const liveScenes = effectiveScenes.filter((s) => !s.deleted)
   const frontierCount = liveScenes.filter(
     (s) => s.provenance && (spineById.get(s.provenance)?.status ?? 'grounded') !== 'grounded',
@@ -1154,8 +1195,8 @@ function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerPr
           {(effectiveWhyBrief.problem || !readOnly) && (
             <div className="pt-1">
               <FieldLabel>The problem we're solving</FieldLabel>
-              <textarea
-                className={inputCls(readOnly) + ' resize-y min-h-[3rem]'}
+              <AutoTextarea
+                className={inputCls(readOnly) + ' resize-none min-h-[3rem]'}
                 value={effectiveWhyBrief.problem ?? ''}
                 readOnly={readOnly}
                 rows={3}
@@ -1216,7 +1257,7 @@ function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerPr
           </h2>
           <p className="text-xs text-stone-600 mb-3">
             <span className="text-emerald-300">Grounded</span> = backed by shipped code ·{' '}
-            <span className="text-amber-300">Frontier</span> = intended, not built yet. Each scene = one beat of the demo.
+            <span className="text-amber-300">New feature</span> = intended, not built yet. Each scene = one beat of the demo.
             Per-scene numbers are AI actionability estimates (1–5; passes at ≥4).
           </p>
           <div className="space-y-4">
@@ -1361,8 +1402,8 @@ function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerPr
           <h2 className="text-sm font-semibold text-stone-400 uppercase tracking-wider mb-2">
             Overall feedback
           </h2>
-          <textarea
-            className="w-full rounded border bg-stone-900 px-3 py-2 text-sm text-stone-200 resize-y min-h-[3rem] border-stone-700 focus:border-stone-500 focus:outline-none transition-colors"
+          <AutoTextarea
+            className="w-full rounded border bg-stone-900 px-3 py-2 text-sm text-stone-200 resize-none min-h-[3rem] border-stone-700 focus:border-stone-500 focus:outline-none transition-colors"
             value={overallFeedback}
             onChange={(e) =>
               dispatch({ type: 'APPEND_OP', op: { op: 'set-overall-feedback', text: e.target.value } })
@@ -1455,7 +1496,7 @@ function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerPr
         <div className="flex flex-col items-end gap-1">
           {(frontierCount > 0 || belowBarCount > 0) && resolvedChoice('narrative-verdict') !== 'redraft' && (
             <p className="text-[11px] text-amber-300/90 max-w-md text-right mb-1">
-              ⚠ {frontierCount > 0 && `${frontierCount} scene${frontierCount === 1 ? ' is' : 's are'} Frontier (not built yet)`}
+              ⚠ {frontierCount > 0 && `${frontierCount} scene${frontierCount === 1 ? ' shows a new feature' : 's show new features'} (not built yet)`}
               {frontierCount > 0 && belowBarCount > 0 && '; '}
               {belowBarCount > 0 && `${belowBarCount} below the ≥4 actionability bar`}
               . Approving commits to building these as intended — they are not yet verified.

--- a/frontend/src/pages/ReviewPage.tsx
+++ b/frontend/src/pages/ReviewPage.tsx
@@ -362,6 +362,8 @@ interface SceneCardProps {
   onEditRationale?: (value: string) => void
   /** Edit a gap field (persists to the why-brief gap). */
   onEditGap?: (gapId: string, field: 'detail' | 'proposed_action', value: string) => void
+  /** When true, the scene's details start expanded (e.g. ?expand=1 / print/judge view). */
+  defaultOpen?: boolean
 }
 
 function StatusBadge({ status }: { status?: string }) {
@@ -399,6 +401,7 @@ function SceneCard({
   onSceneFeedback,
   onEditRationale,
   onEditGap,
+  defaultOpen,
 }: SceneCardProps) {
   if (scene.deleted) return null
 
@@ -407,7 +410,8 @@ function SceneCard({
   const hasGrounding = grounding != null || (gaps != null && gaps.length > 0)
   // Collapsed by default: header + narration stay visible (the skimmable arc);
   // features + grounding hide behind a toggle so the page isn't a wall.
-  const [open, setOpen] = useState(false)
+  // defaultOpen (?expand=1) starts expanded so the full substance is captured for judging/print.
+  const [open, setOpen] = useState(defaultOpen ?? false)
 
   return (
     <div className="rounded-lg border border-stone-700 bg-stone-950 p-4 space-y-3">
@@ -854,6 +858,9 @@ function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerPr
 
   // Active tab — reflected in the URL (?tab=cuts) so it's shareable/linkable.
   const initialTab = new URLSearchParams(window.location.search).get('tab') === 'cuts' ? 'cuts' : 'narrative'
+  // ?expand=1 starts every scene expanded — so the full build substance + evidence is visible
+  // (the default collapsed view is for fast human skimming; expand is for judging/print/audit).
+  const expandAll = new URLSearchParams(window.location.search).get('expand') === '1'
   const [tab, setTab] = useState<'narrative' | 'cuts'>(initialTab)
   const selectTab = useCallback((t: 'narrative' | 'cuts') => {
     setTab(t)
@@ -1229,6 +1236,7 @@ function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerPr
                 key={scene.id}
                 scene={scene}
                 sceneNumber={sceneNumberById.get(scene.id)}
+                defaultOpen={expandAll}
                 persona={scene.persona ? personas[scene.persona] : undefined}
                 grounding={scene.provenance ? spineById.get(scene.provenance) : undefined}
                 gaps={scene.provenance ? gapsByRef.get(scene.provenance) : undefined}

--- a/frontend/src/pages/ReviewPage.tsx
+++ b/frontend/src/pages/ReviewPage.tsx
@@ -460,7 +460,17 @@ function SceneCard({
         />
       </div>
 
-      {/* Details toggle — collapsed by default so the arc (titles + narration) stays skimmable */}
+      {/* Collapsed-by-default details. A one-line buildability summary stays visible
+          so a reviewer can judge what they're approving without expanding all scenes. */}
+      {!open && activeFeatures.length > 0 && (
+        <p className="text-xs text-stone-500">
+          <span className="text-stone-600">Builds: </span>
+          {activeFeatures[0].description.length > 90
+            ? activeFeatures[0].description.slice(0, 90) + '…'
+            : activeFeatures[0].description}
+          {activeFeatures.length > 1 ? ` +${activeFeatures.length - 1} more` : ''}
+        </p>
+      )}
       <button
         type="button"
         onClick={() => setOpen((o) => !o)}
@@ -469,7 +479,7 @@ function SceneCard({
         <span className="text-stone-600">{open ? '▾' : '▸'}</span>
         {open
           ? 'Hide details'
-          : `Show ${activeFeatures.length} feature${activeFeatures.length === 1 ? '' : 's'}${hasGrounding ? ' + why' : ''}`}
+          : `Show ${activeFeatures.length} feature${activeFeatures.length === 1 ? '' : 's'} + verify${hasGrounding ? ' + why' : ''}`}
       </button>
 
       {open && (
@@ -1190,6 +1200,7 @@ function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerPr
           <p className="text-xs text-stone-600 mb-3">
             <span className="text-emerald-300">Grounded</span> = backed by shipped code ·{' '}
             <span className="text-amber-300">Frontier</span> = intended, not built yet. Each scene = one beat of the demo.
+            Per-scene numbers are AI actionability estimates (1–5; passes at ≥4).
           </p>
           <div className="space-y-4">
             {effectiveScenes.map((scene) => (
@@ -1402,7 +1413,7 @@ function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerPr
           )}
         </div>
       ) : (
-        <div className="flex justify-end">
+        <div className="flex flex-col items-end gap-1">
           <button
             type="button"
             onClick={() => void handleSubmit()}
@@ -1414,8 +1425,15 @@ function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerPr
                 : 'bg-orange-500 hover:bg-orange-400 text-white',
             ].join(' ')}
           >
-            {busy ? 'Submitting…' : 'Submit review'}
+            {busy
+              ? 'Submitting…'
+              : resolvedChoice('narrative-verdict') === 'redraft'
+                ? 'Submit — send back to re-draft'
+                : 'Submit — approve & build'}
           </button>
+          <span className="text-[11px] text-stone-600">
+            Commits your decision above (with any edits you made).
+          </span>
         </div>
       )}
         </>

--- a/frontend/src/pages/ReviewPage.tsx
+++ b/frontend/src/pages/ReviewPage.tsx
@@ -369,7 +369,7 @@ function StatusBadge({ status }: { status?: string }) {
   const frontier = status !== 'grounded'
   return (
     <span
-      title={frontier ? 'Frontier — not yet built; this scene shows intended behavior' : 'Built — backed by shipped code/evidence'}
+      title={frontier ? 'Frontier — not yet built; this scene shows intended behavior' : 'Grounded — backed by shipped code/evidence (not re-verified live)'}
       className={[
         'shrink-0 rounded px-2 py-0.5 text-[11px] font-medium select-none',
         frontier
@@ -377,7 +377,7 @@ function StatusBadge({ status }: { status?: string }) {
           : 'bg-emerald-500/15 text-emerald-300 border border-emerald-500/30',
       ].join(' ')}
     >
-      {frontier ? 'Frontier' : 'Built'}
+      {frontier ? 'Frontier' : 'Grounded'}
     </span>
   )
 }
@@ -405,6 +405,9 @@ function SceneCard({
   const missedIds = new Set(sceneActionability?.missed ?? [])
   const activeFeatures = scene.features.filter((f) => !f.deleted)
   const hasGrounding = grounding != null || (gaps != null && gaps.length > 0)
+  // Collapsed by default: header + narration stay visible (the skimmable arc);
+  // features + grounding hide behind a toggle so the page isn't a wall.
+  const [open, setOpen] = useState(false)
 
   return (
     <div className="rounded-lg border border-stone-700 bg-stone-950 p-4 space-y-3">
@@ -457,6 +460,20 @@ function SceneCard({
         />
       </div>
 
+      {/* Details toggle — collapsed by default so the arc (titles + narration) stays skimmable */}
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="text-xs text-stone-500 hover:text-stone-300 transition-colors flex items-center gap-1.5"
+      >
+        <span className="text-stone-600">{open ? '▾' : '▸'}</span>
+        {open
+          ? 'Hide details'
+          : `Show ${activeFeatures.length} feature${activeFeatures.length === 1 ? '' : 's'}${hasGrounding ? ' + why' : ''}`}
+      </button>
+
+      {open && (
+        <>
       {/* Features list */}
       {(activeFeatures.length > 0 || !readOnly) && (
         <div className="space-y-2">
@@ -543,6 +560,8 @@ function SceneCard({
             </div>
           ))}
         </div>
+      )}
+        </>
       )}
 
       {/* Per-scene feedback */}
@@ -982,8 +1001,14 @@ function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerPr
       <header className="flex items-start justify-between gap-4 flex-wrap">
         <div className="flex items-start gap-3 flex-wrap">
           <div>
-            <h1 className="text-xl font-semibold text-stone-100">Review gate: {req.gate}</h1>
-            <p className="text-sm text-stone-500 mt-0.5">Run {req.run_id}</p>
+            <h1 className="text-xl font-semibold text-stone-100">
+              {req.gate === 'concept_change'
+                ? 'Approve the story before we build it'
+                : req.gate === 'external_release'
+                  ? 'Approve for release'
+                  : `Review: ${req.gate}`}
+            </h1>
+            <p className="text-sm text-stone-500 mt-0.5">{req.run_id}</p>
           </div>
           {overallScore != null && (
             <div className="mt-0.5">
@@ -1163,7 +1188,7 @@ function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerPr
             {readOnly ? 'Scenes (submitted)' : 'Scenes — the story, beat by beat'}
           </h2>
           <p className="text-xs text-stone-600 mb-3">
-            <span className="text-emerald-300">Built</span> = backed by shipped code ·{' '}
+            <span className="text-emerald-300">Grounded</span> = backed by shipped code ·{' '}
             <span className="text-amber-300">Frontier</span> = intended, not built yet. Each scene = one beat of the demo.
           </p>
           <div className="space-y-4">

--- a/frontend/src/pages/ReviewPage.tsx
+++ b/frontend/src/pages/ReviewPage.tsx
@@ -754,7 +754,7 @@ function inputCls(readOnly: boolean): string {
   return [
     'w-full rounded border bg-stone-900 px-2.5 py-1.5 text-sm text-stone-200',
     'border-stone-700 focus:border-stone-500 focus:outline-none transition-colors',
-    readOnly ? 'opacity-70 cursor-default' : '',
+    readOnly ? 'opacity-70 cursor-default' : 'hover:border-stone-500 cursor-text',
   ].join(' ')
 }
 
@@ -1147,18 +1147,9 @@ function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerPr
             The demo
           </h2>
           {req.narrative?.trim() && (
-            <div className="space-y-1.5">
-              {req.narrative
-                .trim()
-                .split(/(?<=\.)\s+/)
-                .filter((s) => s.trim())
-                .map((sentence, i) => (
-                  <p key={i} className="text-[15px] leading-relaxed text-stone-200 flex gap-2">
-                    <span className="text-stone-600 tabular-nums shrink-0 select-none">{i + 1}.</span>
-                    <span>{sentence.trim()}</span>
-                  </p>
-                ))}
-            </div>
+            <p className="text-[15px] leading-relaxed text-stone-200">
+              {req.narrative.trim()}
+            </p>
           )}
           {(effectiveWhyBrief.problem || !readOnly) && (
             <div className="pt-1">
@@ -1195,20 +1186,7 @@ function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerPr
         }
       />
 
-      {/* Narrative verdict decision tile */}
-      {narrativeVerdictDecision && (
-        <section>
-          <h2 className="text-sm font-semibold text-stone-400 uppercase tracking-wider mb-3">
-            {readOnly ? 'Decision (submitted)' : 'Your decision'}
-          </h2>
-          <NarrativeVerdictControl
-            decision={narrativeVerdictDecision}
-            chosen={resolvedChoice('narrative-verdict')}
-            onChange={(val) => setChoices((prev) => ({ ...prev, 'narrative-verdict': val }))}
-            readOnly={readOnly}
-          />
-        </section>
-      )}
+      {/* Narrative verdict decision now lives at the bottom, next to Submit (single decision zone). */}
 
       {/* Other decisions */}
       {otherDecisions.length > 0 && (
@@ -1444,6 +1422,21 @@ function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerPr
         <p className="text-sm text-red-400 rounded border border-red-500/30 bg-red-500/10 px-3 py-2">
           {error}
         </p>
+      )}
+
+      {/* Your decision — single decision zone, immediately above Submit */}
+      {narrativeVerdictDecision && (
+        <section>
+          <h2 className="text-sm font-semibold text-stone-400 uppercase tracking-wider mb-3">
+            {readOnly ? 'Decision (submitted)' : 'Your decision'}
+          </h2>
+          <NarrativeVerdictControl
+            decision={narrativeVerdictDecision}
+            chosen={resolvedChoice('narrative-verdict')}
+            onChange={(val) => setChoices((prev) => ({ ...prev, 'narrative-verdict': val }))}
+            readOnly={readOnly}
+          />
+        </section>
       )}
 
       {/* Submit / resolved state */}

--- a/frontend/src/pages/ReviewPage.tsx
+++ b/frontend/src/pages/ReviewPage.tsx
@@ -9,6 +9,7 @@ import {
   type ReviewSubmitPayload,
   type ReviewSubmittedScene,
   type ReviewPersona,
+  type ReviewWhyBrief,
 } from '../api/reviews'
 import { walkthroughContentUrl } from '../api/walkthroughs'
 import {
@@ -593,6 +594,215 @@ function BuildSequenceSection({
 }
 
 // ---------------------------------------------------------------------------
+// Personas section — the cast, visible + editable
+// ---------------------------------------------------------------------------
+
+function inputCls(readOnly: boolean): string {
+  return [
+    'w-full rounded border bg-stone-900 px-2.5 py-1.5 text-sm text-stone-200',
+    'border-stone-700 focus:border-stone-500 focus:outline-none transition-colors',
+    readOnly ? 'opacity-70 cursor-default' : '',
+  ].join(' ')
+}
+
+function FieldLabel({ children }: { children: React.ReactNode }) {
+  return <span className="block text-[10px] uppercase tracking-wider text-stone-600 mb-0.5">{children}</span>
+}
+
+function PersonasSection({
+  personas,
+  readOnly,
+  onEdit,
+}: {
+  personas: Record<string, ReviewPersona>
+  readOnly: boolean
+  onEdit: (key: string, field: 'name' | 'org' | 'role' | 'intro', value: string) => void
+}) {
+  const keys = Object.keys(personas)
+  if (keys.length === 0) return null
+  return (
+    <section>
+      <h2 className="text-sm font-semibold text-stone-400 uppercase tracking-wider mb-3">
+        Personas
+      </h2>
+      <div className="grid gap-3 sm:grid-cols-2">
+        {keys.map((key) => {
+          const p = personas[key]
+          return (
+            <div key={key} className="rounded-lg border border-stone-700 bg-stone-950 p-4 space-y-2">
+              <div className="flex items-center gap-2">
+                <span
+                  className="inline-block h-3 w-3 rounded-full shrink-0"
+                  style={{ backgroundColor: p.color || '#78716c' }}
+                />
+                <span className="text-xs text-stone-600">persona: {key}</span>
+              </div>
+              <div className="grid grid-cols-2 gap-2">
+                <div>
+                  <FieldLabel>Name</FieldLabel>
+                  <input
+                    className={inputCls(readOnly)}
+                    value={p.name}
+                    readOnly={readOnly}
+                    onChange={(e) => !readOnly && onEdit(key, 'name', e.target.value)}
+                  />
+                </div>
+                <div>
+                  <FieldLabel>Org</FieldLabel>
+                  <input
+                    className={inputCls(readOnly)}
+                    value={p.org ?? ''}
+                    readOnly={readOnly}
+                    placeholder="e.g. Dimagi"
+                    onChange={(e) => !readOnly && onEdit(key, 'org', e.target.value)}
+                  />
+                </div>
+              </div>
+              <div>
+                <FieldLabel>Role</FieldLabel>
+                <input
+                  className={inputCls(readOnly)}
+                  value={p.role}
+                  readOnly={readOnly}
+                  onChange={(e) => !readOnly && onEdit(key, 'role', e.target.value)}
+                />
+              </div>
+              <div>
+                <FieldLabel>Intro</FieldLabel>
+                <textarea
+                  className={inputCls(readOnly) + ' resize-y min-h-[3rem]'}
+                  value={p.intro}
+                  readOnly={readOnly}
+                  rows={2}
+                  onChange={(e) => !readOnly && onEdit(key, 'intro', e.target.value)}
+                />
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </section>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Why-brief section — the grounding doc, visible + editable
+// ---------------------------------------------------------------------------
+
+function WhyBriefSection({
+  whyBrief,
+  readOnly,
+  onEditProblem,
+  onEditSpine,
+  onEditGap,
+}: {
+  whyBrief: ReviewWhyBrief
+  readOnly: boolean
+  onEditProblem: (value: string) => void
+  onEditSpine: (id: string, field: 'claim' | 'rationale', value: string) => void
+  onEditGap: (id: string, field: 'detail' | 'proposed_action', value: string) => void
+}) {
+  const spine = whyBrief.spine ?? []
+  const gaps = whyBrief.gaps ?? []
+  if (!whyBrief.problem && spine.length === 0 && gaps.length === 0) return null
+  return (
+    <section>
+      <h2 className="text-sm font-semibold text-stone-400 uppercase tracking-wider mb-1">
+        Why this matters (grounding)
+      </h2>
+      <p className="text-xs text-stone-600 mb-3">
+        The why-brief grounds the demo. Editable here; ids / status / type are structural and fixed.
+      </p>
+      <div className="rounded-lg border border-stone-700 bg-stone-950 p-4 space-y-4">
+        <div>
+          <FieldLabel>Problem</FieldLabel>
+          <textarea
+            className={inputCls(readOnly) + ' resize-y min-h-[4rem]'}
+            value={whyBrief.problem ?? ''}
+            readOnly={readOnly}
+            rows={3}
+            onChange={(e) => !readOnly && onEditProblem(e.target.value)}
+          />
+        </div>
+
+        {spine.length > 0 && (
+          <div className="space-y-3">
+            <p className="text-[11px] font-semibold uppercase tracking-wider text-stone-500">Spine</p>
+            {spine.map((item) => (
+              <div key={item.id} className="rounded border border-stone-800 p-3 space-y-2">
+                <div className="flex items-center gap-2 text-xs">
+                  <span className="font-mono text-stone-400">{item.id}</span>
+                  {item.status && (
+                    <span className="rounded bg-stone-800 px-1.5 py-0.5 text-stone-400">{item.status}</span>
+                  )}
+                </div>
+                <div>
+                  <FieldLabel>Claim</FieldLabel>
+                  <textarea
+                    className={inputCls(readOnly) + ' resize-y min-h-[3rem]'}
+                    value={item.claim}
+                    readOnly={readOnly}
+                    rows={2}
+                    onChange={(e) => !readOnly && onEditSpine(item.id, 'claim', e.target.value)}
+                  />
+                </div>
+                <div>
+                  <FieldLabel>Rationale</FieldLabel>
+                  <textarea
+                    className={inputCls(readOnly) + ' resize-y min-h-[3rem]'}
+                    value={item.rationale ?? ''}
+                    readOnly={readOnly}
+                    rows={2}
+                    onChange={(e) => !readOnly && onEditSpine(item.id, 'rationale', e.target.value)}
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {gaps.length > 0 && (
+          <div className="space-y-3">
+            <p className="text-[11px] font-semibold uppercase tracking-wider text-stone-500">Gaps</p>
+            {gaps.map((gap) => (
+              <div key={gap.id} className="rounded border border-stone-800 p-3 space-y-2">
+                <div className="flex items-center gap-2 text-xs">
+                  <span className="font-mono text-stone-400">{gap.id}</span>
+                  {gap.type && (
+                    <span className="rounded bg-amber-500/15 text-amber-300 px-1.5 py-0.5">{gap.type}</span>
+                  )}
+                  {gap.claim_ref && <span className="text-stone-600">→ {gap.claim_ref}</span>}
+                </div>
+                <div>
+                  <FieldLabel>Detail</FieldLabel>
+                  <textarea
+                    className={inputCls(readOnly) + ' resize-y min-h-[3rem]'}
+                    value={gap.detail}
+                    readOnly={readOnly}
+                    rows={2}
+                    onChange={(e) => !readOnly && onEditGap(gap.id, 'detail', e.target.value)}
+                  />
+                </div>
+                <div>
+                  <FieldLabel>Proposed action</FieldLabel>
+                  <textarea
+                    className={inputCls(readOnly) + ' resize-y min-h-[3rem]'}
+                    value={gap.proposed_action}
+                    readOnly={readOnly}
+                    rows={2}
+                    onChange={(e) => !readOnly && onEditGap(gap.id, 'proposed_action', e.target.value)}
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  )
+}
+
+// ---------------------------------------------------------------------------
 // Inner editor — has access to the ReviewEditor context
 // Owns all user interaction + submit logic.
 // ---------------------------------------------------------------------------
@@ -605,12 +815,31 @@ interface ReviewEditorInnerProps {
 }
 
 function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerProps) {
-  const { effectiveScenes, overallFeedback, buildOrder, isDirty, dispatch } = useReviewEditor()
+  const {
+    effectiveScenes,
+    effectivePersonas,
+    effectiveWhyBrief,
+    overallFeedback,
+    buildOrder,
+    isDirty,
+    dispatch,
+  } = useReviewEditor()
 
   const shareToken = useRef(new URLSearchParams(window.location.search).get('t')).current
 
   const newFeatureCounterRef = useRef(0)
   const newSceneCounterRef = useRef(0)
+
+  // Active tab — reflected in the URL (?tab=cuts) so it's shareable/linkable.
+  const initialTab = new URLSearchParams(window.location.search).get('tab') === 'cuts' ? 'cuts' : 'narrative'
+  const [tab, setTab] = useState<'narrative' | 'cuts'>(initialTab)
+  const selectTab = useCallback((t: 'narrative' | 'cuts') => {
+    setTab(t)
+    const url = new URL(window.location.href)
+    if (t === 'cuts') url.searchParams.set('tab', 'cuts')
+    else url.searchParams.delete('tab')
+    window.history.replaceState({}, '', url)
+  }, [])
 
   const [choices, setChoices] = useState<Record<string, string>>(() => {
     const initial: Record<string, string> = {}
@@ -629,7 +858,8 @@ function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerPr
   const actionability = req.actionability ?? null
   const overallScore = actionability?.overall_score ?? null
   const perScene = actionability?.per_scene ?? {}
-  const personas = req.personas ?? {}
+  // Use the projected personas so chips + cards reflect in-flight edits.
+  const personas = effectivePersonas
 
   // 1-based scene numbers among non-deleted scenes (renumbers as scenes are added/deleted).
   const sceneNumberById = new Map<string, number>()
@@ -668,12 +898,51 @@ function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerPr
         feedback: scene.feedback,
       }))
 
+      // Diff personas: send only changed fields per persona key.
+      const origPersonas = review.request_json.personas ?? {}
+      const editedPersonas: ReviewSubmitPayload['edited_personas'] = {}
+      for (const [key, p] of Object.entries(effectivePersonas)) {
+        const o = origPersonas[key]
+        const delta: Record<string, string> = {}
+        for (const f of ['name', 'org', 'role', 'intro'] as const) {
+          if ((p[f] ?? '') !== (o?.[f] ?? '')) delta[f] = p[f] ?? ''
+        }
+        if (Object.keys(delta).length > 0) editedPersonas![key] = delta
+      }
+
+      // Diff why-brief prose fields.
+      const origWb = review.request_json.why_brief ?? {}
+      const wbDelta: ReviewSubmitPayload['edited_why_brief'] = {}
+      if ((effectiveWhyBrief.problem ?? '') !== (origWb.problem ?? '')) {
+        wbDelta!.problem = effectiveWhyBrief.problem ?? ''
+      }
+      const spineDelta: Record<string, { claim?: string; rationale?: string }> = {}
+      for (const item of effectiveWhyBrief.spine ?? []) {
+        const o = (origWb.spine ?? []).find((s) => s.id === item.id)
+        const d: { claim?: string; rationale?: string } = {}
+        if ((item.claim ?? '') !== (o?.claim ?? '')) d.claim = item.claim ?? ''
+        if ((item.rationale ?? '') !== (o?.rationale ?? '')) d.rationale = item.rationale ?? ''
+        if (Object.keys(d).length > 0) spineDelta[item.id] = d
+      }
+      if (Object.keys(spineDelta).length > 0) wbDelta!.spine = spineDelta
+      const gapDelta: Record<string, { detail?: string; proposed_action?: string }> = {}
+      for (const gap of effectiveWhyBrief.gaps ?? []) {
+        const o = (origWb.gaps ?? []).find((g) => g.id === gap.id)
+        const d: { detail?: string; proposed_action?: string } = {}
+        if ((gap.detail ?? '') !== (o?.detail ?? '')) d.detail = gap.detail ?? ''
+        if ((gap.proposed_action ?? '') !== (o?.proposed_action ?? '')) d.proposed_action = gap.proposed_action ?? ''
+        if (Object.keys(d).length > 0) gapDelta[gap.id] = d
+      }
+      if (Object.keys(gapDelta).length > 0) wbDelta!.gaps = gapDelta
+
       const payload: ReviewSubmitPayload = {
         decisions: choices,
         edited_scenes: editedScenes,
         overall_feedback: overallFeedback,
         build_order: buildOrder,
       }
+      if (Object.keys(editedPersonas!).length > 0) payload.edited_personas = editedPersonas
+      if (Object.keys(wbDelta!).length > 0) payload.edited_why_brief = wbDelta
 
       const updated = await submitReview(review.id, payload, shareToken)
       onResolved(updated)
@@ -682,7 +951,7 @@ function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerPr
     } finally {
       setBusy(false)
     }
-  }, [effectiveScenes, overallFeedback, buildOrder, choices, review.id, shareToken, onResolved])
+  }, [effectiveScenes, effectivePersonas, effectiveWhyBrief, overallFeedback, buildOrder, choices, review.id, review.request_json, shareToken, onResolved])
 
   const canSubmit = !busy && decisions.every((d) => !!choices[d.id])
 
@@ -757,6 +1026,43 @@ function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerPr
         </div>
       )}
 
+      {/* Tabs — narrative review vs the rendered cut(s) */}
+      <div className="flex items-center gap-1 border-b border-stone-800">
+        {(['narrative', 'cuts'] as const).map((t) => (
+          <button
+            key={t}
+            type="button"
+            onClick={() => selectTab(t)}
+            className={[
+              'px-4 py-2 text-sm font-medium -mb-px border-b-2 transition-colors',
+              tab === t
+                ? 'border-orange-500 text-stone-100'
+                : 'border-transparent text-stone-500 hover:text-stone-300',
+            ].join(' ')}
+          >
+            {t === 'narrative' ? 'Narrative' : 'Cuts'}
+          </button>
+        ))}
+      </div>
+
+      {/* Cuts tab — the rendered demo cut; kept off the main view so it isn't distracting */}
+      {tab === 'cuts' && (
+        <section>
+          <h2 className="text-sm font-semibold text-stone-400 uppercase tracking-wider mb-2">
+            Current cut
+          </h2>
+          <div className="rounded-lg border border-stone-700 bg-black overflow-hidden">
+            {videoElement}
+          </div>
+          <p className="text-xs text-stone-600 mt-2">
+            This tab shows the rendered demo cut. Spec/yaml history lives in git — not version-controlled here.
+          </p>
+        </section>
+      )}
+
+      {/* Narrative tab — the story, personas, why-brief, scenes, decision */}
+      {tab === 'narrative' && (
+        <>
       {/* The demo narrative — the cohesive story the scenes decompose */}
       {req.narrative && req.narrative.trim() && (
         <section className="rounded-lg border border-stone-700 bg-stone-900/60 p-5 space-y-3">
@@ -777,15 +1083,29 @@ function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerPr
         </section>
       )}
 
-      {/* Current cut */}
-      <section>
-        <h2 className="text-sm font-semibold text-stone-400 uppercase tracking-wider mb-2">
-          Current cut
-        </h2>
-        <div className="rounded-lg border border-stone-700 bg-black overflow-hidden">
-          {videoElement}
-        </div>
-      </section>
+      {/* Personas — visible + editable */}
+      <PersonasSection
+        personas={personas}
+        readOnly={readOnly}
+        onEdit={(key, field, value) =>
+          dispatch({ type: 'APPEND_OP', op: { op: 'edit-persona', key, field, value } })
+        }
+      />
+
+      {/* Why-brief — visible + editable */}
+      <WhyBriefSection
+        whyBrief={effectiveWhyBrief}
+        readOnly={readOnly}
+        onEditProblem={(value) =>
+          dispatch({ type: 'APPEND_OP', op: { op: 'edit-why-problem', value } })
+        }
+        onEditSpine={(id, field, value) =>
+          dispatch({ type: 'APPEND_OP', op: { op: 'edit-why-spine', id, field, value } })
+        }
+        onEditGap={(id, field, value) =>
+          dispatch({ type: 'APPEND_OP', op: { op: 'edit-why-gap', id, field, value } })
+        }
+      />
 
       {/* Narrative verdict decision tile */}
       {narrativeVerdictDecision && (
@@ -1005,6 +1325,8 @@ function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerPr
           </button>
         </div>
       )}
+        </>
+      )}
     </div>
   )
 }
@@ -1054,6 +1376,8 @@ export function ReviewPage() {
     <ReviewEditorProvider
       original={review.request_json.narration ?? []}
       initialBuildOrder={review.request_json.build_order ?? null}
+      personas={review.request_json.personas ?? {}}
+      whyBrief={review.request_json.why_brief ?? null}
     >
       <ReviewEditorInner
         review={review}

--- a/frontend/src/pages/ReviewPage.tsx
+++ b/frontend/src/pages/ReviewPage.tsx
@@ -19,6 +19,24 @@ import {
 } from '../components/reviews/ReviewEditorContext'
 
 // ---------------------------------------------------------------------------
+// Narrative-banner per-sentence tints. Each sentence in the top "The demo"
+// paragraph is wrapped in a clickable span; in sentence-mode (sentence count
+// matches scene count) clicks scroll to that scene's card. Subtle base tint;
+// brighter on hover so it's clear the span is interactive.
+// ---------------------------------------------------------------------------
+
+const NARRATIVE_TINTS: Array<{ base: string; hover: string }> = [
+  { base: 'bg-sky-500/10', hover: 'hover:bg-sky-500/20' },
+  { base: 'bg-emerald-500/10', hover: 'hover:bg-emerald-500/20' },
+  { base: 'bg-violet-500/10', hover: 'hover:bg-violet-500/20' },
+  { base: 'bg-amber-500/10', hover: 'hover:bg-amber-500/20' },
+  { base: 'bg-rose-500/10', hover: 'hover:bg-rose-500/20' },
+  { base: 'bg-teal-500/10', hover: 'hover:bg-teal-500/20' },
+  { base: 'bg-indigo-500/10', hover: 'hover:bg-indigo-500/20' },
+  { base: 'bg-fuchsia-500/10', hover: 'hover:bg-fuchsia-500/20' },
+]
+
+// ---------------------------------------------------------------------------
 // AutoTextarea — a textarea that grows to fit its content (never internally
 // scrolls). Re-fits on value changes and window resize; honors any min-height
 // supplied via className.
@@ -466,8 +484,9 @@ function SceneCard({
 
   return (
     <div
+      id={`scene-${scene.id}`}
       className={[
-        'rounded-lg border p-4 space-y-3 transition-colors',
+        'rounded-lg border p-4 space-y-3 transition-colors scroll-mt-4',
         isEdited
           ? 'border-sky-500/60 bg-sky-500/5 ring-1 ring-sky-500/20'
           : 'border-stone-700 bg-stone-950',
@@ -1221,7 +1240,57 @@ function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerPr
           </h2>
           {req.narrative?.trim() && (
             <p className="text-[15px] leading-relaxed text-stone-200">
-              {req.narrative.trim()}
+              {(() => {
+                const paragraph = req.narrative.trim()
+                // Sentence-split client-side: same shape as scripts/ddd/narrative.py
+                // _split_narrative_sentences. Conservative: splits on sentence-ending
+                // punctuation followed by whitespace + a capital letter or opening quote.
+                const sentences = paragraph
+                  .split(/(?<=[.!?])\s+(?=[A-Z"'])/)
+                  .map((s) => s.trim())
+                  .filter((s) => s.length > 0)
+                // Sentence-mode: when sentence count matches scene count, each
+                // sentence maps 1:1 to a scene and clicks scroll to that scene's
+                // card. Otherwise (under-drafted paragraph, multi-sentence scene)
+                // we still tint the sentences but don't wire click targets — the
+                // mapping isn't deterministic without per-scene sentence ranges.
+                const liveScenes = effectiveScenes.filter((s) => !s.deleted)
+                const sceneMode = sentences.length === liveScenes.length
+                if (sentences.length <= 1) {
+                  return paragraph
+                }
+                return sentences.map((sentence, i) => {
+                  const sceneId = sceneMode ? liveScenes[i].id : null
+                  const palette = NARRATIVE_TINTS[i % NARRATIVE_TINTS.length]
+                  const isEdited = sceneId ? editedSceneIds.has(sceneId) : false
+                  const tintCls = isEdited
+                    ? 'bg-sky-500/10 hover:bg-sky-500/20'
+                    : `${palette.base} ${palette.hover}`
+                  return (
+                    <span key={i}>
+                      {i > 0 && ' '}
+                      <span
+                        className={[
+                          tintCls,
+                          'rounded px-1 py-0.5 transition-colors',
+                          sceneId ? 'cursor-pointer' : '',
+                        ].join(' ')}
+                        onClick={
+                          sceneId
+                            ? () => {
+                                const el = document.getElementById(`scene-${sceneId}`)
+                                if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+                              }
+                            : undefined
+                        }
+                        title={sceneId ? `Jump to scene ${i + 1}` : undefined}
+                      >
+                        {sentence}
+                      </span>
+                    </span>
+                  )
+                })
+              })()}
             </p>
           )}
           {(effectiveWhyBrief.problem || !readOnly) && (


### PR DESCRIPTION
## Summary

The top 'The demo' narrative paragraph was a single block of text. The reviewer had to re-read the prose, locate the matching scene card, and scroll there manually. With multi-sentence beats coming, that gets worse.

## What ships

- 8-color subtle tint palette (sky / emerald / violet / amber / rose / teal / indigo / fuchsia at /10 base, /20 on hover) cycling by sentence position.
- Client-side sentence split (same regex as `scripts.ddd.narrative._split_narrative_sentences`).
- In sentence-mode (sentence count == live scene count): each sentence is a clickable span; click scrolls the matching scene card into view smoothly. Out of sentence-mode: tints still render, clicks are no-op.
- Edited sentences pick up the scene's sky-tint so the 'Edited' indicator follows the eye through the narrative too.
- SceneCard outer div gets `id='scene-<id>'` + `scroll-mt-4` for clean anchoring.

## Test plan

- [ ] Open any review with a multi-sentence narrative; confirm tints render and clicks scroll to the matching scene
- [ ] Edit a sentence; confirm both the banner span and the scene card pick up the sky 'Edited' tint
- [ ] Open a single-sentence-narrative review; banner renders unchanged
