### PR TITLE
feat(ddd): surface a version-pinned narrative video on the narrative page

### DIFF
--- a/apps/runs/aggregate.py
+++ b/apps/runs/aggregate.py
@@ -460,6 +460,19 @@ def build_narrative(slug: str) -> dict | None:
     versions_by_id = {str(r.id): r for r in versions}
     current = versions[-1] if versions else None
 
+    # Version-pinned narrative videos. A video walkthrough stamped with a
+    # version's review id (``narrative_review_id``) belongs to that exact story
+    # version — so a later narration edit can't leave a stale video on a newer
+    # version. Queried separately from ``wts`` above (which is run-scoped); a
+    # narrative-version video may carry no run_id. Ascending order → latest wins.
+    video_by_review: dict[str, Walkthrough] = {}
+    if versions:
+        for w in Walkthrough.objects.filter(
+            kind=Walkthrough.KIND_VIDEO,
+            narrative_review_id__in=[r.id for r in versions],
+        ).order_by("created_at"):
+            video_by_review[str(w.narrative_review_id)] = w
+
     # Resolve which version each run rendered.
     def _version_review_for(run_id) -> ReviewRequest | None:
         run_wts = wts_by_run.get(run_id, [])
@@ -488,6 +501,7 @@ def build_narrative(slug: str) -> dict | None:
     versions_payload = []
     for r in reversed(versions):  # newest version first
         np = _narrative_payload(r)
+        vid = video_by_review.get(str(r.id))
         versions_payload.append(
             {
                 "version": r.version,
@@ -497,6 +511,8 @@ def build_narrative(slug: str) -> dict | None:
                 "created_at": r.created_at,
                 "gate": r.gate,
                 "status": r.status,
+                "video_url": _content_url(vid) if vid else None,
+                "video_viewer_url": _viewer_url(vid) if vid else None,
                 "runs": _sorted_runs(buckets.get(str(r.id), [])),
             }
         )
@@ -518,11 +534,14 @@ def build_narrative(slug: str) -> dict | None:
     current_payload = None
     if current is not None:
         cp = _narrative_payload(current)
