### PR TITLE
feat(ddd): server backstop — reject narrative-less package artifacts

### DIFF
--- a/apps/runs/aggregate.py
+++ b/apps/runs/aggregate.py
@@ -59,6 +59,17 @@ def _narrative_versions_for(feature: str) -> list[ReviewRequest]:
     return out
 
 
+def has_narrative_version(feature: str) -> bool:
+    """True iff ``feature`` has at least one story-bearing narrative version.
+
+    A narrative version is a ``concept_change`` review carrying a story (see
+    :func:`_is_narrative_version`) — i.e. the ``ddd-narrative-review`` gate ran
+    for this narrative. When this is False, any run uploaded under ``feature``
+    renders as **"no narrative"**, so the upload path refuses to publish it.
+    """
+    return bool(_narrative_versions_for((feature or "").strip()))
+
+
 def _narrative_payload(r: ReviewRequest | None) -> dict | None:
     if r is None:
         return None

--- a/apps/walkthroughs/api.py
+++ b/apps/walkthroughs/api.py
@@ -15,6 +15,7 @@ from ninja.files import UploadedFile
 
 from apps.api.auth import session_auth
 from apps.api.errors import (
+    TYPE_CONFLICT,
     TYPE_DRIVE_NOT_CONFIGURED,
     TYPE_DRIVE_UPLOAD_FAILED,
     TYPE_FORBIDDEN,
@@ -24,6 +25,7 @@ from apps.api.errors import (
 )
 
 from apps.common.ddd import feature_from_run_id
+from apps.runs.aggregate import has_narrative_version
 
 from . import storage
 from .drive_client import DriveNotConfigured
@@ -42,6 +44,13 @@ router = Router(auth=session_auth, tags=["walkthroughs"])
 
 CONTENT_TYPE_BY_KIND: dict[str, str] = {"html": "text/html", "video": "video/mp4"}
 FILENAME_BY_KIND: dict[str, str] = {"html": "slideshow.html", "video": "video.mp4"}
+
+# Terminal DDD package artifacts — the ones ddd-upload publishes. Uploading one
+# without a narrative is what produces a "no narrative" package, so the server
+# refuses it as a backstop to the plugin-side guard. Intermediate ddd-run
+# artifacts (deck/clip) and non-DDD walkthrough-share uploads carry neither of
+# these roles and are unaffected.
+_NARRATIVE_REQUIRED_ROLES = {Walkthrough.ROLE_HERO_VIDEO, Walkthrough.ROLE_DOCS}
 
 
 def _require_enabled() -> None:
@@ -179,6 +188,30 @@ def upload_walkthrough(
             resolved_review_id = UUID(narrative_review_id.strip())
         except ValueError:
             resolved_review_id = None
+
+    # Backstop guard: refuse to publish a terminal DDD package artifact
+    # (hero_video / docs) for a narrative that has no story-bearing version —
+    # such a package renders as "no narrative". A supplied narrative_review_id is
+    # proof the narrative gate ran, so it's trusted and skips the check. Mirrors
+    # the plugin-side guard in scripts/ddd/upload.py so the rule holds even for
+    # older plugin versions or manual uploads.
+    if (
+        resolved_role in _NARRATIVE_REQUIRED_ROLES
+        and resolved_feature
+        and resolved_review_id is None
+        and not has_narrative_version(resolved_feature)
+    ):
+        raise ProblemError(
+            409,
+            "Narrative required",
+            type_=TYPE_CONFLICT,
+            detail=(
+                f"Refusing to publish a {resolved_role!r} artifact for narrative "
+                f"{resolved_feature!r}: it has no narrative version, so the run "
+                f"would render as \"no narrative\". Run the ddd-narrative-review "
+                f"gate for this run first, then re-upload."
+            ),
+        )
 
     # Create ORM row first — if Drive fails, delete to avoid orphan row.
     w = Walkthrough.objects.create(

--- a/apps/walkthroughs/tests/test_api.py
+++ b/apps/walkthroughs/tests/test_api.py
@@ -539,3 +539,140 @@ def test_endpoints_404_when_disabled(auth_client, owner):
     # POST /{wid}/rotate-token/
     resp = auth_client.post(f"{BASE}/{w.id}/rotate-token/")
     assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Server-side narrative backstop — refuse terminal DDD artifacts with no
+# narrative (mirrors the plugin guard in scripts/ddd/upload.py).
+# ---------------------------------------------------------------------------
+
+_DDD_SETTINGS = dict(
+    WALKTHROUGHS_ENABLED=True,
+    CANOPY_DRIVE_ROOT_FOLDER_ID="root-folder",
+    CANOPY_DRIVE_SA_KEY_JSON='{"x":"y"}',
+)
+
+
+def _make_narrative_version(feature, run_id):
+    """A story-bearing concept_change review = a narrative version for `feature`."""
+    from apps.reviews.models import ReviewRequest
+
+    return ReviewRequest.objects.create(
+        run_id=run_id,
+        feature=feature,
+        version=1,
+        gate="concept_change",
+        status=ReviewRequest.STATUS_PENDING,
+        request_json={"run_id": run_id, "feature": feature, "narrative": "A story."},
+    )
+
+
+@pytest.mark.django_db
+@override_settings(**_DDD_SETTINGS)
+def test_hero_video_without_narrative_is_refused(auth_client, fake_drive, owner):
+    resp = auth_client.post(
+        f"{BASE}/",
+        data={
+            "file": _file_part("video.mp4", b"\x00\x00", "video/mp4"),
+            "title": "hero", "kind": "video",
+            "run_id": "verified-monitoring-2026-06-04-001",
+            "feature": "verified-monitoring",
+            "role": "hero_video",
+        },
+        format="multipart",
+    )
+    assert resp.status_code == 409, resp.content
+    assert "no narrative" in resp.json().get("detail", "").lower()
+    # Nothing persisted.
+    assert not Walkthrough.objects.filter(feature="verified-monitoring").exists()
+
+
+@pytest.mark.django_db
+@override_settings(**_DDD_SETTINGS)
+def test_docs_without_narrative_is_refused(auth_client, fake_drive, owner):
+    resp = auth_client.post(
+        f"{BASE}/",
+        data={
+            "file": _file_part("slideshow.html", b"<html></html>", "text/html"),
+            "title": "deck", "kind": "html",
+            "run_id": "verified-monitoring-2026-06-04-001",
+            "feature": "verified-monitoring",
+            "role": "docs",
+        },
+        format="multipart",
+    )
+    assert resp.status_code == 409, resp.content
+
+
+@pytest.mark.django_db
+@override_settings(**_DDD_SETTINGS)
+def test_hero_video_with_narrative_is_allowed(auth_client, fake_drive, owner):
+    _make_narrative_version("verified-monitoring", "verified-monitoring-2026-06-04-001")
+    resp = auth_client.post(
+        f"{BASE}/",
+        data={
+            "file": _file_part("video.mp4", b"\x00\x00", "video/mp4"),
+            "title": "hero", "kind": "video",
+            "run_id": "verified-monitoring-2026-06-04-001",
+            "feature": "verified-monitoring",
+            "role": "hero_video",
+        },
+        format="multipart",
+    )
+    assert resp.status_code == 201, resp.content
+
+
+@pytest.mark.django_db
+@override_settings(**_DDD_SETTINGS)
+def test_stamped_review_id_bypasses_server_check(auth_client, fake_drive, owner):
+    """A supplied narrative_review_id is trusted proof — no narrative row needed."""
+    resp = auth_client.post(
+        f"{BASE}/",
+        data={
+            "file": _file_part("video.mp4", b"\x00\x00", "video/mp4"),
+            "title": "hero", "kind": "video",
+            "run_id": "verified-monitoring-2026-06-04-001",
+            "feature": "verified-monitoring",
+            "role": "hero_video",
+            "narrative_review_id": str(uuid.uuid4()),
+        },
+        format="multipart",
+    )
+    assert resp.status_code == 201, resp.content
+
+
+@pytest.mark.django_db
+@override_settings(**_DDD_SETTINGS)
+def test_intermediate_deck_clip_not_guarded(auth_client, fake_drive, owner):
+    """ddd-run mid-loop uploads (deck/clip) must NOT be blocked by the guard."""
+    for role, kind, fname, ct in [
+        ("deck", "html", "slideshow.html", "text/html"),
+        ("clip", "video", "video.mp4", "video/mp4"),
+    ]:
+        resp = auth_client.post(
+            f"{BASE}/",
+            data={
+                "file": _file_part(fname, b"\x00\x00", ct),
+                "title": role, "kind": kind,
+                "run_id": "verified-monitoring-2026-06-04-001",
+                "feature": "verified-monitoring",
+                "role": role,
+            },
+            format="multipart",
+        )
+        assert resp.status_code == 201, (role, resp.content)
+
+
+@pytest.mark.django_db
+@override_settings(**_DDD_SETTINGS)
+def test_non_ddd_walkthrough_share_not_guarded(auth_client, fake_drive, owner):
+    """A plain walkthrough-share upload (no role, no feature) is unaffected."""
+    resp = auth_client.post(
+        f"{BASE}/",
+        data={
+            "file": _file_part("slideshow.html", b"<html></html>", "text/html"),
+            "title": "share", "kind": "html",
+        },
+        format="multipart",
+    )
+    assert resp.status_code == 201, resp.content


### PR DESCRIPTION
## Problem

A DDD run uploaded without a narrative renders as **"no narrative"** in the `/ddd` UI (observed live on `verified-monitoring`). The plugin-side guard (canopy PR #141) prevents this, but only for updated plugins — the server accepted the upload unconditionally.

## Fix

Server backstop in the walkthroughs upload endpoint: refuse a **terminal DDD package artifact** (`role=hero_video` or `docs`) for a `feature` that has no narrative version → **409**. A supplied `narrative_review_id` is trusted proof and skips the check.

Scoped deliberately to `hero_video`/`docs` so:
- `ddd-run` intermediate uploads (`deck`/`clip`) are **not** blocked, and
- non-DDD `walkthrough-share` uploads (no role/feature) are unaffected.

Adds `aggregate.has_narrative_version(feature)`.

## Tests

Full suite: **383 passed, 1 skipped**. New cases: refuse hero_video/docs without narrative (409, nothing persisted), allow with a narrative version, allow with a stamped `narrative_review_id`, and confirm deck/clip + plain walkthrough-share are not guarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)