### PR TITLE
feat(insights): add Alignment category filter tab

### DIFF
--- a/frontend/src/pages/InsightsPage.tsx
+++ b/frontend/src/pages/InsightsPage.tsx
@@ -16,6 +16,7 @@ const CATEGORIES = [
   { key: 'pattern', label: 'Patterns' },
   { key: 'stale', label: 'Stale' },
   { key: 'opportunity', label: 'Opportunities' },
+  { key: 'alignment', label: 'Alignment' },
 ]
 
 function InsightCard({ insight, onDismiss }: { insight: Insight; onDismiss: (id: number) => void }) {


### PR DESCRIPTION
## What

Adds an **Alignment** tab to the `/insights` category filter, completing the alignment-category UX started by the badge PR (#60). Users can now filter the feed down to just `canopy:alignment` cards.

One line in `frontend/src/pages/InsightsPage.tsx` — appends `{ key: 'alignment', label: 'Alignment' }` to the `CATEGORIES` filter array. The backend already filters insights by the `[category]` prefix (`content__startswith`), so no backend change is needed.

## Verification

- `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)