+        cvid = video_by_review.get(cp["review_id"])
         current_payload = {
             "review_id": cp["review_id"],
             "version": cp["version"],
             "title": cp["title"],
             "story": cp["story"],
+            "video_url": _content_url(cvid) if cvid else None,
+            "video_viewer_url": _viewer_url(cvid) if cvid else None,
         }
 
     return {

--- a/apps/runs/schemas.py
+++ b/apps/runs/schemas.py
@@ -40,6 +40,10 @@ class NarrativeVersionOut(StrictModel):
     created_at: dt.datetime | None = None
     gate: str | None = None
     status: str | None = None
+    # A narrated video pinned to THIS version (a video walkthrough stamped with
+    # this version's review id). None until one is uploaded for the version.
+    video_url: str | None = None
+    video_viewer_url: str | None = None
     runs: list[NarrativeRunOut] = []
 
 
@@ -50,6 +54,9 @@ class NarrativeStoryOut(StrictModel):
     version: int | None = None
     title: str | None = None
     story: str | None = None
+    # The narrated video pinned to the current version, if one was uploaded.
+    video_url: str | None = None
+    video_viewer_url: str | None = None
 
 
 class NarrativeDetailOut(StrictModel):

--- a/frontend/src/api/ddd.ts
+++ b/frontend/src/api/ddd.ts
@@ -37,6 +37,8 @@ export interface DddNarrativeStory {
   version: number | null
   title: string | null
   story: string | null
+  video_url: string | null
+  video_viewer_url: string | null
 }
 
 export interface DddNarrativeVersion {
@@ -47,6 +49,8 @@ export interface DddNarrativeVersion {
   created_at: string | null
   gate: string | null
   status: string | null
+  video_url: string | null
+  video_viewer_url: string | null
   runs: DddNarrativeRun[]
 }
 

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -1190,6 +1190,40 @@ export interface paths {
         readonly patch?: never;
         readonly trace?: never;
     };
+    readonly "/api/agents/{slug}/tasks/": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        /** List the agent's tasks (board) */
+        readonly get: operations["apps_agents_api_list_tasks"];
+        readonly put?: never;
+        readonly post?: never;
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
+    readonly "/api/agents/{slug}/tasks/sync": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly get?: never;
+        readonly put?: never;
+        /** Sync (replace) the agent's task board from the source sheet */
+        readonly post: operations["apps_agents_api_sync_tasks"];
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
     readonly "/api/share/{token}": {
         readonly parameters: {
             readonly query?: never;
@@ -2533,6 +2567,10 @@ export interface components {
             readonly title?: string | null;
             /** Story */
             readonly story?: string | null;
+            /** Video Url */
+            readonly video_url?: string | null;
+            /** Video Viewer Url */
+            readonly video_viewer_url?: string | null;
         };
         /** NarrativeVersionOut */
         readonly NarrativeVersionOut: {
@@ -2550,6 +2588,10 @@ export interface components {
             readonly gate?: string | null;
             /** Status */
             readonly status?: string | null;
+            /** Video Url */
+            readonly video_url?: string | null;
+            /** Video Viewer Url */
+            readonly video_viewer_url?: string | null;
             /**
              * Runs
              * @default []
@@ -3084,6 +3126,11 @@ export interface components {
              * @default 0
              */
             readonly skill_count: number;
+            /**
+             * Task Count
+             * @default 0
+             */
+            readonly task_count: number;
             /** Latest Sync At */
             readonly latest_sync_at?: string | null;
         };
@@ -3289,6 +3336,106 @@ export interface components {
              * @default
              */
             readonly improvement_note: string;
+        };
+        /** AgentTaskLink */
+        readonly AgentTaskLink: {
+            /** Label */
+            readonly label: string;
+            /** Url */
+            readonly url: string;
+        };
+        /** AgentTaskOut */
+        readonly AgentTaskOut: {
+            /** Id */
+            readonly id: number;
+            /** Agent Slug */
+            readonly agent_slug: string;
+            /** Ext Id */
+            readonly ext_id: string;
+            /** Title */
+            readonly title: string;
+            /** Next Action */
+            readonly next_action: string;
+            /** Status */
+            readonly status: string;
+            /** Owner */
+            readonly owner: string;
+            /** Assigned */
+            readonly assigned: string;
+            /** Confidence */
+            readonly confidence: string;
+            /** Due */
+            readonly due?: string | null;
+            /** Links */
+            readonly links?: readonly components["schemas"]["AgentTaskLink"][];
+            /** Notes */
+            readonly notes: string;
+            /** Position */
+            readonly position: number;
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            readonly updated_at: string;
+        };
+        /** AgentTaskIn */
+        readonly AgentTaskIn: {
+            /** Ext Id */
+            readonly ext_id: string;
+            /** Title */
+            readonly title: string;
+            /**
+             * Next Action
+             * @default
+             */
+            readonly next_action: string;
+            /**
+             * Status
+             * @default suggested
+             */
+            readonly status: string;
+            /**
+             * Owner
+             * @default
+             */
+            readonly owner: string;
+            /**
+             * Assigned
+             * @default
+             */
+            readonly assigned: string;
+            /**
+             * Confidence
+             * @default
+             */
+            readonly confidence: string;
+            /** Due */
+            readonly due?: string | null;
+            /** Links */
+            readonly links?: readonly components["schemas"]["AgentTaskLink"][];
+            /**
+             * Notes
+             * @default
+             */
+            readonly notes: string;
+            /**
+             * Position
+             * @default 0
+             */
+            readonly position: number;
+            /**
+             * Source
+             * @default
+             */
+            readonly source: string;
+        };
+        /**
+         * AgentTaskSyncIn
+         * @description Full replacement of the agent's task board from the source sheet.
+         */
+        readonly AgentTaskSyncIn: {
+            /** Tasks */
+            readonly tasks?: readonly components["schemas"]["AgentTaskIn"][];
         };
         /**
          * SharedSessionOut
@@ -5292,6 +5439,54 @@ export interface operations {
         readonly requestBody: {
             readonly content: {
                 readonly "application/json": components["schemas"]["AgentSkillCatalogIn"];
+            };
+        };
+        readonly responses: {
+            /** @description OK */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["CountOut"];
+                };
+            };
+        };
+    };
+    readonly apps_agents_api_list_tasks: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path: {
+                readonly slug: string;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description OK */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": readonly components["schemas"]["AgentTaskOut"][];
+                };
+            };
+        };
+    };
+    readonly apps_agents_api_sync_tasks: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path: {
+                readonly slug: string;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody: {
+            readonly content: {
+                readonly "application/json": components["schemas"]["AgentTaskSyncIn"];
             };
         };
         readonly responses: {

--- a/frontend/src/components/ddd/NarrativeLanding.tsx
+++ b/frontend/src/components/ddd/NarrativeLanding.tsx
@@ -183,6 +183,14 @@ function VersionBlock({
               {version.story}
             </p>
           )}
+          {version.video_url && (
+            <video
+              src={version.video_url}
+              controls
+              preload="metadata"
+              className="mb-3 w-full max-w-2xl rounded-lg border border-stone-800 bg-black"
+            />
+          )}
           {version.review_id && (
             <a
               href={`/review/${version.review_id}`}


### PR DESCRIPTION
## Product Description

When a narrated walkthrough video is rendered for a DDD narrative and uploaded, it now appears **inline on that narrative's page**, attached to the exact story version it was made from. Edit the narration and cut a new version, and the old video stays with the old version instead of misleadingly showing under the new text.

## Technical Summary

- `Walkthrough.narrative_review_id` (already on the model) is the pin. `build_narrative` looks up the latest `kind=video` walkthrough per version's review id — queried separately from the run-scoped `wts` list, since a narrative-version video may carry no `run_id` — and exposes `video_url` / `video_viewer_url` on `NarrativeVersionOut` + `NarrativeStoryOut`.
- Frontend (`NarrativeLanding.tsx`) renders an inline `<video controls>` per version when present.
- No migration (reuses the existing field). `generated.ts` will be regenerated by the regen-openapi workflow.
- Uploaded by the canopy plugin's `/canopy:ddd-ace-render --upload` (separate PR jjackson/canopy#190), which stamps `narrative_review_id` to the narrative's current version.

## Safety Assurance

- `py_compile` clean on the changed Python. Video lookup is read-only and additive (new nullable fields default null → no behavior change for narratives without a video). Frontend renders the `<video>` only when `video_url` is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)