### PR TITLE
feat(shareouts): clear endpoint

### DIFF
--- a/apps/shareouts/api.py
+++ b/apps/shareouts/api.py
@@ -10,7 +10,13 @@ from apps.api.auth import session_auth
 from apps.api.pagination import Page, paginate
 
 from . import services
-from .schemas import ShareoutBatchIn, ShareoutBatchOut, ShareoutOut
+from .schemas import (
+    ShareoutBatchIn,
+    ShareoutBatchOut,
+    ShareoutOut,
+    ShareoutsClearIn,
+    ShareoutsClearOut,
+)
 
 router = Router(auth=session_auth, tags=["shareouts"])
 
@@ -51,3 +57,23 @@ def create_shareouts(
     source replaces the prior rows (see services.upsert_shareouts)."""
     result = services.upsert_shareouts(payload.shareouts)
     return Status(201, ShareoutBatchOut(**result))
+
+
+@router.post(
+    "/clear/",
+    response=ShareoutsClearOut,
+    summary="Clear shareouts by source / project / date (AND-combined)",
+    openapi_extra={"x-mcp-expose": True},
+)
+def clear_shareouts(
+    request: HttpRequest,
+    payload: ShareoutsClearIn,
+) -> ShareoutsClearOut:
+    """Delete shareouts matching the filters. An empty body clears all."""
+    count = services.clear_shareouts(
+        source=payload.source,
+        project=payload.project,
+        date_from=payload.date_from,
+        date_to=payload.date_to,
+    )
+    return ShareoutsClearOut(cleared=count)

--- a/apps/shareouts/schemas.py
+++ b/apps/shareouts/schemas.py
@@ -45,6 +45,20 @@ class ShareoutBatchOut(StrictModel):
     skipped: int
 
 
+class ShareoutsClearIn(StrictModel):
+    """Body of POST /api/shareouts/clear/. All optional, AND-combined. An empty
+    body clears ALL shareouts."""
+
+    source: str | None = None
+    project: str | None = None  # project slug
+    date_from: dt.date | None = None
+    date_to: dt.date | None = None
+
+
+class ShareoutsClearOut(StrictModel):
+    cleared: int
+
+
 class ShareoutOut(StrictModel):
     id: int
     project_slug: str | None = None

--- a/apps/shareouts/services.py
+++ b/apps/shareouts/services.py
@@ -89,6 +89,37 @@ def upsert_shareouts(items: list) -> dict:
     return {"created": created, "replaced": replaced, "skipped": skipped}
 
 
+def clear_shareouts(
+    *,
+    source: str | None = None,
+    project: str | None = None,
+    date_from: dt.date | None = None,
+    date_to: dt.date | None = None,
+) -> int:
+    """Delete shareouts matching the filters (AND-combined); return the count.
+
+    - source:    exact source match (e.g. a prior run's source tag)
+    - project:   project slug exact match
+    - date_from: period_end date >= date_from
+    - date_to:   period_start date <= date_to
+
+    A call with no filters deletes ALL shareouts — intended (matches the
+    insights clear contract).
+    """
+    qs = Shareout.objects.all()
+    if source:
+        qs = qs.filter(source=source)
+    if project:
+        qs = qs.filter(project__slug=project)
+    if date_from is not None:
+        qs = qs.filter(period_end__date__gte=date_from)
+    if date_to is not None:
+        qs = qs.filter(period_start__date__lte=date_to)
+    count = qs.count()
+    qs.delete()
+    return count
+
+
 def list_shareouts(
     *,
     date_from: dt.date | None = None,

--- a/apps/shareouts/tests/test_api.py
+++ b/apps/shareouts/tests/test_api.py
@@ -180,3 +180,30 @@ def test_list_date_filter():
     body = resp.json()
     assert body["total"] == 1
     assert body["items"][0]["period_start"].startswith("2026-06-03")
+
+
+# --- clear ----------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_clear_by_source():
+    _make_project()
+    c = _auth_client()
+    _post(c, {"shareouts": [_item(source="run-A")]})
+    _post(c, {"shareouts": [_item(period_start="2026-06-04T09:00:00Z", period_end="2026-06-04T17:00:00Z", source="run-B")]})
+    resp = c.post("/api/shareouts/clear/", data=json.dumps({"source": "run-A"}), content_type="application/json")
+    assert resp.status_code == 200
+    assert resp.json() == {"cleared": 1}
+    assert Shareout.objects.count() == 1
+    assert Shareout.objects.get().source == "run-B"
+
+
+@pytest.mark.django_db
+def test_clear_empty_body_clears_all():
+    _make_project()
+    c = _auth_client()
+    _post(c, {"shareouts": [_item()]})
+    resp = c.post("/api/shareouts/clear/", data=json.dumps({}), content_type="application/json")
+    assert resp.status_code == 200
+    assert resp.json()["cleared"] >= 1
+    assert Shareout.objects.count() == 0

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -1011,6 +1011,26 @@ export interface paths {
         readonly patch?: never;
         readonly trace?: never;
     };
+    readonly "/api/shareouts/clear/": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly get?: never;
+        readonly put?: never;
+        /**
+         * Clear shareouts by source / project / date (AND-combined)
+         * @description Delete shareouts matching the filters. An empty body clears all.
+         */
+        readonly post: operations["apps_shareouts_api_clear_shareouts"];
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -2613,6 +2633,26 @@ export interface components {
             /** Source */
             readonly source: string;
         };
+        /** ShareoutsClearOut */
+        readonly ShareoutsClearOut: {
+            /** Cleared */
+            readonly cleared: number;
+        };
+        /**
+         * ShareoutsClearIn
+         * @description Body of POST /api/shareouts/clear/. All optional, AND-combined. An empty
+         *     body clears ALL shareouts.
+         */
+        readonly ShareoutsClearIn: {
+            /** Source */
+            readonly source?: string | null;
+            /** Project */
+            readonly project?: string | null;
+            /** Date From */
+            readonly date_from?: string | null;
+            /** Date To */
+            readonly date_to?: string | null;
+        };
     };
     responses: never;
     parameters: never;
@@ -4205,6 +4245,30 @@ export interface operations {
                 };
                 content: {
                     readonly "application/json": components["schemas"]["ShareoutBatchOut"];
+                };
+            };
+        };
+    };
+    readonly apps_shareouts_api_clear_shareouts: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly requestBody: {
+            readonly content: {
+                readonly "application/json": components["schemas"]["ShareoutsClearIn"];
+            };
+        };
+        readonly responses: {
+            /** @description OK */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["ShareoutsClearOut"];
                 };
             };
         };


### PR DESCRIPTION
Adds `POST /api/shareouts/clear/` — delete shareouts by `source` / `project` / `date_from` / `date_to` (AND-combined; empty body clears all), mirroring the insights clear contract. `x-mcp-expose`'d. Enables hands-off re-runs and cleanup of stale/duplicate rows (needed right now to remove the pre-timestamp midnight rows the migration left behind). +2 tests; 12 shareout tests pass.