### PR TITLE
feat(sessions): default share view to clean Conversation, toggle to Full

### DIFF
--- a/frontend/src/components/transcript/conversation.ts
+++ b/frontend/src/components/transcript/conversation.ts
@@ -1,0 +1,54 @@
+import type { SessionMessage } from "../../api/sessions";
+
+// Harness-authored "user" lines that aren't things the human typed.
+const NOISE_PREFIXES = [
+  "<system-reminder",
+  "<command-name",
+  "<command-message",
+  "<command-args",
+  "<local-command-stdout",
+  "<local-command-stderr",
+  "<local-command-caveat",
+  "<task-notification",
+  "<system>",
+  "Caveat:",
+  "[Request interrupted",
+];
+
+function isNoiseUser(text: string): boolean {
+  const t = text.replace(/^\s+/, "");
+  return NOISE_PREFIXES.some((p) => t.startsWith(p));
+}
+
+/**
+ * Reduce a raw transcript to a readable conversation: what the human typed,
+ * plus the FINAL assistant text of each turn.
+ *
+ * Drops tool_use / tool_result / system rows and harness-noise user lines,
+ * and collapses each run of consecutive assistant messages to its last one
+ * (the intermediate "thinking, then call a tool" fragments are hidden; the
+ * final summary Claude presented at the end of the turn is kept).
+ *
+ * Client-side only — the full transcript stays available via the toggle.
+ */
+export function conversationOnly(messages: SessionMessage[]): SessionMessage[] {
+  const kept: SessionMessage[] = [];
+  for (const m of messages) {
+    if (m.role === "user") {
+      if (m.plaintext.trim() && !isNoiseUser(m.plaintext)) kept.push(m);
+    } else if (m.role === "assistant") {
+      if (m.plaintext.trim()) kept.push(m);
+    }
+    // tool_use / tool_result / system are dropped.
+  }
+
+  // Collapse consecutive assistant rows to the last in each run.
+  return kept.filter(
+    (m, i) =>
+      !(
+        m.role === "assistant" &&
+        i + 1 < kept.length &&
+        kept[i + 1].role === "assistant"
+      ),
+  );
+}

--- a/frontend/src/pages/SessionSharePage.tsx
+++ b/frontend/src/pages/SessionSharePage.tsx
@@ -1,24 +1,32 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useParams } from "react-router-dom";
 
 import { ApiError, getSharedSession } from "../api/sessions";
 import type { SharedSession } from "../api/sessions";
 import { MessageList } from "../components/transcript/MessageList";
+import { conversationOnly } from "../components/transcript/conversation";
 
 type LoadState =
   | { kind: "loading" }
   | { kind: "loaded"; session: SharedSession }
   | { kind: "error"; code: string; message: string };
 
+type ViewMode = "conversation" | "full";
+
 /**
  * Public, read-only view of a shared Claude session.
  *
  * Mounted OUTSIDE AppLayout so anonymous (non-dimagi) visitors can read it
  * without the app chrome's authenticated calls bouncing them to login.
+ *
+ * Defaults to a clean Conversation view (human prompts + Claude's final reply
+ * per turn). The full transcript — every tool call and intermediate step — is
+ * one client-side toggle away; no re-fetch, the data is all here.
  */
 export default function SessionSharePage() {
   const { token = "" } = useParams();
   const [state, setState] = useState<LoadState>({ kind: "loading" });
+  const [mode, setMode] = useState<ViewMode>("conversation");
 
   useEffect(() => {
     if (!token) return;
@@ -32,6 +40,12 @@ export default function SessionSharePage() {
         }
       });
   }, [token]);
+
+  const session = state.kind === "loaded" ? state.session : null;
+  const conversation = useMemo(
+    () => (session ? conversationOnly(session.messages) : []),
+    [session],
+  );
 
   if (state.kind === "loading") {
     return (
@@ -55,30 +69,77 @@ export default function SessionSharePage() {
     );
   }
 
-  const { session } = state;
+  const displayed =
+    mode === "conversation" ? conversation : state.session.messages;
 
   return (
     <div className="min-h-screen bg-white">
       <div className="mx-auto max-w-3xl px-4 py-8">
-        <h1 className="text-xl font-semibold text-zinc-900">
-          {session.title || "Claude session"}
-        </h1>
-        <div className="mt-1 flex items-center gap-3 text-xs text-zinc-500">
-          <span>Shared session — read only</span>
-          {session.redaction_count > 0 && (
-            <span
-              className="rounded-full bg-amber-50 px-2 py-0.5 text-amber-700"
-              title="Best-effort secret scrub. Not a guarantee — review before sharing widely."
-            >
-              {session.redaction_count} secret
-              {session.redaction_count === 1 ? "" : "s"} redacted
-            </span>
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h1 className="text-xl font-semibold text-zinc-900">
+              {state.session.title || "Claude session"}
+            </h1>
+            <div className="mt-1 flex flex-wrap items-center gap-3 text-xs text-zinc-500">
+              <span>Shared session — read only</span>
+              {state.session.redaction_count > 0 && (
+                <span
+                  className="rounded-full bg-amber-50 px-2 py-0.5 text-amber-700"
+                  title="Best-effort secret scrub. Not a guarantee — review before sharing widely."
+                >
+                  {state.session.redaction_count} secret
+                  {state.session.redaction_count === 1 ? "" : "s"} redacted
+                </span>
+              )}
+            </div>
+          </div>
+          <ViewToggle mode={mode} setMode={setMode} />
+        </div>
+
+        <div className="mt-6">
+          {mode === "conversation" && displayed.length === 0 ? (
+            <p className="text-sm text-zinc-500">
+              No plain conversation turns found — switch to Full transcript to
+              see tool activity.
+            </p>
+          ) : (
+            <MessageList messages={displayed} />
           )}
         </div>
-        <div className="mt-6">
-          <MessageList messages={session.messages} />
-        </div>
       </div>
+    </div>
+  );
+}
+
+function ViewToggle({
+  mode,
+  setMode,
+}: {
+  mode: ViewMode;
+  setMode: (m: ViewMode) => void;
+}) {
+  const base =
+    "px-3 py-1 text-xs font-medium transition-colors first:rounded-l-md last:rounded-r-md";
+  const on = "bg-zinc-900 text-white";
+  const off = "bg-white text-zinc-600 hover:bg-zinc-50";
+  return (
+    <div className="inline-flex shrink-0 overflow-hidden rounded-md border border-zinc-300">
+      <button
+        type="button"
+        className={`${base} ${mode === "conversation" ? on : off}`}
+        onClick={() => setMode("conversation")}
+        aria-pressed={mode === "conversation"}
+      >
+        Conversation
+      </button>
+      <button
+        type="button"
+        className={`${base} border-l border-zinc-300 ${mode === "full" ? on : off}`}
+        onClick={() => setMode("full")}
+        aria-pressed={mode === "full"}
+      >
+        Full transcript
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
The raw transcript view is hard to read — every tool call, tool result, and intermediate assistant fragment shows. This adds a **client-side** Conversation view (default) with a toggle to the **Full transcript**.

- **Conversation** (default): what the human typed + the final assistant text of each turn. Drops `tool_use`/`tool_result`/`system` rows and harness-noise user lines (`<system-reminder>`, command wrappers, `<task-notification>`, interrupt markers), and collapses each consecutive assistant run to its last message.
- **Full transcript**: the existing everything-view.

Per the ask: **client-side only** — the full transcript is uploaded once and `conversationOnly()` filters it in the browser. No new server upload/parse mode, no re-fetch.

`npm run build` clean (tsc -b + vite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)