### PR TITLE
feat(ddd): first-class run objects (video/slides/documentation) + one-per-role guard

### DIFF
--- a/apps/runs/aggregate.py
+++ b/apps/runs/aggregate.py
@@ -192,11 +192,17 @@ def build_run(run_id: str) -> dict | None:
         lambda w: w.role == Walkthrough.ROLE_CLIP,
         lambda w: w.kind == Walkthrough.KIND_VIDEO,
     )
-    deck = _pick(
+    # First-class, single-valued outputs (newest of each role). `slides` is the
+    # canopy:walkthrough HTML slideshow (role=deck); `documentation` is the
+    # feature docs page (role=docs). An unroled HTML artifact falls back to
+    # documentation so legacy uploads still surface somewhere, but a role=deck
+    # artifact never leaks into documentation (and vice-versa).
+    slides = _pick(wts, lambda w: w.role == Walkthrough.ROLE_DECK)
+    documentation = _pick(
         wts,
         lambda w: w.role == Walkthrough.ROLE_DOCS,
-        lambda w: w.role == Walkthrough.ROLE_DECK,
-        lambda w: w.kind == Walkthrough.KIND_HTML,
+        lambda w: w.kind == Walkthrough.KIND_HTML
+        and w.role != Walkthrough.ROLE_DECK,
     )
 
     # Explicit narrative_slug (uploaded by the plugin) wins; run_id parsing is fallback.
@@ -274,7 +280,8 @@ def build_run(run_id: str) -> dict | None:
         "latest_at": latest_at,
         "phase": phase,
         "video": _artifact_payload(video),
-        "deck": _artifact_payload(deck),
+        "slides": _artifact_payload(slides),
+        "documentation": _artifact_payload(documentation),
         "narrative": narrative_payload,
         "links": links,
         "all_artifacts": all_artifacts,

--- a/apps/runs/schemas.py
+++ b/apps/runs/schemas.py
@@ -106,7 +106,12 @@ class RunPackageOut(StrictModel):
     latest_at: dt.datetime | None = None
     phase: str | None = None
     video: RunArtifactOut | None = None
-    deck: RunArtifactOut | None = None
+    # First-class, single-valued run outputs. `slides` is the canopy:walkthrough
+    # HTML slideshow (role=deck); `documentation` is the feature docs page
+    # (role=docs). They were previously collapsed into one `deck` field that
+    # picked docs-then-deck, which hid the slides entirely.
+    slides: RunArtifactOut | None = None
+    documentation: RunArtifactOut | None = None
     narrative: RunNarrativeOut | None = None
     links: list[WalkthroughLink] = []
     all_artifacts: list[RunArtifactRefOut] = []

--- a/apps/runs/tests/test_aggregate.py
+++ b/apps/runs/tests/test_aggregate.py
@@ -31,30 +31,35 @@ def test_feature_fallbacks():
 # ---------------------------------------------------------------------------
 
 
-def test_build_run_picks_hero_video_and_docs_over_iteration_artifacts():
+def test_build_run_surfaces_video_slides_and_documentation_as_first_class():
     u = make_user()
     rid = "microplans-2026-06-02-001"
     make_walkthrough(u, kind="video", run_id=rid, role="clip", title="iter0 clip")
     hero = make_walkthrough(u, kind="video", run_id=rid, role="hero_video", title="hero")
-    make_walkthrough(u, kind="html", run_id=rid, role="deck", title="iter0 deck")
+    slides = make_walkthrough(u, kind="html", run_id=rid, role="deck", title="slideshow")
     docs = make_walkthrough(u, kind="html", run_id=rid, role="docs", title="docs page")
 
     run = aggregate.build_run(rid)
     assert run is not None
     assert run["video"]["id"] == hero.id
-    assert run["deck"]["id"] == docs.id
+    # slides (role=deck) and documentation (role=docs) are distinct first-class
+    # objects — the slideshow must not be hidden behind the docs page.
+    assert run["slides"]["id"] == slides.id
+    assert run["documentation"]["id"] == docs.id
     assert run["narrative_slug"] == "microplans"
     assert run["video"]["content_url"] == f"/w/{hero.id}/content"
 
 
-def test_build_run_falls_back_to_kind_when_no_role():
+def test_build_run_unroled_html_falls_back_to_documentation():
     u = make_user()
     rid = "calendar-2026-06-01-002"
     vid = make_walkthrough(u, kind="video", run_id=rid)
-    deck = make_walkthrough(u, kind="html", run_id=rid)
+    html = make_walkthrough(u, kind="html", run_id=rid)
     run = aggregate.build_run(rid)
     assert run["video"]["id"] == vid.id
-    assert run["deck"]["id"] == deck.id
+    # An unroled HTML artifact surfaces as documentation, not slides.
+    assert run["documentation"]["id"] == html.id
+    assert run["slides"] is None
 
 
 def test_build_run_returns_none_for_unknown_run():

--- a/apps/runs/tests/test_api.py
+++ b/apps/runs/tests/test_api.py
@@ -67,7 +67,8 @@ def test_run_package(client, owner):
     assert resp.status_code == 200, resp.content
     body = resp.json()
     assert body["video"]["id"] == str(vid.id)
-    assert body["deck"] is not None
+    assert body["documentation"] is not None  # role=docs
+    assert body["slides"] is None  # no role=deck slideshow in this run
     assert body["narrative"]["story"] == "Story line one."
     assert body["narrative"]["review_id"]  # deep-links to /review/<id> for editing
     assert len(body["all_artifacts"]) == 2

--- a/apps/walkthroughs/api.py
+++ b/apps/walkthroughs/api.py
@@ -263,6 +263,34 @@ def upload_walkthrough(
     if visibility == Walkthrough.VISIBILITY_LINK:
         w.ensure_share_token()
 
+    # Enforce one artifact per (run_id, role): a re-upload of the same role into
+    # the same run REPLACES the prior one (e.g. healing a docs page), so a run
+    # can never accumulate two videos / two slideshows / two docs pages. Genuine
+    # re-renders mint a fresh run_id upstream and are unaffected. Only applies
+    # when both run_id and role are set — roleless / orphan uploads aren't
+    # first-class run objects and are left alone. Runs only after the new row is
+    # safely stored, so a failed upload never destroys the prior good artifact.
+    if resolved_run_id and resolved_role:
+        superseded = Walkthrough.objects.filter(
+            run_id=resolved_run_id, role=resolved_role
+        ).exclude(pk=w.pk)
+        for old in superseded:
+            if old.drive_file_id:
+                try:
+                    storage.delete_stored(
+                        file_id=old.drive_file_id, folder_id=old.drive_folder_id
+                    )
+                except Exception:
+                    # Don't block on a Drive hiccup — an orphan Drive file is
+                    # cheap to sweep later; log loudly.
+                    log.exception(
+                        "upload replace: drive cleanup failed (walkthrough_id=%s, "
+                        "drive_file_id=%s)",
+                        old.id,
+                        old.drive_file_id,
+                    )
+            old.delete()
+
     return Status(201, WalkthroughDetailOut.model_validate(_detail_payload(w, is_owner=True)))
 
 

--- a/apps/walkthroughs/tests/test_api.py
+++ b/apps/walkthroughs/tests/test_api.py
@@ -116,6 +116,53 @@ def test_upload_walkthrough_html(auth_client, fake_drive, owner):
     assert out.share_token is not None
 
 
+@pytest.mark.django_db
+@override_settings(
+    WALKTHROUGHS_ENABLED=True,
+    CANOPY_DRIVE_ROOT_FOLDER_ID="root-folder",
+    CANOPY_DRIVE_SA_KEY_JSON='{"x":"y"}',
+)
+def test_upload_replaces_same_run_id_and_role(auth_client, fake_drive, owner):
+    """Re-uploading the same (run_id, role) supersedes the prior one, so a run
+    never holds two of the same role. A different role under the same run is
+    untouched."""
+    from apps.walkthroughs.models import Walkthrough
+
+    def _upload(role: str, title: str):
+        return auth_client.post(
+            f"{BASE}/",
+            data={
+                "file": _file_part("a.html", b"<html>x</html>", "text/html"),
+                "title": title,
+                "kind": "html",
+                "visibility": "link",
+                "run_id": "feat-2026-06-01-001",
+                "role": role,
+            },
+            format="multipart",
+        )
+
+    # role=deck (slides) — not narrative-gated, so it exercises the replace path.
+    first = _upload("deck", "slides v1")
+    assert first.status_code == 201
+    first_id = first.json()["id"]
+
+    # Same role, same run → replaces.
+    second = _upload("deck", "slides v2")
+    assert second.status_code == 201
+    second_id = second.json()["id"]
+
+    # Different role, same run → coexists.
+    clip = _upload("clip", "a clip")
+    assert clip.status_code == 201
+
+    rows = Walkthrough.objects.filter(run_id="feat-2026-06-01-001")
+    assert not rows.filter(pk=first_id).exists()  # v1 superseded
+    assert rows.filter(pk=second_id).exists()  # v2 kept
+    assert rows.filter(role="deck").count() == 1
+    assert rows.filter(role="clip").count() == 1
+
+
 # ---------------------------------------------------------------------------
 # 1b. test_upload_with_links round-trips the companion links
 # ---------------------------------------------------------------------------

--- a/frontend/src/api/ddd.ts
+++ b/frontend/src/api/ddd.ts
@@ -120,7 +120,10 @@ export interface DddRunPackage {
   latest_at: string | null
   phase: string | null
   video: DddRunArtifact | null
-  deck: DddRunArtifact | null
+  // First-class run outputs. `slides` = the canopy:walkthrough HTML slideshow
+  // (role=deck); `documentation` = the feature docs page (role=docs).
+  slides: DddRunArtifact | null
+  documentation: DddRunArtifact | null
   narrative: DddRunNarrative | null
   links: DddLink[]
   all_artifacts: DddRunArtifactRef[]

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -2487,7 +2487,8 @@ export interface components {
             /** Phase */
             readonly phase?: string | null;
             readonly video?: components["schemas"]["RunArtifactOut"] | null;
-            readonly deck?: components["schemas"]["RunArtifactOut"] | null;
+            readonly slides?: components["schemas"]["RunArtifactOut"] | null;
+            readonly documentation?: components["schemas"]["RunArtifactOut"] | null;
             readonly narrative?: components["schemas"]["RunNarrativeOut"] | null;
             /**
              * Links

--- a/frontend/src/components/ddd/RunPackage.tsx
+++ b/frontend/src/components/ddd/RunPackage.tsx
@@ -20,16 +20,37 @@ import {
  * at something that isn't on the page.
  */
 function presentSections(run: DddRunPackage): RunSection[] {
+  // Video, Walkthrough slides, and Documentation are first-class run objects —
+  // always listed (each shows an empty state when absent), so they're
+  // discoverable and the rail mirrors the object model.
   const out: RunSection[] = [
     { id: 'video', label: 'Video' },
-    { id: 'walkthrough', label: 'Walkthrough' },
+    { id: 'slides', label: 'Walkthrough slides' },
+    { id: 'documentation', label: 'Documentation' },
     { id: 'narrative', label: 'Narrative' },
   ]
   if (run.links.length > 0) out.push({ id: 'links', label: 'Links' })
-  out.push({ id: 'artifacts', label: 'All artifacts' })
+  out.push({ id: 'outputs', label: 'Outputs' })
   if (run.previous_runs.length > 0)
     out.push({ id: 'previous', label: 'Previous runs' })
   return out
+}
+
+/** Human label for an artifact role, so Outputs reads in product terms rather
+ *  than raw role/kind codes. */
+function roleLabel(role: string | null, kind: string): string {
+  switch (role) {
+    case 'hero_video':
+      return 'Video'
+    case 'deck':
+      return 'Walkthrough slides'
+    case 'docs':
+      return 'Documentation'
+    case 'clip':
+      return 'Clip'
+    default:
+      return kind === 'video' ? 'Video' : 'Document'
+  }
 }
 
 function fmtDate(iso: string | null): string {
@@ -76,6 +97,48 @@ function Empty({ children }: { children: React.ReactNode }) {
   return (
     <div className="rounded-lg border border-dashed border-stone-800 px-4 py-6 text-center text-xs text-stone-600">
       {children}
+    </div>
+  )
+}
+
+/** A clear, visitable URL — opens the artifact's own page in a new tab. */
+function OpenLink({ href, label = 'Open' }: { href: string; label?: string }) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center gap-1 rounded-md border border-stone-800 px-2 py-0.5 text-[11px] text-stone-400 transition-colors hover:border-stone-700 hover:text-orange-300"
+    >
+      <span className="truncate font-mono">{href}</span>
+      <span aria-hidden>↗</span>
+      <span className="sr-only">{label}</span>
+    </a>
+  )
+}
+
+/** Embed a self-contained HTML artifact (slideshow or docs page) in a sandboxed
+ *  iframe, with a clear open-in-new-tab URL above it. */
+function HtmlEmbed({
+  contentUrl,
+  viewerUrl,
+  title,
+}: {
+  contentUrl: string
+  viewerUrl: string
+  title: string
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <OpenLink href={viewerUrl} />
+      <div className="overflow-hidden rounded-xl border border-stone-800 bg-white">
+        <iframe
+          src={contentUrl}
+          title={title}
+          sandbox="allow-scripts allow-same-origin"
+          className="h-[70vh] w-full bg-white"
+        />
+      </div>
     </div>
   )
 }
@@ -285,30 +348,46 @@ export function RunPackage({ runId }: { runId: string }) {
 
       <Section id="video" title="Video">
         {run.video ? (
-          <div className="overflow-hidden rounded-xl border border-stone-800 bg-black">
-            <video
-              src={run.video.content_url}
-              controls
-              className="max-h-[70vh] w-full bg-black"
-            />
+          <div className="flex flex-col gap-2">
+            <OpenLink href={run.video.viewer_url} />
+            <div className="overflow-hidden rounded-xl border border-stone-800 bg-black">
+              <video
+                src={run.video.content_url}
+                controls
+                className="max-h-[70vh] w-full bg-black"
+              />
+            </div>
           </div>
         ) : (
           <Empty>No video for this run.</Empty>
         )}
       </Section>
 
-      <Section id="walkthrough" title="Walkthrough">
-        {run.deck ? (
-          <div className="overflow-hidden rounded-xl border border-stone-800 bg-white">
-            <iframe
-              src={run.deck.content_url}
-              title={run.deck.title}
-              sandbox="allow-scripts allow-same-origin"
-              className="h-[70vh] w-full bg-white"
-            />
-          </div>
+      <Section
+        id="slides"
+        title="Walkthrough slides"
+        subtitle="canopy:walkthrough slideshow"
+      >
+        {run.slides ? (
+          <HtmlEmbed
+            contentUrl={run.slides.content_url}
+            viewerUrl={run.slides.viewer_url}
+            title={run.slides.title}
+          />
         ) : (
-          <Empty>No walkthrough deck for this run.</Empty>
+          <Empty>No walkthrough slides for this run.</Empty>
+        )}
+      </Section>
+
+      <Section id="documentation" title="Documentation" subtitle="feature docs page">
+        {run.documentation ? (
+          <HtmlEmbed
+            contentUrl={run.documentation.content_url}
+            viewerUrl={run.documentation.viewer_url}
+            title={run.documentation.title}
+          />
+        ) : (
+          <Empty>No documentation page for this run.</Empty>
         )}
       </Section>
 
@@ -341,28 +420,31 @@ export function RunPackage({ runId }: { runId: string }) {
       )}
 
       <Section
-        id="artifacts"
-        title="All artifacts"
-        subtitle={`${run.all_artifacts.length} uploaded`}
+        id="outputs"
+        title="Outputs"
+        subtitle={`${run.all_artifacts.length} file${run.all_artifacts.length === 1 ? '' : 's'} · every output we made, with a link`}
       >
         <div className="flex flex-col gap-1">
           {run.all_artifacts.map((a) => (
-            <Link
+            <a
               key={a.id}
-              to={a.viewer_url}
+              href={a.viewer_url}
+              target="_blank"
+              rel="noopener noreferrer"
               className="group flex items-center gap-3 rounded-lg border border-stone-800 bg-stone-950/40 px-3 py-1.5 text-xs transition-colors hover:border-stone-700 hover:bg-stone-950/70"
             >
-              <span className="w-12 shrink-0 font-mono text-[10px] text-stone-600">
-                {a.kind}
+              <span className="w-28 shrink-0 text-[10px] font-medium text-stone-400">
+                {roleLabel(a.role, a.kind)}
               </span>
-              {a.role && (
-                <span className="shrink-0 rounded bg-stone-800 px-1.5 py-0.5 text-[9px] text-stone-400">
-                  {a.role}
-                </span>
-              )}
               <span className="flex-1 truncate text-stone-300">{a.title}</span>
               <span className="shrink-0 text-stone-600">{fmtDate(a.created_at)}</span>
-            </Link>
+              <span
+                aria-hidden
+                className="shrink-0 font-mono text-[11px] text-stone-600 transition-colors group-hover:text-orange-300"
+              >
+                {a.viewer_url} ↗
+              </span>
+            </a>
           ))}
         </div>
       </Section>


### PR DESCRIPTION
## Product Description

A DDD run produces three different things, but the run page was only showing two — and mislabeling one. There's the **video**, the **walkthrough slides** (the canopy:walkthrough slideshow with the captured scenes), and the **documentation** page. The page had a single "Walkthrough" panel that actually showed the *documentation* page and hid the slideshow entirely. Now each is its own clearly-named section — **Video**, **Walkthrough slides**, **Documentation** — and the **Outputs** list gives every file we made a plain, clickable URL you can open in a new tab. A run also can't silently pile up two videos / two slideshows / two docs anymore: re-uploading one replaces the old one.

## Technical Summary

Two problems, both rooted in `run_id` being a free-form grouping key with no per-role constraint:

1. **Conflated objects.** `aggregate.build_run` exposed a single `deck` field that picked `role=docs` then `role=deck`, so the slideshow (role=deck) never surfaced and the docs page wore the "Walkthrough" label. Split into first-class single-valued `slides` (role=deck) and `documentation` (role=docs), each newest-of-role; an unroled HTML artifact falls back to documentation, and a role=deck never leaks into documentation. `RunPackageOut` + `frontend/api/ddd.ts` updated to match.
2. **No invariant.** The upload endpoint always appended, so iterating produced 2× of each role under one run_id. Added a replace-on-`(run_id, role)` guard: a new upload supersedes any prior artifact with the same run_id+role (best-effort Drive cleanup), runs only after the new row is stored, and only when both run_id and role are set (roleless/orphan uploads untouched). The DDD flow already mints a fresh run_id per run (`runstate._next_run_id`), so no flow change was needed — the dupes came from re-uploading into one run, which the guard now collapses.

UI: `RunPackage` renders Video / Walkthrough slides / Documentation as first-class sections (each with an open-in-new-tab URL via a shared `HtmlEmbed`/`OpenLink`), the rail jump-nav mirrors them, and "All artifacts" → "Outputs" with product-named role labels and a visible URL per row. Data: the existing `microplans-study-groups-2026-06-05-002` run was cleaned to one-of-each (kept newest slides/video/docs, deleted 3 superseded).

## Safety Assurance

- `pytest apps/runs apps/walkthroughs` — 45 passed. New/updated tests: build_run surfaces video/slides/documentation distinctly; unroled HTML → documentation; upload replaces same `(run_id, role)` and leaves other roles intact.
- `tsc -b` clean on changed files.
- Contract change (`deck` → `slides`+`documentation`) is covered by the CI schemathesis job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)