### PR TITLE
feat(ddd): explicit feature as narrative source of truth + title-inference backfill

### DIFF
--- a/apps/runs/aggregate.py
+++ b/apps/runs/aggregate.py
@@ -42,6 +42,29 @@ def narrative_of_review(r: ReviewRequest) -> str:
     return feature_from_run_id(r.run_id)
 
 
+def narrative_for_run_id(run_id: str, feature_map: dict[str, str] | None = None) -> str:
+    """Narrative slug for a run.
+
+    The explicitly-uploaded ``feature`` of any walkthrough in the run is the
+    source of truth (the plugin sends it). Parsing the run_id slug
+    (:func:`feature_from_run_id`) is only a last-resort fallback for runs that
+    have no walkthrough carrying an explicit feature (e.g. a review-only run).
+    """
+    if feature_map and feature_map.get(run_id):
+        return feature_map[run_id]
+    return feature_from_run_id(run_id)
+
+
+def _feature_map(walkthroughs) -> dict[str, str]:
+    """run_id -> explicit feature, from walkthroughs that carry both."""
+    m: dict[str, str] = {}
+    for w in walkthroughs:
+        feat = (getattr(w, "feature", None) or "").strip()
+        if w.run_id and feat:
+            m.setdefault(w.run_id, feat)
+    return m
+
+
 def _content_url(w: Walkthrough) -> str:
     """In-app viewer stream. Session auth covers private artifacts for the
     dimagi-gated app; share tokens are managed on the /w/<id> viewer page."""
@@ -187,9 +210,11 @@ def build_run(run_id: str) -> dict | None:
         for w in sorted(wts, key=lambda x: x.created_at)
     ]
 
-    narrative_slug = (
-        narrative_of_walkthrough(wts[0]) if wts else feature_from_run_id(run_id)
+    # Explicit feature (uploaded by the plugin) wins; run_id parsing is fallback.
+    explicit_feature = next(
+        (w.feature for w in wts if (w.feature or "").strip()), None
     )
+    narrative_slug = explicit_feature or feature_from_run_id(run_id)
 
     # Previous runs in the same narrative (excluding this one), newest first.
     sibling = _runs_in_narrative(narrative_slug)
@@ -223,13 +248,17 @@ def build_run(run_id: str) -> dict | None:
 def _runs_in_narrative(slug: str) -> dict[str, datetime]:
     """Map run_id -> latest activity timestamp for every run under ``slug``."""
     out: dict[str, datetime] = {}
+    feature_map: dict[str, str] = {}
     wq = (
         Walkthrough.objects.exclude(run_id__isnull=True)
         .exclude(run_id="")
         .values_list("run_id", "feature", "created_at")
     )
     for run_id, feature, created_at in wq:
-        s = (feature or "").strip() or feature_from_run_id(run_id)
+        feat = (feature or "").strip()
+        if run_id and feat:
+            feature_map.setdefault(run_id, feat)
+        s = feat or feature_from_run_id(run_id)
         if s != slug:
             continue
         if run_id not in out or created_at > out[run_id]:
@@ -237,7 +266,7 @@ def _runs_in_narrative(slug: str) -> dict[str, datetime]:
     for run_id, created_at in ReviewRequest.objects.values_list(
         "run_id", "created_at"
     ):
-        if feature_from_run_id(run_id) != slug:
+        if narrative_for_run_id(run_id, feature_map) != slug:
             continue
         if run_id not in out or created_at > out[run_id]:
             out[run_id] = created_at
@@ -286,6 +315,8 @@ def _aggregate(project: str | None, owner_id: int | None) -> dict[str, dict]:
     )
     revs = list(ReviewRequest.objects.all())
 
+    feature_map = _feature_map(wts)
+
     narr: dict[str, dict] = {}
     for w in wts:
         slug = narrative_of_walkthrough(w)
@@ -303,7 +334,7 @@ def _aggregate(project: str | None, owner_id: int | None) -> dict[str, dict]:
             a["has_deck"] = True
 
     for r in revs:
-        slug = narrative_of_review(r)
+        slug = narrative_for_run_id(r.run_id, feature_map)
         a = narr.setdefault(slug, _blank_narrative(slug))
         a["run_ids"].add(r.run_id)
         if r.owner_id:

