### PR TITLE
feat(reviews): label BUILD SEQUENCE items built vs to-build

### DIFF
--- a/frontend/src/pages/ReviewPage.tsx
+++ b/frontend/src/pages/ReviewPage.tsx
@@ -702,6 +702,10 @@ interface BuildSequenceSectionProps {
   onReorder: (orderedIds: string[]) => void
   /** Submitted build order (readOnly mode). */
   resolvedBuildOrder: string[] | null
+  /** scene id → frontier (true = New feature / to-build, false = Existing feature).
+   *  Same `sceneIsFrontier` the scene cards use, so the build sequence labels
+   *  already-built beats instead of presenting everything as undifferentiated to-do. */
+  frontierById: Map<string, boolean>
 }
 
 function BuildSequenceSection({
@@ -710,6 +714,7 @@ function BuildSequenceSection({
   readOnly,
   onReorder,
   resolvedBuildOrder,
+  frontierById,
 }: BuildSequenceSectionProps) {
   // Build a lookup from scene id → title (only active scenes)
   const sceneById = new Map(
@@ -774,6 +779,9 @@ function BuildSequenceSection({
                   </p>
                 )}
               </div>
+
+              {/* Built vs to-build — so the reviewer isn't asked to "build" what's already live */}
+              <StatusBadge frontier={frontierById.get(scene.id) ?? false} />
 
               {/* Up / Down controls — edit mode only */}
               {!readOnly && (
@@ -1016,6 +1024,9 @@ function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerPr
     (s.provenance ? (spineById.get(s.provenance)?.status ?? 'grounded') : 'grounded') !== 'grounded' ||
     (s.provenance ? (gapsByRef.get(s.provenance)?.length ?? 0) : 0) > 0
   const frontierScenes = liveScenes.filter(sceneIsFrontier)
+  // scene id → frontier, so the BUILD SEQUENCE panel can label built vs to-build
+  // using the exact same rule as the scene cards.
+  const frontierById = new Map(liveScenes.map((s) => [s.id, sceneIsFrontier(s)]))
   const frontierCount = frontierScenes.length
   const builtSceneCount = liveScenes.length - frontierCount
   const toBuildFeatures = frontierScenes.flatMap((s) => (s.features ?? []).filter((f) => !f.deleted))
@@ -1526,6 +1537,7 @@ function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerPr
               ? review.response_json.build_order
               : null
           }
+          frontierById={frontierById}
         />
       )}
 


### PR DESCRIPTION
## What

The DDD narrative-agreement review's **BUILD SEQUENCE** panel rendered each beat with only a number + title — no built/new signal. So a review for an already-shipped feature read as an all-new build plan, even though the scene cards right above already badge each beat `Existing feature` / `New feature`.

## Fix

Reuse the existing `sceneIsFrontier` (spine item is a gap, or a why-brief gap references it) — the exact rule the scene cards use. Compute a `frontierById` map in the parent and render the existing `StatusBadge` on each BUILD SEQUENCE item. No new definition, no backend dependency: it's computed client-side from `request_json.why_brief`, so the badge also appears on **already-posted reviews** the moment this deploys.

Pairs with canopy `ddd-build-status-built-new` (jjackson/canopy#157), which adds the same status to `narration[].status` for the API + the `ddd-narrative-review` inline table.

## Verification

- `tsc -b`: clean (exit 0).
- eslint: no new errors (the 10 reported are pre-existing `react-hooks/refs` on `withChrome`, lines 464/1705–1734 — untouched by this 12-line diff).
- On the live `verified-monitoring` review (`bf432c5c`): renders 5 `Existing feature` / 1 `New feature` (the back-check drill, a CAPABILITY gap), matching the scene-card badges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
