### PR TITLE
fix(ddd): forward #scene-N deep-links into the walkthrough deck (closes #103)

### DIFF
--- a/frontend/src/components/ddd/RunPackage.tsx
+++ b/frontend/src/components/ddd/RunPackage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { Link, useLocation, useNavigate } from 'react-router-dom'
 import {
   deleteRun,
   getRun,
@@ -7,6 +7,7 @@ import {
   type DddRunNarrative,
   type DddRunPackage,
 } from '@/api/ddd'
+import { sceneHashFragment, withSceneHash } from '@/lib/sceneHash'
 import {
   runSectionDomId,
   useRunSectionNav,
@@ -116,22 +117,27 @@ function OpenLink({ href, label = 'Open' }: { href: string; label?: string }) {
 }
 
 /** Embed a self-contained HTML artifact (slideshow or docs page) in a sandboxed
- *  iframe, with a clear open-in-new-tab URL above it. */
+ *  iframe, with a clear open-in-new-tab URL above it. When `sceneHash` is a
+ *  `#scene-N` deep-link, it's forwarded into both the embedded iframe and the
+ *  open-in-new-tab URL so the deck opens on that scene (the deck's own JS reads
+ *  its hash). Non-scene hashes are ignored by withSceneHash. */
 function HtmlEmbed({
   contentUrl,
   viewerUrl,
   title,
+  sceneHash = '',
 }: {
   contentUrl: string
   viewerUrl: string
   title: string
+  sceneHash?: string
 }) {
   return (
     <div className="flex flex-col gap-2">
-      <OpenLink href={viewerUrl} />
+      <OpenLink href={withSceneHash(viewerUrl, sceneHash)} />
       <div className="overflow-hidden rounded-xl border border-stone-800 bg-white">
         <iframe
-          src={contentUrl}
+          src={withSceneHash(contentUrl, sceneHash)}
           title={title}
           sandbox="allow-scripts allow-same-origin"
           className="h-[70vh] w-full bg-white"
@@ -231,9 +237,15 @@ function ExternalSystemsBlock({ links }: { links: DddLink[] }) {
 
 export function RunPackage({ runId }: { runId: string }) {
   const navigate = useNavigate()
+  const location = useLocation()
   const [run, setRun] = useState<DddRunPackage | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [deleting, setDeleting] = useState(false)
+
+  // A `#scene-N` deep-link on the run page (e.g. surfaced findings linking to
+  // /ddd/<slug>/<runId>#scene-3) is forwarded into the embedded slides deck.
+  // Non-scene hashes (the rail's own section anchors) normalize to '' here.
+  const sceneHash = sceneHashFragment(location.hash)
 
   const nav = useRunSectionNav()
   // useState setters and the memoized jump are referentially stable, so pulling
@@ -287,6 +299,15 @@ export function RunPackage({ runId }: { runId: string }) {
       setActiveId(null)
     }
   }, [run, setSections, setActiveId])
+
+  // On a `#scene-N` deep-link, bring the slides deck into view once the run has
+  // rendered — otherwise the reviewer lands at the top (video) with the deck's
+  // forwarded scene below the fold. Runs once per (run, sceneHash) pair.
+  useEffect(() => {
+    if (!run || !sceneHash) return
+    const el = document.getElementById(runSectionDomId('slides'))
+    el?.scrollIntoView({ block: 'start' })
+  }, [run, sceneHash])
 
   async function onDeleteRun() {
     if (!run) return
@@ -369,6 +390,7 @@ export function RunPackage({ runId }: { runId: string }) {
             contentUrl={run.slides.content_url}
             viewerUrl={run.slides.viewer_url}
             title={run.slides.title}
+            sceneHash={sceneHash}
           />
         ) : (
           <Empty>No walkthrough slides for this run.</Empty>

--- a/frontend/src/lib/sceneHash.test.ts
+++ b/frontend/src/lib/sceneHash.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { sceneHashFragment, withSceneHash } from './sceneHash'
+
+describe('sceneHashFragment', () => {
+  it('normalizes a #scene-N hash to a canonical fragment', () => {
+    expect(sceneHashFragment('#scene-3')).toBe('#scene-3')
+    expect(sceneHashFragment('#scene-12')).toBe('#scene-12')
+  })
+
+  it('accepts a hash without the leading #', () => {
+    expect(sceneHashFragment('scene-4')).toBe('#scene-4')
+  })
+
+  it('ignores non-scene hashes so unrelated anchors are not forwarded', () => {
+    // The run page uses run-section-* anchors for its own scroll-spy; those
+    // must never leak into the deck iframe.
+    expect(sceneHashFragment('#run-section-slides')).toBe('')
+    expect(sceneHashFragment('#scene-')).toBe('')
+    expect(sceneHashFragment('#scene-3-extra')).toBe('')
+    expect(sceneHashFragment('#section-3')).toBe('')
+  })
+
+  it('returns empty for empty / null / undefined', () => {
+    expect(sceneHashFragment('')).toBe('')
+    expect(sceneHashFragment(null)).toBe('')
+    expect(sceneHashFragment(undefined)).toBe('')
+  })
+})
+
+describe('withSceneHash', () => {
+  const base = '/w/abc/content?t=tok'
+
+  it('appends a valid scene fragment to the content URL', () => {
+    expect(withSceneHash(base, '#scene-3')).toBe('/w/abc/content?t=tok#scene-3')
+  })
+
+  it('leaves the URL untouched when there is no scene hash', () => {
+    expect(withSceneHash(base, '')).toBe(base)
+    expect(withSceneHash(base, '#run-section-video')).toBe(base)
+    expect(withSceneHash(base, null)).toBe(base)
+  })
+
+  it('works on a URL with no query string', () => {
+    expect(withSceneHash('/w/abc/content', 'scene-2')).toBe('/w/abc/content#scene-2')
+  })
+})

--- a/frontend/src/lib/sceneHash.ts
+++ b/frontend/src/lib/sceneHash.ts
@@ -1,0 +1,34 @@
+/**
+ * The DDD deep-link contract: a `#scene-<N>` fragment on a run/deck URL means
+ * "open the walkthrough deck on scene N". Surfaced judge findings and reviews
+ * link to `<DECK_URL>#scene-N`, and the run page (`/ddd/<slug>/<runId>#scene-N`)
+ * forwards that fragment into the embedded slides iframe. The deck's own JS
+ * (canopy `generate_presentation.py`) resolves the anchor to a slide.
+ *
+ * These helpers keep the fragment shape in one place so the run page and the
+ * standalone `/w/:id` viewer forward exactly the anchors the deck understands —
+ * never an arbitrary hash (e.g. the run page's own section anchors).
+ */
+
+/** A `#scene-<N>` fragment matcher. Accepts an optional leading `#`. */
+const SCENE_HASH = /^#?(scene-\d+)$/;
+
+/**
+ * Normalize a raw `location.hash` to a canonical `#scene-N` fragment, or `''`
+ * if it isn't a scene deep-link. Only scene anchors are forwarded; anything
+ * else (empty, a section id, junk) yields `''` so callers pass through unchanged.
+ */
+export function sceneHashFragment(rawHash: string | null | undefined): string {
+  const m = (rawHash ?? "").match(SCENE_HASH);
+  return m ? `#${m[1]}` : "";
+}
+
+/**
+ * Append a scene fragment to a content URL. No-op when there's no scene hash.
+ * The URL is assumed fragment-free (deck content/viewer URLs are), so we just
+ * concatenate rather than rewrite an existing fragment.
+ */
+export function withSceneHash(url: string, rawHash: string | null | undefined): string {
+  const frag = sceneHashFragment(rawHash);
+  return frag ? `${url}${frag}` : url;
+}

--- a/frontend/src/pages/WalkthroughViewerPage.tsx
+++ b/frontend/src/pages/WalkthroughViewerPage.tsx
@@ -8,6 +8,7 @@ import {
   walkthroughContentUrl,
   type WalkthroughDetail,
 } from '../api/walkthroughs'
+import { withSceneHash } from '../lib/sceneHash'
 
 export function WalkthroughViewerPage() {
   const { id } = useParams<{ id: string }>()
@@ -90,7 +91,13 @@ export function WalkthroughViewerPage() {
 
   const params = new URLSearchParams(window.location.search)
   const viewerToken = params.get('t') ?? w.share_token ?? null
-  const contentSrc = walkthroughContentUrl(w.id, viewerToken)
+  // Forward a `#scene-N` deep-link (e.g. /w/<id>?t=<tok>#scene-3) into the deck
+  // iframe so it opens on that scene; the deck's own JS reads its hash. Videos
+  // ignore it. Non-scene hashes normalize to '' and pass through unchanged.
+  const contentSrc = withSceneHash(
+    walkthroughContentUrl(w.id, viewerToken),
+    window.location.hash,
+  )
 
   const links = w.links ?? []
   // narrative + companion are provenance / sibling-artifact nav; reference


### PR DESCRIPTION
Closes #103. Companion to **jjackson/canopy#164** (the deck generator that reads the hash).

## Problem

The DDD deep-link contract is `<DECK_URL>#scene-N` — surfaced judge findings and reviews link a reviewer straight to the judged scene. But the run page (`/ddd/<slug>/<runId>`) and the standalone `/w/:id` viewer both embed the deck in an `<iframe>` whose `src` **dropped the hash**. So even once the deck honors `#scene-N`, the embedded/opened deck still started on scene 1.

## Fix (canopy-web half)

- **`frontend/src/lib/sceneHash.ts`** (new) — `sceneHashFragment()` normalizes a raw `location.hash` to a canonical `#scene-N`, or `''` for anything else. That `''` matters: the run page uses `run-section-*` anchors for its own scroll-spy, and those must never leak into the deck iframe. `withSceneHash()` appends the fragment to a (fragment-free) content/viewer URL.
- **`RunPackage.tsx`** — read the page hash, forward a scene fragment into the slides iframe `src` **and** its open-in-new-tab URL, and scroll the slides section into view on a deep-link so the reviewer doesn't land at the top (video) with the deck below the fold.
- **`WalkthroughViewerPage.tsx`** — forward the page hash into the deck content iframe (videos ignore it; non-scene hashes pass through unchanged).

## The other half

The deck itself had no `location.hash`/`hashchange` handling — that's the **root cause**, fixed in jjackson/canopy#164. Forwarding here is a no-op until that lands; together they make `<DECK_URL>#scene-N` land on the right scene from the run page, the standalone viewer, and a direct deck link.

## Verification

- `npm run build` (tsc -b + vite) — clean.
- `npx vitest run` — 34 passed, incl. 7 new `sceneHash` unit tests (canonical `#scene-N`, leading-`#` tolerance, **non-scene anchors → `''`**, null/empty, URL-with/without query).
- Real-browser check of the companion deck fix (Chromium): `#scene-4` on load → opens scene-4; hash→`#scene-2` → navigates; no hash → first slide; bogus `#scene-99` → graceful fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)