### PR TITLE
ci(regen): push regenerated types with a PAT so CI re-triggers

### DIFF
--- a/.github/workflows/regen-openapi.yml
+++ b/.github/workflows/regen-openapi.yml
@@ -16,7 +16,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Push with a PAT when one is configured (secret REGEN_TOKEN) so the
+          # regenerated-types commit RE-TRIGGERS CI on the PR. Commits pushed
+          # with the default GITHUB_TOKEN do not start new workflow runs, which
+          # leaves the PR head with no status checks — a problem once `main`
+          # requires status checks (the merge gets blocked). With REGEN_TOKEN
+          # set you can safely enforce branch protection on admins too.
+          # Falls back to GITHUB_TOKEN when the secret is absent.
+          token: ${{ secrets.REGEN_TOKEN || secrets.GITHUB_TOKEN }}
       - uses: actions/setup-node@v4
         with:
           node-version: "20"


### PR DESCRIPTION
## Summary
Commits pushed with the default `GITHUB_TOKEN` don't trigger new workflow runs (GitHub loop-prevention). So when the `regen-openapi` workflow auto-commits regenerated `generated.ts` to a PR, that commit lands with **no status checks** — which blocks the merge once `main` requires status checks (we hit this on #86).

Fix: the regen checkout/push uses `secrets.REGEN_TOKEN` when present (a fine-grained PAT with `contents: write`), so the regen commit **re-triggers CI**. Falls back to `GITHUB_TOKEN` when the secret isn't set (current behavior).

Once `REGEN_TOKEN` is configured, branch protection can safely **enforce on admins** too.

### Manual step to fully activate (one-time)
1. Create a fine-grained PAT scoped to `jjackson/canopy-web` with **Contents: Read and write** (+ Pull requests if you later want it to label/comment).
2. Add it as repo secret **`REGEN_TOKEN`** (Settings → Secrets and variables → Actions).

Until then this is a safe no-op fallback.

## Test plan
- [x] Workflow YAML parses
- [ ] After secret added: a PR touching `apps/**/api.py` shows CI re-running on the regen commit (head ends green, not "no checks reported")

🤖 Generated with [Claude Code](https://claude.com/claude-code)