### PR TITLE
Tokenless Public/Private visibility + narrative-level toggle

### DIFF
--- a/apps/common/middleware.py
+++ b/apps/common/middleware.py
@@ -26,13 +26,6 @@ def _is_public(path: str) -> bool:
     return any(path == p or path.startswith(p) for p in PUBLIC_PATH_PREFIXES)
 
 
-def _is_walkthrough_content(path: str) -> bool:
-    # /w/<uuid>/content — the view itself enforces token-or-session auth.
-    # We let it through the middleware so the per-token public link can
-    # be served without a session cookie.
-    return path.startswith("/w/") and path.endswith("/content")
-
-
 def _is_review_link(path: str) -> bool:
     # /review/<uuid>/  (SPA shell) and the per-review API read/submit endpoints
     # self-enforce token-or-session auth, so let the per-token public link
@@ -41,6 +34,22 @@ def _is_review_link(path: str) -> bool:
     if path.startswith("/review/"):
         return True
     return path.startswith("/api/reviews/") and path != "/api/reviews/"
+
+
+def _is_walkthrough_link(request) -> bool:
+    # Everything under /w/ — the viewer SPA shell (/w/<uuid>) and the content
+    # stream (/w/<uuid>/content) — plus the per-walkthrough detail GET
+    # self-enforce tokenless public access, so let anonymous callers through
+    # the middleware. The bare collection (/api/walkthroughs/) is NOT included —
+    # list/upload still require auth.
+    path = request.path
+    if path.startswith("/w/"):
+        return True
+    return (
+        request.method == "GET"
+        and path.startswith("/api/walkthroughs/")
+        and path != "/api/walkthroughs/"
+    )
 
 
 class LoginRequiredMiddleware:
@@ -67,7 +76,7 @@ class LoginRequiredMiddleware:
         if (
             request.user.is_authenticated
             or _is_public(request.path)
-            or _is_walkthrough_content(request.path)
+            or _is_walkthrough_link(request)
             or _is_review_link(request.path)
         ):
             return self.get_response(request)

--- a/apps/reviews/api.py
+++ b/apps/reviews/api.py
@@ -69,21 +69,17 @@ def _token_ok(request: HttpRequest, review: ReviewRequest) -> bool:
 
 
 def _can_read(request: HttpRequest, review: ReviewRequest) -> bool:
-    """Authenticated users always see all reviews; link-visibility also allows ?t= bearer."""
-    if request.user.is_authenticated:
-        return True
-    if review.visibility == ReviewRequest.VISIBILITY_LINK and _token_ok(request, review):
-        return True
-    return False
+    """Authenticated users see all reviews; public (link) reviews are readable by anyone."""
+    return (
+        request.user.is_authenticated
+        or review.visibility == ReviewRequest.VISIBILITY_LINK
+    )
 
 
 def _can_write(request: HttpRequest, review: ReviewRequest) -> bool:
-    """Submit and token-rotation require owner or a valid ?t= bearer."""
-    if _is_owner(request, review):
-        return True
-    if review.visibility == ReviewRequest.VISIBILITY_LINK and _token_ok(request, review):
-        return True
-    return False
+    """Submitting a decision (approve/redraft) requires a Dimagi login —
+    public-readable does NOT grant anonymous write."""
+    return request.user.is_authenticated
 
 
 def _detail_payload(review: ReviewRequest, *, is_owner: bool, expose_token: bool) -> dict:
@@ -266,7 +262,7 @@ def create_review(request: HttpRequest, payload: ReviewCreateIn) -> Status:
 @router.get(
     "/{rid}/",
     response=ReviewRequestOut,
-    auth=None,  # Allow unauthenticated access when ?t= matches share_token
+    auth=None,  # Public (visibility=link) reviews are readable without a session.
     summary="Get review request detail or poll for resolution",
 )
 def get_review(request: HttpRequest, rid: UUID) -> ReviewRequestOut:
@@ -301,7 +297,7 @@ def get_review(request: HttpRequest, rid: UUID) -> ReviewRequestOut:
 @router.post(
     "/{rid}/submit/",
     response=ReviewRequestOut,
-    auth=None,  # Allow unauthenticated submit when ?t= matches share_token
+    auth=None,  # handler enforces _can_write (auth required); 403 not 401 for readable-but-anonymous
     summary="Submit decisions + narration edits (human → server)",
 )
 def submit_review(request: HttpRequest, rid: UUID, payload: ReviewSubmitIn) -> ReviewRequestOut:
@@ -313,8 +309,13 @@ def submit_review(request: HttpRequest, rid: UUID, payload: ReviewSubmitIn) -> R
     """
     review = _get_or_404(rid)
 
-    if not _can_write(request, review):
+    # Give a 404 (not 403) when the caller can't even read the review, so we don't
+    # leak existence.  When they CAN read but lack write permission (e.g. anonymous
+    # caller on a public review), return 403.
+    if not _can_read(request, review):
         raise ProblemError(404, "Review request not found", type_=TYPE_NOT_FOUND)
+    if not _can_write(request, review):
+        raise ProblemError(403, "Authentication required to submit a review", type_=TYPE_FORBIDDEN)
 
     if review.status == ReviewRequest.STATUS_RESOLVED:
         raise ProblemError(

--- a/apps/reviews/api.py
+++ b/apps/reviews/api.py
@@ -13,7 +13,8 @@ create_token) and sends `Authorization: Bearer <raw>` on every call.
 BearerTokenAuthMiddleware resolves the token to a real Django user, so all
 three endpoints see an authenticated request.user — no special allowlist
 hacks needed. The human review page uses the same session_auth (already
-logged in via Google OAuth) or, if visibility=="link", the ?t= query token.
+logged in via Google OAuth) or, if visibility=="link", the review is readable
+by anyone with the URL (no ?t= token required).
 """
 from __future__ import annotations
 
@@ -62,12 +63,6 @@ def _is_owner(request: HttpRequest, review: ReviewRequest) -> bool:
     )
 
 
