### PR TITLE
feat(ddd): section jump-nav + scroll-spy under the active run

### DIFF
--- a/frontend/src/components/ddd/DddLeftNav.tsx
+++ b/frontend/src/components/ddd/DddLeftNav.tsx
@@ -7,11 +7,50 @@ import {
   type DddNarrativeDetail,
   type DddNarrativeListItem,
 } from '@/api/ddd'
+import { useRunSectionNav } from './runSectionNav'
 
 function runStamp(runId: string): string {
   // "microplans-2026-06-02-001" -> "2026-06-02-001"
   const m = runId.match(/(\d{4}-\d{2}-\d{2}-\d+)$/)
   return m ? m[1] : runId
+}
+
+/**
+ * Jump-list of the active run's sections, nested under its run entry. The run
+ * package registers these and reports the active one via scroll-spy (see
+ * runSectionNav); clicking scrolls the package to that section so the rail
+ * navigates a run instead of forcing one long scroll. Renders nothing until the
+ * package has mounted and published its sections.
+ */
+function RunSectionList() {
+  const nav = useRunSectionNav()
+  if (!nav || nav.sections.length === 0) return null
+  return (
+    <div className="ml-6 mt-0.5 flex flex-col gap-0.5 border-l border-stone-800/70 pl-1">
+      {nav.sections.map((s) => (
+        <button
+          key={s.id}
+          type="button"
+          onClick={() => nav.jump(s.id)}
+          className={clsx(
+            'flex items-center gap-2 rounded-md px-3 py-0.5 text-left text-[11px] transition-colors',
+            s.id === nav.activeId
+              ? 'text-orange-300'
+              : 'text-stone-500 hover:text-stone-300',
+          )}
+        >
+          <span
+            aria-hidden
+            className={clsx(
+              'h-1 w-1 shrink-0 rounded-full',
+              s.id === nav.activeId ? 'bg-orange-400' : 'bg-stone-700',
+            )}
+          />
+          <span className="truncate">{s.label}</span>
+        </button>
+      ))}
+    </div>
+  )
 }
 
 /**
@@ -75,21 +114,23 @@ function NarrativeRuns({
             ) : (
               <div className="ml-3 flex flex-col gap-0.5 border-l border-stone-800/70 pl-1">
                 {runs.map((r) => (
-                  <Link
-                    key={r.run_id}
-                    to={`/ddd/${encodeURIComponent(slug)}/${encodeURIComponent(r.run_id)}`}
-                    className={clsx(
-                      'flex items-center gap-2 rounded-md px-3 py-1 text-xs transition-colors',
-                      r.run_id === activeRunId
-                        ? 'bg-orange-500/10 text-orange-300 border border-orange-500/30'
-                        : 'text-stone-400 hover:bg-stone-800/60 hover:text-stone-200 border border-transparent',
-                    )}
-                  >
-                    <span aria-hidden className="text-stone-600">
-                      {r.run_id === activeRunId ? '●' : '○'}
-                    </span>
-                    <span className="truncate font-mono">{runStamp(r.run_id)}</span>
-                  </Link>
+                  <div key={r.run_id} className="flex flex-col gap-0.5">
+                    <Link
+                      to={`/ddd/${encodeURIComponent(slug)}/${encodeURIComponent(r.run_id)}`}
+                      className={clsx(
+                        'flex items-center gap-2 rounded-md px-3 py-1 text-xs transition-colors',
+                        r.run_id === activeRunId
+                          ? 'bg-orange-500/10 text-orange-300 border border-orange-500/30'
+                          : 'text-stone-400 hover:bg-stone-800/60 hover:text-stone-200 border border-transparent',
+                      )}
+                    >
+                      <span aria-hidden className="text-stone-600">
+                        {r.run_id === activeRunId ? '●' : '○'}
+                      </span>
+                      <span className="truncate font-mono">{runStamp(r.run_id)}</span>
+                    </Link>
+                    {r.run_id === activeRunId && <RunSectionList />}
+                  </div>
                 ))}
               </div>
             )}

--- a/frontend/src/components/ddd/DddShell.tsx
+++ b/frontend/src/components/ddd/DddShell.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
 import { DddLeftNav } from './DddLeftNav'
+import { RunSectionNavProvider } from './runSectionNav'
 
 /**
  * The DDD section chrome: the persistent left rail (narratives → versions →
@@ -8,7 +9,9 @@ import { DddLeftNav } from './DddLeftNav'
  * stays put and highlights wherever you are.
  *
  * Assumes a full-bleed parent (AppLayout renders /ddd and /review at full
- * viewport height); the main area owns its own scroll.
+ * viewport height); the main area owns its own scroll. ``data-ddd-scroll``
+ * marks it as the scroll-spy root so the run package can observe its sections
+ * against the right container.
  */
 export function DddShell({
   activeSlug,
@@ -20,9 +23,13 @@ export function DddShell({
   children: ReactNode
 }) {
   return (
-    <div className="flex h-full">
-      <DddLeftNav activeSlug={activeSlug} activeRunId={activeRunId} />
-      <main className="flex-1 overflow-y-auto">{children}</main>
-    </div>
+    <RunSectionNavProvider>
+      <div className="flex h-full">
+        <DddLeftNav activeSlug={activeSlug} activeRunId={activeRunId} />
+        <main data-ddd-scroll className="flex-1 overflow-y-auto">
+          {children}
+        </main>
+      </div>
+    </RunSectionNavProvider>
   )
 }

--- a/frontend/src/components/ddd/RunPackage.tsx
+++ b/frontend/src/components/ddd/RunPackage.tsx
@@ -7,6 +7,30 @@ import {
   type DddRunNarrative,
   type DddRunPackage,
 } from '@/api/ddd'
+import {
+  runSectionDomId,
+  useRunSectionNav,
+  type RunSection,
+} from './runSectionNav'
+
+/**
+ * Which sections a loaded run actually renders, in display order. Drives both
+ * the anchored DOM ids here and the jump list in the left rail — empty
+ * sections (no links, no previous runs) are omitted so the rail never points
+ * at something that isn't on the page.
+ */
+function presentSections(run: DddRunPackage): RunSection[] {
+  const out: RunSection[] = [
+    { id: 'video', label: 'Video' },
+    { id: 'walkthrough', label: 'Walkthrough' },
+    { id: 'narrative', label: 'Narrative' },
+  ]
+  if (run.links.length > 0) out.push({ id: 'links', label: 'Links' })
+  out.push({ id: 'artifacts', label: 'All artifacts' })
+  if (run.previous_runs.length > 0)
+    out.push({ id: 'previous', label: 'Previous runs' })
+  return out
+}
 
 function fmtDate(iso: string | null): string {
   if (!iso) return ''
@@ -24,16 +48,18 @@ function fmtDate(iso: string | null): string {
 }
 
 function Section({
+  id,
   title,
   subtitle,
   children,
 }: {
+  id: string
   title: string
   subtitle?: string
   children: React.ReactNode
 }) {
   return (
-    <section className="mt-6">
+    <section id={runSectionDomId(id)} className="mt-6 scroll-mt-4">
       <div className="mb-2 flex items-baseline gap-2">
         <h2 className="text-[10px] font-semibold uppercase tracking-wider text-stone-500">
           {title}
@@ -150,6 +176,12 @@ export function RunPackage({ runId }: { runId: string }) {
   const [error, setError] = useState<string | null>(null)
   const [deleting, setDeleting] = useState(false)
 
+  const nav = useRunSectionNav()
+  // useState setters and the memoized jump are referentially stable, so pulling
+  // them out keeps the scroll-spy effect from re-running on every active change.
+  const setSections = nav?.setSections
+  const setActiveId = nav?.setActiveId
+
   useEffect(() => {
     let cancelled = false
     setRun(null)
@@ -161,6 +193,41 @@ export function RunPackage({ runId }: { runId: string }) {
       cancelled = true
     }
   }, [runId])
+
+  // Publish the run's sections to the rail and scroll-spy the active one. A
+  // section is "active" once it crosses into the top third of the scroll
+  // container; the topmost such section in display order wins.
+  useEffect(() => {
+    if (!run || !setSections || !setActiveId) return
+    const sections = presentSections(run)
+    setSections(sections)
+
+    const root = document.querySelector('[data-ddd-scroll]')
+    const els = sections
+      .map((s) => document.getElementById(runSectionDomId(s.id)))
+      .filter((el): el is HTMLElement => el != null)
+
+    const visible = new Set<string>()
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const e of entries) {
+          const id = e.target.id.replace('run-section-', '')
+          if (e.isIntersecting) visible.add(id)
+          else visible.delete(id)
+        }
+        const top = sections.find((s) => visible.has(s.id))
+        if (top) setActiveId(top.id)
+      },
+      { root, rootMargin: '0px 0px -66% 0px', threshold: 0 },
+    )
+    els.forEach((el) => observer.observe(el))
+
+    return () => {
+      observer.disconnect()
+      setSections([])
+      setActiveId(null)
+    }
+  }, [run, setSections, setActiveId])
 
   async function onDeleteRun() {
     if (!run) return
@@ -216,7 +283,7 @@ export function RunPackage({ runId }: { runId: string }) {
         </div>
       </header>
 
-      <Section title="Video">
+      <Section id="video" title="Video">
         {run.video ? (
           <div className="overflow-hidden rounded-xl border border-stone-800 bg-black">
             <video
@@ -230,7 +297,7 @@ export function RunPackage({ runId }: { runId: string }) {
         )}
       </Section>
 
-      <Section title="Walkthrough">
+      <Section id="walkthrough" title="Walkthrough">
         {run.deck ? (
           <div className="overflow-hidden rounded-xl border border-stone-800 bg-white">
             <iframe
@@ -246,6 +313,7 @@ export function RunPackage({ runId }: { runId: string }) {
       </Section>
 
       <Section
+        id="narrative"
         title="Narrative"
         subtitle={run.narrative?.version != null ? `v${run.narrative.version}` : undefined}
       >
@@ -267,12 +335,16 @@ export function RunPackage({ runId }: { runId: string }) {
       </Section>
 
       {run.links.length > 0 && (
-        <Section title="Links">
+        <Section id="links" title="Links">
           <LinksBlock links={run.links} />
         </Section>
       )}
 
-      <Section title="All artifacts" subtitle={`${run.all_artifacts.length} uploaded`}>
+      <Section
+        id="artifacts"
+        title="All artifacts"
+        subtitle={`${run.all_artifacts.length} uploaded`}
+      >
         <div className="flex flex-col gap-1">
           {run.all_artifacts.map((a) => (
             <Link
@@ -296,7 +368,7 @@ export function RunPackage({ runId }: { runId: string }) {
       </Section>
 
       {run.previous_runs.length > 0 && (
-        <Section title="Previous runs">
+        <Section id="previous" title="Previous runs">
           <div className="flex flex-wrap gap-2">
             {run.previous_runs.map((p) => (
               <Link

--- a/frontend/src/components/ddd/runSectionNav.tsx
+++ b/frontend/src/components/ddd/runSectionNav.tsx
@@ -1,0 +1,67 @@
+/**
+ * Coordination between the run package (which owns the section content + scroll
+ * position) and the left rail (which lists the sections as jump links and
+ * highlights the one you're looking at).
+ *
+ * The package registers the sections it actually rendered and reports the
+ * active one via scroll-spy; the rail reads that and calls {@link jump} to
+ * scroll-to-section. Kept in context so neither component has to re-fetch the
+ * run or thread props through the shell.
+ */
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react'
+
+export interface RunSection {
+  id: string
+  label: string
+}
+
+/** DOM id for a run section anchor, so the rail and package agree on targets. */
+export function runSectionDomId(id: string): string {
+  return `run-section-${id}`
+}
+
+interface RunSectionNavValue {
+  sections: RunSection[]
+  activeId: string | null
+  setSections: (sections: RunSection[]) => void
+  setActiveId: (id: string | null) => void
+  jump: (id: string) => void
+}
+
+const RunSectionNavContext = createContext<RunSectionNavValue | null>(null)
+
+export function RunSectionNavProvider({ children }: { children: ReactNode }) {
+  const [sections, setSections] = useState<RunSection[]>([])
+  const [activeId, setActiveId] = useState<string | null>(null)
+
+  const jump = useCallback((id: string) => {
+    const el = document.getElementById(runSectionDomId(id))
+    if (!el) return
+    el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    // Reflect the click immediately; scroll-spy will keep it honest after.
+    setActiveId(id)
+  }, [])
+
+  const value = useMemo(
+    () => ({ sections, activeId, setSections, setActiveId, jump }),
+    [sections, activeId, jump],
+  )
+
+  return (
+    <RunSectionNavContext.Provider value={value}>
+      {children}
+    </RunSectionNavContext.Provider>
+  )
+}
+
+/** Returns the nav context, or null when rendered outside a provider. */
+export function useRunSectionNav(): RunSectionNavValue | null {
+  return useContext(RunSectionNavContext)
+}


### PR DESCRIPTION
## Product Description

On a DDD run page, the run's contents (Video → Walkthrough → Narrative → Links → All artifacts → Previous runs) were one long vertical scroll with no way to jump around. Now, when you open a run, its sections hang underneath it in the left rail — click any one to jump straight to it, and the rail highlights the section you're currently looking at as you scroll. Same page, just navigable instead of an endless scroll.

## Technical Summary

Requested: "explicit sections hang under the run in the left panel rather than one long vertical scroll." Chosen interaction model (confirmed with the user): **anchor scroll-spy** — sections stay on one page; the rail lists them as jump links and scroll-spy tracks the active one.

- `runSectionNav.tsx` (new) — a small context so the run package (owns the section content + scroll position) and the left rail (lists + highlights the sections) coordinate without re-fetching the run. The `setSections`/`setActiveId` setters are referentially stable, so the package's scroll-spy effect runs once per run rather than on every active-section change.
- `RunPackage.tsx` — every `<Section>` gets a stable anchor id (`run-section-<id>`); on load the package publishes the sections it actually rendered (empty Links / Previous runs are omitted so the rail never points at nothing) and runs an `IntersectionObserver` rooted on the shell's scroll container, marking a section active once it crosses into the top third.
- `DddLeftNav.tsx` — `RunSectionList` renders the jump links under the active run; clicking scrolls the package to that section.
- `DddShell.tsx` — provides the context and tags `<main>` with `data-ddd-scroll` as the scroll-spy root.

## Safety Assurance

- `tsc -b` passes on the changed files (the only errors in the tree are pre-existing `ShareoutsPage` imports missing from a borrowed `node_modules`, unrelated to this change).
- Pure additive UI: the run package renders identically; the rail just gains a sub-list under the active run, and shows nothing when no run is open (so the narrative landing and `/review` screens are unaffected).
- Not yet visually verified on the deployed Cloud Run service — needs a deploy to dogfood the scroll-spy live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)