### PR TITLE
Agent workspace: full-bleed workbench layout (left rail + sub-routes)

### DIFF
--- a/apps/agents/schemas.py
+++ b/apps/agents/schemas.py
@@ -36,6 +36,7 @@ class AgentDetailOut(AgentOut):
     sync_count: int = 0
     work_product_count: int = 0
     skill_count: int = 0
+    task_count: int = 0
     latest_sync_at: dt.datetime | None = None
 
 

--- a/apps/agents/services.py
+++ b/apps/agents/services.py
@@ -57,6 +57,7 @@ def agent_detail(agent: Agent) -> dict:
         "sync_count": agent.syncs.count(),
         "work_product_count": agent.work_products.count(),
         "skill_count": agent.skills.count(),
+        "task_count": agent.tasks.count(),
         "latest_sync_at": latest.period_end if latest else None,
     }
 

--- a/frontend/src/api/agents.ts
+++ b/frontend/src/api/agents.ts
@@ -32,6 +32,7 @@ export interface AgentDetailOut extends AgentOut {
   sync_count: number
   work_product_count: number
   skill_count: number
+  task_count: number
   latest_sync_at: string | null
 }
 

--- a/frontend/src/components/AppLayout/AppLayout.tsx
+++ b/frontend/src/components/AppLayout/AppLayout.tsx
@@ -230,7 +230,11 @@ export function AppLayout() {
           </div>
         </div>
       </header>
-      {location.pathname.startsWith('/ddd') || location.pathname.startsWith('/review') ? (
+      {location.pathname.startsWith('/ddd') ||
+      location.pathname.startsWith('/review') ||
+      // An individual Agent Workspace (/agents/<slug>) is a full-bleed workbench
+      // like DDD; the bare /agents LIST stays in the standard container.
+      /^\/agents\/[^/]+/.test(location.pathname) ? (
         // DDD (and the narrative editor at /review) is a full-bleed workspace:
         // persistent left rail + wide main. The page owns its own scroll.
         <main className="h-[calc(100vh-53px)]"><Outlet /></main>

--- a/frontend/src/components/agents/AgentLeftNav.tsx
+++ b/frontend/src/components/agents/AgentLeftNav.tsx
@@ -1,0 +1,88 @@
+import { Link, NavLink } from 'react-router-dom'
+import { clsx } from 'clsx'
+import type { AgentDetailOut } from '@/api/agents'
+
+/**
+ * The persistent left rail for the Agent Workspace. Mirrors DddLeftNav's shell
+ * (a bordered aside with a top identity block + a vertical section nav). Each
+ * section links to its own sub-route under /agents/:slug and carries a
+ * right-aligned count badge sourced from the agent detail.
+ */
+type NavItem = {
+  to: string
+  label: string
+  count?: number
+}
+
+export function AgentLeftNav({ agent }: { agent: AgentDetailOut }) {
+  const items: NavItem[] = [
+    { to: 'overview', label: 'Overview' },
+    { to: 'tasks', label: 'Tasks', count: agent.task_count },
+    { to: 'syncs', label: 'Syncs', count: agent.sync_count },
+    { to: 'work-products', label: 'Work products', count: agent.work_product_count },
+    { to: 'skills', label: 'Skills', count: agent.skill_count },
+  ]
+
+  return (
+    <aside className="flex w-64 shrink-0 flex-col border-r border-stone-800 bg-stone-950/40">
+      <div className="border-b border-stone-800 px-4 py-4">
+        <Link
+          to="/agents"
+          className="text-[12px] text-stone-500 hover:text-orange-400 transition-colors"
+        >
+          ← Agents
+        </Link>
+        <div className="flex items-start gap-3 mt-3">
+          {agent.avatar_url ? (
+            <img
+              src={agent.avatar_url}
+              alt=""
+              className="h-10 w-10 rounded-full shrink-0 object-cover border border-stone-800"
+            />
+          ) : (
+            <span className="h-10 w-10 rounded-full shrink-0 bg-orange-500/90 text-white text-sm font-semibold flex items-center justify-center">
+              {(agent.name || agent.slug).slice(0, 1).toUpperCase()}
+            </span>
+          )}
+          <div className="min-w-0">
+            <h2 className="text-sm font-semibold text-stone-100 leading-snug truncate">
+              {agent.name}
+            </h2>
+            {agent.email && (
+              <a
+                href={`mailto:${agent.email}`}
+                className="block text-[11px] text-stone-500 hover:text-orange-400 transition-colors truncate"
+              >
+                {agent.email}
+              </a>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <nav className="flex-1 overflow-y-auto px-2 py-3">
+        <div className="flex flex-col gap-0.5">
+          {items.map((item) => (
+            <NavLink
+              key={item.to}
+              to={item.to}
+              className={({ isActive }) =>
+                clsx(
+                  'flex items-center justify-between gap-2 rounded-md px-3 py-1.5 text-sm transition-colors',
+                  isActive
+                    ? 'bg-orange-400/10 border border-orange-400/30 text-orange-400 font-medium'
+                    : 'border border-transparent text-stone-400 hover:bg-stone-800/40 hover:text-stone-200',
+                )
+              }
+            >
+              <span className="truncate">{item.label}</span>
+              {item.count !== undefined && (
+                <span className="shrink-0 text-[11px] text-stone-500">{item.count}</span>
+              )}
+            </NavLink>
+          ))}
+        </div>
+      </nav>
+    </aside>
+  )
+}

--- a/frontend/src/components/agents/SectionSubHeader.tsx
+++ b/frontend/src/components/agents/SectionSubHeader.tsx
@@ -1,0 +1,42 @@
+import type { ReactNode } from 'react'
+
+/**
+ * The consistent bar at the top of every Agent Workspace section: a title, an
+ * optional count, and an optional contextual action on the right. Sits inside
+ * the scrolling main area above each section's content.
+ */
+export function SectionSubHeader({
+  title,
+  count,
+  action,
+}: {
+  title: string
+  count?: number
+  action?: ReactNode
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3 pb-4 mb-6 border-b border-stone-800">
+      <div className="flex items-baseline gap-2 min-w-0">
+        <h1 className="text-base font-semibold text-stone-100">{title}</h1>
+        {count !== undefined && (
+          <span className="text-[12px] text-stone-600">{count}</span>
+        )}
+      </div>
+      {action && <div className="shrink-0">{action}</div>}
+    </div>
+  )
+}
+
+/** A pulsing card placeholder used while a section lazy-loads its own data. */
+export function SectionSkeleton({ rows = 3 }: { rows?: number }) {
+  return (
+    <div className="animate-pulse space-y-3">
+      {Array.from({ length: rows }).map((_, i) => (
+        <div key={i} className="bg-stone-900 border border-stone-800 rounded-xl p-5">
+          <div className="h-4 bg-stone-800 rounded w-2/3 mb-2" />
+          <div className="h-3 bg-stone-800/70 rounded w-full" />
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/components/agents/cards.tsx
+++ b/frontend/src/components/agents/cards.tsx
@@ -1,0 +1,149 @@
+// Shared presentational pieces for the Agent Workspace sections. Extracted
+// verbatim from the old single-column AgentWorkspacePage so the lazy-loaded
+// section routes (overview / syncs / work-products / skills) can share them.
+// Styling is preserved exactly as it was inline on the page.
+
+import type {
+  AgentSkillOut,
+  AgentSyncOut,
+  AgentWorkProductOut,
+} from '@/api/agents'
+
+export function formatDate(s: string): string {
+  return new Date(s).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}
+
+export function formatPeriod(start: string, end: string): string {
+  const s = formatDate(start)
+  const e = formatDate(end)
+  return s === e ? s : `${s} – ${e}`
+}
+
+export function CountStat({ value, label }: { value: number; label: string }) {
+  return (
+    <div className="flex flex-col">
+      <span className="text-lg font-semibold text-stone-100 leading-none">{value}</span>
+      <span className="text-[10px] uppercase tracking-wide text-stone-600 mt-1">{label}</span>
+    </div>
+  )
+}
+
+export function SectionHeading({ label, count }: { label: string; count?: number }) {
+  return (
+    <div className="flex items-baseline gap-2 mb-3 mt-8 first:mt-0">
+      <h2 className="text-[11px] font-bold uppercase tracking-[0.08em] text-orange-300">{label}</h2>
+      {count !== undefined && <span className="text-[11px] text-stone-600">{count}</span>}
+    </div>
+  )
+}
+
+// "work: C+" → an outlined badge. Generic so any grade dimension renders.
+function GradeBadge({ dimension, grade }: { dimension: string; grade: string }) {
+  return (
+    <span className="inline-flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wide text-stone-300 bg-stone-950/80 border border-stone-700/60 px-2 py-0.5 rounded">
+      <span className="text-stone-500">{dimension}:</span>
+      <span className="text-orange-300">{grade}</span>
+    </span>
+  )
+}
+
+function OpenDocChip({ url, label }: { url: string; label: string }) {
+  if (!url) return null
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noreferrer"
+      className="inline-flex items-center gap-1 text-[11px] font-medium text-stone-300 hover:text-orange-300 bg-stone-950/80 border border-stone-700/60 hover:border-orange-400/50 px-2.5 py-1 rounded-md transition-colors"
+    >
+      <span className="text-orange-400/70">↗</span>
+      {label}
+    </a>
+  )
+}
+
+export function SyncCard({ sync }: { sync: AgentSyncOut }) {
+  const grades = Object.entries(sync.self_grades ?? {})
+  return (
+    <div className="bg-stone-900/70 border border-stone-800 rounded-xl p-5">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="text-[11px] text-stone-500">{formatPeriod(sync.period_start, sync.period_end)}</p>
+          <h3 className="text-[15px] font-semibold text-stone-100 mt-0.5 leading-snug">{sync.title}</h3>
+        </div>
+        <OpenDocChip url={sync.doc_url} label="Open in Google Docs" />
+      </div>
+      {sync.summary && (
+        <p className="text-[13px] text-stone-400 leading-relaxed mt-2">{sync.summary}</p>
+      )}
+      {grades.length > 0 && (
+        <div className="flex flex-wrap gap-1.5 mt-3">
+          {grades.map(([dimension, grade]) => (
+            <GradeBadge key={dimension} dimension={dimension} grade={grade} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function WorkProductCard({ wp }: { wp: AgentWorkProductOut }) {
+  return (
+    <a
+      href={wp.url}
+      target="_blank"
+      rel="noreferrer"
+      className="group block bg-stone-900/70 border border-stone-800 rounded-xl p-4 hover:border-orange-400/40 hover:bg-stone-900 transition-colors"
+    >
+      <div className="flex items-start gap-2">
+        <h3 className="text-[14px] font-semibold text-stone-100 leading-snug group-hover:text-orange-300 transition-colors min-w-0 flex-1">
+          {wp.title}
+        </h3>
+        <span className="text-orange-400/70 text-xs shrink-0">↗</span>
+      </div>
+      {wp.kind && (
+        <span className="inline-block mt-2 text-[10px] font-semibold uppercase tracking-wide text-stone-400 bg-stone-800 px-1.5 py-0.5 rounded">
+          {wp.kind}
+        </span>
+      )}
+      {wp.description && (
+        <p className="text-[12px] text-stone-400 leading-relaxed mt-2 line-clamp-3">{wp.description}</p>
+      )}
+      {wp.tags && wp.tags.length > 0 && (
+        <div className="flex flex-wrap gap-1 mt-2">
+          {wp.tags.map((t) => (
+            <span key={t} className="text-[10px] text-stone-500 bg-stone-950/60 border border-stone-800 px-1.5 py-0.5 rounded">
+              {t}
+            </span>
+          ))}
+        </div>
+      )}
+    </a>
+  )
+}
+
+export function SkillCard({ skill }: { skill: AgentSkillOut }) {
+  return (
+    <div className="bg-stone-900/70 border border-stone-800 rounded-xl p-4">
+      <div className="flex items-start justify-between gap-2">
+        <h3 className="text-[14px] font-semibold text-stone-100 leading-snug min-w-0">{skill.name}</h3>
+        <OpenDocChip url={skill.url} label="SKILL.md" />
+      </div>
+      {skill.description && (
+        <p className="text-[12px] text-stone-400 leading-relaxed mt-2">{skill.description}</p>
+      )}
+      {skill.improvement_note && (
+        <p className="text-[12px] text-stone-300 leading-relaxed mt-2 pl-3 border-l-2 border-orange-400/40">
+          <span className="text-[10px] font-semibold uppercase tracking-wide text-orange-300/80 mr-1">
+            Improvement
+          </span>
+          {skill.improvement_note}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/AgentWorkspacePage.tsx
+++ b/frontend/src/pages/AgentWorkspacePage.tsx
@@ -1,165 +1,22 @@
 import { useEffect, useState } from 'react'
-import { Link, useParams } from 'react-router-dom'
-import {
-  getAgent,
-  listAgentSkills,
-  listAgentSyncs,
-  listAgentTasks,
-  listAgentWorkProducts,
-  type AgentDetailOut,
-  type AgentSkillOut,
-  type AgentSyncOut,
-  type AgentTaskOut,
-  type AgentWorkProductOut,
-} from '@/api/agents'
-import { TasksBoard } from '@/components/TasksBoard'
+import { Link, Outlet, useParams } from 'react-router-dom'
+import { getAgent, type AgentDetailOut } from '@/api/agents'
+import { AgentLeftNav } from '@/components/agents/AgentLeftNav'
 
-function formatDate(s: string): string {
-  return new Date(s).toLocaleDateString(undefined, {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  })
+/** Context the section sub-routes read via useOutletContext. */
+export interface AgentOutletContext {
+  agent: AgentDetailOut
 }
 
-function formatPeriod(start: string, end: string): string {
-  const s = formatDate(start)
-  const e = formatDate(end)
-  return s === e ? s : `${s} – ${e}`
-}
-
-function CountStat({ value, label }: { value: number; label: string }) {
-  return (
-    <div className="flex flex-col">
-      <span className="text-lg font-semibold text-stone-100 leading-none">{value}</span>
-      <span className="text-[10px] uppercase tracking-wide text-stone-600 mt-1">{label}</span>
-    </div>
-  )
-}
-
-function SectionHeading({ label, count }: { label: string; count?: number }) {
-  return (
-    <div className="flex items-baseline gap-2 mb-3 mt-8 first:mt-0">
-      <h2 className="text-[11px] font-bold uppercase tracking-[0.08em] text-orange-300">{label}</h2>
-      {count !== undefined && <span className="text-[11px] text-stone-600">{count}</span>}
-    </div>
-  )
-}
-
-// "work: C+" → an outlined badge. Generic so any grade dimension renders.
-function GradeBadge({ dimension, grade }: { dimension: string; grade: string }) {
-  return (
-    <span className="inline-flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wide text-stone-300 bg-stone-950/80 border border-stone-700/60 px-2 py-0.5 rounded">
-      <span className="text-stone-500">{dimension}:</span>
-      <span className="text-orange-300">{grade}</span>
-    </span>
-  )
-}
-
-function OpenDocChip({ url, label }: { url: string; label: string }) {
-  if (!url) return null
-  return (
-    <a
-      href={url}
-      target="_blank"
-      rel="noreferrer"
-      className="inline-flex items-center gap-1 text-[11px] font-medium text-stone-300 hover:text-orange-300 bg-stone-950/80 border border-stone-700/60 hover:border-orange-400/50 px-2.5 py-1 rounded-md transition-colors"
-    >
-      <span className="text-orange-400/70">↗</span>
-      {label}
-    </a>
-  )
-}
-
-function SyncCard({ sync }: { sync: AgentSyncOut }) {
-  const grades = Object.entries(sync.self_grades ?? {})
-  return (
-    <div className="bg-stone-900/70 border border-stone-800 rounded-xl p-5">
-      <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0">
-          <p className="text-[11px] text-stone-500">{formatPeriod(sync.period_start, sync.period_end)}</p>
-          <h3 className="text-[15px] font-semibold text-stone-100 mt-0.5 leading-snug">{sync.title}</h3>
-        </div>
-        <OpenDocChip url={sync.doc_url} label="Open in Google Docs" />
-      </div>
-      {sync.summary && (
-        <p className="text-[13px] text-stone-400 leading-relaxed mt-2">{sync.summary}</p>
-      )}
-      {grades.length > 0 && (
-        <div className="flex flex-wrap gap-1.5 mt-3">
-          {grades.map(([dimension, grade]) => (
-            <GradeBadge key={dimension} dimension={dimension} grade={grade} />
-          ))}
-        </div>
-      )}
-    </div>
-  )
-}
-
-function WorkProductCard({ wp }: { wp: AgentWorkProductOut }) {
-  return (
-    <a
-      href={wp.url}
-      target="_blank"
-      rel="noreferrer"
-      className="group block bg-stone-900/70 border border-stone-800 rounded-xl p-4 hover:border-orange-400/40 hover:bg-stone-900 transition-colors"
-    >
-      <div className="flex items-start gap-2">
-        <h3 className="text-[14px] font-semibold text-stone-100 leading-snug group-hover:text-orange-300 transition-colors min-w-0 flex-1">
-          {wp.title}
-        </h3>
-        <span className="text-orange-400/70 text-xs shrink-0">↗</span>
-      </div>
-      {wp.kind && (
-        <span className="inline-block mt-2 text-[10px] font-semibold uppercase tracking-wide text-stone-400 bg-stone-800 px-1.5 py-0.5 rounded">
-          {wp.kind}
-        </span>
-      )}
-      {wp.description && (
-        <p className="text-[12px] text-stone-400 leading-relaxed mt-2 line-clamp-3">{wp.description}</p>
-      )}
-      {wp.tags && wp.tags.length > 0 && (
-        <div className="flex flex-wrap gap-1 mt-2">
-          {wp.tags.map((t) => (
-            <span key={t} className="text-[10px] text-stone-500 bg-stone-950/60 border border-stone-800 px-1.5 py-0.5 rounded">
-              {t}
-            </span>
-          ))}
-        </div>
-      )}
-    </a>
-  )
-}
-
-function SkillCard({ skill }: { skill: AgentSkillOut }) {
-  return (
-    <div className="bg-stone-900/70 border border-stone-800 rounded-xl p-4">
-      <div className="flex items-start justify-between gap-2">
-        <h3 className="text-[14px] font-semibold text-stone-100 leading-snug min-w-0">{skill.name}</h3>
-        <OpenDocChip url={skill.url} label="SKILL.md" />
-      </div>
-      {skill.description && (
-        <p className="text-[12px] text-stone-400 leading-relaxed mt-2">{skill.description}</p>
-      )}
-      {skill.improvement_note && (
-        <p className="text-[12px] text-stone-300 leading-relaxed mt-2 pl-3 border-l-2 border-orange-400/40">
-          <span className="text-[10px] font-semibold uppercase tracking-wide text-orange-300/80 mr-1">
-            Improvement
-          </span>
-          {skill.improvement_note}
-        </p>
-      )}
-    </div>
-  )
-}
-
+/**
+ * The Agent Workspace shell: a full-bleed rail + scrolling main workbench. It
+ * loads the agent detail once (counts for the rail badges + identity), then
+ * renders the active section through <Outlet />. Each section lazy-loads its
+ * own list data. Mirrors the DDD shell (DddShell + DddLeftNav).
+ */
 export function AgentWorkspacePage() {
   const { slug } = useParams<{ slug: string }>()
   const [agent, setAgent] = useState<AgentDetailOut | null>(null)
-  const [syncs, setSyncs] = useState<AgentSyncOut[]>([])
-  const [workProducts, setWorkProducts] = useState<AgentWorkProductOut[]>([])
-  const [skills, setSkills] = useState<AgentSkillOut[]>([])
-  const [tasks, setTasks] = useState<AgentTaskOut[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
@@ -168,27 +25,16 @@ export function AgentWorkspacePage() {
     let cancelled = false
     setLoading(true)
     setError(null)
-    void (async () => {
-      try {
-        const [detail, syncPage, wpPage, skillList, taskList] = await Promise.all([
-          getAgent(slug),
-          listAgentSyncs(slug, { limit: 200 }),
-          listAgentWorkProducts(slug, { limit: 200 }),
-          listAgentSkills(slug),
-          listAgentTasks(slug),
-        ])
-        if (cancelled) return
-        setAgent(detail)
-        setSyncs(syncPage.items)
-        setWorkProducts(wpPage.items)
-        setSkills(skillList)
-        setTasks(taskList)
-      } catch (err) {
+    getAgent(slug)
+      .then((detail) => {
+        if (!cancelled) setAgent(detail)
+      })
+      .catch((err) => {
         if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load agent')
-      } finally {
+      })
+      .finally(() => {
         if (!cancelled) setLoading(false)
-      }
-    })()
+      })
     return () => {
       cancelled = true
     }
@@ -196,29 +42,31 @@ export function AgentWorkspacePage() {
 
   if (loading) {
     return (
-      <div className="max-w-4xl">
-        <div className="animate-pulse">
-          <div className="flex items-center gap-4 mb-8">
-            <div className="h-14 w-14 rounded-full bg-stone-800" />
-            <div className="flex-1 space-y-2">
-              <div className="h-5 bg-stone-800 rounded w-1/3" />
-              <div className="h-3 bg-stone-800/70 rounded w-1/2" />
-            </div>
+      <div className="flex h-full">
+        <aside className="w-64 shrink-0 border-r border-stone-800 bg-stone-950/40 p-4">
+          <div className="animate-pulse space-y-3">
+            <div className="h-10 w-10 rounded-full bg-stone-800" />
+            <div className="h-4 bg-stone-800 rounded w-2/3" />
+            <div className="h-3 bg-stone-800/70 rounded w-1/2" />
           </div>
-          {Array.from({ length: 3 }).map((_, i) => (
-            <div key={i} className="bg-stone-900 border border-stone-800 rounded-xl p-5 mb-3">
-              <div className="h-4 bg-stone-800 rounded w-2/3 mb-2" />
-              <div className="h-3 bg-stone-800/70 rounded w-full" />
-            </div>
-          ))}
-        </div>
+        </aside>
+        <main className="flex-1 overflow-y-auto px-6 py-8">
+          <div className="max-w-4xl animate-pulse space-y-3">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="bg-stone-900 border border-stone-800 rounded-xl p-5">
+                <div className="h-4 bg-stone-800 rounded w-2/3 mb-2" />
+                <div className="h-3 bg-stone-800/70 rounded w-full" />
+              </div>
+            ))}
+          </div>
+        </main>
       </div>
     )
   }
 
   if (error || !agent) {
     return (
-      <div className="max-w-4xl">
+      <div className="px-6 py-8 max-w-4xl">
         <Link to="/agents" className="text-[12px] text-stone-500 hover:text-orange-400 transition-colors">
           ← Agents
         </Link>
@@ -230,97 +78,11 @@ export function AgentWorkspacePage() {
   }
 
   return (
-    <div className="max-w-4xl">
-      <Link
-        to="/agents"
-        className="text-[12px] text-stone-500 hover:text-orange-400 transition-colors"
-      >
-        ← Agents
-      </Link>
-
-      <header className="flex items-start gap-4 mt-3 mb-6 pb-6 border-b border-stone-800">
-        {agent.avatar_url ? (
-          <img
-            src={agent.avatar_url}
-            alt=""
-            className="h-14 w-14 rounded-full shrink-0 object-cover border border-stone-800"
-          />
-        ) : (
-          <span className="h-14 w-14 rounded-full shrink-0 bg-orange-500/90 text-white text-lg font-semibold flex items-center justify-center">
-            {(agent.name || agent.slug).slice(0, 1).toUpperCase()}
-          </span>
-        )}
-        <div className="min-w-0 flex-1">
-          <h1 className="text-xl font-semibold text-stone-100 leading-snug">{agent.name}</h1>
-          {agent.persona && (
-            <p className="text-[13px] text-stone-400 mt-0.5 leading-relaxed">{agent.persona}</p>
-          )}
-          {agent.email && (
-            <a
-              href={`mailto:${agent.email}`}
-              className="inline-block text-[12px] text-stone-500 hover:text-orange-400 transition-colors mt-1"
-            >
-              {agent.email}
-            </a>
-          )}
-          {agent.description && (
-            <p className="text-[13px] text-stone-400 mt-3 leading-relaxed">{agent.description}</p>
-          )}
-        </div>
-        <div className="hidden sm:flex items-end gap-5 shrink-0">
-          <CountStat value={agent.sync_count} label="Syncs" />
-          <CountStat value={agent.work_product_count} label="Work" />
-          <CountStat value={agent.skill_count} label="Skills" />
-        </div>
-      </header>
-
-      <section>
-        <SectionHeading label="Task board" count={tasks.length} />
-        {tasks.length === 0 ? (
-          <p className="text-[13px] text-stone-600">No tasks yet.</p>
-        ) : (
-          <TasksBoard tasks={tasks} />
-        )}
-      </section>
-
-      <section>
-        <SectionHeading label="Syncs" count={syncs.length} />
-        {syncs.length === 0 ? (
-          <p className="text-[13px] text-stone-600">No syncs yet.</p>
-        ) : (
-          <div className="space-y-3">
-            {syncs.map((s) => (
-              <SyncCard key={s.id} sync={s} />
-            ))}
-          </div>
-        )}
-      </section>
-
-      <section>
-        <SectionHeading label="Work products" count={workProducts.length} />
-        {workProducts.length === 0 ? (
-          <p className="text-[13px] text-stone-600">No work products yet.</p>
-        ) : (
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            {workProducts.map((wp) => (
-              <WorkProductCard key={wp.id} wp={wp} />
-            ))}
-          </div>
-        )}
-      </section>
-
-      <section className="mb-4">
-        <SectionHeading label="Skills" count={skills.length} />
-        {skills.length === 0 ? (
-          <p className="text-[13px] text-stone-600">No skills yet.</p>
-        ) : (
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            {skills.map((sk) => (
-              <SkillCard key={sk.id} skill={sk} />
-            ))}
-          </div>
-        )}
-      </section>
+    <div className="flex h-full">
+      <AgentLeftNav agent={agent} />
+      <main className="flex-1 overflow-y-auto">
+        <Outlet context={{ agent } satisfies AgentOutletContext} />
+      </main>
     </div>
   )
 }

--- a/frontend/src/pages/agents/AgentOverviewSection.tsx
+++ b/frontend/src/pages/agents/AgentOverviewSection.tsx
@@ -1,0 +1,167 @@
+import { useEffect, useState } from 'react'
+import { Link, useOutletContext } from 'react-router-dom'
+import {
+  listAgentSyncs,
+  listAgentTasks,
+  type AgentSyncOut,
+  type AgentTaskOut,
+  type AgentTaskStatus,
+} from '@/api/agents'
+import type { AgentOutletContext } from '@/pages/AgentWorkspacePage'
+import { CountStat, SyncCard } from '@/components/agents/cards'
+import { SectionSubHeader, SectionSkeleton } from '@/components/agents/SectionSubHeader'
+
+const TASK_COLUMNS: { status: AgentTaskStatus; label: string; dot: string }[] = [
+  { status: 'todo', label: 'To do', dot: 'bg-stone-500' },
+  { status: 'in_progress', label: 'In progress', dot: 'bg-orange-400' },
+  { status: 'blocked', label: 'Blocked', dot: 'bg-red-400' },
+  { status: 'done', label: 'Done', dot: 'bg-emerald-400' },
+]
+
+const QUICK_LINKS: { to: string; label: string }[] = [
+  { to: '../tasks', label: 'Task board' },
+  { to: '../syncs', label: 'Syncs' },
+  { to: '../work-products', label: 'Work products' },
+  { to: '../skills', label: 'Skills' },
+]
+
+/**
+ * A compact landing dashboard for an agent — NOT the full lists. Persona +
+ * description, a counts row, the single latest sync, a condensed task summary
+ * (counts per board column), and quick links into the deeper sections.
+ */
+export function AgentOverviewSection() {
+  const { agent } = useOutletContext<AgentOutletContext>()
+  const [latestSync, setLatestSync] = useState<AgentSyncOut | null>(null)
+  const [tasks, setTasks] = useState<AgentTaskOut[] | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setLatestSync(null)
+    setTasks(null)
+    void Promise.all([
+      listAgentSyncs(agent.slug, { limit: 1 }),
+      listAgentTasks(agent.slug),
+    ])
+      .then(([syncPage, taskList]) => {
+        if (cancelled) return
+        setLatestSync(syncPage.items[0] ?? null)
+        setTasks(taskList)
+      })
+      .catch(() => {
+        if (cancelled) return
+        setLatestSync(null)
+        setTasks([])
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [agent.slug])
+
+  const tasksLoading = tasks === null
+  const countFor = (status: AgentTaskStatus) =>
+    (tasks ?? []).filter((t) => t.status === status).length
+
+  return (
+    <div className="max-w-4xl px-6 py-8">
+      <SectionSubHeader title="Overview" />
+
+      {/* Persona / description */}
+      {(agent.persona || agent.description) && (
+        <div className="mb-6">
+          {agent.persona && (
+            <p className="text-[14px] text-stone-300 leading-relaxed">{agent.persona}</p>
+          )}
+          {agent.description && (
+            <p className="text-[13px] text-stone-400 leading-relaxed mt-2">{agent.description}</p>
+          )}
+        </div>
+      )}
+
+      {/* Counts row */}
+      <div className="flex flex-wrap gap-6 pb-6 mb-6 border-b border-stone-800">
+        <CountStat value={agent.task_count} label="Tasks" />
+        <CountStat value={agent.sync_count} label="Syncs" />
+        <CountStat value={agent.work_product_count} label="Work" />
+        <CountStat value={agent.skill_count} label="Skills" />
+      </div>
+
+      {/* Task summary — counts per board column */}
+      <div className="mb-8">
+        <div className="flex items-baseline justify-between mb-3">
+          <h2 className="text-[11px] font-bold uppercase tracking-[0.08em] text-orange-300">
+            Tasks
+          </h2>
+          <Link
+            to="../tasks"
+            className="text-[11px] text-stone-500 hover:text-orange-400 transition-colors"
+          >
+            Open board →
+          </Link>
+        </div>
+        {tasksLoading ? (
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+            {TASK_COLUMNS.map((c) => (
+              <div key={c.status} className="h-16 rounded-lg bg-stone-900 border border-stone-800 animate-pulse" />
+            ))}
+          </div>
+        ) : (
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+            {TASK_COLUMNS.map((c) => (
+              <div
+                key={c.status}
+                className="rounded-lg bg-stone-900/70 border border-stone-800 px-3 py-3"
+              >
+                <div className="flex items-center gap-2">
+                  <span className={`h-1.5 w-1.5 rounded-full ${c.dot}`} />
+                  <span className="text-[10px] font-semibold uppercase tracking-[0.06em] text-stone-400">
+                    {c.label}
+                  </span>
+                </div>
+                <span className="block text-lg font-semibold text-stone-100 leading-none mt-2">
+                  {countFor(c.status)}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Latest sync */}
+      <div className="mb-8">
+        <div className="flex items-baseline justify-between mb-3">
+          <h2 className="text-[11px] font-bold uppercase tracking-[0.08em] text-orange-300">
+            Latest sync
+          </h2>
+          <Link
+            to="../syncs"
+            className="text-[11px] text-stone-500 hover:text-orange-400 transition-colors"
+          >
+            All syncs →
+          </Link>
+        </div>
+        {latestSync === null && tasksLoading ? (
+          <SectionSkeleton rows={1} />
+        ) : latestSync ? (
+          <SyncCard sync={latestSync} />
+        ) : (
+          <p className="text-[13px] text-stone-600">No syncs yet.</p>
+        )}
+      </div>
+
+      {/* Quick links */}
+      <div className="flex flex-wrap gap-2">
+        {QUICK_LINKS.map((l) => (
+          <Link
+            key={l.to}
+            to={l.to}
+            className="inline-flex items-center gap-1 text-[12px] font-medium text-stone-300 hover:text-orange-300 bg-stone-900/70 border border-stone-800 hover:border-orange-400/40 px-3 py-1.5 rounded-md transition-colors"
+          >
+            {l.label}
+            <span className="text-orange-400/70">→</span>
+          </Link>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/agents/AgentSkillsSection.tsx
+++ b/frontend/src/pages/agents/AgentSkillsSection.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react'
+import { useOutletContext } from 'react-router-dom'
+import { listAgentSkills, type AgentSkillOut } from '@/api/agents'
+import type { AgentOutletContext } from '@/pages/AgentWorkspacePage'
+import { SkillCard } from '@/components/agents/cards'
+import { SectionSubHeader, SectionSkeleton } from '@/components/agents/SectionSubHeader'
+
+export function AgentSkillsSection() {
+  const { agent } = useOutletContext<AgentOutletContext>()
+  const [skills, setSkills] = useState<AgentSkillOut[] | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setSkills(null)
+    listAgentSkills(agent.slug)
+      .then((list) => !cancelled && setSkills(list))
+      .catch(() => !cancelled && setSkills([]))
+    return () => {
+      cancelled = true
+    }
+  }, [agent.slug])
+
+  return (
+    <div className="max-w-4xl px-6 py-8">
+      <SectionSubHeader title="Skills" count={skills?.length} />
+      {skills === null ? (
+        <SectionSkeleton />
+      ) : skills.length === 0 ? (
+        <p className="text-[13px] text-stone-600">No skills yet.</p>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          {skills.map((sk) => (
+            <SkillCard key={sk.id} skill={sk} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/agents/AgentSyncsSection.tsx
+++ b/frontend/src/pages/agents/AgentSyncsSection.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react'
+import { useOutletContext } from 'react-router-dom'
+import { listAgentSyncs, type AgentSyncOut } from '@/api/agents'
+import type { AgentOutletContext } from '@/pages/AgentWorkspacePage'
+import { SyncCard } from '@/components/agents/cards'
+import { SectionSubHeader, SectionSkeleton } from '@/components/agents/SectionSubHeader'
+
+export function AgentSyncsSection() {
+  const { agent } = useOutletContext<AgentOutletContext>()
+  const [syncs, setSyncs] = useState<AgentSyncOut[] | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setSyncs(null)
+    listAgentSyncs(agent.slug, { limit: 200 })
+      .then((page) => !cancelled && setSyncs(page.items))
+      .catch(() => !cancelled && setSyncs([]))
+    return () => {
+      cancelled = true
+    }
+  }, [agent.slug])
+
+  return (
+    <div className="max-w-4xl px-6 py-8">
+      <SectionSubHeader title="Syncs" count={syncs?.length} />
+      {syncs === null ? (
+        <SectionSkeleton />
+      ) : syncs.length === 0 ? (
+        <p className="text-[13px] text-stone-600">No syncs yet.</p>
+      ) : (
+        <div className="space-y-3">
+          {syncs.map((s) => (
+            <SyncCard key={s.id} sync={s} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/agents/AgentTasksSection.tsx
+++ b/frontend/src/pages/agents/AgentTasksSection.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react'
+import { useOutletContext } from 'react-router-dom'
+import { listAgentTasks, type AgentTaskOut } from '@/api/agents'
+import type { AgentOutletContext } from '@/pages/AgentWorkspacePage'
+import { TasksBoard } from '@/components/TasksBoard'
+import { SectionSubHeader, SectionSkeleton } from '@/components/agents/SectionSubHeader'
+
+export function AgentTasksSection() {
+  const { agent } = useOutletContext<AgentOutletContext>()
+  const [tasks, setTasks] = useState<AgentTaskOut[] | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setTasks(null)
+    listAgentTasks(agent.slug)
+      .then((list) => !cancelled && setTasks(list))
+      .catch(() => !cancelled && setTasks([]))
+    return () => {
+      cancelled = true
+    }
+  }, [agent.slug])
+
+  return (
+    <div className="max-w-4xl px-6 py-8">
+      <SectionSubHeader title="Task board" count={tasks?.length} />
+      {tasks === null ? (
+        <SectionSkeleton />
+      ) : tasks.length === 0 ? (
+        <p className="text-[13px] text-stone-600">No tasks yet.</p>
+      ) : (
+        <TasksBoard tasks={tasks} />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/agents/AgentWorkProductsSection.tsx
+++ b/frontend/src/pages/agents/AgentWorkProductsSection.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react'
+import { useOutletContext } from 'react-router-dom'
+import { listAgentWorkProducts, type AgentWorkProductOut } from '@/api/agents'
+import type { AgentOutletContext } from '@/pages/AgentWorkspacePage'
+import { WorkProductCard } from '@/components/agents/cards'
+import { SectionSubHeader, SectionSkeleton } from '@/components/agents/SectionSubHeader'
+
+export function AgentWorkProductsSection() {
+  const { agent } = useOutletContext<AgentOutletContext>()
+  const [items, setItems] = useState<AgentWorkProductOut[] | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setItems(null)
+    listAgentWorkProducts(agent.slug, { limit: 200 })
+      .then((page) => !cancelled && setItems(page.items))
+      .catch(() => !cancelled && setItems([]))
+    return () => {
+      cancelled = true
+    }
+  }, [agent.slug])
+
+  return (
+    <div className="max-w-4xl px-6 py-8">
+      <SectionSubHeader title="Work products" count={items?.length} />
+      {items === null ? (
+        <SectionSkeleton />
+      ) : items.length === 0 ? (
+        <p className="text-[13px] text-stone-600">No work products yet.</p>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          {items.map((wp) => (
+            <WorkProductCard key={wp.id} wp={wp} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -1,3 +1,4 @@
+import { lazy, Suspense } from 'react'
 import { createBrowserRouter, Navigate } from 'react-router-dom'
 import { AppLayout } from './components/AppLayout/AppLayout'
 import { WorkspacePage } from './pages/WorkspacePage'
@@ -19,6 +20,38 @@ import { AgentsPage } from './pages/AgentsPage'
 import { AgentWorkspacePage } from './pages/AgentWorkspacePage'
 import SessionSharePage from './pages/SessionSharePage'
 
+// Agent Workspace sections are lazy-loaded — each owns its data fetch and only
+// the active section's bundle is pulled in.
+const AgentOverviewSection = lazy(() =>
+  import('./pages/agents/AgentOverviewSection').then((m) => ({ default: m.AgentOverviewSection })),
+)
+const AgentTasksSection = lazy(() =>
+  import('./pages/agents/AgentTasksSection').then((m) => ({ default: m.AgentTasksSection })),
+)
+const AgentSyncsSection = lazy(() =>
+  import('./pages/agents/AgentSyncsSection').then((m) => ({ default: m.AgentSyncsSection })),
+)
+const AgentWorkProductsSection = lazy(() =>
+  import('./pages/agents/AgentWorkProductsSection').then((m) => ({ default: m.AgentWorkProductsSection })),
+)
+const AgentSkillsSection = lazy(() =>
+  import('./pages/agents/AgentSkillsSection').then((m) => ({ default: m.AgentSkillsSection })),
+)
+
+// Each lazy section renders inside the workspace shell's scrolling <main>; this
+// keeps a minimal fallback in that same content area while the chunk loads.
+function LazySection({ children }: { children: React.ReactNode }) {
+  return (
+    <Suspense
+      fallback={
+        <div className="max-w-4xl px-6 py-8 text-[13px] text-stone-600">Loading…</div>
+      }
+    >
+      {children}
+    </Suspense>
+  )
+}
+
 export const router = createBrowserRouter([
   {
     element: <AppLayout />,
@@ -32,7 +65,18 @@ export const router = createBrowserRouter([
       { path: '/w/:id', element: <WalkthroughViewerPage /> },
       { path: '/sessions', element: <SessionsPage /> },
       { path: '/agents', element: <AgentsPage /> },
-      { path: '/agents/:slug', element: <AgentWorkspacePage /> },
+      {
+        path: '/agents/:slug',
+        element: <AgentWorkspacePage />,
+        children: [
+          { index: true, element: <Navigate to="overview" replace /> },
+          { path: 'overview', element: <LazySection><AgentOverviewSection /></LazySection> },
+          { path: 'tasks', element: <LazySection><AgentTasksSection /></LazySection> },
+          { path: 'syncs', element: <LazySection><AgentSyncsSection /></LazySection> },
+          { path: 'work-products', element: <LazySection><AgentWorkProductsSection /></LazySection> },
+          { path: 'skills', element: <LazySection><AgentSkillsSection /></LazySection> },
+        ],
+      },
       { path: '/ddd', element: <DddPage /> },
       { path: '/ddd/:narrative', element: <DddPage /> },
       { path: '/ddd/:narrative/:runId', element: <DddPage /> },


### PR DESCRIPTION
Restructures `/agents/:slug` from one crammed column into the DDD-style workbench: a full-bleed two-column shell (left rail + scrolling main), each section a lazy-loaded, deep-linkable sub-route (Overview/Tasks/Syncs/Work products/Skills). Left rail has the agent identity + section nav with live count badges; Overview is a compact dashboard. Reuses the existing shell/card patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)