### PR TITLE
fix(sessions): strip NUL bytes before persisting transcript turns

### DIFF
--- a/apps/sessions/redact.py
+++ b/apps/sessions/redact.py
@@ -92,11 +92,17 @@ _PATTERNS: list[tuple[re.Pattern[str], Callable[[re.Match], str]]] = [
 
 
 def redact_text(text: str) -> tuple[str, int]:
-    """Return (scrubbed_text, redaction_count)."""
+    """Return (scrubbed_text, redaction_count).
+
+    Also strips NUL bytes (``\\x00``): Postgres ``jsonb`` rejects the ``\\u0000``
+    code point and ``text`` columns reject raw NULs, so a transcript carrying one
+    (common in tool output) would 500 the whole upload at ``bulk_create``. NUL
+    removal is not counted as a redaction — it's data sanitation, not a secret.
+    """
     if not text:
         return text, 0
+    out = text.replace("\x00", "")
     total = 0
-    out = text
     for pattern, sub in _PATTERNS:
         out, n = pattern.subn(sub, out)
         total += n

--- a/apps/sessions/tests/test_redact.py
+++ b/apps/sessions/tests/test_redact.py
@@ -59,6 +59,23 @@ def test_ordinary_prose_and_code_not_mangled():
     assert out == text
 
 
+def test_nul_bytes_stripped_not_counted():
+    # Postgres jsonb/text reject \x00 — it must be removed (but not counted as
+    # a secret redaction) or bulk_create 500s the whole upload.
+    out, n = redact.redact_text("before\x00after")
+    assert out == "beforeafter"
+    assert n == 0
+
+
+def test_redact_turn_strips_nul_in_nested_content():
+    _, content, n = redact.redact_turn(
+        "ok", {"type": "tool_result", "content": [{"type": "text", "text": "a\x00b"}]}
+    )
+    import json as _json
+
+    assert "\x00" not in _json.dumps(content)
+
+
 def test_redact_turn_walks_nested_content():
     content = {
         "type": "tool_result",


### PR DESCRIPTION
A real 4.4 MB / 1012-turn session upload 500'd at `bulk_create`:
`psycopg.errors.UntranslatableCharacter: unsupported Unicode escape sequence`.

**Cause:** Postgres `jsonb` rejects the U+0000 code point (and `text` columns reject raw NULs). Tool output in transcripts can contain a NUL byte.

**Fix:** strip the NUL from every string leaf in `redact_text` — the scrub already visits both `plaintext` and all `content` leaves via `redact_turn`. Not counted as a secret redaction (it's sanitation). +2 tests.

`uv run pytest apps/sessions/tests/` → 19 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
