### PR TITLE
fix(walkthroughs): build — cast immutable links array + optional kind

### DIFF
--- a/frontend/src/api/walkthroughs.ts
+++ b/frontend/src/api/walkthroughs.ts
@@ -43,7 +43,10 @@ export async function getWalkthrough(id: string): Promise<WalkthroughDetail> {
     params: { path: { wid: id } },
   });
   if (error) throw new Error("Failed to load walkthrough");
-  return data;
+  // openapi-fetch's immutable response type deep-freezes the `links` array
+  // (method signatures become `{}`), which no longer structurally matches the
+  // plain schema alias. Same cast `listWalkthroughs` uses for its array body.
+  return data as unknown as WalkthroughDetail;
 }
 
 export async function patchWalkthrough(
@@ -60,7 +63,7 @@ export async function patchWalkthrough(
     },
   });
   if (error) throw new Error("Failed to update walkthrough");
-  return data;
+  return data as unknown as WalkthroughDetail;
 }
 
 export async function deleteWalkthrough(id: string): Promise<void> {
@@ -98,7 +101,7 @@ export async function uploadWalkthrough(
     bodySerializer: (body: unknown) => body as FormData,
   });
   if (error) throw new Error("Upload failed");
-  return data;
+  return data as unknown as WalkthroughDetail;
 }
 
 export function walkthroughContentUrl(

--- a/frontend/src/pages/WalkthroughViewerPage.tsx
+++ b/frontend/src/pages/WalkthroughViewerPage.tsx
@@ -100,7 +100,7 @@ export function WalkthroughViewerPage() {
   )
   const referenceLinks = links.filter((l) => l.kind === 'reference')
 
-  const siblingIcon = (kind: string) =>
+  const siblingIcon = (kind: string | undefined) =>
     kind === 'narrative' ? '📖' : '🎞️'
 
   return (


### PR DESCRIPTION
## Product Description

No user-visible change — fixes the frontend build so the companion-links feature (#74) can actually deploy.

## Technical Summary

#74's new `links` array tripped `tsc -b`: openapi-fetch's immutable response type deep-freezes the array (its method signatures map to `{}`), so `return data` no longer structurally matches the `WalkthroughDetail` schema alias. The three detail-returning functions now cast the same way `listWalkthroughs` already casts its array body. Also widened `siblingIcon`'s param to `string | undefined` (link `kind` is optional).

## Safety Assurance

`npm run build` (`tsc -b && vite build`) is green locally. This unblocks the Cloud Run deploy that was skipped when #74's build failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)