### PR TITLE
refactor(reviews): DDD Plans page at /ddd-plans (redirect /reviews)

### DIFF
--- a/frontend/src/components/AppLayout/AppLayout.tsx
+++ b/frontend/src/components/AppLayout/AppLayout.tsx
@@ -9,7 +9,7 @@ const NAV_ITEMS = [
   { path: '/insights', label: 'Insights' },
   { path: '/skills', label: 'Skills' },
   { path: '/walkthroughs', label: 'Walkthroughs' },
-  { path: '/reviews', label: 'DDD Plans' },
+  { path: '/ddd-plans', label: 'DDD Plans' },
   { path: '/workspaces', label: 'Workspaces' },
   { path: '/leaderboard', label: 'Leaderboard' },
   { path: '/guide', label: 'Guide' },

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -1,4 +1,4 @@
-import { createBrowserRouter } from 'react-router-dom'
+import { createBrowserRouter, Navigate } from 'react-router-dom'
 import { AppLayout } from './components/AppLayout/AppLayout'
 import { WorkspacePage } from './pages/WorkspacePage'
 import { WorkspacesPage } from './pages/WorkspacesPage'
@@ -24,7 +24,8 @@ export const router = createBrowserRouter([
       { path: '/skills', element: <DiscoveryPage /> },
       { path: '/walkthroughs', element: <WalkthroughsPage /> },
       { path: '/w/:id', element: <WalkthroughViewerPage /> },
-      { path: '/reviews', element: <ReviewsPage /> },
+      { path: '/ddd-plans', element: <ReviewsPage /> },
+      { path: '/reviews', element: <Navigate to="/ddd-plans" replace /> },
       { path: '/review/:id', element: <ReviewPage /> },
       { path: '/new', element: <NewCollectionPage /> },
       { path: '/workspaces', element: <WorkspacesPage /> },


### PR DESCRIPTION
Renames the dashboard route from `/reviews` to **`/ddd-plans`** (clearer URL; nav label unchanged). Adds a `/reviews` → `/ddd-plans` redirect so any already-shared link keeps working. Frontend-only; the API stays `/api/reviews/`.

`npm run build` (tsc + vite) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)