--- a/apps/runs/inference.py
+++ b/apps/runs/inference.py
@@ -1,0 +1,64 @@
+"""Best-effort inference of a narrative slug + run_id from a walkthrough title.
+
+Only used to backfill artifacts uploaded *before* the plugin sent run_id/feature
+explicitly. Going forward those fields arrive on the upload, so this is a
+one-time historical cleanup, not a runtime path.
+
+Rules are intentionally simple and ordered (first match wins): narrower
+narratives are checked before the catch-all ``microplans`` bucket.
+"""
+from __future__ import annotations
+
+import re
+from datetime import date
+
+# A run "token": prefer an embedded run stamp, then an iteration/version marker,
+# else the upload date — so a narrative's artifacts split into the runs they
+# actually came from rather than collapsing into one.
+_STAMP = re.compile(r"(\d{4}-\d{2}-\d{2}-\d{3})")
+_ITER = re.compile(r"\biter\s*(\d+)", re.IGNORECASE)
+_VER = re.compile(r"\bv(\d+)\b", re.IGNORECASE)
+
+
+def narrative_slug(title: str) -> str | None:
+    """Map a walkthrough title to a narrative slug, or None if unclassifiable."""
+    t = (title or "").lower()
+    if "program admin report" in t:
+        return "program-admin-report"
+    if "demo-driven development" in t:
+        return "demo-driven-development"
+    if "left-rail" in t:
+        return "microplans-left-rail"
+    if "rooftop study" in t or "two-arm rooftop" in t:
+        return "madobi-rooftop-study"
+    if "opportunity" in t:
+        return "microplan-to-opp"
+    if "microplans" in t or "compare page" in t:
+        return "microplans-10-wards"
+    return None
+
+
+def run_token(title: str, created: date) -> str:
+    m = _STAMP.search(title or "")
+    if m:
+        return m.group(1)
+    m = _ITER.search(title or "")
+    if m:
+        return f"iter{m.group(1)}"
+    m = _VER.search(title or "")
+    if m:
+        return f"v{m.group(1)}"
+    if "final" in (title or "").lower():
+        return "final"
+    return created.isoformat()
+
+
+def infer(title: str, created: date) -> tuple[str, str] | None:
+    """Return ``(feature_slug, run_id)`` for a title, or None if unclassifiable.
+
+    ``run_id`` is ``"<slug>-<run_token>"`` so artifacts group into their runs.
+    """
+    slug = narrative_slug(title)
+    if not slug:
+        return None
+    return slug, f"{slug}-{run_token(title, created)}"

--- a/apps/runs/management/commands/backfill_run_ids.py
+++ b/apps/runs/management/commands/backfill_run_ids.py
@@ -1,23 +1,27 @@
-"""Backfill ``run_id`` / ``feature`` on existing walkthroughs.
+"""Backfill ``run_id`` / ``feature`` on walkthroughs uploaded before the DDD
+upload contract (which now sends both explicitly).
 
-Pre-dates the DDD-run upload contract, so artifacts uploaded before the plugin
-started sending ``run_id`` need grouping inferred:
+Two passes, in priority order:
 
-1. Authoritative — every ``ReviewRequest`` may reference its rendered video via
-   ``request_json.video.walkthrough_id``. If that walkthrough has no run_id,
-   stamp it from the review's run_id.
-2. Heuristic (opt-in, ``--from-titles``) — match walkthroughs whose title starts
-   with a known narrative slug (derived from review run_ids).
+1. **Authoritative** — a ``ReviewRequest`` whose ``request_json.video`` points
+   at a walkthrough via ``walkthrough_id`` pins that walkthrough to the review's
+   ``run_id``.
+2. **Title inference** — for everything still unstamped, infer a narrative slug
+   + run_id from the title (see ``apps/runs/inference.py``). This produces the
+   real multiple-runs-per-narrative shape from human-authored titles.
 
