### PR TITLE
feat(insights): filter-aware clear (category/project/source/age) + MCP tool + Clear button

### DIFF
--- a/apps/projects/api.py
+++ b/apps/projects/api.py
@@ -1,9 +1,12 @@
 """Django Ninja v2 router for the projects + insights surface."""
 from __future__ import annotations
 
+from datetime import timedelta
+
 from django.db import IntegrityError
 from django.db.models import Prefetch
 from django.http import HttpRequest
+from django.utils import timezone
 from ninja import Body, Router, Status
 
 from apps.api.auth import session_auth
@@ -20,6 +23,7 @@ from .schemas import (
     BatchContextIn,
     InsightDismissOut,
     InsightOut,
+    InsightsClearIn,
     InsightsClearOut,
     ProjectActionCreateIn,
     ProjectActionOut,
@@ -568,15 +572,36 @@ def list_insights(
     return paginate(items, offset=0, limit=limit)
 
 
-@insights_router.post("/clear/", response=InsightsClearOut, summary="Clear insights")
+@insights_router.post(
+    "/clear/",
+    response=InsightsClearOut,
+    summary="Clear insights",
+    openapi_extra={"x-mcp-expose": True},
+)
 def clear_insights(
     request: HttpRequest,
-    source: str | None = None,
+    payload: InsightsClearIn,
 ) -> InsightsClearOut:
-    """Clear all insights (optionally filtered by source)."""
+    """Delete insights matching the provided filters.
+
+    All filters in the request body are optional and AND-combined:
+      - source: ProjectContext.source exact match
+      - category: content starts with "[<category>]"
+      - project: project slug exact match
+      - older_than_days: created_at older than N days ago
+
+    A body with no filters ({}) clears ALL insights — this is intended.
+    """
     qs = ProjectContext.objects.filter(context_type="insight")
-    if source:
-        qs = qs.filter(source=source)
+    if payload.source:
+        qs = qs.filter(source=payload.source)
+    if payload.category:
+        qs = qs.filter(content__startswith=f"[{payload.category}]")
+    if payload.project:
+        qs = qs.filter(project__slug=payload.project)
+    if payload.older_than_days is not None:
+        cutoff = timezone.now() - timedelta(days=payload.older_than_days)
+        qs = qs.filter(created_at__lt=cutoff)
     count = qs.count()
     qs.delete()
     return InsightsClearOut(cleared=count)

--- a/apps/projects/schemas.py
+++ b/apps/projects/schemas.py
@@ -157,6 +157,18 @@ class InsightOut(StrictModel):
     created_at: dt.datetime
 
 
+class InsightsClearIn(StrictModel):
+    """Body of POST /api/insights/clear/.
+
+    All fields optional. Provided filters are AND-combined to narrow which
+    insights are deleted. A body with no filters clears ALL insights.
+    """
+    source: str | None = None
+    category: str | None = None
+    project: str | None = None  # project slug
+    older_than_days: int | None = None
+
+
 class InsightsClearOut(StrictModel):
     cleared: int
 

--- a/apps/projects/tests/test_api.py
+++ b/apps/projects/tests/test_api.py
@@ -518,17 +518,122 @@ def test_list_insights_pat_readable():
 
 
 @pytest.mark.django_db
-def test_clear_insights_200():
+def test_clear_insights_all_empty_body():
+    """An empty body clears ALL insights."""
     p = _make_project(slug="ins-clear")
     ProjectContext.objects.create(
-        project=p, context_type="insight", content="x", source="test"
+        project=p, context_type="insight", content="[a] x", source="src-a"
+    )
+    ProjectContext.objects.create(
+        project=p, context_type="insight", content="[b] y", source="src-b"
     )
     c = _auth_client()
     resp = _post_json(c, "/api/insights/clear/", {})
     assert resp.status_code == 200
     body = resp.json()
-    assert "cleared" in body
-    assert body["cleared"] >= 1
+    assert body["cleared"] == 2
+    assert not ProjectContext.objects.filter(context_type="insight").exists()
+
+
+@pytest.mark.django_db
+def test_clear_insights_source_filter():
+    p = _make_project(slug="ins-clear-src")
+    keep = ProjectContext.objects.create(
+        project=p, context_type="insight", content="[a] x", source="keep"
+    )
+    ProjectContext.objects.create(
+        project=p, context_type="insight", content="[a] y", source="drop"
+    )
+    c = _auth_client()
+    resp = _post_json(c, "/api/insights/clear/", {"source": "drop"})
+    assert resp.status_code == 200
+    assert resp.json()["cleared"] == 1
+    remaining = list(ProjectContext.objects.filter(context_type="insight"))
+    assert [r.pk for r in remaining] == [keep.pk]
+
+
+@pytest.mark.django_db
+def test_clear_insights_category_filter():
+    p = _make_project(slug="ins-clear-cat")
+    ProjectContext.objects.create(
+        project=p, context_type="insight", content="[ship_gap] X", source="test"
+    )
+    keep = ProjectContext.objects.create(
+        project=p, context_type="insight", content="[debt] Y", source="test"
+    )
+    c = _auth_client()
+    resp = _post_json(c, "/api/insights/clear/", {"category": "ship_gap"})
+    assert resp.status_code == 200
+    assert resp.json()["cleared"] == 1
+    remaining = list(ProjectContext.objects.filter(context_type="insight"))
+    assert [r.pk for r in remaining] == [keep.pk]
+
+
+@pytest.mark.django_db
+def test_clear_insights_project_filter():
+    p1 = _make_project(slug="ins-clear-p1")
+    p2 = _make_project(slug="ins-clear-p2")
+    ProjectContext.objects.create(
+        project=p1, context_type="insight", content="[a] x", source="test"
+    )
+    keep = ProjectContext.objects.create(
+        project=p2, context_type="insight", content="[a] y", source="test"
+    )
+    c = _auth_client()
+    resp = _post_json(c, "/api/insights/clear/", {"project": "ins-clear-p1"})
+    assert resp.status_code == 200
+    assert resp.json()["cleared"] == 1
+    remaining = list(ProjectContext.objects.filter(context_type="insight"))
+    assert [r.pk for r in remaining] == [keep.pk]
+
+
+@pytest.mark.django_db
+def test_clear_insights_older_than_days_filter():
+    from django.utils import timezone as _tz
+
+    p = _make_project(slug="ins-clear-age")
+    old = ProjectContext.objects.create(
+        project=p, context_type="insight", content="[a] old", source="test"
+    )
+    # auto_now_add sets created_at; force it into the past.
+    ProjectContext.objects.filter(pk=old.pk).update(
+        created_at=_tz.now() - dt.timedelta(days=30)
+    )
+    fresh = ProjectContext.objects.create(
+        project=p, context_type="insight", content="[a] fresh", source="test"
+    )
+    c = _auth_client()
+    resp = _post_json(c, "/api/insights/clear/", {"older_than_days": 7})
+    assert resp.status_code == 200
+    assert resp.json()["cleared"] == 1
+    remaining = list(ProjectContext.objects.filter(context_type="insight"))
+    assert [r.pk for r in remaining] == [fresh.pk]
+
+
+@pytest.mark.django_db
+def test_clear_insights_combined_filters():
+    p1 = _make_project(slug="ins-clear-c1")
+    p2 = _make_project(slug="ins-clear-c2")
+    target = ProjectContext.objects.create(
+        project=p1, context_type="insight", content="[ship_gap] X", source="test"
+    )
+    # Same category, different project — must survive.
+    survives_project = ProjectContext.objects.create(
+        project=p2, context_type="insight", content="[ship_gap] Y", source="test"
+    )
+    # Same project, different category — must survive.
+    survives_category = ProjectContext.objects.create(
+        project=p1, context_type="insight", content="[debt] Z", source="test"
+    )
+    c = _auth_client()
+    resp = _post_json(
+        c, "/api/insights/clear/", {"category": "ship_gap", "project": "ins-clear-c1"}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["cleared"] == 1
+    remaining = {r.pk for r in ProjectContext.objects.filter(context_type="insight")}
+    assert remaining == {survives_project.pk, survives_category.pk}
+    assert not ProjectContext.objects.filter(pk=target.pk).exists()
 
 
 @pytest.mark.django_db

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -245,7 +245,15 @@ export interface paths {
         readonly put?: never;
         /**
          * Clear insights
-         * @description Clear all insights (optionally filtered by source).
+         * @description Delete insights matching the provided filters.
+         *
+         *     All filters in the request body are optional and AND-combined:
+         *       - source: ProjectContext.source exact match
+         *       - category: content starts with "[<category>]"
+         *       - project: project slug exact match
+         *       - older_than_days: created_at older than N days ago
+         *
+         *     A body with no filters ({}) clears ALL insights — this is intended.
          */
         readonly post: operations["apps_projects_api_clear_insights"];
         readonly delete?: never;
@@ -1328,6 +1336,23 @@ export interface components {
         readonly InsightsClearOut: {
             /** Cleared */
             readonly cleared: number;
+        };
+        /**
+         * InsightsClearIn
+         * @description Body of POST /api/insights/clear/.
+         *
+         *     All fields optional. Provided filters are AND-combined to narrow which
+         *     insights are deleted. A body with no filters clears ALL insights.
+         */
+        readonly InsightsClearIn: {
+            /** Source */
+            readonly source?: string | null;
+            /** Category */
+            readonly category?: string | null;
+            /** Project */
+            readonly project?: string | null;
+            /** Older Than Days */
+            readonly older_than_days?: number | null;
         };
         /** InsightDismissOut */
         readonly InsightDismissOut: {
@@ -2500,14 +2525,16 @@ export interface operations {
     };
     readonly apps_projects_api_clear_insights: {
         readonly parameters: {
-            readonly query?: {
-                readonly source?: string | null;
-            };
+            readonly query?: never;
             readonly header?: never;
             readonly path?: never;
             readonly cookie?: never;
         };
-        readonly requestBody?: never;
+        readonly requestBody: {
+            readonly content: {
+                readonly "application/json": components["schemas"]["InsightsClearIn"];
+            };
+        };
         readonly responses: {
             /** @description OK */
             readonly 200: {

--- a/frontend/src/api/insights.ts
+++ b/frontend/src/api/insights.ts
@@ -21,6 +21,13 @@ export interface InsightListParams {
   limit?: number
 }
 
+export interface InsightClearParams {
+  source?: string
+  category?: string
+  project?: string
+  older_than_days?: number
+}
+
 // Category weight for the dashboard "Today's top 3" hero. Higher = more
 // urgent to surface. Tuned for the morning-triage flow: ship gaps and
 // opportunities are time-sensitive (a release, a CWS review, an upstream PR
@@ -81,5 +88,17 @@ export const insightsApi = {
     });
     if (error) throw new Error("Failed to dismiss insight");
     return data as { dismissed: number };
+  },
+  clear: async (params: InsightClearParams = {}): Promise<{ cleared: number }> => {
+    const { data, error } = await apiV2.POST("/api/insights/clear/", {
+      body: {
+        source: params.source ?? null,
+        category: params.category ?? null,
+        project: params.project ?? null,
+        older_than_days: params.older_than_days ?? null,
+      },
+    });
+    if (error) throw new Error("Failed to clear insights");
+    return data as { cleared: number };
   },
 }

--- a/frontend/src/pages/InsightsPage.tsx
+++ b/frontend/src/pages/InsightsPage.tsx
@@ -89,6 +89,8 @@ export function InsightsPage() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [activeFilter, setActiveFilter] = useState('all')
+  const [clearing, setClearing] = useState(false)
+  const [notice, setNotice] = useState<string | null>(null)
   const [searchParams, setSearchParams] = useSearchParams()
   const projectFilter = searchParams.get('project') || ''
 
@@ -135,6 +137,38 @@ export function InsightsPage() {
     return hit?.project_name || projectFilter
   }, [projectFilter, insights])
 
+  // Clear exactly what the active filter currently shows: category (unless
+  // 'all') and project (if set). Refetches afterward and surfaces the count.
+  async function handleClear() {
+    const catLabel =
+      activeFilter === 'all'
+        ? ''
+        : (CATEGORIES.find((c) => c.key === activeFilter)?.label ?? activeFilter) + ' '
+    const scope = projectFilter ? ` for ${projectFilterLabel}` : ''
+    const confirmed = window.confirm(
+      `Clear all ${insights.length} ${catLabel}insight${insights.length === 1 ? '' : 's'}${scope}? This cannot be undone.`,
+    )
+    if (!confirmed) return
+    setClearing(true)
+    setNotice(null)
+    try {
+      const { cleared } = await insightsApi.clear({
+        category: activeFilter === 'all' ? undefined : activeFilter,
+        project: projectFilter || undefined,
+      })
+      const data = await insightsApi.list({
+        category: activeFilter === 'all' ? undefined : activeFilter,
+        project: projectFilter || undefined,
+      })
+      setInsights(data)
+      setNotice(`Cleared ${cleared} insight${cleared === 1 ? '' : 's'}.`)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to clear insights')
+    } finally {
+      setClearing(false)
+    }
+  }
+
   const emptyMessage = (() => {
     if (projectFilter && activeFilter !== 'all') {
       const catLabel = CATEGORIES.find((c) => c.key === activeFilter)?.label.toLowerCase() ?? activeFilter
@@ -152,10 +186,29 @@ export function InsightsPage() {
     <div className="max-w-3xl mx-auto">
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-lg font-semibold text-stone-100">Insights</h1>
-        <span className="text-xs text-stone-600 bg-stone-900 px-2.5 py-1 rounded">
-          {loading ? 'loading...' : `${insights.length} insights`}
-        </span>
+        <div className="flex items-center gap-2">
+          {!loading && !error && insights.length > 0 && (
+            <button
+              onClick={handleClear}
+              disabled={clearing}
+              className="text-xs font-medium text-stone-400 hover:text-red-400 border border-stone-800 hover:border-red-400/40 bg-stone-900 px-2.5 py-1 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              title="Clear the insights currently in view"
+            >
+              {clearing ? 'Clearing…' : 'Clear'}
+            </button>
+          )}
+          <span className="text-xs text-stone-600 bg-stone-900 px-2.5 py-1 rounded">
+            {loading ? 'loading...' : `${insights.length} insights`}
+          </span>
+        </div>
       </div>
+
+      {/* Clear confirmation notice */}
+      {notice && (
+        <div className="mb-3 text-xs text-stone-400 bg-stone-900 border border-stone-800 px-3 py-2 rounded">
+          {notice}
+        </div>
+      )}
 
       {/* Active project filter chip */}
       {projectFilter && (


### PR DESCRIPTION
## What

Makes insight cleanup first-class and exposes it everywhere from one definition.

- **Backend** (`apps/projects/api.py`, `schemas.py`): `clear_insights` now takes an `InsightsClearIn` **body** (all-optional `source`, `category`, `project`, `older_than_days`) instead of a lone `source` query param. Filters AND-combine; an empty body clears all. Tagged `openapi_extra={"x-mcp-expose": True}` → it auto-becomes the `clear_insights` **MCP tool** (the MCP `_build_tool` sends POST args as a JSON body, so a body schema is required for the tool to work).
- **Frontend**: `insightsApi.clear(...)` + a filter-aware **Clear** button on `/insights` that clears what the active filter shows (category + project), behind a `window.confirm`, then refetches.
- Regenerated `generated.ts` from the updated schema.

No backwards compatibility kept (sole user; changing the query param to a body is fine).

## Why

Insights live only in canopy-web, so cleanup belongs here. One Ninja route now backs the REST endpoint, the MCP tool, and the UI button — no duplicated deletion logic.

## Verification

- `apps/projects/tests/test_api.py` → 35 passed (new: clear-all, source, category, project, older_than_days, combined category+project).
- `apps/api/tests/` → 17 passed. `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)