### PR TITLE
fix(ddd): product_findings reviews are not narrative versions (left-rail fix)

### DIFF
--- a/apps/runs/aggregate.py
+++ b/apps/runs/aggregate.py
@@ -42,10 +42,18 @@ def narrative_of_review(r: ReviewRequest) -> str:
     return (getattr(r, "feature", None) or "").strip() or feature_from_run_id(r.run_id)
 
 
+#: Gates that carry a one-line narration but are NOT a narrative version — they hang
+#: off the run, not the narrative timeline. ``external_release`` is an approval gate;
+#: ``product_findings`` is a run-child findings review (its narration is a degradation
+#: mirror). Including either pollutes the version list and lets it drive the narrative's
+#: title/phase (the "v0 findings review" bug).
+_NON_NARRATIVE_GATES = ("external_release", "product_findings")
+
+
 def _is_narrative_version(r: ReviewRequest) -> bool:
-    """A narrative version = a story-bearing review that isn't the external
-    release gate (which also carries a one-line narration but is not the story)."""
-    return _review_has_narrative(r) and r.gate != "external_release"
+    """A narrative version = a story-bearing review on a narrative gate (not an
+    external-release approval or a run-child product-findings review)."""
+    return _review_has_narrative(r) and r.gate not in _NON_NARRATIVE_GATES
 
 
 def _narrative_versions_for(feature: str) -> list[ReviewRequest]:

--- a/apps/runs/tests/test_aggregate.py
+++ b/apps/runs/tests/test_aggregate.py
@@ -216,3 +216,44 @@ def test_build_run_resolves_version_from_stamp():
 
 def test_build_narrative_unknown_slug_is_none():
     assert aggregate.build_narrative("nope") is None
+
+
+def test_product_findings_review_is_not_a_narrative_version():
+    """A run-child product_findings review carries a narration *mirror*, but it must
+    NOT be counted as a narrative version — otherwise it shows as a bogus 'v0' row in
+    the DDD shell and hijacks the narrative's title/phase from the real story."""
+    u = make_user()
+    rid = "program-admin-report-2026-06-11-001"
+    # The real narrative.
+    make_review(
+        u,
+        run_id=rid,
+        gate="narrative-agreement",
+        request_json={
+            "run_id": rid,
+            "gate": "narrative-agreement",
+            "narrative": "Amani opens the weekly nutrition review.\nThe table has already flagged a worker.",
+            "narration": [{"scene": 1, "id": "n1", "text": "Scene one"}],
+        },
+    )
+    # A run-child findings review (carries a narration mirror + a one-line title).
+    make_review(
+        u,
+        run_id=rid,
+        gate="product_findings",
+        request_json={
+            "run_id": rid,
+            "gate": "product_findings",
+            "clusters": [{"id": "c1", "title": "x"}],
+            "narration": [{"scene": 1, "id": "f1", "title": "The interaction model is coherent"}],
+        },
+    )
+
+    feature = feature_from_run_id(rid)
+    versions = aggregate._narrative_versions_for(feature)
+    # Only the narrative-agreement review is a version — the findings review is excluded.
+    assert [v.gate for v in versions] == ["narrative-agreement"]
+
+    run = aggregate.build_run(rid)
+    # Title/current_version come from the real narrative, not the findings cluster text.
+    assert run["narrative"]["title"] == "Amani opens the weekly nutrition review."


### PR DESCRIPTION
## Product Description
The DDD left rail no longer shows a findings review as a phantom narrative 'version' row, and the narrative's title/phase stop being hijacked by the findings review's text. Findings reviews now correctly appear only under their run.

## Technical Summary
Run-child `product_findings` reviews carry a `narration` mirror for graceful degradation; `_is_narrative_version()` only excluded `external_release`, so the findings review was pulled into the version timeline as v0 and drove `current_version`/title. Added `product_findings` to the non-narrative gates. Follow-up to #108.

## Safety Assurance
Added `test_product_findings_review_is_not_a_narrative_version`; `apps/runs/tests/test_aggregate.py` 14 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)