-Idempotent: never overwrites a non-null run_id. ``--dry-run`` prints the plan
-without writing.
+Idempotent: never overwrites a non-null ``run_id``. ``--dry-run`` prints the
+full plan (grouped by narrative) without writing.
 """
 from __future__ import annotations
+
+import collections
 
 from django.core.management.base import BaseCommand
 
 from apps.common.ddd import feature_from_run_id
 from apps.reviews.models import ReviewRequest
+from apps.runs.inference import infer
 from apps.walkthroughs.models import Walkthrough
 
 
@@ -26,23 +30,16 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            "--dry-run",
-            action="store_true",
-            help="Print what would change without writing.",
-        )
-        parser.add_argument(
-            "--from-titles",
-            action="store_true",
-            help="Also match walkthroughs by title-prefix against known narrative slugs.",
+            "--dry-run", action="store_true", help="Print the plan without writing."
         )
 
     def handle(self, *args, **opts):
         dry = opts["dry_run"]
-        from_titles = opts["from_titles"]
 
-        planned: dict[str, tuple[str, str]] = {}  # walkthrough_id -> (run_id, feature)
+        # walkthrough_id -> (run_id, feature, source)
+        planned: dict[str, tuple[str, str, str]] = {}
 
-        # 1. Authoritative — review.request_json.video.walkthrough_id
+        # 1. Authoritative: review.request_json.video.walkthrough_id
         for r in ReviewRequest.objects.all():
             rj = r.request_json if isinstance(r.request_json, dict) else {}
             video = rj.get("video") or {}
@@ -52,36 +49,45 @@ class Command(BaseCommand):
             w = Walkthrough.objects.filter(pk=wid).first()
             if w is None or w.run_id:
                 continue
-            planned[str(w.id)] = (r.run_id, feature_from_run_id(r.run_id))
+            planned[str(w.id)] = (r.run_id, feature_from_run_id(r.run_id), "review")
 
-        # 2. Heuristic — title prefix against known narrative slugs.
-        if from_titles:
-            slugs = {
-                feature_from_run_id(rid)
-                for rid in ReviewRequest.objects.values_list("run_id", flat=True)
-            }
-            for w in Walkthrough.objects.filter(run_id__isnull=True):
-                if str(w.id) in planned:
-                    continue
-                title = (w.title or "").lower()
-                match = next(
-                    (s for s in slugs if s and title.startswith(s.lower())), None
-                )
-                if match:
-                    # No run_id known from a title alone — group under the
-                    # narrative via feature, leave run_id null so it doesn't
-                    # masquerade as a specific run.
-                    planned[str(w.id)] = ("", match)
+        # 2. Title inference for the rest.
+        for w in Walkthrough.objects.filter(run_id__isnull=True):
+            if str(w.id) in planned:
+                continue
+            result = infer(w.title, w.created_at.date())
+            if result is None:
+                self.stdout.write(f"  [skip — unclassifiable] {w.id} :: {w.title}")
+                continue
+            feature, run_id = result
+            planned[str(w.id)] = (run_id, feature, "title")
 
         if not planned:
             self.stdout.write("Nothing to backfill.")
             return
 
-        for wid, (run_id, feature) in planned.items():
-            label = f"  {wid} -> run_id={run_id or '(none)'} feature={feature}"
-            if dry:
-                self.stdout.write(f"[dry-run]{label}")
-                continue
+        # Group the plan by narrative for a readable summary.
+        by_feature: dict[str, set[str]] = collections.defaultdict(set)
+        for _wid, (run_id, feature, _src) in planned.items():
+            by_feature[feature].add(run_id)
+
+        self.stdout.write("Plan (narrative -> runs -> artifacts):")
+        for feature in sorted(by_feature):
+            runs = by_feature[feature]
+            n_art = sum(
+                1 for v in planned.values() if v[1] == feature
+            )
+            self.stdout.write(f"  {feature}: {len(runs)} run(s), {n_art} artifact(s)")
+            for rid in sorted(runs):
+                arts = [wid for wid, v in planned.items() if v[0] == rid]
+                self.stdout.write(f"      {rid}  ({len(arts)})")
+
+        if dry:
+            self.stdout.write(self.style.WARNING(f"[dry-run] {len(planned)} walkthrough(s) would change. No writes."))
+            return
+
+        written = 0
+        for wid, (run_id, feature, _src) in planned.items():
             w = Walkthrough.objects.get(pk=wid)
             fields = []
             if run_id and not w.run_id:
@@ -92,7 +98,6 @@ class Command(BaseCommand):
                 fields.append("feature")
             if fields:
                 w.save(update_fields=[*fields, "updated_at"])
-                self.stdout.write(label)
+                written += 1
 
-        verb = "Would update" if dry else "Updated"
-        self.stdout.write(self.style.SUCCESS(f"{verb} {len(planned)} walkthrough(s)."))
+        self.stdout.write(self.style.SUCCESS(f"Updated {written} walkthrough(s)."))

--- a/apps/runs/tests/test_backfill.py
+++ b/apps/runs/tests/test_backfill.py
@@ -13,7 +13,7 @@ pytestmark = pytest.mark.django_db
 
 def test_backfill_from_review_video_link():
     u = make_user()
-    w = make_walkthrough(u, kind="video")  # no run_id yet
+    w = make_walkthrough(u, kind="video", title="some hero video")  # no run_id
     assert w.run_id is None
     make_review(
         u,
@@ -24,45 +24,43 @@ def test_backfill_from_review_video_link():
             "video": {"walkthrough_id": str(w.id)},
         },
     )
-
     call_command("backfill_run_ids", stdout=StringIO())
     w.refresh_from_db()
     assert w.run_id == "microplans-2026-06-02-001"
     assert w.feature == "microplans"
 
 
+def test_backfill_infers_run_from_title():
+    u = make_user()
+    w = make_walkthrough(u, kind="video", title="microplans-10-wards iter1 video (2026-06-01-002)")
+    call_command("backfill_run_ids", stdout=StringIO())
+    w.refresh_from_db()
+    assert w.feature == "microplans-10-wards"
+    assert w.run_id == "microplans-10-wards-2026-06-01-002"
+
+
 def test_backfill_dry_run_writes_nothing():
     u = make_user()
-    w = make_walkthrough(u, kind="video")
-    make_review(
-        u,
-        run_id="x-2026-06-02-001",
-        request_json={"run_id": "x-2026-06-02-001", "gate": "g", "video": {"walkthrough_id": str(w.id)}},
-    )
+    w = make_walkthrough(u, kind="video", title="Program Admin Report — HTML deck (v4)")
     call_command("backfill_run_ids", "--dry-run", stdout=StringIO())
     w.refresh_from_db()
     assert w.run_id is None
 
 
-def test_backfill_is_idempotent_and_skips_existing():
+def test_backfill_skips_existing_run_id():
     u = make_user()
-    w = make_walkthrough(u, kind="video", run_id="already-2026-01-01-001", feature="already")
-    make_review(
-        u,
-        run_id="new-2026-06-02-001",
-        request_json={"run_id": "new-2026-06-02-001", "gate": "g", "video": {"walkthrough_id": str(w.id)}},
+    w = make_walkthrough(
+        u, kind="video", title="microplans-10-wards iter1", run_id="already-2026-01-01-001", feature="already"
     )
     call_command("backfill_run_ids", stdout=StringIO())
     w.refresh_from_db()
-    # Existing run_id must not be overwritten.
     assert w.run_id == "already-2026-01-01-001"
 
 
-def test_backfill_from_titles_groups_by_feature():
+def test_backfill_leaves_unclassifiable_untouched():
     u = make_user()
-    make_review(u, run_id="microplans-2026-06-02-001")
-    w = make_walkthrough(u, kind="html", title="Microplans deep dive")
-    call_command("backfill_run_ids", "--from-titles", stdout=StringIO())
+    w = make_walkthrough(u, kind="video", title="totally unrelated artifact")
+    call_command("backfill_run_ids", stdout=StringIO())
     w.refresh_from_db()
-    assert w.feature == "microplans"
-    assert w.run_id is None  # a title alone doesn't pin a specific run
+    assert w.run_id is None
+    assert w.feature is None

--- a/apps/runs/tests/test_inference.py
+++ b/apps/runs/tests/test_inference.py
@@ -1,0 +1,52 @@
+"""Tests for title-based narrative/run inference, anchored on real prod titles."""
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from apps.runs.inference import infer, narrative_slug, run_token
+
+
+@pytest.mark.parametrize(
+    "title,expected",
+    [
+        ("Program Admin Report — HTML deck (v4)", "program-admin-report"),
+        ("Demo-Driven Development — hero demo", "demo-driven-development"),
+        ("Microplans — Left-rail redesign (video)", "microplans-left-rail"),
+        ("Madobi two-arm rooftop study — DDD walkthrough", "madobi-rooftop-study"),
+        ("Microplan → Opportunity — full cycle (tightened, 2.5min)", "microplan-to-opp"),
+        ("microplans-10-wards iter1 video (2026-06-01-002)", "microplans-10-wards"),
+        ("Microplans 10 wards — Madobi LGA / Kim (scenes 1-5)", "microplans-10-wards"),
+        ("compare page — simplified", "microplans-10-wards"),
+        ("something totally unrelated", None),
+    ],
+)
+def test_narrative_slug(title, expected):
+    assert narrative_slug(title) == expected
+
+
+def test_madobi_lga_is_10_wards_not_rooftop():
+    # "Madobi LGA" inside a 10-wards title must NOT route to the rooftop study.
+    assert narrative_slug("Microplans 10 wards — Madobi LGA — dead-space fixed") == "microplans-10-wards"
+
+
+def test_run_token_prefers_stamp_then_iter_then_version_then_date():
+    d = date(2026, 5, 28)
+    assert run_token("microplans-10-wards iter1 video (2026-06-01-002)", d) == "2026-06-01-002"
+    assert run_token("microplans-10-wards iter1 clip", d) == "iter1"
+    assert run_token("Program Admin Report — HTML deck (v4)", d) == "v4"
+    assert run_token("Program Admin Report — HTML deck (final)", d) == "final"
+    assert run_token("microplans-10-wards — documentation", d) == "2026-05-28"
+
+
+def test_infer_builds_slug_and_run_id():
+    assert infer("microplans-10-wards iter0 video (2026-06-01-002)", date(2026, 6, 1)) == (
+        "microplans-10-wards",
+        "microplans-10-wards-2026-06-01-002",
+    )
+    assert infer("Program Admin Report — manager flow (v3)", date(2026, 5, 28)) == (
+        "program-admin-report",
+        "program-admin-report-v3",
+    )
+    assert infer("unrelated thing", date(2026, 1, 1)) is None


### PR DESCRIPTION
## What & why

Follow-up to #77, refining how a run's **narrative** is determined and backfilling historical artifacts.

### 1. Explicit `feature` is the source of truth (not run_id parsing)
Per design feedback: the narrative slug should be the value the plugin sends **explicitly** (`feature`), not something parsed from the `run_id` naming convention. The aggregator now builds a `run_id → feature` map from walkthroughs and resolves every run's narrative from it (reviews included). `feature_from_run_id` (slug-stripping) is now a **last-resort fallback only**, for runs with no walkthrough carrying an explicit feature.

### 2. Title-inference backfill (historical)
The 52 pre-existing prod walkthroughs were uploaded before the contract, so they have no `run_id`. `apps/runs/inference.py` infers a narrative slug from the title (6 narratives) and a **per-artifact run_id** (`<slug>-<token>`, where token = embedded `YYYY-MM-DD-NNN` stamp › `iterN`/`vN` › `final` › upload date). This produces the real *multiple-runs-per-narrative* shape instead of collapsing. `backfill_run_ids` runs the authoritative review→video link first, then title inference; `--dry-run` prints the plan grouped by narrative. Idempotent (never overwrites an existing `run_id`).

## Testing
- `apps/runs` suite **33 passed**: `test_inference.py` (anchored on real prod titles, incl. the "Madobi LGA ≠ rooftop study" case), `test_backfill.py`, and the existing aggregate/api tests under the explicit-feature resolution.
- Lint clean.

## Notes
- Pairs with canopy plugin #119 (uploads send `run_id`/`feature`/`role`).
- Historical walkthrough-runs and review-runs may not perfectly merge (different legacy slugs like `…-fullrun`); that's the naming fragility this change removes going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
