### PR TITLE
fix(deploy): pass --project on all gcloud run steps

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -69,6 +69,7 @@ echo "==> Deploying to Cloud Run..."
 # --allow-unauthenticated is correct: the app's LoginRequiredMiddleware
 # enforces the Google OAuth gate at the application layer.
 gcloud run deploy "${SERVICE_NAME}" \
+  --project="${PROJECT_ID}" \
   --image="${REPO}/${SERVICE_NAME}:${TAG}" \
   --region="${REGION}" \
   --platform=managed \
@@ -87,7 +88,7 @@ gcloud run deploy "${SERVICE_NAME}" \
   --allow-unauthenticated \
   --quiet
 
-SERVICE_URL=$(gcloud run services describe "${SERVICE_NAME}" --region="${REGION}" --format="value(status.url)")
+SERVICE_URL=$(gcloud run services describe "${SERVICE_NAME}" --project="${PROJECT_ID}" --region="${REGION}" --format="value(status.url)")
 echo ""
 echo "==> Deployment complete!"
 echo "    URL: ${SERVICE_URL}"
@@ -96,4 +97,4 @@ echo "    Authorized redirect URI in Google OAuth must include:"
 echo "    ${SERVICE_URL}/accounts/google/login/callback/"
 echo ""
 echo "    To run migrations:"
-echo "    gcloud run jobs execute canopy-web-migrate --region=${REGION}"
+echo "    gcloud run jobs execute canopy-web-migrate --project=${PROJECT_ID} --region=${REGION}"


### PR DESCRIPTION
`deploy.sh`'s `gcloud run deploy`, `services describe`, and the printed migrate-job command relied on the caller's *active* gcloud config project. The `builds submit` step already passes `--project`, so the image always lands in `canopy-494811` — but if the active project was something else (e.g. `connect-labs`), the deploy step targeted the wrong project and 403'd reading the image (`artifactregistry.repositories.downloadArtifacts denied`). This bit a real deploy today.

Fix: scope every `gcloud run` step to `${PROJECT_ID}`. Deploys no longer depend on `gcloud config get-value project`.

`bash -n deploy.sh` clean. No code/test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)