### PR TITLE
fix(test): correct function name in product_findings aggregate test (unblock deploy)

### DIFF
--- a/apps/runs/tests/test_aggregate.py
+++ b/apps/runs/tests/test_aggregate.py
@@ -243,7 +243,7 @@ def test_product_findings_review_is_not_a_narrative_version():
         },
     )
 
-    feature = feature_from_run_id(rid)
+    feature = narrative_slug_from_run_id(rid)
     versions = aggregate._narrative_versions_for(feature)
     # Only the narrative-agreement review is a version — the findings review is excluded.
     assert [v.gate for v in versions] == ["narrative-agreement"]


### PR DESCRIPTION
## Product Description
None (test-only fix).

## Technical Summary
#109's test referenced `feature_from_run_id` (renamed to `narrative_slug_from_run_id` on main) — landed from a stale local checkout, so CI Backend tests failed with NameError and gated off the workflow_dispatch deploy. One-line fix; the aggregate.py fix from #109 is correct and already on main.

## Safety Assurance
`apps/runs/tests/test_aggregate.py` 13 passed; full `apps/` suite 310 passed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)