### PR TITLE
ci: enforce deploy-from-main on both deploy paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,13 +164,23 @@ jobs:
     name: Deploy to Cloud Run
     needs: [test-backend, test-frontend]
     # Manual-only: must be triggered from the Actions tab via "Run workflow".
-    # Tests still gate the deploy because of `needs:` above.
+    # Tests still gate the deploy because of `needs:` above. The first step
+    # also hard-fails unless the dispatched ref is `main` — production ships
+    # from main only, never from a feature branch.
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write  # Required for Workload Identity Federation
     steps:
+      - name: Guard — deploy from main only
+        run: |
+          if [ "${{ github.ref_name }}" != "main" ]; then
+            echo "::error::Refusing to deploy from '${{ github.ref_name }}'. Production deploys must run from main — merge your branch, then dispatch the deploy from main."
+            exit 1
+          fi
+          echo "Ref guard OK: deploying from main (${{ github.sha }})."
+
       - uses: actions/checkout@v4
 
       - name: Authenticate to Google Cloud

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,8 +37,12 @@ docker compose up
 
 # Deploy to GCP Cloud Run. CI also has a manual deploy job — trigger it from
 # the Actions tab ("CI / Deploy" → Run workflow).
-./deploy.sh                  # Cloud Build → push → gcloud run deploy
+# Production ships from `main` ONLY — merge your branch first. Both deploy
+# paths enforce this: deploy.sh refuses unless on main + in sync with
+# origin/main; the CI deploy job hard-fails unless dispatched from main.
+./deploy.sh                  # Cloud Build → push → gcloud run deploy (must be on main)
 SKIP_TESTS=1 ./deploy.sh     # bypass test gate (emergencies only)
+ALLOW_NON_MAIN_DEPLOY=1 ./deploy.sh   # bypass the main-branch guard (emergencies only)
 ```
 
 When `AI_BACKEND=cli`, the `claude` binary must be on PATH and authenticated. In Docker, use the headless auth flow at `/settings` (drives `claude setup-token` via PTY; token persists in `CLAUDE_CODE_OAUTH_TOKEN`).

--- a/deploy.sh
+++ b/deploy.sh
@@ -9,6 +9,40 @@ SERVICE_NAME="canopy-web"
 TAG="${1:-latest}"
 SKIP_TESTS="${SKIP_TESTS:-0}"
 REQUIRE_AUTH_FLAG="${REQUIRE_AUTH:-True}"
+ALLOW_NON_MAIN_DEPLOY="${ALLOW_NON_MAIN_DEPLOY:-0}"
+
+# --------------------------------------------------------------------------
+# Branch guard: production is deployed from `main` only. Everyone merges to
+# main to ship — no deploying a feature branch's working tree.
+#
+# Under GitHub Actions the checkout is a detached HEAD at a specific SHA, and
+# the CI deploy job enforces ref==main itself (see .github/workflows/ci.yml),
+# so we skip the local branch check there. Emergency local override:
+#   ALLOW_NON_MAIN_DEPLOY=1 ./deploy.sh
+# --------------------------------------------------------------------------
+if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+  echo "==> GitHub Actions run; branch enforcement handled by the workflow."
+elif [ "${ALLOW_NON_MAIN_DEPLOY}" = "1" ]; then
+  echo "==> ALLOW_NON_MAIN_DEPLOY=1 — BYPASSING the main-branch guard (emergency)."
+else
+  CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+  if [ "${CURRENT_BRANCH}" != "main" ]; then
+    echo "ERROR: refusing to deploy from branch '${CURRENT_BRANCH}'." >&2
+    echo "       Production deploys must come from 'main'. Merge your branch first." >&2
+    echo "       Emergency override: ALLOW_NON_MAIN_DEPLOY=1 ./deploy.sh" >&2
+    exit 1
+  fi
+  git fetch origin main --quiet 2>/dev/null || true
+  LOCAL_SHA="$(git rev-parse HEAD 2>/dev/null || echo)"
+  REMOTE_SHA="$(git rev-parse origin/main 2>/dev/null || echo)"
+  if [ -n "${REMOTE_SHA}" ] && [ "${LOCAL_SHA}" != "${REMOTE_SHA}" ]; then
+    echo "ERROR: local main (${LOCAL_SHA:0:9}) is out of sync with origin/main (${REMOTE_SHA:0:9})." >&2
+    echo "       Pull/push so you deploy exactly what's on origin/main." >&2
+    echo "       Emergency override: ALLOW_NON_MAIN_DEPLOY=1 ./deploy.sh" >&2
+    exit 1
+  fi
+  echo "==> Branch guard OK: on main, in sync with origin/main."
+fi
 
 if [ "${SKIP_TESTS}" = "1" ]; then
   echo "==> SKIP_TESTS=1, skipping pre-deploy verification"


### PR DESCRIPTION
## Summary
Production ships from `main` only — everyone merges to main to deploy. This locks it down on both deploy trigger surfaces (which both ultimately run `deploy.sh`).

- **`deploy.sh`** refuses to run unless you're on `main` and in sync with `origin/main`. It skips the check under GitHub Actions (the CI checkout is a detached HEAD at a SHA; the workflow enforces `ref==main` itself). Emergency local override: `ALLOW_NON_MAIN_DEPLOY=1 ./deploy.sh`.
- **CI deploy job** gains a first step that hard-fails unless the dispatched ref is `main`, so an Actions-tab "Run workflow" from a feature branch errors loudly instead of shipping that branch.
- **CLAUDE.md** documents the rule + the emergency override.

No production deploy needed for this change — it only governs future deploys.

## Test plan
- [x] `bash -n deploy.sh` clean; guard blocks on a feature branch with a clear error; `ALLOW_NON_MAIN_DEPLOY=1` bypasses
- [x] `ci.yml` parses as valid YAML
- [ ] After merge: dispatching CI deploy from a non-main ref fails at the guard step; from `main` it proceeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)