### PR TITLE
feat(walkthroughs): companion links on the video/deck viewer page

### DIFF
--- a/apps/walkthroughs/api.py
+++ b/apps/walkthroughs/api.py
@@ -1,11 +1,13 @@
 """Django Ninja v2 router for the walkthroughs surface."""
 from __future__ import annotations
 
+import json
 import logging
 from uuid import UUID
 
 from django.conf import settings
 from django.http import Http404, HttpRequest
+from pydantic import ValidationError
 
 log = logging.getLogger(__name__)
 from ninja import File, Form, Router, Status
@@ -27,6 +29,7 @@ from .models import Walkthrough
 from .schemas import (
     WalkthroughDetailOut,
     WalkthroughKind,
+    WalkthroughLink,
     WalkthroughListItemOut,
     WalkthroughPatchIn,
     WalkthroughRotateTokenOut,
@@ -44,6 +47,29 @@ def _require_enabled() -> None:
         raise Http404("walkthroughs disabled")
 
 
+def _parse_links_field(raw: str) -> list[dict]:
+    """Parse the multipart ``links`` form field (a JSON-encoded list).
+
+    Each entry is validated against :class:`WalkthroughLink`. Returns a list
+    of plain dicts ready to store on the JSONField. An empty/blank field
+    yields ``[]``. Raises ProblemError(422) on malformed input so a buggy
+    uploader fails loud rather than silently dropping the links.
+    """
+    raw = (raw or "").strip()
+    if not raw:
+        return []
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ProblemError(422, "Invalid links JSON", detail=str(exc))
+    if not isinstance(parsed, list):
+        raise ProblemError(422, "links must be a JSON list")
+    try:
+        return [WalkthroughLink.model_validate(item).model_dump() for item in parsed]
+    except ValidationError as exc:
+        raise ProblemError(422, "Invalid link entry", detail=str(exc))
+
+
 def _detail_payload(w: Walkthrough, *, is_owner: bool) -> dict:
     return {
         "id": w.id,
@@ -58,6 +84,7 @@ def _detail_payload(w: Walkthrough, *, is_owner: bool) -> dict:
         "share_token": w.share_token if is_owner else None,
         "content_type": w.content_type,
         "is_owner": is_owner,
+        "links": w.links or [],
         "created_at": w.created_at,
         "updated_at": w.updated_at,
     }
@@ -104,6 +131,7 @@ def upload_walkthrough(
     project_slug: str = Form(""),
     description: str = Form(""),
     visibility: WalkthroughVisibility = Form("private"),
+    links: str = Form(""),
 ) -> Status:
     _require_enabled()
 
@@ -119,6 +147,7 @@ def upload_walkthrough(
     resolved_title = (title.strip() or file.name or "untitled")[:200]
     resolved_project_slug = project_slug.strip() or None
     resolved_description = description.strip()
+    resolved_links = _parse_links_field(links)
     content_type = CONTENT_TYPE_BY_KIND[kind]
     filename = FILENAME_BY_KIND[kind]
     data = file.read()
@@ -131,6 +160,7 @@ def upload_walkthrough(
         project_slug=resolved_project_slug,
         owner=request.user,
         visibility=visibility,
+        links=resolved_links,
         drive_file_id="",
         drive_folder_id="",
         content_type=content_type,

--- a/apps/walkthroughs/migrations/0002_walkthrough_links.py
+++ b/apps/walkthroughs/migrations/0002_walkthrough_links.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("walkthroughs", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="walkthrough",
+            name="links",
+            field=models.JSONField(blank=True, default=list),
+        ),
+    ]

--- a/apps/walkthroughs/models.py
+++ b/apps/walkthroughs/models.py
@@ -44,6 +44,15 @@ class Walkthrough(models.Model):
     content_type = models.CharField(max_length=64)
     size_bytes = models.BigIntegerField()
     duration_sec = models.IntegerField(null=True, blank=True)
+    # Companion links shown on the viewer page. Each entry is
+    # {"label": str, "url": str, "kind": "narrative" | "companion" | "reference"}.
+    #   narrative  — the design narrative / spec that generated this walkthrough
+    #   companion  — the sibling artifact (e.g. the still-frame deck for a video)
+    #   reference  — a destination shown in the demo the viewer can go explore
+    # Authored by the uploader (the DDD loop populates them from the spec); the
+    # viewer groups them into "Narrative", "Still-frame walkthrough", and
+    # "Explore in the app" sections.
+    links = models.JSONField(default=list, blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 

--- a/apps/walkthroughs/schemas.py
+++ b/apps/walkthroughs/schemas.py
@@ -16,6 +16,21 @@ from apps.common.schemas import StrictModel
 
 WalkthroughKind = Literal["html", "video"]
 WalkthroughVisibility = Literal["private", "link"]
+WalkthroughLinkKind = Literal["narrative", "companion", "reference"]
+
+
+class WalkthroughLink(StrictModel):
+    """One companion link rendered on the viewer page.
+
+    ``kind`` drives which section it lands in:
+      narrative  — the design story / spec that generated this walkthrough
+      companion  — the sibling artifact (still-frame deck ↔ video)
+      reference  — a destination shown in the demo, for the viewer to explore
+    """
+
+    label: str = Field(min_length=1, max_length=200)
+    url: str = Field(min_length=1, max_length=2000)
+    kind: WalkthroughLinkKind = "reference"
 
 
 class WalkthroughListItemOut(StrictModel):
@@ -38,6 +53,7 @@ class WalkthroughDetailOut(WalkthroughListItemOut):
     share_token: str | None = None
     content_type: str
     is_owner: bool
+    links: list[WalkthroughLink] = []
 
 
 class WalkthroughUploadIn(StrictModel):
@@ -52,6 +68,7 @@ class WalkthroughUploadIn(StrictModel):
     project_slug: str = ""
     description: str = ""
     visibility: WalkthroughVisibility = "private"
+    links: list[WalkthroughLink] = []
 
 
 class WalkthroughPatchIn(StrictModel):
@@ -59,6 +76,7 @@ class WalkthroughPatchIn(StrictModel):
     description: str | None = None
     project_slug: str | None = None  # may be set to null to detach
     visibility: WalkthroughVisibility | None = None
+    links: list[WalkthroughLink] | None = None
 
 
 class WalkthroughRotateTokenOut(StrictModel):

--- a/apps/walkthroughs/tests/test_api.py
+++ b/apps/walkthroughs/tests/test_api.py
@@ -117,6 +117,62 @@ def test_upload_walkthrough_html(auth_client, fake_drive, owner):
 
 
 # ---------------------------------------------------------------------------
+# 1b. test_upload_with_links round-trips the companion links
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+@override_settings(
+    WALKTHROUGHS_ENABLED=True,
+    CANOPY_DRIVE_ROOT_FOLDER_ID="root-folder",
+    CANOPY_DRIVE_SA_KEY_JSON='{"x":"y"}',
+)
+def test_upload_with_links(auth_client, fake_drive, owner):
+    links = [
+        {"label": "Back to the narrative", "url": "https://x/review/1/", "kind": "narrative"},
+        {"label": "Still-frame walkthrough", "url": "https://x/w/abc", "kind": "companion"},
+        {"label": "Sampling designer", "url": "https://labs/microplans/program/133/new/"},
+    ]
+    resp = auth_client.post(
+        f"{BASE}/",
+        data={
+            "file": _file_part("video.mp4", b"\x00\x00", "video/mp4"),
+            "title": "Video Demo",
+            "kind": "video",
+            "links": json.dumps(links),
+        },
+        format="multipart",
+    )
+    assert resp.status_code == 201, resp.content
+    out = WalkthroughDetailOut.model_validate(resp.json())
+    assert [(l.kind, l.label) for l in out.links] == [
+        ("narrative", "Back to the narrative"),
+        ("companion", "Still-frame walkthrough"),
+        ("reference", "Sampling designer"),  # kind defaults to reference
+    ]
+
+
+@pytest.mark.django_db
+@override_settings(
+    WALKTHROUGHS_ENABLED=True,
+    CANOPY_DRIVE_ROOT_FOLDER_ID="root-folder",
+    CANOPY_DRIVE_SA_KEY_JSON='{"x":"y"}',
+)
+def test_upload_rejects_malformed_links(auth_client, fake_drive, owner):
+    resp = auth_client.post(
+        f"{BASE}/",
+        data={
+            "file": _file_part("video.mp4", b"\x00", "video/mp4"),
+            "title": "Bad links",
+            "kind": "video",
+            "links": json.dumps([{"label": "no url"}]),  # missing required url
+        },
+        format="multipart",
+    )
+    assert resp.status_code == 422, resp.content
+
+
+# ---------------------------------------------------------------------------
 # 2. test_upload_requires_file
 # ---------------------------------------------------------------------------
 

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -1871,6 +1871,24 @@ export interface components {
             readonly content_type: string;
             /** Is Owner */
             readonly is_owner: boolean;
+            /** Links */
+            readonly links?: readonly components["schemas"]["WalkthroughLink"][];
+        };
+        /**
+         * WalkthroughLink
+         * @description One companion link rendered on the viewer page.
+         */
+        readonly WalkthroughLink: {
+            /** Label */
+            readonly label: string;
+            /** Url */
+            readonly url: string;
+            /**
+             * Kind
+             * @default reference
+             * @enum {string}
+             */
+            readonly kind?: "narrative" | "companion" | "reference";
         };
         /** WalkthroughListItemOut */
         readonly WalkthroughListItemOut: {

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -1871,12 +1871,20 @@ export interface components {
             readonly content_type: string;
             /** Is Owner */
             readonly is_owner: boolean;
-            /** Links */
-            readonly links?: readonly components["schemas"]["WalkthroughLink"][];
+            /**
+             * Links
+             * @default []
+             */
+            readonly links: readonly components["schemas"]["WalkthroughLink"][];
         };
         /**
          * WalkthroughLink
          * @description One companion link rendered on the viewer page.
+         *
+         *     ``kind`` drives which section it lands in:
+         *       narrative  — the design story / spec that generated this walkthrough
+         *       companion  — the sibling artifact (still-frame deck ↔ video)
+         *       reference  — a destination shown in the demo, for the viewer to explore
          */
         readonly WalkthroughLink: {
             /** Label */
@@ -1888,7 +1896,7 @@ export interface components {
              * @default reference
              * @enum {string}
              */
-            readonly kind?: "narrative" | "companion" | "reference";
+            readonly kind: "narrative" | "companion" | "reference";
         };
         /** WalkthroughListItemOut */
         readonly WalkthroughListItemOut: {
@@ -1946,6 +1954,8 @@ export interface components {
             readonly project_slug?: string | null;
             /** Visibility */
             readonly visibility?: ("private" | "link") | null;
+            /** Links */
+            readonly links?: readonly components["schemas"]["WalkthroughLink"][] | null;
         };
         /** WalkthroughRotateTokenOut */
         readonly WalkthroughRotateTokenOut: {
@@ -3241,6 +3251,11 @@ export interface operations {
                      * @enum {string}
                      */
                     readonly visibility?: "private" | "link";
+                    /**
+                     * Links
+                     * @default
+                     */
+                    readonly links?: string;
                 };
             };
         };

--- a/frontend/src/api/walkthroughs.ts
+++ b/frontend/src/api/walkthroughs.ts
@@ -6,6 +6,8 @@ export type WalkthroughVisibility = "private" | "link";
 
 export type WalkthroughListItem = components["schemas"]["WalkthroughListItemOut"];
 export type WalkthroughDetail = components["schemas"]["WalkthroughDetailOut"];
+export type WalkthroughLink = components["schemas"]["WalkthroughLink"];
+export type WalkthroughLinkKind = "narrative" | "companion" | "reference";
 
 export interface WalkthroughListFilters {
   project?: string;

--- a/frontend/src/pages/WalkthroughViewerPage.tsx
+++ b/frontend/src/pages/WalkthroughViewerPage.tsx
@@ -92,6 +92,17 @@ export function WalkthroughViewerPage() {
   const viewerToken = params.get('t') ?? w.share_token ?? null
   const contentSrc = walkthroughContentUrl(w.id, viewerToken)
 
+  const links = w.links ?? []
+  // narrative + companion are provenance / sibling-artifact nav; reference
+  // links are destinations the demo visited that the viewer can go open live.
+  const siblingLinks = links.filter(
+    (l) => l.kind === 'narrative' || l.kind === 'companion',
+  )
+  const referenceLinks = links.filter((l) => l.kind === 'reference')
+
+  const siblingIcon = (kind: string) =>
+    kind === 'narrative' ? '📖' : '🎞️'
+
   return (
     <div className="max-w-5xl mx-auto p-6">
       <header className="mb-4 flex items-baseline justify-between gap-4">
@@ -164,6 +175,58 @@ export function WalkthroughViewerPage() {
           />
         )}
       </div>
+
+      {(siblingLinks.length > 0 || referenceLinks.length > 0) && (
+        <div className="mt-4 grid gap-3 sm:grid-cols-2">
+          {siblingLinks.length > 0 && (
+            <section className="rounded border bg-white p-4">
+              <h2 className="text-sm font-semibold text-slate-700 mb-2">
+                This walkthrough
+              </h2>
+              <div className="flex flex-col gap-2">
+                {siblingLinks.map((l) => (
+                  <a
+                    key={l.url}
+                    href={l.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-2 px-3 py-2 rounded border text-sm hover:bg-slate-50"
+                  >
+                    <span aria-hidden>{siblingIcon(l.kind)}</span>
+                    <span>{l.label}</span>
+                  </a>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {referenceLinks.length > 0 && (
+            <section className="rounded border bg-white p-4">
+              <h2 className="text-sm font-semibold text-slate-700 mb-1">
+                Explore in the app
+              </h2>
+              <p className="text-xs text-slate-500 mb-3">
+                Destinations shown in this walkthrough — open them live.
+              </p>
+              <ul className="grid gap-1.5">
+                {referenceLinks.map((l) => (
+                  <li key={l.url}>
+                    <a
+                      href={l.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-sm text-indigo-600 hover:underline inline-flex items-center gap-1"
+                    >
+                      <span>{l.label}</span>
+                      <span aria-hidden>↗</span>
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Product Description

When you watch a walkthrough video on canopy-web, the landing page now shows companion links so you can act on what you just saw:

- **This walkthrough** — jump back to the narrative/story that generated the video, and open the still-frame (slideshow) version of the same demo.
- **Explore in the app** — the actual pages the demo walked through, as clickable links you can open live to go try them yourself.

These appear under the player whenever the uploader attaches them (the DDD loop fills them in automatically). Walkthroughs uploaded without links look exactly as before.

## Technical Summary

- New `links` JSONField on `Walkthrough` (migration 0002). Each entry is `{label, url, kind}` where `kind ∈ {narrative, companion, reference}`.
- `WalkthroughLink` Pydantic schema; `links` added to the detail output, the multipart upload form field (JSON-encoded), and patch.
- Upload handler parses + validates the `links` field and returns 422 on malformed input rather than silently dropping it.
- Viewer (`WalkthroughViewerPage.tsx`) renders two grouped panels under the player: narrative+companion as sibling-artifact buttons, reference links as an 'Explore in the app' list.
- Frontend types hand-extended in `generated.ts` (openapi-typescript shape) + `walkthroughs.ts`.

The producing side (canopy's `walkthrough-share/upload.py` + the ddd-run skill that auto-uploads each iteration's deck and clip) is updated in a companion canopy-plugin PR to pass `--narrative-url`, `--companion-url`, and `--spec` (derives the reference links from the spec's scene URLs).

## Safety Assurance

- `apps/walkthroughs/tests/`: 27 passing, including two new cases — `test_upload_with_links` (round-trips all three kinds, default kind=reference) and `test_upload_rejects_malformed_links` (422).
- `makemigrations --check` clean; `tsc --noEmit` clean.
- Backward compatible: `links` defaults to `[]`; existing rows and link-less uploads render unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)