### PR TITLE
docs: annotate stale design docs with status banners (no deletions)

### DIFF
--- a/docs/superpowers/plans/2026-03-27-canopy-web-implementation.md
+++ b/docs/superpowers/plans/2026-03-27-canopy-web-implementation.md
@@ -1,5 +1,7 @@
 # Canopy Web Implementation Plan
 
+> **⚠️ Historical (shipped, pre-Ninja) — annotated 2026-06-07.** This plan shipped, but its code-level mechanics are superseded: the API was migrated DRF → Django Ninja + Pydantic + OpenAPI (PR #42). Treat the code snippets here (DRF serializers/views, the `{success, data}` envelope) as a historical record; the high-level data model is still broadly accurate. For current state see `/CLAUDE.md` and `docs/superpowers/plans/2026-05-26-api-modernization.md`.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Build a collaborative web workspace where non-technical users co-author reusable skills from conversations, with living eval suites that prove skills improve over time.

--- a/docs/superpowers/plans/2026-04-10-project-workbench.md
+++ b/docs/superpowers/plans/2026-04-10-project-workbench.md
@@ -1,5 +1,7 @@
 # Project Workbench Implementation Plan
 
+> **⚠️ Historical (shipped, pre-Ninja) — annotated 2026-06-07.** Shipped as `apps/projects/`, but via Django Ninja, not the DRF function-based views / `{success, data}` envelope described here (API migrated in PR #42). The data model is still accurate; the transport details are stale. See `/CLAUDE.md`.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Add a project registry with public API and dense tile-grid homepage to canopy-web, replacing the skill discovery feed as the landing page.

--- a/docs/superpowers/plans/2026-04-13-portfolio-insights.md
+++ b/docs/superpowers/plans/2026-04-13-portfolio-insights.md
@@ -1,5 +1,7 @@
 # Portfolio Insights Implementation Plan
 
+> **ℹ️ Shipped — historical record (annotated 2026-06-07).** The `/insights` feed shipped and its core mechanism still holds: insights are `ProjectContext` entries with `context_type="insight"`. The API is now a Django Ninja router (`insights_router` in `apps/projects/api.py`), not the DRF `views_insights.py` / serializers named here (migrated in PR #42). See `/CLAUDE.md`.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Add a cross-portfolio insights feed to canopy-web — an `/insights` page showing actionable AI observations across all projects, plus the API to power it and a canopy skill to generate insights.

--- a/docs/superpowers/plans/2026-05-26-api-modernization.md
+++ b/docs/superpowers/plans/2026-05-26-api-modernization.md
@@ -1,5 +1,7 @@
 # API Modernization Implementation Plan
 
+> **ℹ️ Shipped — historical record (annotated 2026-06-07).** This migration is complete (PR #42, FastMCP layer PR #71): Django Ninja is the only API surface, DRF and the `{success, data, timing_ms}` envelope are gone, frontend types are generated from OpenAPI, and the MCP layer shipped. The phased "mount at `/api/v2/` then rename to `/api/`" path described below is finished — read it as the record of how the migration was done, not as current state. See `/CLAUDE.md`.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Replace DRF with Django Ninja, make Pydantic v2 the single source of truth for every API request/response shape, generate the frontend TypeScript client from the OpenAPI 3.1 schema, kill the `{success, data, timing_ms}` envelope in favor of RFC 7807 `application/problem+json`, add Schemathesis contract tests in CI, and expose a curated read-only slice as MCP tools via FastMCP. Keep Django (ORM, allauth, middleware, SSE streaming) untouched.

--- a/docs/superpowers/plans/2026-05-26-walkthrough-sharing.md
+++ b/docs/superpowers/plans/2026-05-26-walkthrough-sharing.md
@@ -1,5 +1,7 @@
 # Walkthrough Sharing Implementation Plan
 
+> **⚠️ Shipped, but auth + transport superseded — annotated 2026-06-07.** The walkthrough feature shipped, but two mechanisms in this plan are RETIRED: the DRF serializers/views (migrated to Django Ninja, PR #42) and the `/api/auth/e2e-login/` + `CANOPY_E2E_AUTH_TOKEN` auth flow (replaced by Personal Access Tokens, PR #45). **Do not follow this plan's auth instructions** — they point at a dead endpoint. Current API + auth are in `/CLAUDE.md`; the still-accurate design intent is in `docs/superpowers/specs/2026-05-26-walkthrough-sharing-design.md`.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Let canopy-web host HTML slideshows + MP4 videos produced by `/canopy:walkthrough`, with per-walkthrough visibility (private/dimagi-OAuth vs link-token) and Drive-backed storage.

--- a/docs/superpowers/specs/2026-04-10-project-workbench-design.md
+++ b/docs/superpowers/specs/2026-04-10-project-workbench-design.md
@@ -1,7 +1,7 @@
 # Project Workbench — Design Spec
 
 **Date:** 2026-04-10
-**Status:** Draft
+**Status:** Shipped — historical record (annotated 2026-06-07). One stale detail: the `{success, data, error}` envelope referenced below is gone — the API now returns RFC 7807 `application/problem+json` via Django Ninja (PR #42). Design + data model otherwise accurate.
 **Scope:** Canopy-web expansion — project registry + workbench homepage
 
 ## Problem

--- a/docs/superpowers/specs/2026-06-02-ddd-run-views-design.md
+++ b/docs/superpowers/specs/2026-06-02-ddd-run-views-design.md
@@ -1,7 +1,7 @@
 # DDD Run Views — design spec
 
 **Date:** 2026-06-02
-**Status:** Approved (implementing)
+**Status:** Shipped — historical record (annotated 2026-06-07). Its run/grouping model was superseded by `2026-06-03-ddd-narrative-run-versioning-design.md` (versions now nest runs), and the `feature` field was renamed `narrative_slug` (PR #95). Read for context, not current state.
 **Author:** Jonathan + Claude
 
 ## Problem

--- a/docs/superpowers/specs/2026-06-03-ddd-narrative-run-versioning-design.md
+++ b/docs/superpowers/specs/2026-06-03-ddd-narrative-run-versioning-design.md
@@ -1,7 +1,7 @@
 # DDD Narrative / Run / Version model — design spec
 
 **Date:** 2026-06-03
-**Status:** Draft for review (not yet implementing)
+**Status:** Shipped (annotated 2026-06-07) — PRs #80, #82, #95. The narrative → version → run model described here is the current implementation (`apps/runs/`, `narrative_slug`).
 **Author:** Jonathan + Claude
 **Supersedes the grouping model in:** `2026-06-02-ddd-run-views-design.md`
 


### PR DESCRIPTION
Follow-up to the 2026-06-07 doc regen (#96). A staleness audit of the 11 design docs found a **mild, structural** problem: the docs are accurate about *what* the system does but stale about *how* it's built/authed — concentrated entirely at the DRF→Ninja migration boundary (PR #42). Two specs also had status headers that contradicted reality.

This PR adds point-in-time banners only. **No content removed, nothing deleted, no archives moved** — purely additive annotations so the next agent/human isn't misled at a glance.

### Wrong status headers fixed (the sharp edges)
| File | Was | Now |
|---|---|---|
| `specs/2026-06-03-ddd-narrative-run-versioning-design.md` | "Draft for review (not yet implementing)" | Shipped (#80, #82, #95) — it's the current `apps/runs/` model |
| `specs/2026-06-02-ddd-run-views-design.md` | "Approved (implementing)" | Shipped but superseded by the 06-03 grouping model + `feature`→`narrative_slug` (#95) |

### Historical banners added
- `plans/2026-03-27-canopy-web-implementation.md`, `plans/2026-04-10-project-workbench.md`, `specs/2026-04-10-project-workbench-design.md` — pre-Ninja; their DRF serializers/views/`{success,data}` envelope no longer exist.
- `plans/2026-04-13-portfolio-insights.md`, `plans/2026-05-26-api-modernization.md` — shipped; the migration end-state is done.
- `plans/2026-05-26-walkthrough-sharing.md` — ⚠️ flags its **retired auth path** (`/api/auth/e2e-login/` + `CANOPY_E2E_AUTH_TOKEN` → PATs, #45) so an agent doesn't chase a dead endpoint.

The two LIVING specs (OAuth gate, walkthrough-sharing-design) were left untouched — they still match the code.

Deliberately **not** done here: archiving/deleting the three pure-DRF plans. That's a higher-regret call left for you. (The updated `canopy:doc-regeneration` skill — canopy PR #155 — now does exactly this classification automatically and gates deletes behind confirmation.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)