### PR TITLE
feat(mcp): authenticate the /api/mcp/ SSE mount (fail closed)

### DIFF
--- a/apps/api/tests/test_mcp_mount_auth.py
+++ b/apps/api/tests/test_mcp_mount_auth.py
@@ -1,0 +1,39 @@
+"""The /api/mcp/ ASGI mount must be gated by CANOPY_MCP_BEARER.
+
+The FastMCP SSE app sits outside Django's auth middleware, so the gate in
+config.asgi is the only thing standing between the public internet and the
+MCP tools (which re-enter the REST API with the server's bearer).
+"""
+
+import os
+from unittest import mock
+
+from config.asgi import _mcp_authorized
+
+
+def _scope(auth: str | None = None):
+    headers = []
+    if auth is not None:
+        headers.append((b"authorization", auth.encode("latin-1")))
+    return {"type": "http", "path": "/api/mcp/sse", "headers": headers}
+
+
+def test_rejects_when_bearer_unset():
+    """Fail closed: no configured token => mount unreachable even with a header."""
+    with mock.patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("CANOPY_MCP_BEARER", None)
+        assert _mcp_authorized(_scope("Bearer anything")) is False
+        assert _mcp_authorized(_scope(None)) is False
+
+
+def test_rejects_missing_or_wrong_token():
+    with mock.patch.dict(os.environ, {"CANOPY_MCP_BEARER": "secret-pat"}):
+        assert _mcp_authorized(_scope(None)) is False
+        assert _mcp_authorized(_scope("Bearer wrong")) is False
+        assert _mcp_authorized(_scope("secret-pat")) is False  # missing "Bearer "
+        assert _mcp_authorized(_scope("Bearer secret-pat ")) is False  # trailing space
+
+
+def test_accepts_exact_match():
+    with mock.patch.dict(os.environ, {"CANOPY_MCP_BEARER": "secret-pat"}):
+        assert _mcp_authorized(_scope("Bearer secret-pat")) is True

--- a/config/asgi.py
+++ b/config/asgi.py
@@ -7,6 +7,7 @@ For more information on this file, see
 https://docs.djangoproject.com/en/5.0/howto/deployment/asgi/
 """
 
+import hmac
 import os
 
 from django.core.asgi import get_asgi_application
@@ -28,8 +29,48 @@ _django_asgi_app = get_asgi_application()
 _MCP_PREFIX = "/api/mcp"
 
 
+def _mcp_authorized(scope) -> bool:
+    """Gate the public /api/mcp/ mount.
+
+    The MCP SSE app sits OUTSIDE Django's auth middleware, so without this
+    check anyone on the internet could drive its tools (which re-enter the
+    REST API with the server's bearer). We require the caller to present the
+    same token the server uses for its loopback: ``CANOPY_MCP_BEARER``.
+
+    Fail closed: if ``CANOPY_MCP_BEARER`` is unset, the mount is unreachable
+    (no token can match an empty expected value).
+    """
+    expected = os.environ.get("CANOPY_MCP_BEARER", "")
+    if not expected:
+        return False
+    for name, value in scope.get("headers", []):
+        if name == b"authorization":
+            return hmac.compare_digest(
+                value.decode("latin-1"), f"Bearer {expected}"
+            )
+    return False
+
+
+async def _send_401(send) -> None:
+    await send({
+        "type": "http.response.start",
+        "status": 401,
+        "headers": [
+            (b"content-type", b"application/json"),
+            (b"www-authenticate", b'Bearer realm="canopy-web-mcp"'),
+        ],
+    })
+    await send({
+        "type": "http.response.body",
+        "body": b'{"detail":"MCP mount requires a valid bearer token."}',
+    })
+
+
 async def application(scope, receive, send):
     if scope["type"] == "http" and scope.get("path", "").startswith(_MCP_PREFIX):
+        if not _mcp_authorized(scope):
+            await _send_401(send)
+            return
         # Lazy-import so Django's app registry is fully loaded before we
         # touch apps.api.mcp_server (which imports ORM-backed modules).
         from apps.api.mcp_server import mcp_starlette_app  # noqa: PLC0415


### PR DESCRIPTION
## What

Gates the `/api/mcp/` ASGI mount. The FastMCP SSE app sits outside Django's auth middleware, so it was reachable unauthenticated — and its tools re-enter the REST API with the server's bearer. Now the ASGI wrapper requires `Authorization: Bearer <CANOPY_MCP_BEARER>` (constant-time `hmac.compare_digest`) before forwarding; returns 401 otherwise.

**Fails closed:** if `CANOPY_MCP_BEARER` is unset, no token can match, so the mount is unreachable until deliberately configured. This is the prerequisite for actually enabling the MCP tool path (the loopback already uses the same env var), without opening a public unauthenticated gateway to mutating tools.

## Tests

`apps/api/tests/test_mcp_mount_auth.py` — 3 passing: rejects when unset, rejects missing/wrong/malformed bearer, accepts exact match.

## Follow-up (ops, not code)

Set `CANOPY_MCP_BEARER` on Cloud Run to a valid PAT, and configure the canopy plugin's MCP client to send the same token as a header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)