### PR TITLE
feat(ddd): edit-narrative link from run package to the review UI

### DIFF
--- a/apps/runs/aggregate.py
+++ b/apps/runs/aggregate.py
@@ -167,6 +167,7 @@ def build_run(run_id: str) -> dict | None:
             else {}
         )
         narrative_payload = {
+            "review_id": str(narrative_review.id),
             "run_id": narrative_review.run_id,
             "gate": narrative_review.gate,
             "title": _title_from_review(narrative_review),

--- a/apps/runs/schemas.py
+++ b/apps/runs/schemas.py
@@ -61,6 +61,7 @@ class RunArtifactRefOut(StrictModel):
 
 
 class RunNarrativeOut(StrictModel):
+    review_id: str | None = None
     run_id: str
     gate: str
     title: str | None = None

--- a/apps/runs/tests/test_api.py
+++ b/apps/runs/tests/test_api.py
@@ -67,6 +67,7 @@ def test_run_package(client, owner):
     assert body["video"]["id"] == str(vid.id)
     assert body["deck"] is not None
     assert body["narrative"]["story"] == "Story line one."
+    assert body["narrative"]["review_id"]  # deep-links to /review/<id> for editing
     assert len(body["all_artifacts"]) == 2
 
 

--- a/frontend/src/api/ddd.ts
+++ b/frontend/src/api/ddd.ts
@@ -72,6 +72,7 @@ export interface DddNarration {
 }
 
 export interface DddRunNarrative {
+  review_id: string | null
   run_id: string
   gate: string
   title: string | null

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -2340,6 +2340,8 @@ export interface components {
         };
         /** RunNarrativeOut */
         readonly RunNarrativeOut: {
+            /** Review Id */
+            readonly review_id?: string | null;
             /** Run Id */
             readonly run_id: string;
             /** Gate */

--- a/frontend/src/components/ddd/RunPackage.tsx
+++ b/frontend/src/components/ddd/RunPackage.tsx
@@ -214,6 +214,15 @@ export function RunPackage({ runId }: { runId: string }) {
       </Section>
 
       <Section title="Narrative">
+        {run.narrative?.review_id && (
+          <a
+            href={`/review/${run.narrative.review_id}`}
+            className="mb-2 inline-flex items-center gap-1.5 rounded-md border border-orange-500/30 bg-orange-500/10 px-3 py-1 text-xs text-orange-300 transition-colors hover:bg-orange-500/20"
+          >
+            Edit narrative in review
+            <span aria-hidden>→</span>
+          </a>
+        )}
         {run.narrative && (run.narrative.story || run.narrative.narration.length > 0) ? (
           <NarrativeBlock narrative={run.narrative} />
         ) : (


### PR DESCRIPTION
Adds an 'Edit narrative in review →' link in the DDD run package's Narrative section, deep-linking to `/review/<id>` when the run has a ReviewRequest behind it. `build_run` now exposes `narrative.review_id`; `RunNarrativeOut` carries it; `generated.ts` regenerated. Tests + build green.

Part of the 'view + edit the narrative that powered the run' work.