### PR TITLE
feat(reviews): "what approving does" header + gap-aware build/real badges

### DIFF
--- a/frontend/src/pages/ReviewPage.tsx
+++ b/frontend/src/pages/ReviewPage.tsx
@@ -411,9 +411,11 @@ interface SceneCardProps {
   isEdited?: boolean
 }
 
-function StatusBadge({ status }: { status?: string }) {
-  if (!status) return null
-  const frontier = status !== 'grounded'
+function StatusBadge({ status, frontier: frontierOverride }: { status?: string; frontier?: boolean }) {
+  if (frontierOverride === undefined && !status) return null
+  // Caller may pass an explicit `frontier` (e.g. grounded claim WITH an open gap → still
+  // to-build); otherwise fall back to the spine status.
+  const frontier = frontierOverride ?? status !== 'grounded'
   return (
     <span
       title={frontier ? 'New feature — not yet built; this scene shows intended behavior' : 'Existing feature — backed by shipped code/evidence (not re-verified live)'}
@@ -484,7 +486,11 @@ function SceneCard({
           )}
           {persona && <PersonaChip persona={persona} />}
           <span className="text-sm font-medium text-stone-100">{scene.title}</span>
-          {grounding?.status && <StatusBadge status={grounding.status} />}
+          {(grounding?.status || (gaps && gaps.length > 0)) && (
+            <StatusBadge
+              frontier={(grounding?.status ?? 'grounded') !== 'grounded' || (gaps?.length ?? 0) > 0}
+            />
+          )}
           {isEdited && (
             <span
               title="This scene has pending edits in your current session"
@@ -1000,10 +1006,17 @@ function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerPr
   )
 
   // Honesty flag before approval: how many scenes are New features (not built) or below the ≥4 bar.
+  // A scene is "frontier" (to-build) if its spine item is a gap OR a why-brief gap
+  // (CAPABILITY/RESEARCH/DECISION) references it — a grounded claim with an open
+  // capability gap is still something we'd build, so it must read as New, not Existing.
   const liveScenes = effectiveScenes.filter((s) => !s.deleted)
-  const frontierCount = liveScenes.filter(
-    (s) => s.provenance && (spineById.get(s.provenance)?.status ?? 'grounded') !== 'grounded',
-  ).length
+  const sceneIsFrontier = (s: { provenance?: string }) =>
+    (s.provenance ? (spineById.get(s.provenance)?.status ?? 'grounded') : 'grounded') !== 'grounded' ||
+    (s.provenance ? (gapsByRef.get(s.provenance)?.length ?? 0) : 0) > 0
+  const frontierScenes = liveScenes.filter(sceneIsFrontier)
+  const frontierCount = frontierScenes.length
+  const builtSceneCount = liveScenes.length - frontierCount
+  const toBuildFeatures = frontierScenes.flatMap((s) => (s.features ?? []).filter((f) => !f.deleted))
   const belowBarCount = liveScenes.filter((s) => (perScene[s.id]?.score ?? 5) < 4).length
 
   const narrativeVerdictDecision = decisions.find((d) => d.id === 'narrative-verdict') ?? null
@@ -1318,6 +1331,54 @@ function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerPr
         </section>
       )}
 
+      {/* What approving does — the next-action + engage-vs-delegate summary */}
+      {!readOnly && liveScenes.length > 0 && resolvedChoice('narrative-verdict') !== 'redraft' && (
+        <section className="rounded-lg border border-sky-500/30 bg-sky-500/[0.06] p-4">
+          <h2 className="text-sm font-semibold text-sky-200 mb-2">If you approve, running DDD next will…</h2>
+          <ul className="space-y-1 text-sm text-stone-300">
+            <li>
+              <span className="text-stone-500">▶</span>{' '}
+              <span className="text-stone-100">Render {liveScenes.length} scene{liveScenes.length === 1 ? '' : 's'}</span>{' '}
+              against the live app and screenshot each beat.
+            </li>
+            <li>
+              <span className="text-stone-500">🔨</span>{' '}
+              <span className="text-stone-100">
+                Build {frontierCount} new feature{frontierCount === 1 ? '' : 's'}
+              </span>
+              {frontierCount > 0 && toBuildFeatures.length > 0 ? (
+                <>
+                  :{' '}
+                  <span className="text-amber-300">
+                    {toBuildFeatures.map((f) => f.id).join(', ')}
+                  </span>
+                </>
+              ) : (
+                <span className="text-stone-500"> — none; every beat already rides shipped code</span>
+              )}
+              .
+            </li>
+            <li>
+              <span className="text-stone-500">⚖</span>{' '}
+              <span className="text-stone-100">Re-judge</span> (concept + actionability) and loop, stopping at the
+              next <em className="text-stone-400">concept_change</em> or <em className="text-stone-400">external_release</em> gate.
+            </li>
+          </ul>
+          <p className="text-xs text-stone-500 mt-3">
+            {builtSceneCount}/{liveScenes.length} scenes already ride shipped code.{' '}
+            {frontierCount > 0 ? (
+              <>
+                The build is {frontierCount} scoped feature{frontierCount === 1 ? '' : 's'} —{' '}
+                <span className="text-emerald-300">safe to delegate</span>. The story framing is the part that&apos;s{' '}
+                <span className="text-sky-300">yours to approve</span>.
+              </>
+            ) : (
+              <>Nothing new to build — this is a <span className="text-emerald-300">render-and-confirm</span> pass.</>
+            )}
+          </p>
+        </section>
+      )}
+
       {/* Scene cards — driven by op-buffer projection */}
       {(effectiveScenes.length > 0 || !readOnly) && (
         <section>
@@ -1338,9 +1399,7 @@ function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerPr
                 isEdited={editedSceneIds.has(scene.id)}
                 defaultOpen={
                   expandAll ||
-                  (scene.provenance
-                    ? (spineById.get(scene.provenance)?.status ?? 'grounded') !== 'grounded'
-                    : false) ||
+                  sceneIsFrontier(scene) ||
                   (perScene[scene.id]?.score ?? 5) < 4 ||
                   editedSceneIds.has(scene.id)
                 }


### PR DESCRIPTION
## What
Two changes to the DDD narrative-review surface so a reviewer can instantly tell **what running DDD next would do** and **whether to engage or delegate**:

1. **"If you approve, running DDD next will…" header** — renders above the scene list: render N scenes against the live app, build the M new features (listed by id), re-judge and loop, stopping at the next `concept_change`/`external_release`. Plus an engage-vs-delegate line (X/N scenes already ride shipped code; the build is M scoped features → safe to delegate; the framing is yours to approve).

2. **Gap-aware build/real badge** — the per-beat "New feature / Existing feature" badge keyed only off spine `status`, so a *grounded claim with an open CAPABILITY gap* (the common "we'd build this UI on top of shipped data" case) wrongly read as "Existing." Now a scene is frontier if its spine item is a gap **or** a why-brief gap references it. Same calibration feeds the frontier count, the bottom warning, and auto-expand.

## Why
Reviewers (incl. the DDD author) couldn't see, on the review page, which beats are already real vs. which the loop would build — so the engage-vs-delegate decision was opaque. The data was already in the posted review (`provenance`, `why_brief.gaps`, `features`); this just surfaces it.

## Safety
Pure frontend (`ReviewPage.tsx`), no API/schema change. `npm run build` (tsc + vite) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)