### PR TITLE
ci: publish workflow for @canopy/workbench (GitHub Packages)

### DIFF
--- a/.github/workflows/publish-workbench.yml
+++ b/.github/workflows/publish-workbench.yml
@@ -1,0 +1,30 @@
+name: Publish @canopy/workbench
+
+# Publishes the shared front-end workbench package to GitHub Packages.
+# Trigger by pushing a tag like `workbench-v0.1.0`, or manually via the
+# Actions tab (workflow_dispatch). Bump the version in
+# frontend/packages/workbench/package.json to match the tag before tagging.
+on:
+  push:
+    tags: ['workbench-v*']
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: Publish to GitHub Packages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@canopy'
+      - name: Publish
+        run: npm publish
+        working-directory: frontend/packages/workbench
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/frontend/packages/workbench/.npmrc
+++ b/frontend/packages/workbench/.npmrc
@@ -1,0 +1,2 @@
+@canopy:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}


### PR DESCRIPTION
Adds the deferred publish workflow (plan Task 7) so `@canopy/workbench` can be published to GitHub Packages when ace-web is ready to consume it.

- `.github/workflows/publish-workbench.yml` — publishes on a `workbench-v*` tag or manual dispatch; auth via `actions/setup-node` + `GITHUB_TOKEN`; registry from the package's existing `publishConfig`.
- `frontend/packages/workbench/.npmrc` — scopes `@canopy` to GitHub Packages for local/CI publish. Lives in the **package dir** (not `frontend/`) so it never affects the app's root `npm ci` (npm reads .npmrc cwd-upward only).

Verified with `npm publish --dry-run`: publishes `@canopy/workbench@0.1.0` (12 src files; .npmrc excluded from the tarball). No app code changes; ace-web adoption still deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)