### PR TITLE
feat(ddd): External systems section + drop Previous runs

### DIFF
--- a/apps/runs/aggregate.py
+++ b/apps/runs/aggregate.py
@@ -259,16 +259,6 @@ def build_run(run_id: str) -> dict | None:
         for w in sorted(wts, key=lambda x: x.created_at)
     ]
 
-    # Previous runs in the same narrative (excluding this one), newest first.
-    sibling = _runs_in_narrative(narrative_slug)
-    previous_runs = [
-        {"run_id": rid, "latest_at": latest}
-        for rid, latest in sorted(
-            sibling.items(), key=lambda kv: kv[1], reverse=True
-        )
-        if rid != run_id
-    ]
-
     timestamps = [w.created_at for w in wts] + [r.created_at for r in revs]
     created_at = min(timestamps) if timestamps else None
     latest_at = max(timestamps) if timestamps else None
@@ -285,36 +275,7 @@ def build_run(run_id: str) -> dict | None:
         "narrative": narrative_payload,
         "links": links,
         "all_artifacts": all_artifacts,
-        "previous_runs": previous_runs,
     }
-
-
-def _runs_in_narrative(slug: str) -> dict[str, datetime]:
-    """Map run_id -> latest activity timestamp for every run under ``slug``."""
-    out: dict[str, datetime] = {}
-    feature_map: dict[str, str] = {}
-    wq = (
-        Walkthrough.objects.exclude(run_id__isnull=True)
-        .exclude(run_id="")
-        .values_list("run_id", "narrative_slug", "created_at")
-    )
-    for run_id, narrative_slug, created_at in wq:
-        feat = (narrative_slug or "").strip()
-        if run_id and feat:
-            feature_map.setdefault(run_id, feat)
-        s = feat or narrative_slug_from_run_id(run_id)
-        if s != slug:
-            continue
-        if run_id not in out or created_at > out[run_id]:
-            out[run_id] = created_at
-    for run_id, created_at in ReviewRequest.objects.values_list(
-        "run_id", "created_at"
-    ):
-        if narrative_for_run_id(run_id, feature_map) != slug:
-            continue
-        if run_id not in out or created_at > out[run_id]:
-            out[run_id] = created_at
-    return out
 
 
 # ---------------------------------------------------------------------------

--- a/apps/runs/schemas.py
+++ b/apps/runs/schemas.py
@@ -94,11 +94,6 @@ class RunNarrativeOut(StrictModel):
     why_brief: dict[str, Any] | None = None
 
 
-class PreviousRunOut(StrictModel):
-    run_id: str
-    latest_at: dt.datetime | None = None
-
-
 class RunPackageOut(StrictModel):
     run_id: str
     narrative_slug: str
@@ -115,4 +110,3 @@ class RunPackageOut(StrictModel):
     narrative: RunNarrativeOut | None = None
     links: list[WalkthroughLink] = []
     all_artifacts: list[RunArtifactRefOut] = []
-    previous_runs: list[PreviousRunOut] = []

--- a/apps/runs/tests/test_aggregate.py
+++ b/apps/runs/tests/test_aggregate.py
@@ -116,17 +116,6 @@ def test_build_run_dedupes_links_across_artifacts():
     assert urls == [("https://x/repo", "reference"), ("https://x/spec", "narrative")]
 
 
-def test_build_run_lists_previous_runs_in_same_narrative():
-    u = make_user()
-    make_walkthrough(u, kind="video", run_id="feat-2026-05-01-001", narrative_slug="feat")
-    make_walkthrough(u, kind="video", run_id="feat-2026-06-01-002", narrative_slug="feat")
-    make_walkthrough(u, kind="video", run_id="other-2026-06-01-001", narrative_slug="other")
-
-    run = aggregate.build_run("feat-2026-06-01-002")
-    prev_ids = {p["run_id"] for p in run["previous_runs"]}
-    assert prev_ids == {"feat-2026-05-01-001"}
-
-
 # ---------------------------------------------------------------------------
 # Narrative list + detail
 # ---------------------------------------------------------------------------

--- a/frontend/src/api/ddd.ts
+++ b/frontend/src/api/ddd.ts
@@ -108,11 +108,6 @@ export interface DddLink {
   kind: DddLinkKind
 }
 
