### PR TITLE
feat(walkthroughs-web): /w/ video viewer seeks to #t=<seconds> on load

### DIFF
--- a/frontend/src/lib/timeHash.test.ts
+++ b/frontend/src/lib/timeHash.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { timeHashSeconds, withTimeFragment } from './timeHash'
+
+describe('timeHashSeconds', () => {
+  it('parses a #t=N hash into seconds', () => {
+    expect(timeHashSeconds('#t=83')).toBe(83)
+    expect(timeHashSeconds('#t=0')).toBe(0)
+  })
+
+  it('accepts decimals and a hash without the leading #', () => {
+    expect(timeHashSeconds('#t=12.5')).toBe(12.5)
+    expect(timeHashSeconds('t=7')).toBe(7)
+  })
+
+  it('ignores non-time hashes so unrelated anchors never seek the video', () => {
+    expect(timeHashSeconds('#scene-3')).toBeNull()
+    expect(timeHashSeconds('#t=')).toBeNull()
+    expect(timeHashSeconds('#t=abc')).toBeNull()
+    expect(timeHashSeconds('#t=-5')).toBeNull()
+    expect(timeHashSeconds('#t=3&x=1')).toBeNull()
+  })
+
+  it('returns null for empty / null / undefined', () => {
+    expect(timeHashSeconds('')).toBeNull()
+    expect(timeHashSeconds(null)).toBeNull()
+    expect(timeHashSeconds(undefined)).toBeNull()
+  })
+})
+
+describe('withTimeFragment', () => {
+  it('appends a media-fragment start time, preserving any query', () => {
+    expect(withTimeFragment('/w/abc/content?t=tok', 83)).toBe('/w/abc/content?t=tok#t=83')
+    expect(withTimeFragment('/w/abc/content', 12.5)).toBe('/w/abc/content#t=12.5')
+  })
+})

--- a/frontend/src/lib/timeHash.ts
+++ b/frontend/src/lib/timeHash.ts
@@ -1,0 +1,36 @@
+/**
+ * The video deep-link contract: a `#t=<seconds>` fragment on a `/w/<id>` viewer
+ * URL means "start the video at that offset". Canopy's DDD product-findings
+ * review links each finding cluster to `<clip_url>#t=<seconds>` (the start of
+ * the scene the finding is about, from the recorder's per-scene timings), so a
+ * reviewer lands on the exact moment instead of scrubbing.
+ *
+ * `#t=` (a fragment) deliberately does NOT collide with the `?t=<share_token>`
+ * query param — fragment and query are separate URL parts, and the fragment
+ * mirrors the Media Fragments URI syntax browsers already use on media URLs.
+ */
+
+/** A `#t=<seconds>` fragment matcher. Accepts an optional leading `#` and decimals. */
+const TIME_HASH = /^#?t=(\d+(?:\.\d+)?)$/;
+
+/**
+ * Parse a raw `location.hash` into a start offset in seconds, or `null` when
+ * it isn't a time deep-link. Only plain non-negative seconds are accepted —
+ * anything else (scene anchors, junk, negative/NaN) yields `null` so callers
+ * leave playback untouched.
+ */
+export function timeHashSeconds(rawHash: string | null | undefined): number | null {
+  const m = (rawHash ?? "").match(TIME_HASH);
+  if (!m) return null;
+  const seconds = Number.parseFloat(m[1]);
+  return Number.isFinite(seconds) && seconds >= 0 ? seconds : null;
+}
+
+/**
+ * Append a media-fragment start time to a media URL. The URL is assumed
+ * fragment-free (content URLs are); browsers that honor Media Fragments seek
+ * natively, and the viewer's `loadedmetadata` fallback covers the rest.
+ */
+export function withTimeFragment(url: string, seconds: number): string {
+  return `${url}#t=${seconds}`;
+}

--- a/frontend/src/pages/WalkthroughViewerPage.tsx
+++ b/frontend/src/pages/WalkthroughViewerPage.tsx
@@ -8,6 +8,7 @@ import {
   type WalkthroughDetail,
 } from '../api/walkthroughs'
 import { withSceneHash } from '../lib/sceneHash'
+import { timeHashSeconds, withTimeFragment } from '../lib/timeHash'
 
 export function WalkthroughViewerPage() {
   const { id } = useParams<{ id: string }>()
@@ -71,6 +72,16 @@ export function WalkthroughViewerPage() {
     window.location.hash,
   )
 
+  // Video time deep-link: a `#t=<seconds>` fragment (e.g. /w/<id>#t=83) seeks
+  // the video to that offset on load. DDD findings reviews link evidence as
+  // `<clip_url>#t=<scene start>` so the reviewer lands on the exact moment.
+  // The fragment never collides with the `?t=<share_token>` query param.
+  // Two mechanisms, belt-and-braces: a Media Fragments `#t=` on the src
+  // (native seek; the content endpoint supports Range) plus a
+  // `loadedmetadata` fallback that sets currentTime directly.
+  const startAt = w.kind === 'video' ? timeHashSeconds(window.location.hash) : null
+  const videoSrc = startAt != null ? withTimeFragment(contentSrc, startAt) : contentSrc
+
   const links = w.links ?? []
   // narrative + companion are provenance / sibling-artifact nav; reference
   // links are destinations the demo visited that the viewer can go open live.
@@ -125,8 +136,13 @@ export function WalkthroughViewerPage() {
       <div className="rounded-xl border border-stone-800 bg-black overflow-hidden">
         {w.kind === 'video' ? (
           <video
-            src={contentSrc}
+            src={videoSrc}
             controls
+            onLoadedMetadata={(e) => {
+              if (startAt != null && Math.abs(e.currentTarget.currentTime - startAt) > 0.5) {
+                e.currentTarget.currentTime = startAt
+              }
+            }}
             className="w-full max-h-[80vh] bg-black"
           />
         ) : (


### PR DESCRIPTION
## What

Adds video time deep-links to the standalone `/w/<id>` walkthrough viewer: a `#t=<seconds>` URL fragment (e.g. `/w/<id>?t=<share_token>#t=83`) starts the video at that offset.

## Why

Companion to canopy's DDD **product-findings review gate** (`review_mode: human`): the walkthrough recorder now stamps per-scene `start_seconds` into the run report, and each posted finding cluster carries an evidence deep-link `<clip_url>#t=<scene start>` — so a reviewer lands on the exact moment of the clip a finding refers to instead of scrubbing. The viewer previously ignored any time hint.

## How

- New `frontend/src/lib/timeHash.ts` (+ tests) — parses a `#t=<seconds>` fragment (decimals OK; scene anchors / junk → `null`); mirrors the existing `sceneHash.ts` contract-helper pattern.
- `WalkthroughViewerPage`: for `kind=video`, the fragment is forwarded onto the content `src` (native Media Fragments seek — `/w/<id>/content` already supports HTTP Range) **and** a `loadedmetadata` fallback sets `currentTime` directly. Deck (`#scene-N`) forwarding is unchanged.
- `#t=` is a fragment, so it never collides with the `?t=<share_token>` query param.

## Verified

- `npm run test` — 39 tests green (5 new)
- `npm run build` — type check + build green

Deploy: manual, per repo convention (`./deploy.sh` or the CI Deploy workflow) — not triggered by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)