-def _token_ok(request: HttpRequest, review: ReviewRequest) -> bool:
-    """True when the ?t= query param matches the review's share_token."""
-    t = request.GET.get("t", "")
-    return bool(t and review.share_token and t == review.share_token)
-
-
 def _can_read(request: HttpRequest, review: ReviewRequest) -> bool:
     """Authenticated users see all reviews; public (link) reviews are readable by anyone."""
     return (
@@ -82,7 +77,7 @@ def _can_write(request: HttpRequest, review: ReviewRequest) -> bool:
     return request.user.is_authenticated
 
 
-def _detail_payload(review: ReviewRequest, *, is_owner: bool, expose_token: bool) -> dict:
+def _detail_payload(review: ReviewRequest, *, is_owner: bool) -> dict:
     return {
         "id": review.id,
         "run_id": review.run_id,
@@ -93,9 +88,6 @@ def _detail_payload(review: ReviewRequest, *, is_owner: bool, expose_token: bool
         or narrative_slug_from_run_id(review.run_id),
         "request_json": review.request_json,
         "response_json": review.response_json,
-        # share_token exposed to owner OR link-token holders (they demonstrably
-        # have it and need it to re-poll / re-submit).
-        "share_token": review.share_token if expose_token else None,
         "is_owner": is_owner,
         "created_at": review.created_at,
         "resolved_at": review.resolved_at,
@@ -131,11 +123,6 @@ def _list_item_payload(request: HttpRequest, review: ReviewRequest) -> dict:
         "created_at": review.created_at,
         "resolved_at": review.resolved_at,
         "last_activity_at": review.resolved_at or review.created_at,
-        # Owners and link-visibility reviews expose the token so the dashboard can
-        # build a working /review/<id>?t= link without a second round-trip.
-        "share_token": review.share_token
-        if (is_own or review.visibility == ReviewRequest.VISIBILITY_LINK)
-        else None,
         "is_owner": is_own,
     }
 
@@ -241,16 +228,12 @@ def create_review(request: HttpRequest, payload: ReviewCreateIn) -> Status:
         owner=request.user if request.user.is_authenticated else None,
     )
 
-    # Always mint a share token: the orchestrator posts the URL to Slack /
-    # wherever humans pick it up, and they may not be logged in.
-    token = review.ensure_share_token()
-
     # Build the hosted-review URL.  The frontend SPA handles /review/<id>.
-    url = f"/review/{review.id}/?t={token}"
+    url = f"/review/{review.id}/"
 
     return Status(
         201,
-        ReviewCreateOut(id=review.id, url=url, share_token=token),
+        ReviewCreateOut(id=review.id, url=url),
     )
 
 
@@ -271,7 +254,7 @@ def get_review(request: HttpRequest, rid: UUID) -> ReviewRequestOut:
 
     Access rules:
     - Any authenticated user can read any review (they're team-internal).
-    - Unauthenticated callers may read if visibility=="link" and ?t= matches.
+    - Unauthenticated callers may read if visibility=="link" (no token required).
     - Otherwise → 404 (don't leak existence).
     """
     review = _get_or_404(rid)
@@ -280,12 +263,9 @@ def get_review(request: HttpRequest, rid: UUID) -> ReviewRequestOut:
         raise ProblemError(404, "Review request not found", type_=TYPE_NOT_FOUND)
 
     is_own = _is_owner(request, review)
-    # For link-token callers we still include the token in the payload —
-    # they demonstrably have it already and need it to re-poll.
-    expose_token = is_own or _token_ok(request, review)
 
     return ReviewRequestOut.model_validate(
-        _detail_payload(review, is_owner=is_own, expose_token=expose_token)
+        _detail_payload(review, is_owner=is_own)
     )
 
 
@@ -331,9 +311,8 @@ def submit_review(request: HttpRequest, rid: UUID, payload: ReviewSubmitIn) -> R
     review.save(update_fields=["response_json", "status", "resolved_at"])
 
     is_own = _is_owner(request, review)
-    expose_token = is_own or _token_ok(request, review)
     return ReviewRequestOut.model_validate(
-        _detail_payload(review, is_owner=is_own, expose_token=expose_token)
+        _detail_payload(review, is_owner=is_own)
     )
 
 

--- a/apps/reviews/models.py
+++ b/apps/reviews/models.py
@@ -18,15 +18,15 @@ class ReviewRequest(models.Model):
     VISIBILITY_LINK = "link"
     VISIBILITY_CHOICES = [
         (VISIBILITY_PRIVATE, "Private (dimagi only)"),
-        (VISIBILITY_LINK, "Link (anyone with token)"),
+        (VISIBILITY_LINK, "Public (anyone with the link)"),
     ]
-    # Visibility semantics:
-    #   private — readable by any dimagi-authenticated user (the whole app is dimagi-OAuth
-    #             gated), but write/submit is owner-or-link-token only.  Non-owners can
-    #             inspect the review but cannot resolve it.
-    #   link    — readable AND submittable by anyone holding the ?t= share token, even
-    #             without a session.  This is how the canopy orchestrator URL is shared
-    #             externally (e.g. posted to Slack so non-owners can act on it).
+    # Visibility semantics (tokenless — the UUID in the URL is the only secret):
+    #   private — readable only by dimagi-authenticated users (the app is dimagi-OAuth
+    #             gated).  Anonymous callers get a 404 (existence is not leaked).
+    #   link    — readable by anyone with the URL, no session required.  This is how the
+    #             canopy orchestrator URL is shared (e.g. posted to Slack).
+    # Submitting a decision ALWAYS requires a dimagi login regardless of visibility —
+    # public-readable does not grant anonymous write.
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     run_id = models.CharField(max_length=255, db_index=True)

--- a/apps/reviews/schemas.py
+++ b/apps/reviews/schemas.py
@@ -24,7 +24,6 @@ class ReviewRequestOut(StrictModel):
     visibility: ReviewVisibility
     request_json: dict[str, Any]
     response_json: dict[str, Any] | None = None
-    share_token: str | None = None
     is_owner: bool
     created_at: dt.datetime
     resolved_at: dt.datetime | None = None
@@ -46,7 +45,6 @@ class ReviewListItemOut(StrictModel):
     resolved_at: dt.datetime | None = None
     # resolved_at when resolved, else created_at — the "last edit" the dashboard sorts by.
     last_activity_at: dt.datetime
-    share_token: str | None = None
     is_owner: bool
 
 
@@ -70,4 +68,3 @@ class ReviewCreateOut(StrictModel):
 
     id: uuid.UUID
     url: str
-    share_token: str

--- a/apps/reviews/tests/test_api.py
+++ b/apps/reviews/tests/test_api.py
@@ -1,9 +1,9 @@
 """Contract tests for the reviews Ninja surface (/api/reviews/).
 
 Covers:
-  POST   /api/reviews/              — create; returns id + url + share_token
-  GET    /api/reviews/<id>/         — owner sees share_token; ?t= unauth OK; bad token → 404
-  POST   /api/reviews/<id>/submit/  — writes response_json, flips status, stamps resolved_at
+  POST   /api/reviews/              — create; returns id + url
+  GET    /api/reviews/<id>/         — authenticated users see all; link-visibility readable by anyone
+  POST   /api/reviews/<id>/submit/  — writes response_json, flips status, stamps resolved_at (auth required)
   Round-trip: create → get reflects request_json correctly
   Submit gate: already-resolved → 403
 """
@@ -97,12 +97,12 @@ def _make_review(owner, **kwargs) -> ReviewRequest:
 
 
 # ---------------------------------------------------------------------------
-# 1. create returns id + url + share_token
+# 1. create returns id + url
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.django_db
-def test_create_returns_id_url_share_token(auth_client):
+def test_create_returns_id_and_url(auth_client):
     resp = auth_client.post(
         f"{BASE}/",
         data={"request_json": SAMPLE_REQUEST_JSON, "visibility": "link"},
@@ -112,87 +112,56 @@ def test_create_returns_id_url_share_token(auth_client):
     body = resp.json()
     assert "id" in body
     assert "url" in body
-    assert "share_token" in body
-    assert body["share_token"] is not None
-    # URL should reference the review id and include the token
+    assert "share_token" not in body
+    # URL should reference the review id
     assert body["id"] in body["url"]
-    assert body["share_token"] in body["url"]
 
 
 # ---------------------------------------------------------------------------
-# 2. GET by owner returns full record including share_token
+# 2. GET by owner returns full record
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.django_db
-def test_get_by_owner_includes_share_token(auth_client, owner):
+def test_get_by_owner_returns_full_record(auth_client, owner):
     review = _make_review(owner, visibility="link")
-    review.ensure_share_token()
 
     resp = auth_client.get(f"{BASE}/{review.id}/")
     assert resp.status_code == 200, resp.content
     body = resp.json()
     assert body["id"] == str(review.id)
     assert body["is_owner"] is True
-    assert body["share_token"] == review.share_token
     assert body["status"] == "pending"
 
 
 # ---------------------------------------------------------------------------
-# 3. GET with valid ?t= (unauthenticated) returns data WITHOUT share_token
+# 3. GET unauthenticated on a link-visibility review returns data
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.django_db
-def test_get_with_valid_token_unauth_share_token_exposed(owner):
+def test_get_link_visibility_unauth_returns_data(owner):
+    """Unauthenticated callers can read link-visibility reviews without a token."""
     review = _make_review(owner, visibility="link")
-    token = review.ensure_share_token()
 
     c = Client()  # unauthenticated
-    resp = c.get(f"{BASE}/{review.id}/?t={token}")
+    resp = c.get(f"{BASE}/{review.id}/")
     assert resp.status_code == 200, resp.content
     body = resp.json()
     assert body["status"] == "pending"
-    # share_token is exposed to link-token holders (they demonstrably have it
-    # and need it to re-poll or submit)
-    assert body["share_token"] == token
-    # is_owner is False — they are not the DB owner, just a link-token holder
     assert body["is_owner"] is False
-
-
-@pytest.mark.django_db
-def test_get_with_valid_token_unauth_returns_data(owner):
-    """An unauthenticated caller with a valid ?t= can read the review."""
-    review = _make_review(owner, visibility="link")
-    token = review.ensure_share_token()
-
-    c = Client()
-    resp = c.get(f"{BASE}/{review.id}/?t={token}")
-    assert resp.status_code == 200, resp.content
-    body = resp.json()
     assert body["run_id"] == review.run_id
     assert body["gate"] == review.gate
 
 
 # ---------------------------------------------------------------------------
-# 4. GET with bad / no token (unauthenticated) → 404
+# 4. GET unauthenticated on a private review → 404
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.django_db
-def test_get_bad_token_unauth_returns_404(owner):
-    review = _make_review(owner, visibility="link")
-    review.ensure_share_token()
-
-    c = Client()
-    resp = c.get(f"{BASE}/{review.id}/?t=WRONG_TOKEN")
-    assert resp.status_code == 404, resp.content
-
-
-@pytest.mark.django_db
-def test_get_no_token_unauth_returns_404(owner):
-    review = _make_review(owner, visibility="link")
-    review.ensure_share_token()
+def test_get_private_review_unauth_returns_404(owner):
+    review = _make_review(owner, visibility="private")
 
     c = Client()
     resp = c.get(f"{BASE}/{review.id}/")
@@ -216,7 +185,6 @@ def test_get_nonexistent_review_404(auth_client):
 @pytest.mark.django_db
 def test_submit_resolves_review(auth_client, owner):
     review = _make_review(owner, visibility="link")
-    review.ensure_share_token()
 
     resp = auth_client.post(
         f"{BASE}/{review.id}/submit/",
@@ -237,43 +205,22 @@ def test_submit_resolves_review(auth_client, owner):
 
 
 # ---------------------------------------------------------------------------
-# 6. submit via valid ?t= (unauth) also works
+# 6. submit requires authentication — unauthenticated → 403
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.django_db
-def test_submit_via_link_token_works(owner):
+def test_submit_unauth_returns_403(owner):
+    """Unauthenticated callers can read link-visibility reviews but cannot submit."""
     review = _make_review(owner, visibility="link")
-    token = review.ensure_share_token()
 
     c = Client()
     resp = c.post(
-        f"{BASE}/{review.id}/submit/?t={token}",
+        f"{BASE}/{review.id}/submit/",
         data={"response_json": SAMPLE_RESPONSE_JSON},
         content_type="application/json",
     )
-    assert resp.status_code == 200, resp.content
-    body = resp.json()
-    assert body["status"] == "resolved"
-
-
-# ---------------------------------------------------------------------------
-# 7. submit is gated — bad/no token unauth → 404
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.django_db
-def test_submit_bad_token_unauth_returns_404(owner):
-    review = _make_review(owner, visibility="link")
-    review.ensure_share_token()
-
-    c = Client()
-    resp = c.post(
-        f"{BASE}/{review.id}/submit/?t=WRONG",
-        data={"response_json": SAMPLE_RESPONSE_JSON},
-        content_type="application/json",
-    )
-    assert resp.status_code == 404, resp.content
+    assert resp.status_code == 403, resp.content
 
 
 # ---------------------------------------------------------------------------
@@ -330,48 +277,37 @@ def test_request_json_round_trips(auth_client, owner):
 @pytest.mark.django_db
 def test_non_owner_authenticated_can_read(other_client, owner):
     review = _make_review(owner, visibility="private")
-    review.ensure_share_token()
 
     resp = other_client.get(f"{BASE}/{review.id}/")
     assert resp.status_code == 200, resp.content
     body = resp.json()
     assert body["is_owner"] is False
-    # Non-owner does not see share_token
-    assert body["share_token"] is None
 
 
 # ---------------------------------------------------------------------------
-# 11. submit on a private review by an authenticated NON-owner is blocked
+# 11. submit by an authenticated NON-owner is allowed (team-internal write)
 #
-#     Write gate semantics: private visibility means the review is readable
-#     by any dimagi-authenticated user, but submit (write) requires being the
-#     owner OR holding a valid ?t= share token.  A non-owner authenticated
-#     session without a token must not be able to resolve the review.
+#     Write gate semantics: any authenticated user may submit, just like
+#     any authenticated user may read — reviews are team-internal resources.
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.django_db
-def test_submit_private_review_by_non_owner_is_blocked(other_client, owner):
-    """Authenticated non-owner without ?t= cannot submit a private review."""
+def test_submit_by_authenticated_non_owner_is_allowed(other_client, owner):
+    """Authenticated non-owner can submit a review (team-internal write access)."""
     review = _make_review(owner, visibility="private")
-    review.ensure_share_token()
 
     resp = other_client.post(
         f"{BASE}/{review.id}/submit/",
         data={"response_json": SAMPLE_RESPONSE_JSON},
         content_type="application/json",
     )
-    # Must be blocked — 403 or 404 (endpoint returns 404 to avoid leaking existence)
-    assert resp.status_code in (403, 404), (
-        f"Expected 403 or 404 but got {resp.status_code}: {resp.content}"
-    )
+    assert resp.status_code == 200, resp.content
+    body = resp.json()
+    assert body["status"] == "resolved"
 
-    # Review must NOT have been resolved in the database
     review.refresh_from_db()
-    assert review.status == ReviewRequest.STATUS_PENDING, (
-        "Review should still be pending after blocked submit attempt"
-    )
-    assert review.response_json is None
+    assert review.status == ReviewRequest.STATUS_RESOLVED
 
 
 # ---------------------------------------------------------------------------

--- a/apps/runs/aggregate.py
+++ b/apps/runs/aggregate.py
@@ -111,8 +111,8 @@ def _narrative_slug_map(walkthroughs) -> dict[str, str]:
 
 
 def _content_url(w: Walkthrough) -> str:
-    """In-app viewer stream. Session auth covers private artifacts for the
-    dimagi-gated app; share tokens are managed on the /w/<id> viewer page."""
+    """In-app viewer stream. Session auth covers private artifacts; public
+    (visibility=link) artifacts stream tokenlessly to anyone with the URL."""
     return f"/w/{w.id}/content"
 
 

--- a/apps/runs/aggregate.py
+++ b/apps/runs/aggregate.py
@@ -293,6 +293,7 @@ def _blank_narrative(slug: str) -> dict[str, Any]:
         "run_ids": set(),
         "project_slugs": set(),
         "owner_ids": set(),
+        "visibilities": set(),
         "latest_at": None,
         "has_video": False,
         "has_deck": False,
@@ -332,6 +333,7 @@ def _aggregate(project: str | None, owner_id: int | None) -> dict[str, dict]:
             if a["project_slug"] is None:
                 a["project_slug"] = w.project_slug
         a["owner_ids"].add(w.owner_id)
+        a["visibilities"].add(w.visibility)
         a["latest_at"] = _max(a["latest_at"], w.created_at)
         if _is_video(w):
             a["has_video"] = True
@@ -344,6 +346,7 @@ def _aggregate(project: str | None, owner_id: int | None) -> dict[str, dict]:
         a["run_ids"].add(r.run_id)
         if r.owner_id:
             a["owner_ids"].add(r.owner_id)
+        a["visibilities"].add(r.visibility)
         a["latest_at"] = _max(a["latest_at"], r.created_at)
         # Latest review overall drives the phase label.
         if a["_latest_rev_at"] is None or r.created_at > a["_latest_rev_at"]:
@@ -408,6 +411,15 @@ def _run_summary(run_id, run_wts, run_revs) -> dict:
         "has_video": any(_is_video(w) for w in run_wts),
         "has_deck": any(_is_deck(w) for w in run_wts),
     }
+
+
+def _agg_visibility(visibilities: set[str]) -> str:
+    """Collapse a set of row visibilities into the narrative's status."""
+    if visibilities == {Walkthrough.VISIBILITY_LINK}:
+        return "public"
+    if visibilities <= {Walkthrough.VISIBILITY_PRIVATE}:  # all private or empty
+        return "private"
+    return "mixed"
 
 
 def build_narrative(slug: str) -> dict | None:
@@ -511,6 +523,33 @@ def build_narrative(slug: str) -> dict | None:
         "story": a["story"],
         "phase": a["phase"],
         "project_slug": a["project_slug"],
+        "visibility": _agg_visibility(a["visibilities"]),
         "current_version": current_payload,
         "versions": versions_payload,
     }
+
+
+def set_narrative_visibility(slug: str, visibility: str) -> tuple[int, int]:
+    """Set visibility on every walkthrough + review grouped under ``slug``.
+
+    Matches the exact same rows the narrative aggregate displays (explicit
+    narrative_slug wins; run_id-derived slug is the fallback). Returns
+    (walkthroughs_updated, reviews_updated).
+    """
+    slug = (slug or "").strip()
+    wts = list(
+        Walkthrough.objects.exclude(run_id__isnull=True).exclude(run_id="")
+    )
+    # Resolve membership exactly as build_narrative does for the /ddd page:
+    # walkthroughs via narrative_of_walkthrough, reviews via narrative_of_review
+    # (the review's own narrative_slug wins). Keeps the cascade flipping precisely
+    # the rows the narrative page shows.
+    wt_pks = [w.pk for w in wts if narrative_of_walkthrough(w) == slug]
+    rev_pks = [
+        r.pk
+        for r in ReviewRequest.objects.all()
+        if narrative_of_review(r) == slug
+    ]
+    wt_n = Walkthrough.objects.filter(pk__in=wt_pks).update(visibility=visibility)
+    rev_n = ReviewRequest.objects.filter(pk__in=rev_pks).update(visibility=visibility)
+    return wt_n, rev_n

--- a/apps/runs/api.py
+++ b/apps/runs/api.py
@@ -14,7 +14,13 @@ from apps.api.auth import session_auth
 from apps.api.errors import TYPE_NOT_FOUND, ProblemError
 
 from . import aggregate, delete
-from .schemas import NarrativeDetailOut, NarrativeListItemOut, RunPackageOut
+from .schemas import (
+    NarrativeDetailOut,
+    NarrativeListItemOut,
+    NarrativeVisibilityIn,
+    NarrativeVisibilityOut,
+    RunPackageOut,
+)
 
 router = Router(auth=session_auth, tags=["ddd"])
 
@@ -58,6 +64,27 @@ def get_run(request: HttpRequest, run_id: str) -> RunPackageOut:
     if data is None:
         raise ProblemError(404, "Run not found", type_=TYPE_NOT_FOUND)
     return RunPackageOut.model_validate(data)
+
+
+@router.patch(
+    "/narratives/{slug}/visibility/",
+    response=NarrativeVisibilityOut,
+    summary="Set visibility for an entire narrative (cascades to all artifacts + reviews)",
+)
+def set_narrative_visibility(
+    request: HttpRequest, slug: str, payload: NarrativeVisibilityIn
+) -> NarrativeVisibilityOut:
+    wt_n, rev_n = aggregate.set_narrative_visibility(slug, payload.visibility)
+    detail = aggregate.build_narrative(slug)
+    status = detail["visibility"] if detail else (
+        "public" if payload.visibility == "link" else "private"
+    )
+    return NarrativeVisibilityOut(
+        slug=slug,
+        visibility=status,
+        walkthroughs_updated=wt_n,
+        reviews_updated=rev_n,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/apps/runs/schemas.py
+++ b/apps/runs/schemas.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import datetime as dt
 import uuid
-from typing import Any
+from typing import Any, Literal
 
 from apps.common.schemas import StrictModel
 from apps.walkthroughs.schemas import WalkthroughKind, WalkthroughLink
@@ -58,6 +58,7 @@ class NarrativeDetailOut(StrictModel):
     story: str | None = None
     phase: str | None = None
     project_slug: str | None = None
+    visibility: Literal["public", "private", "mixed"] = "private"
     current_version: NarrativeStoryOut | None = None
     versions: list[NarrativeVersionOut] = []
 
@@ -110,3 +111,14 @@ class RunPackageOut(StrictModel):
     narrative: RunNarrativeOut | None = None
     links: list[WalkthroughLink] = []
     all_artifacts: list[RunArtifactRefOut] = []
+
+
+class NarrativeVisibilityIn(StrictModel):
+    visibility: Literal["private", "link"]
+
+
+class NarrativeVisibilityOut(StrictModel):
+    slug: str
+    visibility: Literal["public", "private", "mixed"]
+    walkthroughs_updated: int
+    reviews_updated: int

--- a/apps/walkthroughs/api.py
+++ b/apps/walkthroughs/api.py
@@ -36,7 +36,6 @@ from .schemas import (
     WalkthroughLink,
     WalkthroughListItemOut,
     WalkthroughPatchIn,
-    WalkthroughRotateTokenOut,
     WalkthroughVisibility,
 )
 
@@ -92,7 +91,6 @@ def _detail_payload(w: Walkthrough, *, is_owner: bool) -> dict:
         "owner_email": w.owner.email,
         "size_bytes": w.size_bytes,
         "duration_sec": w.duration_sec,
-        "share_token": w.share_token if is_owner else None,
         "content_type": w.content_type,
         "is_owner": is_owner,
         "links": w.links or [],
@@ -260,9 +258,6 @@ def upload_walkthrough(
     w.drive_folder_id = stored.folder_id
     w.save(update_fields=["drive_file_id", "drive_folder_id", "updated_at"])
 
-    if visibility == Walkthrough.VISIBILITY_LINK:
-        w.ensure_share_token()
-
     # Enforce one artifact per (run_id, role): a re-upload of the same role into
     # the same run REPLACES the prior one (e.g. healing a docs page), so a run
     # can never accumulate two videos / two slideshows / two docs pages. Genuine
@@ -375,9 +370,6 @@ def patch_walkthrough(
     w.save()
     w.refresh_from_db()
 
-    if w.visibility == Walkthrough.VISIBILITY_LINK and not w.share_token:
-        w.ensure_share_token()
-
     return WalkthroughDetailOut.model_validate(_detail_payload(w, is_owner=True))
 
 
@@ -420,23 +412,3 @@ def delete_walkthrough(request: HttpRequest, wid: UUID) -> Status:
     w.delete()
     return Status(204, None)
 
-
-# ---------------------------------------------------------------------------
-# Rotate token
-# ---------------------------------------------------------------------------
-
-
-@router.post(
-    "/{wid}/rotate-token/",
-    response=WalkthroughRotateTokenOut,
-    summary="Rotate share token (owner only)",
-)
-def rotate_token(request: HttpRequest, wid: UUID) -> WalkthroughRotateTokenOut:
-    _require_enabled()
-    w = _get_or_404(wid)
-
-    if not (request.user.is_authenticated and w.owner_id == request.user.id):
-        raise ProblemError(403, "Forbidden — owner only", type_=TYPE_FORBIDDEN)
-
-    new_token = w.rotate_share_token()
-    return WalkthroughRotateTokenOut(share_token=new_token)

--- a/apps/walkthroughs/api.py
+++ b/apps/walkthroughs/api.py
@@ -333,11 +333,17 @@ def list_walkthroughs(
 @router.get(
     "/{wid}/",
     response=WalkthroughDetailOut,
+    auth=None,  # Public (visibility=link) walkthroughs load without a session.
     summary="Get walkthrough detail",
 )
 def get_walkthrough(request: HttpRequest, wid: UUID) -> WalkthroughDetailOut:
     _require_enabled()
     w = _get_or_404(wid)
+    if not (
+        request.user.is_authenticated
+        or w.visibility == Walkthrough.VISIBILITY_LINK
+    ):
+        raise Http404("walkthrough not found")  # don't leak private existence
     is_owner = request.user.is_authenticated and w.owner_id == request.user.id
     return WalkthroughDetailOut.model_validate(_detail_payload(w, is_owner=is_owner))
 

--- a/apps/walkthroughs/schemas.py
+++ b/apps/walkthroughs/schemas.py
@@ -52,9 +52,8 @@ class WalkthroughListItemOut(StrictModel):
 
 
 class WalkthroughDetailOut(WalkthroughListItemOut):
-    """Detail view adds share_token (owner only), content_type, is_owner."""
+    """Detail view adds content_type and is_owner."""
 
-    share_token: str | None = None
     content_type: str
     is_owner: bool
     links: list[WalkthroughLink] = []
@@ -86,5 +85,3 @@ class WalkthroughPatchIn(StrictModel):
     links: list[WalkthroughLink] | None = None
 
 
-class WalkthroughRotateTokenOut(StrictModel):
-    share_token: str

--- a/apps/walkthroughs/streaming.py
+++ b/apps/walkthroughs/streaming.py
@@ -62,14 +62,12 @@ def walkthrough_content(request, wid):
     if w is None:
         raise Http404("walkthrough not found")
 
-    token = request.GET.get("t", "")
-    is_authed = request.user.is_authenticated
-    token_ok = (
-        w.visibility == Walkthrough.VISIBILITY_LINK
-        and bool(w.share_token)
-        and token == w.share_token
-    )
-    if not (is_authed or token_ok):
+    # Tokenless public access: visibility=link means anyone with the URL.
+    # The UUID is the only secret. Private stays session-gated.
+    if not (
+        request.user.is_authenticated
+        or w.visibility == Walkthrough.VISIBILITY_LINK
+    ):
         raise Http404("walkthrough not found")
 
     range_hdr = request.META.get("HTTP_RANGE", "")

--- a/apps/walkthroughs/streaming.py
+++ b/apps/walkthroughs/streaming.py
@@ -1,7 +1,7 @@
 """Streaming endpoint for the public walkthrough viewer.
 
-Preserved as a bare Django view (NOT ported to Ninja) — HTTP Range +
-token-based public-link auth don't fit cleanly into Ninja's contract.
+Preserved as a bare Django view (NOT ported to Ninja) — HTTP Range support
+(for ``<video>`` scrubbing) doesn't fit cleanly into Ninja's contract.
 
 Mounted at /w/<uuid:wid>/content in config/urls.py.
 """
@@ -46,9 +46,10 @@ def _get_or_404(wid):
 def walkthrough_content(request, wid):
     """GET /w/<id>/content — stream the file bytes from Drive.
 
-    Auth: caller is the authenticated owner OR visibility=link with a
-    valid ?t=<share_token>. Mismatch returns 404 (don't leak existence
-    of private walkthroughs).
+    Auth (tokenless): any authenticated session user OR a walkthrough with
+    visibility=link (the UUID in the URL is the only access secret). A
+    private walkthrough returns 404 to unauthenticated callers so its
+    existence isn't leaked.
 
     Django's SecurityMiddleware sets ``X-Frame-Options: DENY`` globally,
     which breaks our own viewer page (``/w/<id>``) when it tries to embed

--- a/apps/walkthroughs/tests/test_api.py
+++ b/apps/walkthroughs/tests/test_api.py
@@ -112,8 +112,6 @@ def test_upload_walkthrough_html(auth_client, fake_drive, owner):
     assert out.kind == "html"
     assert out.is_owner is True
     assert out.visibility == "link"
-    # share_token minted when visibility=link
-    assert out.share_token is not None
 
 
 @pytest.mark.django_db
@@ -386,13 +384,11 @@ def test_list_filter_mine(auth_client, owner, other_user):
 @override_settings(WALKTHROUGHS_ENABLED=True)
 def test_get_detail_owner_sees_token(auth_client, owner):
     w = _make_walkthrough(owner, visibility="link")
-    w.ensure_share_token()
     resp = auth_client.get(f"{BASE}/{w.id}/")
     assert resp.status_code == 200
     body = resp.json()
     out = WalkthroughDetailOut.model_validate(body)
     assert out.is_owner is True
-    assert out.share_token == w.share_token
 
 
 # ---------------------------------------------------------------------------
@@ -404,7 +400,6 @@ def test_get_detail_owner_sees_token(auth_client, owner):
 @override_settings(WALKTHROUGHS_ENABLED=True)
 def test_get_detail_non_owner_no_token(owner, other_user):
     w = _make_walkthrough(owner, visibility="link")
-    w.ensure_share_token()
     c = Client()
     c.force_login(other_user)
     resp = c.get(f"{BASE}/{w.id}/")
@@ -412,7 +407,6 @@ def test_get_detail_non_owner_no_token(owner, other_user):
     body = resp.json()
     out = WalkthroughDetailOut.model_validate(body)
     assert out.is_owner is False
-    assert out.share_token is None
 
 
 # ---------------------------------------------------------------------------
@@ -452,15 +446,14 @@ def test_patch_owner_only(owner, other_user):
 
 
 # ---------------------------------------------------------------------------
-# 12. test_patch_to_link_mints_token
+# 12. test_patch_to_link_changes_visibility
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.django_db
 @override_settings(WALKTHROUGHS_ENABLED=True)
-def test_patch_to_link_mints_token(auth_client, owner):
+def test_patch_to_link_changes_visibility(auth_client, owner):
     w = _make_walkthrough(owner, visibility="private")
-    assert w.share_token is None
     resp = auth_client.patch(
         f"{BASE}/{w.id}/",
         data=json.dumps({"visibility": "link"}),
@@ -470,7 +463,6 @@ def test_patch_to_link_mints_token(auth_client, owner):
     body = resp.json()
     out = WalkthroughDetailOut.model_validate(body)
     assert out.visibility == "link"
-    assert out.share_token is not None
 
 
 # ---------------------------------------------------------------------------
@@ -526,26 +518,6 @@ def test_delete_non_owner_403(owner, other_user):
 
 
 # ---------------------------------------------------------------------------
-# 15. test_rotate_token_owner_only
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.django_db
-@override_settings(WALKTHROUGHS_ENABLED=True)
-def test_rotate_token_owner_only(auth_client, owner):
-    w = _make_walkthrough(owner, visibility="link")
-    w.ensure_share_token()
-    old_token = w.share_token
-
-    resp = auth_client.post(f"{BASE}/{w.id}/rotate-token/")
-    assert resp.status_code == 200
-    body = resp.json()
-    new_token = body["share_token"]
-    assert new_token
-    assert new_token != old_token
-
-
-# ---------------------------------------------------------------------------
 # 16. test_endpoints_404_when_disabled
 # ---------------------------------------------------------------------------
 
@@ -581,10 +553,6 @@ def test_endpoints_404_when_disabled(auth_client, owner):
 
     # DELETE /{wid}/
     resp = auth_client.delete(f"{BASE}/{w.id}/")
-    assert resp.status_code == 404
-
-    # POST /{wid}/rotate-token/
-    resp = auth_client.post(f"{BASE}/{w.id}/rotate-token/")
     assert resp.status_code == 404
 
 

--- a/apps/walkthroughs/tests/test_schemas.py
+++ b/apps/walkthroughs/tests/test_schemas.py
@@ -6,7 +6,6 @@ from apps.walkthroughs.schemas import (
     WalkthroughDetailOut,
     WalkthroughListItemOut,
     WalkthroughPatchIn,
-    WalkthroughRotateTokenOut,
     WalkthroughUploadIn,
 )
 
@@ -41,7 +40,6 @@ def test_walkthrough_detail_out_owner_shape():
         "owner_email": "alice@dimagi.com",
         "size_bytes": 9999,
         "duration_sec": 42,
-        "share_token": "abc123",
         "content_type": "video/mp4",
         "is_owner": True,
         "created_at": "2026-05-26T10:00:00Z",
@@ -49,10 +47,9 @@ def test_walkthrough_detail_out_owner_shape():
     }
     parsed = WalkthroughDetailOut.model_validate(raw)
     assert parsed.is_owner is True
-    assert parsed.share_token == "abc123"
 
 
-def test_walkthrough_detail_out_non_owner_null_token():
+def test_walkthrough_detail_out_non_owner_shape():
     parsed = WalkthroughDetailOut.model_validate(
         {
             "id": str(uuid.uuid4()),
@@ -64,14 +61,13 @@ def test_walkthrough_detail_out_non_owner_null_token():
             "owner_email": "bob@dimagi.com",
             "size_bytes": 1,
             "duration_sec": None,
-            "share_token": None,
             "content_type": "text/html",
             "is_owner": False,
             "created_at": "2026-05-26T10:00:00Z",
             "updated_at": "2026-05-26T10:00:00Z",
         }
     )
-    assert parsed.share_token is None
+    assert parsed.is_owner is False
 
 
 def test_walkthrough_kind_literal():
@@ -106,6 +102,3 @@ def test_walkthrough_patch_partial():
     assert dumped == {"visibility": "link"}
 
 
-def test_rotate_token_out():
-    obj = WalkthroughRotateTokenOut(share_token="newtok")
-    assert obj.share_token == "newtok"

--- a/docs/superpowers/plans/2026-06-09-tokenless-narrative-visibility.md
+++ b/docs/superpowers/plans/2026-06-09-tokenless-narrative-visibility.md
@@ -1,0 +1,1028 @@
+# Tokenless Narrative-Level Visibility Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace per-artifact share tokens with a tokenless Public/Private model, and add a narrative-level toggle that cascades visibility to every walkthrough and review under a narrative.
+
+**Architecture:** `visibility` keeps its stored enum (`private`/`link`) but `link` now means "anyone with the URL" — no `?t=` token. Streaming, detail, and review-read gates drop the token check; the login middleware allowlists the walkthrough viewer shell + detail GET (mirroring the existing review-link allowlist). A new `PATCH /api/ddd/narratives/{slug}/visibility/` bulk-updates all rows sharing the narrative. The DDD narrative page gets one toggle; the walkthrough viewer keeps one simplified toggle for standalone artifacts. Review *submission* stays authenticated-only.
+
+**Tech Stack:** Django 5 + Django Ninja, pytest, React 19 + Vite + TypeScript, openapi-typescript.
+
+**Design doc:** `docs/superpowers/specs/2026-06-08-tokenless-narrative-visibility-design.md`
+
+---
+
+## File Structure
+
+**Backend (modify):**
+- `apps/walkthroughs/streaming.py` — drop token check in the content gate (Task 1)
+- `apps/walkthroughs/api.py` — detail GET `auth=None` + self-enforce; remove rotate route; stop minting tokens (Tasks 2, 6)
+- `apps/walkthroughs/schemas.py` — drop `share_token` from detail out; remove rotate out schema (Task 6)
+- `apps/common/middleware.py` — allowlist walkthrough shell + detail GET (Task 3)
+- `apps/reviews/api.py` — tokenless read, authenticated-only write; drop `share_token` from payload (Task 4, 6)
+- `apps/reviews/schemas.py` — drop `share_token` from review out schemas (Task 6)
+- `apps/runs/aggregate.py` — compute narrative `visibility`; add `set_narrative_visibility()` (Task 5)
+- `apps/runs/api.py` — `PATCH /narratives/{slug}/visibility/` (Task 5)
+- `apps/runs/schemas.py` — `visibility` on `NarrativeDetailOut`; new patch in/out schemas (Task 5)
+
+**Backend (test):**
+- `tests/test_visibility_walkthroughs.py` — new (Tasks 1, 2, 3)
+- `tests/test_visibility_reviews.py` — new (Task 4)
+- `tests/test_narrative_visibility.py` — new (Task 5)
+
+**Frontend (modify):**
+- `frontend/src/api/ddd.ts` — `visibility` field + `setNarrativeVisibility()` + `patch` helper (Task 8)
+- `frontend/src/components/ddd/NarrativeLanding.tsx` — narrative toggle (Task 9)
+- `frontend/src/api/walkthroughs.ts` — remove rotate fn; drop token from content URL (Task 10)
+- `frontend/src/pages/WalkthroughViewerPage.tsx` — single toggle, remove copy/rotate (Task 11)
+- `frontend/src/api/generated.ts` — regenerated (Task 7)
+
+---
+
+## Task 1: Walkthrough streaming gate goes tokenless
+
+**Files:**
+- Modify: `apps/walkthroughs/streaming.py` (the `token`/`token_ok` block, ~lines 64–73)
+- Test: `tests/test_visibility_walkthroughs.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_visibility_walkthroughs.py`:
+
+```python
+"""Tokenless visibility behaviour for the walkthrough content stream + detail."""
+from unittest.mock import patch
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import Client, override_settings
+
+from apps.walkthroughs.models import Walkthrough
+
+
+@pytest.fixture
+def owner(db):
+    return get_user_model().objects.create_user(
+        username="owner@dimagi.com", email="owner@dimagi.com",
+    )
+
+
+def _make(owner, **kw):
+    defaults = dict(
+        title="Demo", kind="video", owner=owner,
+        drive_file_id="file-1", drive_folder_id="folder-1",
+        content_type="video/mp4", size_bytes=10,
+    )
+    defaults.update(kw)
+    return Walkthrough.objects.create(**defaults)
+
+
+# Streaming returns bytes; stub the Drive download so tests stay offline.
+def _stub_download():
+    return patch(
+        "apps.walkthroughs.streaming.storage.download",
+        return_value=(b"data", "video/mp4", 4, 4),
+    )
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_public_content_served_to_anonymous_without_token(owner):
+    w = _make(owner, visibility="link")
+    with _stub_download():
+        resp = Client().get(f"/w/{w.id}/content")
+    assert resp.status_code == 200
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_private_content_404s_anonymous(owner):
+    w = _make(owner, visibility="private")
+    resp = Client().get(f"/w/{w.id}/content")
+    assert resp.status_code == 404
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_owner_sees_private_content(owner):
+    w = _make(owner, visibility="private")
+    client = Client()
+    client.force_login(owner)
+    with _stub_download():
+        resp = client.get(f"/w/{w.id}/content")
+    assert resp.status_code == 200
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_visibility_walkthroughs.py::test_public_content_served_to_anonymous_without_token -v`
+Expected: FAIL — anonymous public request 404s because the gate still requires a token.
+
+- [ ] **Step 3: Edit the gate**
+
+In `apps/walkthroughs/streaming.py`, replace the token block:
+
+```python
+    token = request.GET.get("t", "")
+    is_authed = request.user.is_authenticated
+    token_ok = (
+        w.visibility == Walkthrough.VISIBILITY_LINK
+        and bool(w.share_token)
+        and token == w.share_token
+    )
+    if not (is_authed or token_ok):
+        raise Http404("walkthrough not found")
+```
+
+with:
+
+```python
+    # Tokenless public access: visibility=link means anyone with the URL.
+    # The UUID is the only secret. Private stays session-gated.
+    if not (
+        request.user.is_authenticated
+        or w.visibility == Walkthrough.VISIBILITY_LINK
+    ):
+        raise Http404("walkthrough not found")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_visibility_walkthroughs.py -v`
+Expected: the three streaming tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/walkthroughs/streaming.py tests/test_visibility_walkthroughs.py
+git commit -m "feat(walkthroughs): tokenless public content streaming"
+```
+
+---
+
+## Task 2: Walkthrough detail GET becomes anonymously reachable for public
+
+**Files:**
+- Modify: `apps/walkthroughs/api.py` (`get_walkthrough`, ~lines 332–344)
+- Test: `tests/test_visibility_walkthroughs.py` (append)
+
+Note: the detail API is gated by `LoginRequiredMiddleware` before Ninja runs. This task makes the Ninja route `auth=None` and self-enforce; Task 3 opens the middleware. Until Task 3 lands, the anonymous-detail test will still 401 — so write that test in Task 3.
+
+- [ ] **Step 1: Write the failing test (self-enforce branch)**
+
+Append to `tests/test_visibility_walkthroughs.py`:
+
+```python
+def test_detail_handler_404s_private_for_anonymous(owner):
+    """With auth=None the handler itself must hide private rows from anonymous."""
+    from django.test import RequestFactory
+    from django.contrib.auth.models import AnonymousUser
+    from apps.walkthroughs.api import get_walkthrough
+
+    w = _make(owner, visibility="private")
+    req = RequestFactory().get(f"/api/walkthroughs/{w.id}/")
+    req.user = AnonymousUser()
+    with pytest.raises(Exception):  # Http404 / ProblemError → not found
+        get_walkthrough(req, w.id)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_visibility_walkthroughs.py::test_detail_handler_404s_private_for_anonymous -v`
+Expected: FAIL — handler currently returns the payload for anyone (no guard).
+
+- [ ] **Step 3: Add `auth=None` + guard to `get_walkthrough`**
+
+In `apps/walkthroughs/api.py`, change the decorator and body:
+
+```python
+@router.get(
+    "/{wid}/",
+    response=WalkthroughDetailOut,
+    auth=None,  # Public (visibility=link) walkthroughs load without a session.
+    summary="Get walkthrough detail",
+)
+def get_walkthrough(request: HttpRequest, wid: UUID) -> WalkthroughDetailOut:
+    _require_enabled()
+    w = _get_or_404(wid)
+    if not (
+        request.user.is_authenticated
+        or w.visibility == Walkthrough.VISIBILITY_LINK
+    ):
+        raise Http404("walkthrough not found")  # don't leak private existence
+    is_owner = request.user.is_authenticated and w.owner_id == request.user.id
+    return WalkthroughDetailOut.model_validate(_detail_payload(w, is_owner=is_owner))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_visibility_walkthroughs.py::test_detail_handler_404s_private_for_anonymous -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/walkthroughs/api.py tests/test_visibility_walkthroughs.py
+git commit -m "feat(walkthroughs): detail GET self-enforces tokenless public access"
+```
+
+---
+
+## Task 3: Middleware allowlists the walkthrough shell + detail GET
+
+**Files:**
+- Modify: `apps/common/middleware.py` (add `_is_walkthrough_link`, wire into `__call__`)
+- Test: `tests/test_visibility_walkthroughs.py` (append)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_visibility_walkthroughs.py`:
+
+```python
+@override_settings(REQUIRE_AUTH=True)
+def test_public_detail_api_reachable_anonymous(owner):
+    w = _make(owner, visibility="link")
+    resp = Client().get(f"/api/walkthroughs/{w.id}/")
+    assert resp.status_code == 200
+    assert resp.json()["id"] == str(w.id)
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_private_detail_api_404s_anonymous(owner):
+    w = _make(owner, visibility="private")
+    resp = Client().get(f"/api/walkthroughs/{w.id}/")
+    # Reaches the handler (allowlisted) and the handler hides it.
+    assert resp.status_code == 404
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_walkthrough_shell_served_to_anonymous(owner):
+    w = _make(owner, visibility="link")
+    resp = Client().get(f"/w/{w.id}")
+    assert resp.status_code == 200  # SPA shell, not redirected to login
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_walkthrough_collection_still_gated(db):
+    # The list/upload collection must NOT be public.
+    resp = Client().get("/api/walkthroughs/")
+    assert resp.status_code == 401
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_visibility_walkthroughs.py -k "anonymous or shell or collection" -v`
+Expected: the public-detail and shell tests FAIL (401/302) — middleware blocks them.
+
+- [ ] **Step 3: Add the allowlist helper + wire it in**
+
+In `apps/common/middleware.py`, add after `_is_review_link` (~line 43):
+
+```python
+def _is_walkthrough_link(request) -> bool:
+    # The walkthrough viewer SPA shell (/w/<uuid>) and the per-walkthrough
+    # detail GET self-enforce tokenless public access, so let anonymous
+    # callers through the middleware. The bare collection (/api/walkthroughs/)
+    # is NOT included — list/upload still require auth. /w/<uuid>/content is
+    # already covered by _is_walkthrough_content.
+    path = request.path
+    if path.startswith("/w/"):
+        return True
+    return (
+        request.method == "GET"
+        and path.startswith("/api/walkthroughs/")
+        and path != "/api/walkthroughs/"
+    )
+```
+
+Then add it to the bypass condition in `__call__`:
+
+```python
+        if (
+            request.user.is_authenticated
+            or _is_public(request.path)
+            or _is_walkthrough_content(request.path)
+            or _is_walkthrough_link(request)
+            or _is_review_link(request.path)
+        ):
+            return self.get_response(request)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_visibility_walkthroughs.py -v`
+Expected: all tests PASS (including Task 1/2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/common/middleware.py tests/test_visibility_walkthroughs.py
+git commit -m "feat(auth): allowlist walkthrough shell + detail GET for public links"
+```
+
+---
+
+## Task 4: Reviews — tokenless read, authenticated-only write
+
+**Files:**
+- Modify: `apps/reviews/api.py` (`_can_read`, `_can_write`; remove now-unused `_token_ok` use)
+- Test: `tests/test_visibility_reviews.py` (create)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_visibility_reviews.py`:
+
+```python
+"""Tokenless review read; authenticated-only submit."""
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import Client, override_settings
+
+from apps.reviews.models import ReviewRequest
+
+
+@pytest.fixture
+def owner(db):
+    return get_user_model().objects.create_user(
+        username="owner@dimagi.com", email="owner@dimagi.com",
+    )
+
+
+def _review(owner, **kw):
+    defaults = dict(
+        run_id="demo-2026-06-09-001",
+        narrative_slug="demo",
+        gate="narrative-agreement",
+        request_json={"narrative": "A story"},
+        owner=owner,
+    )
+    defaults.update(kw)
+    return ReviewRequest.objects.create(**defaults)
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_public_review_read_anonymous(owner):
+    r = _review(owner, visibility="link")
+    resp = Client().get(f"/api/reviews/{r.id}/")
+    assert resp.status_code == 200
+    assert resp.json()["id"] == str(r.id)
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_private_review_404s_anonymous(owner):
+    r = _review(owner, visibility="private")
+    resp = Client().get(f"/api/reviews/{r.id}/")
+    assert resp.status_code in (403, 404)
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_public_review_submit_blocked_for_anonymous(owner):
+    r = _review(owner, visibility="link")
+    resp = Client().post(
+        f"/api/reviews/{r.id}/submit/",
+        data={"decisions": []},
+        content_type="application/json",
+    )
+    assert resp.status_code in (401, 403)
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_review_submit_allowed_for_authenticated(owner):
+    r = _review(owner, visibility="link")
+    client = Client()
+    client.force_login(owner)
+    resp = client.post(
+        f"/api/reviews/{r.id}/submit/",
+        data={"decisions": []},
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_visibility_reviews.py -v`
+Expected: `test_public_review_read_anonymous` FAILS (read still needs token).
+
+- [ ] **Step 3: Update the access checks**
+
+In `apps/reviews/api.py`, replace `_can_read` and `_can_write`:
+
+```python
+def _can_read(request: HttpRequest, review: ReviewRequest) -> bool:
+    """Authenticated users see all reviews; public (link) reviews are readable by anyone."""
+    return (
+        request.user.is_authenticated
+        or review.visibility == ReviewRequest.VISIBILITY_LINK
+    )
+
+
+def _can_write(request: HttpRequest, review: ReviewRequest) -> bool:
+    """Submitting a decision (approve/redraft) requires a Dimagi login —
+    public-readable does NOT grant anonymous write."""
+    return request.user.is_authenticated
+```
+
+If `_token_ok` is now unused anywhere in the module, delete its definition to keep the linter quiet. (Search: `grep -n "_token_ok" apps/reviews/api.py` — remove if no remaining references.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_visibility_reviews.py -v`
+Expected: all four PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/reviews/api.py tests/test_visibility_reviews.py
+git commit -m "feat(reviews): tokenless public read; authenticated-only submit"
+```
+
+---
+
+## Task 5: Narrative visibility — cascade endpoint + aggregate field
+
+**Files:**
+- Modify: `apps/runs/aggregate.py` (`_blank_narrative`, `_aggregate` loops, `build_narrative`; add `set_narrative_visibility`)
+- Modify: `apps/runs/schemas.py` (`NarrativeDetailOut.visibility`; add `NarrativeVisibilityIn` / `NarrativeVisibilityOut`)
+- Modify: `apps/runs/api.py` (new PATCH route)
+- Test: `tests/test_narrative_visibility.py` (create)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_narrative_visibility.py`:
+
+```python
+"""Narrative-level visibility cascade + computed aggregate field."""
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import Client, override_settings
+
+from apps.reviews.models import ReviewRequest
+from apps.runs import aggregate
+from apps.walkthroughs.models import Walkthrough
+
+
+@pytest.fixture
+def owner(db):
+    return get_user_model().objects.create_user(
+        username="owner@dimagi.com", email="owner@dimagi.com",
+    )
+
+
+def _wt(owner, **kw):
+    defaults = dict(
+        title="art", kind="video", owner=owner,
+        drive_file_id="f", drive_folder_id="d",
+        content_type="video/mp4", size_bytes=1,
+        run_id="demo-2026-06-09-001", narrative_slug="demo",
+    )
+    defaults.update(kw)
+    return Walkthrough.objects.create(**defaults)
+
+
+def _rev(owner, **kw):
+    defaults = dict(
+        run_id="demo-2026-06-09-001", narrative_slug="demo",
+        gate="narrative-agreement", request_json={"narrative": "s"}, owner=owner,
+    )
+    defaults.update(kw)
+    return ReviewRequest.objects.create(**defaults)
+
+
+def test_set_narrative_visibility_cascades(db, owner):
+    w1 = _wt(owner, drive_file_id="f1", visibility="private")
+    w2 = _wt(owner, drive_file_id="f2", visibility="private", run_id="demo-2026-06-09-002")
+    r1 = _rev(owner, visibility="private")
+    wt_n, rev_n = aggregate.set_narrative_visibility("demo", "link")
+    assert (wt_n, rev_n) == (2, 1)
+    w1.refresh_from_db(); w2.refresh_from_db(); r1.refresh_from_db()
+    assert w1.visibility == w2.visibility == "link"
+    assert r1.visibility == "link"
+
+
+def test_aggregate_visibility_public_private_mixed(db, owner):
+    _wt(owner, drive_file_id="fa", visibility="link")
+    _rev(owner, visibility="link")
+    assert aggregate.build_narrative("demo")["visibility"] == "public"
+    aggregate.set_narrative_visibility("demo", "private")
+    assert aggregate.build_narrative("demo")["visibility"] == "private"
+    # Make one row disagree → mixed.
+    Walkthrough.objects.filter(narrative_slug="demo").update(visibility="link")
+    assert aggregate.build_narrative("demo")["visibility"] == "mixed"
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_patch_endpoint_requires_auth(db, owner):
+    _wt(owner)
+    resp = Client().patch(
+        "/api/ddd/narratives/demo/visibility/",
+        data={"visibility": "link"}, content_type="application/json",
+    )
+    assert resp.status_code == 401
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_patch_endpoint_cascades(db, owner):
+    _wt(owner, visibility="private")
+    _rev(owner, visibility="private")
+    client = Client(); client.force_login(owner)
+    resp = client.patch(
+        "/api/ddd/narratives/demo/visibility/",
+        data={"visibility": "link"}, content_type="application/json",
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["visibility"] == "public"
+    assert body["walkthroughs_updated"] == 1
+    assert body["reviews_updated"] == 1
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_narrative_visibility.py -v`
+Expected: FAIL — `set_narrative_visibility` and the route don't exist; `build_narrative` has no `visibility` key.
+
+- [ ] **Step 3a: Track visibility in the aggregate**
+
+In `apps/runs/aggregate.py`, add to `_blank_narrative`'s returned dict (next to `"owner_ids": set(),`):
+
+```python
+        "visibilities": set(),
+```
+
+In `_aggregate`, inside the walkthrough loop (after `a["owner_ids"].add(w.owner_id)`):
+
+```python
+        a["visibilities"].add(w.visibility)
+```
+
+In `_aggregate`, inside the review loop (after `a["run_ids"].add(r.run_id)`):
+
+```python
+        a["visibilities"].add(r.visibility)
+```
+
+- [ ] **Step 3b: Expose computed visibility from `build_narrative`**
+
+In `apps/runs/aggregate.py`, add this helper above `build_narrative`:
+
+```python
+def _agg_visibility(visibilities: set[str]) -> str:
+    """Collapse a set of row visibilities into the narrative's status."""
+    if visibilities == {Walkthrough.VISIBILITY_LINK}:
+        return "public"
+    if visibilities <= {Walkthrough.VISIBILITY_PRIVATE}:  # all private or empty
+        return "private"
+    return "mixed"
+```
+
+Then in `build_narrative`, add the `"visibility"` key to the final return dict literal (which currently ends `"current_version": current_payload, "versions": versions_payload,`):
+
+```python
+    return {
+        "slug": slug,
+        "title": a["title"],
+        "story": a["story"],
+        "phase": a["phase"],
+        "project_slug": a["project_slug"],
+        "visibility": _agg_visibility(a["visibilities"]),
+        "current_version": current_payload,
+        "versions": versions_payload,
+    }
+```
+
+- [ ] **Step 3c: Add the cascade function**
+
+In `apps/runs/aggregate.py`, add near the bottom:
+
+```python
+def set_narrative_visibility(slug: str, visibility: str) -> tuple[int, int]:
+    """Set visibility on every walkthrough + review grouped under ``slug``.
+
+    Matches the exact same rows the narrative aggregate displays (explicit
+    narrative_slug wins; run_id-derived slug is the fallback). Returns
+    (walkthroughs_updated, reviews_updated).
+    """
+    slug = (slug or "").strip()
+    wts = list(
+        Walkthrough.objects.exclude(run_id__isnull=True).exclude(run_id="")
+    )
+    feature_map = _narrative_slug_map(wts)
+    wt_pks = [w.pk for w in wts if narrative_of_walkthrough(w) == slug]
+    rev_pks = [
+        r.pk
+        for r in ReviewRequest.objects.all()
+        if narrative_for_run_id(r.run_id, feature_map) == slug
+    ]
+    wt_n = Walkthrough.objects.filter(pk__in=wt_pks).update(visibility=visibility)
+    rev_n = ReviewRequest.objects.filter(pk__in=rev_pks).update(visibility=visibility)
+    return wt_n, rev_n
+```
+
+- [ ] **Step 3d: Add schemas**
+
+In `apps/runs/schemas.py`, add `visibility` to `NarrativeDetailOut` (after `project_slug`):
+
+```python
+    visibility: str = "private"  # "public" | "private" | "mixed"
+```
+
+And add two new schemas (near the other narrative schemas):
+
+```python
+class NarrativeVisibilityIn(StrictModel):
+    visibility: Literal["private", "link"]
+
+
+class NarrativeVisibilityOut(StrictModel):
+    slug: str
+    visibility: str  # "public" | "private" | "mixed"
+    walkthroughs_updated: int
+    reviews_updated: int
+```
+
+If `Literal` isn't imported, add `from typing import Literal` at the top.
+
+- [ ] **Step 3e: Add the route**
+
+In `apps/runs/api.py`, import the new schemas and `aggregate` (already imported), then add:
+
+```python
+@router.patch(
+    "/narratives/{slug}/visibility/",
+    response=NarrativeVisibilityOut,
+    summary="Set visibility for an entire narrative (cascades to all artifacts + reviews)",
+)
+def set_narrative_visibility(
+    request: HttpRequest, slug: str, payload: NarrativeVisibilityIn
+) -> NarrativeVisibilityOut:
+    wt_n, rev_n = aggregate.set_narrative_visibility(slug, payload.visibility)
+    detail = aggregate.build_narrative(slug)
+    status = detail["visibility"] if detail else (
+        "public" if payload.visibility == "link" else "private"
+    )
+    return NarrativeVisibilityOut(
+        slug=slug,
+        visibility=status,
+        walkthroughs_updated=wt_n,
+        reviews_updated=rev_n,
+    )
+```
+
+Add `NarrativeVisibilityIn, NarrativeVisibilityOut` to the schema imports at the top of `apps/runs/api.py`. (The route is named `set_narrative_visibility` — distinct from the aggregate function of the same name, which is called as `aggregate.set_narrative_visibility`.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_narrative_visibility.py -v`
+Expected: all five PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/runs/aggregate.py apps/runs/schemas.py apps/runs/api.py tests/test_narrative_visibility.py
+git commit -m "feat(ddd): narrative-level visibility cascade endpoint + aggregate status"
+```
+
+---
+
+## Task 6: Remove dead token surfaces
+
+**Files:**
+- Modify: `apps/walkthroughs/api.py` (delete `rotate_token` route; stop minting in `patch_walkthrough` + upload)
+- Modify: `apps/walkthroughs/schemas.py` (drop `share_token` from `WalkthroughDetailOut`; remove `WalkthroughRotateTokenOut`)
+- Modify: `apps/walkthroughs/api.py` `_detail_payload` (drop `share_token` key)
+- Modify: `apps/reviews/api.py` `_detail_payload` (drop `expose_token` param + `share_token` key) and its call sites
+- Modify: `apps/reviews/schemas.py` (drop `share_token` from review out schemas)
+- Test: existing suites must stay green.
+
+- [ ] **Step 1: Delete the walkthrough rotate route**
+
+In `apps/walkthroughs/api.py`, delete the entire `@router.post("/{wid}/rotate-token/", ...)` block and the `def rotate_token(...)` function. Remove `WalkthroughRotateTokenOut` from the schema imports.
+
+- [ ] **Step 2: Stop minting walkthrough tokens**
+
+In `apps/walkthroughs/api.py`, in `patch_walkthrough`, delete:
+
+```python
+    if w.visibility == Walkthrough.VISIBILITY_LINK and not w.share_token:
+        w.ensure_share_token()
+```
+
+In the upload handler (`create` / `POST /`), find and delete the auto-mint on link visibility (the `ensure_share_token()` call near where visibility is set, ~lines 263–264).
+
+- [ ] **Step 3: Drop `share_token` from the detail payload + schema**
+
+In `apps/walkthroughs/api.py` `_detail_payload`, remove the `"share_token": ...` entry.
+In `apps/walkthroughs/schemas.py`, remove the `share_token: str | None = None` line from `WalkthroughDetailOut` and delete the `WalkthroughRotateTokenOut` class.
+
+- [ ] **Step 4: Drop `share_token` from reviews**
+
+In `apps/reviews/api.py`, change `_detail_payload(review, *, is_owner, expose_token)` to `_detail_payload(review, *, is_owner)`, delete the `"share_token": ...` key, and update all call sites to drop the `expose_token=` argument.
+In `apps/reviews/schemas.py`, remove the `share_token: str | None = None` lines from both review out classes (lines ~27 and ~49). Leave the `share_token: str` at line ~73 only if it belongs to a still-used schema; if it's a rotate-out schema with no remaining route, delete that class too. (Search `grep -rn "share_token" apps/reviews/` and remove every response-facing reference; the model field stays.)
+
+- [ ] **Step 5: Run the full backend suite**
+
+Run: `uv run pytest`
+Expected: PASS. Fix any test that asserted on `share_token` in a response by removing that assertion (the field is intentionally gone). The model-level token tests in `tests/test_walkthroughs_models.py` stay — the column/methods are retained.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/walkthroughs/api.py apps/walkthroughs/schemas.py apps/reviews/api.py apps/reviews/schemas.py
+git commit -m "refactor: drop share_token from API responses + remove rotate route"
+```
+
+---
+
+## Task 7: Regenerate OpenAPI types
+
+**Files:**
+- Modify: `frontend/src/api/generated.ts` (generated)
+
+- [ ] **Step 1: Regenerate**
+
+Run (backend must be importable; this reads the schema):
+
+```bash
+cd frontend && npm run gen:api
+```
+
+- [ ] **Step 2: Verify the diff**
+
+Run: `git diff --stat frontend/src/api/generated.ts`
+Expected: `WalkthroughDetailOut` loses `share_token`; `ReviewRequestOut` loses `share_token`; `WalkthroughRotateTokenOut` and the rotate path removed; `NarrativeDetailOut` gains `visibility`; new `/api/ddd/narratives/{slug}/visibility/` PATCH appears.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/api/generated.ts
+git commit -m "chore(api): regenerate OpenAPI types for tokenless visibility"
+```
+
+---
+
+## Task 8: Frontend DDD client — visibility field + setter
+
+**Files:**
+- Modify: `frontend/src/api/ddd.ts`
+
+- [ ] **Step 1: Add the `visibility` field to the detail type**
+
+In `frontend/src/api/ddd.ts`, add to `interface DddNarrativeDetail` (after `project_slug`):
+
+```typescript
+  visibility: 'public' | 'private' | 'mixed'
+```
+
+- [ ] **Step 2: Add a `patch` helper next to `del`**
+
+In `frontend/src/api/ddd.ts`, after the `del` function, add:
+
+```typescript
+async function patchJson<T>(url: string, body: unknown): Promise<T> {
+  const csrf = csrfToken()
+  const resp = await fetch(url, {
+    method: 'PATCH',
+    credentials: 'same-origin',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(csrf ? { 'X-CSRFToken': decodeURIComponent(csrf) } : {}),
+    },
+    body: JSON.stringify(body),
+  })
+  if (!resp.ok) {
+    let detail = ''
+    try {
+      const b = await resp.json()
+      detail = b?.detail ?? b?.title ?? ''
+    } catch {
+      /* ignore */
+    }
+    throw new Error(detail || `Request failed (${resp.status})`)
+  }
+  return resp.json() as Promise<T>
+}
+```
+
+- [ ] **Step 3: Add the setter + its result type**
+
+In `frontend/src/api/ddd.ts`, add near the other narrative functions:
+
+```typescript
+export interface SetNarrativeVisibilityResult {
+  slug: string
+  visibility: 'public' | 'private' | 'mixed'
+  walkthroughs_updated: number
+  reviews_updated: number
+}
+
+/** Make an entire narrative public or private (cascades to all artifacts + reviews). */
+export function setNarrativeVisibility(
+  slug: string,
+  makePublic: boolean,
+): Promise<SetNarrativeVisibilityResult> {
+  return patchJson(`/api/ddd/narratives/${encodeURIComponent(slug)}/visibility/`, {
+    visibility: makePublic ? 'link' : 'private',
+  })
+}
+```
+
+- [ ] **Step 4: Type-check**
+
+Run: `cd frontend && npm run build`
+Expected: build succeeds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/api/ddd.ts
+git commit -m "feat(ddd-web): narrative visibility client (field + setter)"
+```
+
+---
+
+## Task 9: Narrative page toggle
+
+**Files:**
+- Modify: `frontend/src/components/ddd/NarrativeLanding.tsx`
+
+- [ ] **Step 1: Import the setter + add state**
+
+In `frontend/src/components/ddd/NarrativeLanding.tsx`, add `setNarrativeVisibility` to the `@/api/ddd` import. Inside `function NarrativeLanding({ slug })`, add (near the existing `useState` calls):
+
+```typescript
+  const [vizBusy, setVizBusy] = useState(false)
+
+  async function toggleVisibility() {
+    if (!detail) return
+    const makePublic = detail.visibility !== 'public'
+    setVizBusy(true)
+    try {
+      const res = await setNarrativeVisibility(slug, makePublic)
+      setDetail({ ...detail, visibility: res.visibility })
+    } catch (err) {
+      window.alert(`Could not change visibility: ${(err as Error).message || err}`)
+    } finally {
+      setVizBusy(false)
+    }
+  }
+```
+
+- [ ] **Step 2: Render the toggle in the header**
+
+In the `<header>` block (the right-hand side, near where the version count / delete-narrative control sits, ~line 261–289), add a toggle button. Place it before the existing controls:
+
+```tsx
+        <button
+          type="button"
+          onClick={toggleVisibility}
+          disabled={vizBusy}
+          title="Toggle whether this whole narrative (video, deck, docs, reviews) is public"
+          className={`rounded-lg border px-3 py-1 text-sm transition-colors disabled:opacity-50 ${
+            detail.visibility === 'public'
+              ? 'border-emerald-400/25 bg-emerald-400/10 text-emerald-400/90 hover:bg-emerald-400/20'
+              : 'border-stone-700 bg-stone-800/60 text-stone-300 hover:bg-stone-800'
+          }`}
+        >
+          {vizBusy
+            ? '…'
+            : detail.visibility === 'public'
+              ? 'Public'
+              : detail.visibility === 'mixed'
+                ? 'Mixed — make public'
+                : 'Private'}
+        </button>
+```
+
+- [ ] **Step 3: Type-check + build**
+
+Run: `cd frontend && npm run build`
+Expected: build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/ddd/NarrativeLanding.tsx
+git commit -m "feat(ddd-web): one Public/Private toggle on the narrative page"
+```
+
+---
+
+## Task 10: Walkthrough client cleanup
+
+**Files:**
+- Modify: `frontend/src/api/walkthroughs.ts`
+
+- [ ] **Step 1: Remove the rotate function**
+
+In `frontend/src/api/walkthroughs.ts`, delete the entire `export async function rotateWalkthroughToken(...) { ... }` block.
+
+- [ ] **Step 2: Drop the token param from the content URL**
+
+Replace `walkthroughContentUrl`:
+
+```typescript
+export function walkthroughContentUrl(id: string): string {
+  return `/w/${id}/content`;
+}
+```
+
+- [ ] **Step 3: Type-check**
+
+Run: `cd frontend && npm run build`
+Expected: build FAILS in `WalkthroughViewerPage.tsx` (still references `rotateWalkthroughToken` / passes a token arg). That's fixed in Task 11 — proceed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/api/walkthroughs.ts
+git commit -m "refactor(walkthroughs-web): drop rotate fn + token from content URL"
+```
+
+---
+
+## Task 11: Walkthrough viewer — single toggle
+
+**Files:**
+- Modify: `frontend/src/pages/WalkthroughViewerPage.tsx`
+
+- [ ] **Step 1: Remove the rotate + copy-link handlers and import**
+
+In `frontend/src/pages/WalkthroughViewerPage.tsx`:
+- Remove `rotateWalkthroughToken` from the `@/api/walkthroughs` (or relative) import.
+- Delete the `copyShareLink` function (lines ~45–55) and the `rotate` function (lines ~57–68).
+
+- [ ] **Step 2: Drop the viewer token + fix the iframe src**
+
+Remove the `viewerToken` line (~93) and change `contentSrc`:
+
+```typescript
+  const contentSrc = withSceneHash(
+    walkthroughContentUrl(w.id),
+    window.location.hash,
+  )
+```
+
+- [ ] **Step 3: Relabel the toggle + remove the two buttons**
+
+In the owner controls block (~lines 134–158):
+- Change the first button's label from `{w.visibility === 'link' ? 'Make private' : 'Enable link'}` to:
+
+```tsx
+            {w.visibility === 'link' ? 'Make private' : 'Make public'}
+```
+
+- Delete the "Copy share link" `<button>` block and the `{w.visibility === 'link' && (<button ...>Rotate token</button>)}` block entirely.
+
+- [ ] **Step 4: Relabel the status badge**
+
+In the badge (`~line 130`), change the text:
+
+```tsx
+          {w.visibility === 'link' ? 'Public' : 'Private (dimagi)'}
+```
+
+- [ ] **Step 5: Build**
+
+Run: `cd frontend && npm run build`
+Expected: build succeeds (no remaining references to the removed functions or the token arg).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/pages/WalkthroughViewerPage.tsx
+git commit -m "feat(walkthroughs-web): single Public/Private toggle, drop token UI"
+```
+
+---
+
+## Task 12: Full verification
+
+- [ ] **Step 1: Backend**
+
+Run: `uv run pytest`
+Expected: all PASS.
+
+- [ ] **Step 2: Frontend**
+
+Run: `cd frontend && npm run build`
+Expected: type-check + build succeed.
+
+- [ ] **Step 3: Manual smoke (optional but recommended)**
+
+With the dev servers running:
+1. Open a DDD narrative at `/ddd/<slug>`, click the toggle → "Public".
+2. In a logged-out browser (or incognito), open `/w/<id>` for one of its artifacts and `/review/<id>` — both load; the video scrubs.
+3. Toggle back to "Private" → both 404 / redirect to login when logged out.
+
+- [ ] **Step 4: Final commit (if any stragglers)**
+
+```bash
+git status   # should be clean
+```
+
+---
+
+## Notes for the implementer
+
+- **No data migration.** Enum values are unchanged; existing `link` rows transparently become tokenless-public and existing tokens simply stop being read. The `share_token` column and the `ensure_share_token`/`rotate_share_token` model methods are intentionally **kept** (dormant) so this is reversible — do not delete them.
+- **Why `build_narrative` for the response status:** after the bulk update, re-aggregating returns the authoritative `"public"`/`"private"`/`"mixed"` (it will be uniform right after a cascade, but re-reading avoids drift).
+- **Review submit body:** `test_review_submit_allowed_for_authenticated` posts `{"decisions": []}`. If `ReviewSubmitIn` requires other fields, adjust the test body to the minimal valid payload (read `apps/reviews/schemas.py` `ReviewSubmitIn`).
+```

--- a/docs/superpowers/specs/2026-06-08-tokenless-narrative-visibility-design.md
+++ b/docs/superpowers/specs/2026-06-08-tokenless-narrative-visibility-design.md
@@ -1,0 +1,247 @@
+# Tokenless narrative-level visibility — design
+
+**Date:** 2026-06-08
+**Status:** Approved (design)
+**Author:** Jonathan Jackson (+ Claude)
+
+## Problem
+
+The walkthrough viewer exposes three overlapping sharing controls — a green
+"Shareable link" status badge, a "Make private" toggle, a "Copy share link"
+button, and a "Rotate token" button. The mental model is confusing: "link"
+visibility means *anyone with a secret `?t=<token>` query param*, so there are
+two secrets (the UUID and the token), a rotate-to-revoke flow, and a copy-link
+button that mints tokens as a side effect.
+
+In practice the user is "mostly making everything public for now," and sharing
+happens at the level of a **DDD narrative** (a story that bundles a hero video,
+a deck, docs, and review surfaces), not a single artifact. Toggling one
+walkthrough leaves its siblings at their original visibility.
+
+## Goals
+
+- One **Public / Private** toggle that operates on an entire narrative and
+  cascades to every artifact and review surface under it.
+- Drop share tokens from the UI entirely. "Public" means the plain
+  `/w/<id>` and `/review/<id>` URLs load for anyone — the UUID is the only
+  secret.
+- Keep a single simplified per-item toggle on the walkthrough viewer for
+  standalone (non-narrative) walkthroughs.
+- New artifacts keep defaulting to **private**.
+
+## Non-goals
+
+- No per-run toggle (narrative-level only).
+- No multi-tenant / per-narrative ownership model — single-tenant V1, any
+  authenticated Dimagi user may toggle.
+- Not deleting the `share_token` column or model methods — left dormant so the
+  change is reversible ("remove tokens *for now*").
+
+## Background: the data model
+
+There is **no Narrative or Run table.** Narratives and runs are read-time
+aggregations (`apps/runs/aggregate.py`) over two row types that carry a
+`narrative_slug` (and `run_id`):
+
+- `Walkthrough` (`apps/walkthroughs/models.py`) — video / deck / docs / clip
+  artifacts. Has `visibility` (`private` | `link`), `share_token`, `owner`,
+  `run_id`, `narrative_slug`, `role`.
+- `ReviewRequest` (`apps/reviews/models.py`) — narrative-agreement review
+  surfaces. Same `visibility` / `share_token` semantics, plus `narrative_slug`,
+  `version`, `gate`, `status`.
+
+So a "narrative toggle" is an endpoint that flips `visibility` on every
+`Walkthrough` and `ReviewRequest` sharing a `narrative_slug`.
+
+### Existing auth scaffolding we mirror
+
+`apps/common/middleware.py` is default-deny with an allowlist. Reviews already
+implement tokenless-ish public read via:
+
+- `_is_review_link(path)` — allowlists the `/review/<uuid>/` SPA shell and the
+  per-review API endpoints (but **not** the bare collection `POST
+  /api/reviews/`).
+- Per-route `auth=None` on `get_review` / `submit_review`, with
+  `_can_read` / `_can_write` self-enforcing inside the handler.
+
+Walkthrough content (`/w/<uuid>/content`, a bare Django view in
+`streaming.py`) is allowlisted via `_is_walkthrough_content`, but the SPA shell
+`/w/<uuid>` and the detail API `GET /api/walkthroughs/<uuid>/` are **not** —
+today an anonymous holder can fetch the raw content stream but cannot load the
+full viewer page chrome. This design fixes that for public walkthroughs.
+
+## Redefining `visibility`
+
+Keep the stored enum values `private` and `link` (no data migration of
+choices). Redefine and relabel:
+
+| Stored value | Old meaning | New meaning | UI label |
+|---|---|---|---|
+| `private` | Dimagi-OAuth only | Dimagi-OAuth only | **Private** |
+| `link` | anyone with `?t=<token>` | anyone with the link (tokenless) | **Public** |
+
+`share_token` is no longer read or minted. The column and the
+`ensure_share_token` / `rotate_share_token` methods remain but become dead.
+
+### Access matrix after this change
+
+| Surface | Private | Public (`link`) |
+|---|---|---|
+| `/w/<id>` viewer shell | Dimagi login | anyone with URL |
+| `GET /api/walkthroughs/<id>/` detail | Dimagi login | anyone with URL |
+| `/w/<id>/content` stream | owner/Dimagi login | anyone with URL |
+| `/review/<id>` read | Dimagi login | anyone with URL |
+| `POST /api/reviews/<id>/submit/` (approve/redraft) | Dimagi login | **Dimagi login only** |
+
+**Deliberate tradeoffs:**
+- Dropping tokens removes per-link revocation. To cut off a leaked URL, flip the
+  narrative (or item) back to Private.
+- Review **submission stays authenticated-only** even when the narrative is
+  public-readable — anonymous internet users must not be able to approve or
+  redraft narratives. The previous token-based anonymous-approval flow is
+  removed (accepted by product owner).
+
+## Backend changes
+
+### 1. Narrative visibility cascade endpoint
+
+`PATCH /api/ddd/narratives/{slug}/visibility/` (in `apps/runs/api.py`).
+
+- Body: `{ "visibility": "private" | "link" }`.
+- Effect: `Walkthrough.objects.filter(narrative_slug=slug).update(visibility=...)`
+  and `ReviewRequest.objects.filter(narrative_slug=slug).update(visibility=...)`.
+  Also handle rows that carry the slug only via `run_id`
+  (`narrative_slug_from_run_id`) — match the same set the aggregate uses, so
+  the toggle covers exactly what the narrative page displays.
+- Auth: `session_auth` (any authenticated Dimagi user).
+- Response: `{ slug, visibility, walkthroughs_updated, reviews_updated }`.
+
+### 2. Narrative aggregate exposes computed visibility
+
+In `apps/runs/aggregate.py` + the narrative schema (`apps/runs/schemas.py`),
+add a computed `visibility` to the narrative payload:
+
+- `"public"` if every matched row is `link`.
+- `"private"` if every matched row is `private`.
+- `"mixed"` if rows disagree (e.g. legacy data). The toggle resolves mixed by
+  setting all rows to the chosen value.
+
+The UI renders the toggle from this field; "mixed" shows as an indeterminate
+state biased toward Private.
+
+### 3. Walkthrough streaming gate (`apps/walkthroughs/streaming.py`)
+
+Replace the token check:
+
+```python
+# before
+token_ok = (w.visibility == VISIBILITY_LINK and bool(w.share_token)
+            and token == w.share_token)
+if not (is_authed or token_ok): raise Http404
+
+# after
+if not (request.user.is_authenticated
+        or w.visibility == Walkthrough.VISIBILITY_LINK):
+    raise Http404("walkthrough not found")
+```
+
+### 4. Walkthrough detail GET becomes tokenless-public
+
+`get_walkthrough` (`apps/walkthroughs/api.py`): set `auth=None`, self-enforce:
+
+```python
+if not (request.user.is_authenticated
+        or w.visibility == Walkthrough.VISIBILITY_LINK):
+    raise Http404  # don't leak private existence
+```
+
+### 5. Middleware allowlist (`apps/common/middleware.py`)
+
+Add `_is_walkthrough_link(path)`, mirroring `_is_review_link`:
+
+- allow the SPA shell `/w/<uuid>` (path starts with `/w/`),
+- allow `GET /api/walkthroughs/<uuid>/` (a detail path under
+  `/api/walkthroughs/` that is not the bare collection),
+- **not** the bare collection `POST /api/walkthroughs/` (upload still requires
+  auth).
+
+Wire it into `LoginRequiredMiddleware.__call__` alongside the existing
+`_is_walkthrough_content` / `_is_review_link` checks. (`/w/<uuid>/content`
+remains covered by `_is_walkthrough_content`.)
+
+### 6. Reviews access checks (`apps/reviews/api.py`)
+
+- `_can_read`: `request.user.is_authenticated or review.visibility ==
+  VISIBILITY_LINK`. (Drop the token comparison.)
+- `_can_write`: `request.user.is_authenticated` (owner or any Dimagi user).
+  Drop the token-write path.
+
+### 7. Remove dead surfaces
+
+- Delete the `POST /api/walkthroughs/{wid}/rotate-token/` route and
+  `WalkthroughRotateTokenOut` schema.
+- Remove `share_token` from `WalkthroughDetailOut` and `ReviewRequestOut`
+  response schemas (and the `_detail_payload` builder).
+- Stop auto-minting tokens in `patch_walkthrough`, `create` (upload), and
+  review creation.
+- Keep the model column + methods (dormant).
+
+### 8. Regenerate OpenAPI types
+
+`cd frontend && npm run gen:api` after schema changes (or let `regen-openapi`
+CI do it).
+
+## Frontend changes
+
+### 9. DDD narrative page (`NarrativeLanding`)
+
+Add a single **Public / Private** toggle in the narrative header, bound to the
+aggregate `visibility`. Calls `PATCH /api/ddd/narratives/{slug}/visibility/`,
+optimistically updates, shows "mixed" as a distinct (indeterminate) state that
+resolves on click. Add the API client wrapper in the runs/ddd api module.
+
+### 10. Walkthrough viewer (`WalkthroughViewerPage`)
+
+- Remove "Copy share link" and "Rotate token" buttons and their handlers
+  (`copyShareLink`, `rotate`), plus the `rotateWalkthroughToken` client fn.
+- Keep one **Public / Private** toggle (the existing `toggleVisibility`, now
+  labeled Public/Private) and the status badge (green "Public" /
+  gray "Private").
+- Iframe `src` drops the `?t=` token: `contentSrc =
+  withSceneHash(walkthroughContentUrl(w.id), window.location.hash)`. Remove the
+  `viewerToken` plumbing.
+
+### 11. List / package pages
+
+No functional change. If any list item renders token/share affordances, drop
+them. Run package page (`RunPackage`) continues to link to artifacts by clean
+URL.
+
+## Testing
+
+- **Backend** (`uv run pytest`):
+  - Cascade endpoint flips all walkthroughs + reviews for a slug; counts
+    correct; covers rows matched via `run_id`-derived slug.
+  - Aggregate `visibility` returns public / private / mixed correctly.
+  - Streaming gate: public content served to anonymous (no token); private
+    404s anonymous; owner always served.
+  - Walkthrough detail GET: public reachable anonymous, private 404s anonymous.
+  - Reviews: public read anonymous OK; submit anonymous → 401/403; submit
+    authenticated OK.
+  - Middleware allowlist: `/w/<uuid>` and `GET /api/walkthroughs/<uuid>/` pass
+    for anonymous; `POST /api/walkthroughs/` and `/api/reviews/` (collection)
+    still gated.
+  - Removed `rotate-token` route returns 404; `share_token` absent from
+    detail/review responses.
+- **Frontend** (`cd frontend && npm run build`): type-checks against
+  regenerated OpenAPI types (no `share_token` / rotate references remain).
+- **Manual:** flip a narrative to Public, open `/w/<id>` and `/review/<id>` in a
+  logged-out browser, confirm both load and the video scrubs; flip back to
+  Private, confirm both 404 / redirect.
+
+## Rollout
+
+Single PR. No data migration required (enum values unchanged; existing `link`
+rows transparently become tokenless-public, existing tokens simply stop being
+checked). Reversible by restoring the token checks and UI; the `share_token`
+data is preserved.

--- a/frontend/src/api/ddd.ts
+++ b/frontend/src/api/ddd.ts
@@ -56,6 +56,7 @@ export interface DddNarrativeDetail {
   story: string | null
   phase: string | null
   project_slug: string | null
+  visibility: 'public' | 'private' | 'mixed'
   current_version: DddNarrativeStory | null
   versions: DddNarrativeVersion[]
 }
@@ -161,6 +162,30 @@ async function del(url: string): Promise<void> {
   }
 }
 
+async function patchJson<T>(url: string, body: unknown): Promise<T> {
+  const csrf = csrfToken()
+  const resp = await fetch(url, {
+    method: 'PATCH',
+    credentials: 'same-origin',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(csrf ? { 'X-CSRFToken': decodeURIComponent(csrf) } : {}),
+    },
+    body: JSON.stringify(body),
+  })
+  if (!resp.ok) {
+    let detail = ''
+    try {
+      const b = await resp.json()
+      detail = b?.detail ?? b?.title ?? ''
+    } catch {
+      /* ignore */
+    }
+    throw new Error(detail || `Request failed (${resp.status})`)
+  }
+  return resp.json() as Promise<T>
+}
+
 export interface ListNarrativesParams {
   project?: string
   mine?: boolean
@@ -178,6 +203,23 @@ export function listNarratives(
 
 export function getNarrative(slug: string): Promise<DddNarrativeDetail> {
   return getJson(`/api/ddd/narratives/${encodeURIComponent(slug)}/`)
+}
+
+export interface SetNarrativeVisibilityResult {
+  slug: string
+  visibility: 'public' | 'private' | 'mixed'
+  walkthroughs_updated: number
+  reviews_updated: number
+}
+
+/** Make an entire narrative public or private (cascades to all artifacts + reviews). */
+export function setNarrativeVisibility(
+  slug: string,
+  makePublic: boolean,
+): Promise<SetNarrativeVisibilityResult> {
+  return patchJson(`/api/ddd/narratives/${encodeURIComponent(slug)}/visibility/`, {
+    visibility: makePublic ? 'link' : 'private',
+  })
 }
 
 export function getRun(runId: string): Promise<DddRunPackage> {

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -774,23 +774,6 @@ export interface paths {
         readonly patch: operations["apps_walkthroughs_api_patch_walkthrough"];
         readonly trace?: never;
     };
-    readonly "/api/walkthroughs/{wid}/rotate-token/": {
-        readonly parameters: {
-            readonly query?: never;
-            readonly header?: never;
-            readonly path?: never;
-            readonly cookie?: never;
-        };
-        readonly get?: never;
-        readonly put?: never;
-        /** Rotate share token (owner only) */
-        readonly post: operations["apps_walkthroughs_api_rotate_token"];
-        readonly delete?: never;
-        readonly options?: never;
-        readonly head?: never;
-        readonly patch?: never;
-        readonly trace?: never;
-    };
     readonly "/api/tokens/": {
         readonly parameters: {
             readonly query?: never;
@@ -872,7 +855,7 @@ export interface paths {
          *
          *     Access rules:
          *     - Any authenticated user can read any review (they're team-internal).
-         *     - Unauthenticated callers may read if visibility=="link" and ?t= matches.
+         *     - Unauthenticated callers may read if visibility=="link" (no token required).
          *     - Otherwise → 404 (don't leak existence).
          */
         readonly get: operations["apps_reviews_api_get_review"];
@@ -967,6 +950,23 @@ export interface paths {
         readonly options?: never;
         readonly head?: never;
         readonly patch?: never;
+        readonly trace?: never;
+    };
+    readonly "/api/ddd/narratives/{slug}/visibility/": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly get?: never;
+        readonly put?: never;
+        readonly post?: never;
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        /** Set visibility for an entire narrative (cascades to all artifacts + reviews) */
+        readonly patch: operations["apps_runs_api_set_narrative_visibility"];
         readonly trace?: never;
     };
     readonly "/api/ddd/narratives/{slug}/versions/{version}/": {
@@ -1934,7 +1934,7 @@ export interface components {
         };
         /**
          * WalkthroughDetailOut
-         * @description Detail view adds share_token (owner only), content_type, is_owner.
+         * @description Detail view adds content_type and is_owner.
          */
         readonly WalkthroughDetailOut: {
             /**
@@ -1986,8 +1986,6 @@ export interface components {
              * Format: date-time
              */
             readonly updated_at: string;
-            /** Share Token */
-            readonly share_token?: string | null;
             /** Content Type */
             readonly content_type: string;
             /** Is Owner */
@@ -2084,11 +2082,6 @@ export interface components {
             /** Links */
             readonly links?: readonly components["schemas"]["WalkthroughLink"][] | null;
         };
-        /** WalkthroughRotateTokenOut */
-        readonly WalkthroughRotateTokenOut: {
-            /** Share Token */
-            readonly share_token: string;
-        };
         /**
          * PersonalTokenOut
          * @description A token as listed to its owner. Never contains the raw value.
@@ -2179,8 +2172,6 @@ export interface components {
              * Format: date-time
              */
             readonly last_activity_at: string;
-            /** Share Token */
-            readonly share_token?: string | null;
             /** Is Owner */
             readonly is_owner: boolean;
         };
@@ -2196,8 +2187,6 @@ export interface components {
             readonly id: string;
             /** Url */
             readonly url: string;
-            /** Share Token */
-            readonly share_token: string;
         };
         /**
          * ReviewCreateIn
@@ -2249,8 +2238,6 @@ export interface components {
             readonly response_json?: {
                 readonly [key: string]: unknown;
             } | null;
-            /** Share Token */
-            readonly share_token?: string | null;
             /** Is Owner */
             readonly is_owner: boolean;
             /**
@@ -2316,6 +2303,12 @@ export interface components {
             readonly phase?: string | null;
             /** Project Slug */
             readonly project_slug?: string | null;
+            /**
+             * Visibility
+             * @default private
+             * @enum {string}
+             */
+            readonly visibility: "public" | "private" | "mixed";
             readonly current_version?: components["schemas"]["NarrativeStoryOut"] | null;
             /**
              * Versions
@@ -2493,6 +2486,28 @@ export interface components {
              * @default []
              */
             readonly all_artifacts: readonly components["schemas"]["RunArtifactRefOut"][];
+        };
+        /** NarrativeVisibilityOut */
+        readonly NarrativeVisibilityOut: {
+            /** Slug */
+            readonly slug: string;
+            /**
+             * Visibility
+             * @enum {string}
+             */
+            readonly visibility: "public" | "private" | "mixed";
+            /** Walkthroughs Updated */
+            readonly walkthroughs_updated: number;
+            /** Reviews Updated */
+            readonly reviews_updated: number;
+        };
+        /** NarrativeVisibilityIn */
+        readonly NarrativeVisibilityIn: {
+            /**
+             * Visibility
+             * @enum {string}
+             */
+            readonly visibility: "private" | "link";
         };
         /** Page[ShareoutOut] */
         readonly Page_ShareoutOut_: {
@@ -3859,28 +3874,6 @@ export interface operations {
             };
         };
     };
-    readonly apps_walkthroughs_api_rotate_token: {
-        readonly parameters: {
-            readonly query?: never;
-            readonly header?: never;
-            readonly path: {
-                readonly wid: string;
-            };
-            readonly cookie?: never;
-        };
-        readonly requestBody?: never;
-        readonly responses: {
-            /** @description OK */
-            readonly 200: {
-                headers: {
-                    readonly [name: string]: unknown;
-                };
-                content: {
-                    readonly "application/json": components["schemas"]["WalkthroughRotateTokenOut"];
-                };
-            };
-        };
-    };
     readonly apps_tokens_api_list_tokens: {
         readonly parameters: {
             readonly query?: never;
@@ -4165,6 +4158,32 @@ export interface operations {
                     readonly [name: string]: unknown;
                 };
                 content?: never;
+            };
+        };
+    };
+    readonly apps_runs_api_set_narrative_visibility: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path: {
+                readonly slug: string;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody: {
+            readonly content: {
+                readonly "application/json": components["schemas"]["NarrativeVisibilityIn"];
+            };
+        };
+        readonly responses: {
+            /** @description OK */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["NarrativeVisibilityOut"];
+                };
             };
         };
     };

--- a/frontend/src/api/walkthroughs.ts
+++ b/frontend/src/api/walkthroughs.ts
@@ -73,19 +73,6 @@ export async function deleteWalkthrough(id: string): Promise<void> {
   if (error) throw new Error("Failed to delete walkthrough");
 }
 
-export async function rotateWalkthroughToken(
-  id: string,
-): Promise<{ share_token: string }> {
-  const { data, error } = await apiV2.POST(
-    "/api/walkthroughs/{wid}/rotate-token/",
-    {
-      params: { path: { wid: id } },
-    },
-  );
-  if (error) throw new Error("Failed to rotate token");
-  return data;
-}
-
 // Multipart upload — openapi-fetch's bodySerializer is used to pass FormData
 // directly rather than JSON-encoding the body.
 // Note: openapi-fetch types the body as the schema type; we override with
@@ -104,10 +91,6 @@ export async function uploadWalkthrough(
   return data as unknown as WalkthroughDetail;
 }
 
-export function walkthroughContentUrl(
-  id: string,
-  shareToken: string | null,
-): string {
-  const t = shareToken ? `?t=${encodeURIComponent(shareToken)}` : "";
-  return `/w/${id}/content${t}`;
+export function walkthroughContentUrl(id: string): string {
+  return `/w/${id}/content`;
 }

--- a/frontend/src/auth/AuthProvider.tsx
+++ b/frontend/src/auth/AuthProvider.tsx
@@ -9,10 +9,12 @@ type AuthState =
 
 const AuthContext = createContext<AuthState>({ status: 'loading', user: null })
 
-// Routes that are reachable via a per-token share link without a Dimagi session.
-// The page itself enforces access via its ?t= token against the API.
+// Routes reachable without a Dimagi session: public (visibility=link) walkthroughs
+// and reviews. These are tokenless — the UUID in the URL is the only secret, and
+// the API self-enforces (private resources 404 to anonymous callers).
 function isPublicLinkRoute(): boolean {
-  return window.location.pathname.startsWith('/review/')
+  const path = window.location.pathname
+  return path.startsWith('/review/') || path.startsWith('/w/')
 }
 
 export function useAuth(): AuthState {
@@ -53,9 +55,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return <LoginPrompt />
   }
 
-  // Authenticated, OR anonymous on a public token-link route (e.g. /review/<id>?t=…).
-  // Public-link pages self-gate on their ?t= share token via the API, so they must
-  // render without a Dimagi session.
+  // Authenticated, OR anonymous on a public link route (e.g. /w/<id> or /review/<id>).
+  // Public resources are tokenless; the API self-enforces (private → 404), so these
+  // pages must render without a Dimagi session.
   return <AuthContext.Provider value={state}>{children}</AuthContext.Provider>
 }
 

--- a/frontend/src/components/ddd/NarrativeLanding.tsx
+++ b/frontend/src/components/ddd/NarrativeLanding.tsx
@@ -5,6 +5,7 @@ import {
   deleteNarrativeVersion,
   deleteRun,
   getNarrative,
+  setNarrativeVisibility,
   type DddNarrativeDetail,
   type DddNarrativeRun,
   type DddNarrativeVersion,
@@ -219,6 +220,7 @@ export function NarrativeLanding({ slug }: { slug: string }) {
   const [error, setError] = useState<string | null>(null)
   const [reloadKey, setReloadKey] = useState(0)
   const [deletingNarrative, setDeletingNarrative] = useState(false)
+  const [vizBusy, setVizBusy] = useState(false)
 
   useEffect(() => {
     let cancelled = false
@@ -251,6 +253,20 @@ export function NarrativeLanding({ slug }: { slug: string }) {
     }
   }
 
+  async function toggleVisibility() {
+    if (!detail) return
+    const makePublic = detail.visibility !== 'public'
+    setVizBusy(true)
+    try {
+      const res = await setNarrativeVisibility(slug, makePublic)
+      setDetail({ ...detail, visibility: res.visibility })
+    } catch (err) {
+      window.alert(`Could not change visibility: ${(err as Error).message || err}`)
+    } finally {
+      setVizBusy(false)
+    }
+  }
+
   if (error) return <div className="p-8 text-sm text-red-400/90">Error: {error}</div>
   if (!detail) return <div className="p-8 text-sm text-stone-500">Loading…</div>
 
@@ -272,14 +288,35 @@ export function NarrativeLanding({ slug }: { slug: string }) {
             {detail.project_slug && <span>· {detail.project_slug}</span>}
           </div>
         </div>
-        <button
-          type="button"
-          onClick={onDeleteNarrative}
-          disabled={deletingNarrative}
-          className="shrink-0 rounded-md border border-stone-800 px-2.5 py-1 text-xs text-stone-500 transition-colors hover:border-red-500/40 hover:bg-red-500/10 hover:text-red-300 disabled:opacity-50"
-        >
-          {deletingNarrative ? 'Deleting…' : 'Delete narrative'}
-        </button>
+        <div className="flex shrink-0 items-center gap-2">
+          <button
+            type="button"
+            onClick={toggleVisibility}
+            disabled={vizBusy}
+            title="Toggle whether this whole narrative (video, deck, docs, reviews) is public"
+            className={`rounded-lg border px-3 py-1 text-sm transition-colors disabled:opacity-50 ${
+              detail.visibility === 'public'
+                ? 'border-emerald-400/25 bg-emerald-400/10 text-emerald-400/90 hover:bg-emerald-400/20'
+                : 'border-stone-700 bg-stone-800/60 text-stone-300 hover:bg-stone-800'
+            }`}
+          >
+            {vizBusy
+              ? '…'
+              : detail.visibility === 'public'
+                ? 'Public'
+                : detail.visibility === 'mixed'
+                  ? 'Mixed — make public'
+                  : 'Private'}
+          </button>
+          <button
+            type="button"
+            onClick={onDeleteNarrative}
+            disabled={deletingNarrative}
+            className="rounded-md border border-stone-800 px-2.5 py-1 text-xs text-stone-500 transition-colors hover:border-red-500/40 hover:bg-red-500/10 hover:text-red-300 disabled:opacity-50"
+          >
+            {deletingNarrative ? 'Deleting…' : 'Delete narrative'}
+          </button>
+        </div>
       </header>
 
       <div className="mt-6 flex items-baseline gap-2">

--- a/frontend/src/pages/ReviewPage.tsx
+++ b/frontend/src/pages/ReviewPage.tsx
@@ -1123,7 +1123,7 @@ function ReviewEditorInner({ review, readOnly, onResolved }: ReviewEditorInnerPr
   // Video embed
   let videoElement: React.ReactNode = null
   if (req.video?.walkthrough_id) {
-    const contentSrc = walkthroughContentUrl(req.video.walkthrough_id, shareToken)
+    const contentSrc = walkthroughContentUrl(req.video.walkthrough_id)
     videoElement = (
       <iframe
         src={contentSrc}

--- a/frontend/src/pages/ReviewPage.tsx
+++ b/frontend/src/pages/ReviewPage.tsx
@@ -1740,7 +1740,9 @@ export function ReviewPage() {
     >
       <ReviewEditorInner
         review={review}
-        readOnly={isResolved}
+        // Submitting requires a Dimagi login (public reviews are read-only to
+        // anonymous viewers); also read-only once resolved.
+        readOnly={isResolved || auth.status !== 'authenticated'}
         onResolved={(updated) => setReview(updated)}
       />
     </ReviewEditorProvider>,

--- a/frontend/src/pages/WalkthroughViewerPage.tsx
+++ b/frontend/src/pages/WalkthroughViewerPage.tsx
@@ -4,7 +4,6 @@ import {
   deleteWalkthrough,
   getWalkthrough,
   patchWalkthrough,
-  rotateWalkthroughToken,
   walkthroughContentUrl,
   type WalkthroughDetail,
 } from '../api/walkthroughs'
@@ -42,31 +41,6 @@ export function WalkthroughViewerPage() {
     }
   }
 
-  async function copyShareLink() {
-    if (!w) return
-    let token = w.share_token
-    if (!token || w.visibility !== 'link') {
-      const updated = await patchWalkthrough(w.id, { visibility: 'link' })
-      setW(updated)
-      token = updated.share_token
-    }
-    const url = `${window.location.origin}/w/${w.id}?t=${encodeURIComponent(token!)}`
-    await navigator.clipboard.writeText(url)
-  }
-
-  async function rotate() {
-    if (!w) return
-    setBusy(true)
-    try {
-      const { share_token } = await rotateWalkthroughToken(w.id)
-      setW({ ...w, share_token })
-      const url = `${window.location.origin}/w/${w.id}?t=${encodeURIComponent(share_token)}`
-      await navigator.clipboard.writeText(url)
-    } finally {
-      setBusy(false)
-    }
-  }
-
   async function destroy() {
     if (!w) return
     if (!confirm(`Delete "${w.title}"? This cannot be undone.`)) return
@@ -89,13 +63,11 @@ export function WalkthroughViewerPage() {
     return <div className="max-w-4xl mx-auto p-6 text-stone-500">Loading…</div>
   }
 
-  const params = new URLSearchParams(window.location.search)
-  const viewerToken = params.get('t') ?? w.share_token ?? null
-  // Forward a `#scene-N` deep-link (e.g. /w/<id>?t=<tok>#scene-3) into the deck
+  // Forward a `#scene-N` deep-link (e.g. /w/<id>#scene-3) into the deck
   // iframe so it opens on that scene; the deck's own JS reads its hash. Videos
   // ignore it. Non-scene hashes normalize to '' and pass through unchanged.
   const contentSrc = withSceneHash(
-    walkthroughContentUrl(w.id, viewerToken),
+    walkthroughContentUrl(w.id),
     window.location.hash,
   )
 
@@ -127,7 +99,7 @@ export function WalkthroughViewerPage() {
               : 'text-stone-400 bg-stone-800/60 border-stone-700'
           }`}
         >
-          {w.visibility === 'link' ? 'Shareable link' : 'Private (dimagi)'}
+          {w.visibility === 'link' ? 'Public' : 'Private (dimagi)'}
         </span>
       </header>
 
@@ -138,24 +110,8 @@ export function WalkthroughViewerPage() {
             onClick={toggleVisibility}
             disabled={busy}
           >
-            {w.visibility === 'link' ? 'Make private' : 'Enable link'}
+            {w.visibility === 'link' ? 'Make private' : 'Make public'}
           </button>
-          <button
-            className="px-3 py-1 rounded-lg border border-stone-800 bg-stone-900 text-stone-300 hover:bg-stone-800 hover:border-stone-700 transition-colors disabled:opacity-50"
-            onClick={copyShareLink}
-            disabled={busy}
-          >
-            Copy share link
-          </button>
-          {w.visibility === 'link' && (
-            <button
-              className="px-3 py-1 rounded-lg border border-stone-800 bg-stone-900 text-stone-300 hover:bg-stone-800 hover:border-stone-700 transition-colors disabled:opacity-50"
-              onClick={rotate}
-              disabled={busy}
-            >
-              Rotate token
-            </button>
-          )}
           <button
             className="px-3 py-1 rounded-lg border border-red-500/30 text-red-400/90 bg-red-500/5 hover:bg-red-500/10 transition-colors disabled:opacity-50 ml-auto"
             onClick={destroy}

--- a/tests/test_narrative_visibility.py
+++ b/tests/test_narrative_visibility.py
@@ -1,0 +1,83 @@
+"""Narrative-level visibility cascade + computed aggregate field."""
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import Client, override_settings
+
+from apps.reviews.models import ReviewRequest
+from apps.runs import aggregate
+from apps.walkthroughs.models import Walkthrough
+
+
+@pytest.fixture
+def owner(db):
+    return get_user_model().objects.create_user(
+        username="owner@dimagi.com", email="owner@dimagi.com",
+    )
+
+
+def _wt(owner, **kw):
+    defaults = dict(
+        title="art", kind="video", owner=owner,
+        drive_file_id="f", drive_folder_id="d",
+        content_type="video/mp4", size_bytes=1,
+        run_id="demo-2026-06-09-001", narrative_slug="demo",
+    )
+    defaults.update(kw)
+    return Walkthrough.objects.create(**defaults)
+
+
+def _rev(owner, **kw):
+    defaults = dict(
+        run_id="demo-2026-06-09-001", narrative_slug="demo",
+        gate="narrative-agreement", request_json={"narrative": "s"}, owner=owner,
+    )
+    defaults.update(kw)
+    return ReviewRequest.objects.create(**defaults)
+
+
+def test_set_narrative_visibility_cascades(db, owner):
+    w1 = _wt(owner, drive_file_id="f1", visibility="private")
+    w2 = _wt(owner, drive_file_id="f2", visibility="private", run_id="demo-2026-06-09-002")
+    r1 = _rev(owner, visibility="private")
+    wt_n, rev_n = aggregate.set_narrative_visibility("demo", "link")
+    assert (wt_n, rev_n) == (2, 1)
+    w1.refresh_from_db(); w2.refresh_from_db(); r1.refresh_from_db()
+    assert w1.visibility == w2.visibility == "link"
+    assert r1.visibility == "link"
+
+
+def test_aggregate_visibility_public_private_mixed(db, owner):
+    _wt(owner, drive_file_id="fa", visibility="link")
+    _rev(owner, visibility="link")
+    assert aggregate.build_narrative("demo")["visibility"] == "public"
+    aggregate.set_narrative_visibility("demo", "private")
+    assert aggregate.build_narrative("demo")["visibility"] == "private"
+    # Make one row disagree -> mixed.
+    Walkthrough.objects.filter(narrative_slug="demo").update(visibility="link")
+    assert aggregate.build_narrative("demo")["visibility"] == "mixed"
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_patch_endpoint_requires_auth(db, owner):
+    _wt(owner)
+    resp = Client().patch(
+        "/api/ddd/narratives/demo/visibility/",
+        data={"visibility": "link"}, content_type="application/json",
+    )
+    assert resp.status_code == 401
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_patch_endpoint_cascades(db, owner):
+    _wt(owner, visibility="private")
+    _rev(owner, visibility="private")
+    client = Client(); client.force_login(owner)
+    resp = client.patch(
+        "/api/ddd/narratives/demo/visibility/",
+        data={"visibility": "link"}, content_type="application/json",
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["visibility"] == "public"
+    assert body["walkthroughs_updated"] == 1
+    assert body["reviews_updated"] == 1

--- a/tests/test_visibility_reviews.py
+++ b/tests/test_visibility_reviews.py
@@ -1,0 +1,64 @@
+"""Tokenless review read; authenticated-only submit."""
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import Client, override_settings
+
+from apps.reviews.models import ReviewRequest
+
+
+@pytest.fixture
+def owner(db):
+    return get_user_model().objects.create_user(
+        username="owner@dimagi.com", email="owner@dimagi.com",
+    )
+
+
+def _review(owner, **kw):
+    defaults = dict(
+        run_id="demo-2026-06-09-001",
+        narrative_slug="demo",
+        gate="narrative-agreement",
+        request_json={"narrative": "A story"},
+        owner=owner,
+    )
+    defaults.update(kw)
+    return ReviewRequest.objects.create(**defaults)
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_public_review_read_anonymous(owner):
+    r = _review(owner, visibility="link")
+    resp = Client().get(f"/api/reviews/{r.id}/")
+    assert resp.status_code == 200
+    assert resp.json()["id"] == str(r.id)
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_private_review_404s_anonymous(owner):
+    r = _review(owner, visibility="private")
+    resp = Client().get(f"/api/reviews/{r.id}/")
+    assert resp.status_code in (403, 404)
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_public_review_submit_blocked_for_anonymous(owner):
+    r = _review(owner, visibility="link")
+    resp = Client().post(
+        f"/api/reviews/{r.id}/submit/",
+        data={"response_json": {}},
+        content_type="application/json",
+    )
+    assert resp.status_code in (401, 403)
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_review_submit_allowed_for_authenticated(owner):
+    r = _review(owner, visibility="link")
+    client = Client()
+    client.force_login(owner)
+    resp = client.post(
+        f"/api/reviews/{r.id}/submit/",
+        data={"response_json": {}},
+        content_type="application/json",
+    )
+    assert resp.status_code == 200

--- a/tests/test_visibility_walkthroughs.py
+++ b/tests/test_visibility_walkthroughs.py
@@ -72,3 +72,16 @@ def test_authed_non_owner_sees_private_content(owner):
     with _stub_download():
         resp = client.get(f"/w/{w.id}/content")
     assert resp.status_code == 200
+
+
+def test_detail_handler_404s_private_for_anonymous(owner):
+    """With auth=None the handler itself must hide private rows from anonymous."""
+    from django.test import RequestFactory
+    from django.contrib.auth.models import AnonymousUser
+    from apps.walkthroughs.api import get_walkthrough
+
+    w = _make(owner, visibility="private")
+    req = RequestFactory().get(f"/api/walkthroughs/{w.id}/")
+    req.user = AnonymousUser()
+    with pytest.raises(Exception):  # Http404 / ProblemError → not found
+        get_walkthrough(req, w.id)

--- a/tests/test_visibility_walkthroughs.py
+++ b/tests/test_visibility_walkthroughs.py
@@ -57,3 +57,18 @@ def test_owner_sees_private_content(owner):
     with _stub_download():
         resp = client.get(f"/w/{w.id}/content")
     assert resp.status_code == 200
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_authed_non_owner_sees_private_content(owner):
+    # The tokenless gate grants any authenticated Dimagi user access,
+    # not just the owner.
+    w = _make(owner, visibility="private")
+    other = get_user_model().objects.create_user(
+        username="other@dimagi.com", email="other@dimagi.com",
+    )
+    client = Client()
+    client.force_login(other)
+    with _stub_download():
+        resp = client.get(f"/w/{w.id}/content")
+    assert resp.status_code == 200

--- a/tests/test_visibility_walkthroughs.py
+++ b/tests/test_visibility_walkthroughs.py
@@ -85,3 +85,37 @@ def test_detail_handler_404s_private_for_anonymous(owner):
     req.user = AnonymousUser()
     with pytest.raises(Exception):  # Http404 / ProblemError → not found
         get_walkthrough(req, w.id)
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_public_detail_api_reachable_anonymous(owner):
+    w = _make(owner, visibility="link")
+    resp = Client().get(f"/api/walkthroughs/{w.id}/")
+    assert resp.status_code == 200
+    assert resp.json()["id"] == str(w.id)
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_private_detail_api_404s_anonymous(owner):
+    w = _make(owner, visibility="private")
+    resp = Client().get(f"/api/walkthroughs/{w.id}/")
+    # Reaches the handler (allowlisted) and the handler hides it.
+    assert resp.status_code == 404
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_walkthrough_shell_served_to_anonymous(owner):
+    w = _make(owner, visibility="link")
+    resp = Client().get(f"/w/{w.id}")
+    # Middleware passes the request through (not a login redirect).
+    # spa_view returns 200 when the frontend is built, 503 when it isn't
+    # (test environment has no build output). Either way, auth did not block it.
+    assert resp.status_code != 302, "Anonymous user was redirected to login"
+    assert resp.status_code in (200, 503)
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_walkthrough_collection_still_gated(db):
+    # The list/upload collection must NOT be public.
+    resp = Client().get("/api/walkthroughs/")
+    assert resp.status_code == 401

--- a/tests/test_visibility_walkthroughs.py
+++ b/tests/test_visibility_walkthroughs.py
@@ -1,0 +1,59 @@
+"""Tokenless visibility behaviour for the walkthrough content stream + detail."""
+from unittest.mock import patch
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import Client, override_settings
+
+from apps.walkthroughs.models import Walkthrough
+
+
+@pytest.fixture
+def owner(db):
+    return get_user_model().objects.create_user(
+        username="owner@dimagi.com", email="owner@dimagi.com",
+    )
+
+
+def _make(owner, **kw):
+    defaults = dict(
+        title="Demo", kind="video", owner=owner,
+        drive_file_id="file-1", drive_folder_id="folder-1",
+        content_type="video/mp4", size_bytes=10,
+    )
+    defaults.update(kw)
+    return Walkthrough.objects.create(**defaults)
+
+
+# Streaming returns bytes; stub the Drive download so tests stay offline.
+# storage.download returns (data, start, end_inclusive, total).
+def _stub_download():
+    return patch(
+        "apps.walkthroughs.streaming.storage.download",
+        return_value=(b"data", 0, 3, 4),
+    )
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_public_content_served_to_anonymous_without_token(owner):
+    w = _make(owner, visibility="link")
+    with _stub_download():
+        resp = Client().get(f"/w/{w.id}/content")
+    assert resp.status_code == 200
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_private_content_404s_anonymous(owner):
+    w = _make(owner, visibility="private")
+    resp = Client().get(f"/w/{w.id}/content")
+    assert resp.status_code == 404
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_owner_sees_private_content(owner):
+    w = _make(owner, visibility="private")
+    client = Client()
+    client.force_login(owner)
+    with _stub_download():
+        resp = client.get(f"/w/{w.id}/content")
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary

Replaces per-artifact **share tokens** with a simpler tokenless **Public/Private** model, and adds a **narrative-level toggle** that cascades visibility to everything under a DDD narrative.

- **`link` visibility now means "public" (tokenless).** Anyone with the `/w/<id>` or `/review/<id>` URL can view — the UUID is the only secret. No more `?t=` tokens, copy-share-link, or rotate-token UI. The `share_token` column + model methods are retained (dormant), so the change is reversible; no data migration.
- **New `PATCH /api/ddd/narratives/{slug}/visibility/`** cascades visibility to every walkthrough **and** review under a narrative. The narrative detail aggregate now reports a computed `visibility` (`public` / `private` / `mixed`).
- **One toggle on the DDD narrative page** (cascades) + **one simplified toggle on the walkthrough viewer** (for standalone artifacts). The old three-button token UI is gone.
- **Auth model:** walkthrough content stream + detail GET are tokenless (authenticated OR `visibility==link`); private + anonymous → 404 (no existence leak). The login middleware allowlists the `/w/` shell + walkthrough detail GET (mirroring the existing review-link allowlist). Review **read** is public; review **submit** (approve/redraft) is **Dimagi-login-only** — public-readable never grants anonymous write.
- Removed `share_token` from all API responses and deleted the walkthrough rotate-token route.

Design + plan: `docs/superpowers/specs/2026-06-08-tokenless-narrative-visibility-design.md`, `docs/superpowers/plans/2026-06-09-tokenless-narrative-visibility.md`.

## Test Plan

- [x] Backend: `uv run pytest` — 397 passed, 1 skipped. New suites cover tokenless content/detail gates, middleware allowlist (collection still gated), tokenless review read + auth-only submit, and the narrative cascade + aggregate status.
- [x] Frontend: `npx tsc --noEmit` clean + `npm run build` passes; generated OpenAPI types regenerated.
- [ ] Manual: flip a narrative to **Public**, open `/w/<id>` and `/review/<id>` logged-out → both load (video scrubs); flip to **Private** → both 404 / redirect.

## Notes / follow-ups (non-blocking)

- Inert review-token plumbing remains in `frontend/src/api/reviews.ts` (a `?t=` param the backend now ignores; `share_token` is always null) — safe to clean up later.
- Pre-existing minor resolver asymmetry between the narrative's *displayed* status and the cascade for the rare case where a review's own `narrative_slug` diverges from its run's walkthroughs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)