-export interface DddPreviousRun {
-  run_id: string
-  latest_at: string | null
-}
-
 export interface DddRunPackage {
   run_id: string
   narrative_slug: string
@@ -127,7 +122,6 @@ export interface DddRunPackage {
   narrative: DddRunNarrative | null
   links: DddLink[]
   all_artifacts: DddRunArtifactRef[]
-  previous_runs: DddPreviousRun[]
 }
 
 async function getJson<T>(url: string): Promise<T> {

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -2387,13 +2387,6 @@ export interface components {
              */
             readonly runs: readonly components["schemas"]["NarrativeRunOut"][];
         };
-        /** PreviousRunOut */
-        readonly PreviousRunOut: {
-            /** Run Id */
-            readonly run_id: string;
-            /** Latest At */
-            readonly latest_at?: string | null;
-        };
         /** RunArtifactOut */
         readonly RunArtifactOut: {
             /**
@@ -2500,11 +2493,6 @@ export interface components {
              * @default []
              */
             readonly all_artifacts: readonly components["schemas"]["RunArtifactRefOut"][];
-            /**
-             * Previous Runs
-             * @default []
-             */
-            readonly previous_runs: readonly components["schemas"]["PreviousRunOut"][];
         };
         /** Page[ShareoutOut] */
         readonly Page_ShareoutOut_: {

--- a/frontend/src/components/ddd/RunPackage.tsx
+++ b/frontend/src/components/ddd/RunPackage.tsx
@@ -19,20 +19,18 @@ import {
  * sections (no links, no previous runs) are omitted so the rail never points
  * at something that isn't on the page.
  */
-function presentSections(run: DddRunPackage): RunSection[] {
-  // Video, Walkthrough slides, and Documentation are first-class run objects —
-  // always listed (each shows an empty state when absent), so they're
-  // discoverable and the rail mirrors the object model.
+function presentSections(): RunSection[] {
+  // The run's first-class objects, in display order. All are always listed —
+  // each section shows its own empty state when absent — so the rail mirrors
+  // the object model and never points at something missing.
   const out: RunSection[] = [
     { id: 'video', label: 'Video' },
     { id: 'slides', label: 'Walkthrough slides' },
     { id: 'documentation', label: 'Documentation' },
     { id: 'narrative', label: 'Narrative' },
+    { id: 'external', label: 'External systems' },
+    { id: 'outputs', label: 'Outputs' },
   ]
-  if (run.links.length > 0) out.push({ id: 'links', label: 'Links' })
-  out.push({ id: 'outputs', label: 'Outputs' })
-  if (run.previous_runs.length > 0)
-    out.push({ id: 'previous', label: 'Previous runs' })
   return out
 }
 
@@ -186,9 +184,13 @@ function NarrativeBlock({ narrative }: { narrative: DddRunNarrative }) {
   )
 }
 
-function LinksBlock({ links }: { links: DddLink[] }) {
-  const sibling = links.filter((l) => l.kind === 'narrative' || l.kind === 'companion')
-  const reference = links.filter((l) => l.kind === 'reference')
+/** The external systems the run used or created — the live app pages, created
+ *  entities, and any related docs/companions — each as a clean, visitable URL.
+ *  Sourced from the run's links (reference = systems we touched; narrative /
+ *  companion = related material). */
+function ExternalSystemsBlock({ links }: { links: DddLink[] }) {
+  const systems = links.filter((l) => l.kind === 'reference')
+  const related = links.filter((l) => l.kind === 'narrative' || l.kind === 'companion')
   const row = (l: DddLink) => (
     <a
       key={`${l.kind}:${l.url}`}
@@ -202,7 +204,10 @@ function LinksBlock({ links }: { links: DddLink[] }) {
           {l.kind === 'narrative' ? '📖' : '🎞️'}
         </span>
       )}
-      <span className="flex-1 truncate text-xs text-stone-300">{l.label}</span>
+      <span className="shrink-0 text-xs text-stone-300">{l.label}</span>
+      <span className="flex-1 truncate text-right font-mono text-[11px] text-stone-600 transition-colors group-hover:text-orange-300">
+        {l.url}
+      </span>
       <span
         aria-hidden
         className="shrink-0 text-[11px] text-stone-600 transition-colors group-hover:text-orange-400"
@@ -212,21 +217,12 @@ function LinksBlock({ links }: { links: DddLink[] }) {
     </a>
   )
   return (
-    <div className="grid gap-3 sm:grid-cols-2">
-      {sibling.length > 0 && (
-        <div className="flex flex-col gap-2">
-          <h3 className="text-[9px] uppercase tracking-wider text-stone-600">
-            Narrative &amp; companion
-          </h3>
-          {sibling.map(row)}
-        </div>
-      )}
-      {reference.length > 0 && (
-        <div className="flex flex-col gap-2">
-          <h3 className="text-[9px] uppercase tracking-wider text-stone-600">
-            Explore in the app
-          </h3>
-          {reference.map(row)}
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-1">{systems.map(row)}</div>
+      {related.length > 0 && (
+        <div className="flex flex-col gap-1">
+          <h3 className="text-[9px] uppercase tracking-wider text-stone-600">Related</h3>
+          {related.map(row)}
         </div>
       )}
     </div>
@@ -262,7 +258,7 @@ export function RunPackage({ runId }: { runId: string }) {
   // container; the topmost such section in display order wins.
   useEffect(() => {
     if (!run || !setSections || !setActiveId) return
-    const sections = presentSections(run)
+    const sections = presentSections()
     setSections(sections)
 
     const root = document.querySelector('[data-ddd-scroll]')
@@ -413,11 +409,17 @@ export function RunPackage({ runId }: { runId: string }) {
         )}
       </Section>
 
-      {run.links.length > 0 && (
-        <Section id="links" title="Links">
-          <LinksBlock links={run.links} />
-        </Section>
-      )}
+      <Section
+        id="external"
+        title="External systems"
+        subtitle="live systems this run used or created"
+      >
+        {run.links.length > 0 ? (
+          <ExternalSystemsBlock links={run.links} />
+        ) : (
+          <Empty>No external systems recorded for this run.</Empty>
+        )}
+      </Section>
 
       <Section
         id="outputs"
@@ -449,21 +451,6 @@ export function RunPackage({ runId }: { runId: string }) {
         </div>
       </Section>
 
-      {run.previous_runs.length > 0 && (
-        <Section id="previous" title="Previous runs">
-          <div className="flex flex-wrap gap-2">
-            {run.previous_runs.map((p) => (
-              <Link
-                key={p.run_id}
-                to={`/ddd/${encodeURIComponent(run.narrative_slug)}/${encodeURIComponent(p.run_id)}`}
-                className="rounded-md border border-stone-800 bg-stone-900 px-2.5 py-1 font-mono text-[11px] text-stone-400 transition-colors hover:border-stone-700 hover:text-stone-200"
-              >
-                {p.run_id}
-              </Link>
-            ))}
-          </div>
-        </Section>
-      )}
     </div>
   )
 }


### PR DESCRIPTION
## Product Description

Two run-page changes:

**External systems** — a new, clearly-named section listing the live systems a run used or created (the app pages / entities it was recorded against), each as a URL you can open in a new tab. Previously these weren't surfaced at all. (The DDD upload flow now populates them from the spec — see canopy PR #159; older runs show a clean empty state until backfilled.)

**Previous runs is gone** — the left rail already lists every run under the narrative version, so the redundant bottom-of-page list (and its data) was removed.

## Technical Summary

- **External systems**: new first-class `external` section in `RunPackage`, rendered from the run's `links` (kind=`reference` = systems used/created; `narrative`/`companion` show under a small "Related" subhead). Always renders, with an empty state. Replaces the old generic "Links" section.
- **Drop previous_runs**: removed from `build_run`, `RunPackageOut` (+ `PreviousRunOut`), the `_runs_in_narrative` helper (its only caller), frontend `DddPreviousRun` type, and the page section + scroll-nav entry.

## Safety Assurance

- `pytest apps/runs apps/walkthroughs` — 71 passed (dropped the previous-runs aggregate test; rest green).
- `tsc -b` clean on changed files.
- Contract change (removed `previous_runs`) covered by CI schemathesis.
- Backfilled the live `microplans-study-groups-2026-06-05-002` run's external links (Connect Labs app + microplans program 133) so the section is populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)