### PR TITLE
Playwright E2E for the agent workspace + fix CSRF on board actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,9 @@ frontend/openapi.json
 .claude/tasks/
 .claude/settings.local.json
 scripts/qa/screenshots/
+
+# e2e
+e2e.sqlite3
+frontend/e2e/.auth/
+frontend/test-results/
+frontend/playwright-report/

--- a/config/settings/development.py
+++ b/config/settings/development.py
@@ -4,3 +4,11 @@ Development settings for canopy-web.
 from .base import *  # noqa: F401, F403
 
 DEBUG = True
+
+# The Vite dev server (port 3000) proxies /api here, so browser POSTs carry an
+# Origin of http://localhost:3000. Trust it so Django's CSRF origin check passes
+# in dev (in prod the SPA is same-origin, handled by production.py).
+CSRF_TRUSTED_ORIGINS = [
+    "http://localhost:3000",
+    "http://127.0.0.1:3000",
+]

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -1,0 +1,17 @@
+# E2E tests (Playwright)
+
+Browser tests for the agent workspace (`/agents/echo`) — board grouping, the
+section panels, and the action loop (accept / decline / dispatch / mark-done).
+
+```bash
+cd frontend && npm run test:e2e
+```
+
+Playwright boots two servers itself (`webServer` in `playwright.config.ts`):
+- **API** on :8000 via `e2e/backend.sh` — a throwaway **SQLite** DB, `REQUIRE_AUTH=False`,
+  migrated + seeded (`e2e/seed.py`), which also **mints a Django session** and writes the key
+  to `e2e/.auth/session.txt`. No Google OAuth needed.
+- **SPA** on :3000 via `npm run dev` (proxies `/api` → :8000).
+
+`e2e/global-setup.ts` turns the minted session key into a Playwright `storageState`
+cookie, so requests are authenticated exactly like a logged-in user (CSRF included).

--- a/frontend/e2e/agents.spec.ts
+++ b/frontend/e2e/agents.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect, type Page } from '@playwright/test'
+
+const cmd = (page: Page) =>
+  page.waitForResponse((r) => r.url().includes('/commands') && r.request().method() === 'POST')
+
+test('agents list shows the Echo agent', async ({ page }) => {
+  await page.goto('/agents')
+  await expect(page.getByText('Echo').first()).toBeVisible()
+})
+
+test('workspace rail exposes the sections', async ({ page }) => {
+  await page.goto('/agents/echo')
+  await expect(page.locator('a[href$="/agents/echo/tasks"]')).toBeVisible()
+  await expect(page.locator('a[href$="/agents/echo/syncs"]')).toBeVisible()
+  await expect(page.locator('a[href$="/agents/echo/skills"]')).toBeVisible()
+})
+
+test('overview shows the latest sync', async ({ page }) => {
+  await page.goto('/agents/echo/overview')
+  await expect(page.getByText('Manager sync 1')).toBeVisible()
+})
+
+test('syncs section lists the sync with its self-grades', async ({ page }) => {
+  await page.goto('/agents/echo/syncs')
+  await expect(page.getByText('Manager sync 1')).toBeVisible()
+  await expect(page.getByText(/C\+/)).toBeVisible()
+})
+
+test('work products section lists the deliverable', async ({ page }) => {
+  await page.goto('/agents/echo/work-products')
+  await expect(page.getByText('Demo story RUWOYD')).toBeVisible()
+})
+
+test('skills section lists the catalog', async ({ page }) => {
+  await page.goto('/agents/echo/skills')
+  await expect(page.getByText('email-communicator')).toBeVisible()
+})
+
+test('task board groups by who has the ball, with context + queue badge', async ({ page }) => {
+  await page.goto('/agents/echo/tasks')
+  for (const label of ['Suggested', 'Waiting on a human', 'Echo working', 'Done']) {
+    await expect(page.getByText(label, { exact: false }).first()).toBeVisible()
+  }
+  await expect(page.getByTestId('task-t1')).toHaveAttribute('data-status', 'suggested')
+  await expect(page.getByTestId('task-t3')).toHaveAttribute('data-status', 'in_progress')
+  await expect(page.getByText(/Strong near-miss/)).toBeVisible() // rationale on the card
+  await expect(page.getByText(/queued for Echo/i)).toBeVisible() // the seeded pending command
+})
+
+test('accept flips a suggested task to in progress and clears its Accept button', async ({ page }) => {
+  await page.goto('/agents/echo/tasks')
+  const card = page.getByTestId('task-t2')
+  await expect(card).toHaveAttribute('data-status', 'suggested')
+  const [resp] = await Promise.all([cmd(page), card.getByRole('button', { name: /^Accept$/ }).click()])
+  expect(resp.status()).toBe(201)
+  await expect(page.getByTestId('task-t2')).toHaveAttribute('data-status', 'in_progress')
+  await expect(page.getByTestId('task-t2').getByRole('button', { name: /^Accept$/ })).toHaveCount(0)
+})
+
+test('decline takes a reason and moves the task to declined', async ({ page }) => {
+  await page.goto('/agents/echo/tasks')
+  const card = page.getByTestId('task-t1')
+  await card.getByRole('button', { name: /^Decline$/ }).click()
+  await card.getByRole('textbox').fill('not a fit right now')
+  const [resp] = await Promise.all([cmd(page), card.getByRole('button', { name: /Confirm/i }).click()])
+  expect(resp.status()).toBe(201)
+  await expect(page.getByTestId('task-t1')).toHaveAttribute('data-status', 'declined')
+})
+
+test('dispatch queues a "do it now" command for the agent', async ({ page }) => {
+  await page.goto('/agents/echo/tasks')
+  const card = page.getByTestId('task-t3') // waiting-on-a-human, in progress
+  const [resp] = await Promise.all([cmd(page), card.getByRole('button', { name: /do this now/i }).click()])
+  expect(resp.status()).toBe(201)
+})
+
+test('mark done moves an in-progress task to Done', async ({ page }) => {
+  await page.goto('/agents/echo/tasks')
+  const card = page.getByTestId('task-t4') // Echo working
+  const [resp] = await Promise.all([cmd(page), card.getByRole('button', { name: /Mark done/i }).click()])
+  expect(resp.status()).toBe(201)
+  await expect(page.getByTestId('task-t4')).toHaveAttribute('data-status', 'done')
+})

--- a/frontend/e2e/backend.sh
+++ b/frontend/e2e/backend.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Boots a local API on :8000 backed by SQLite, no OAuth wall, seeded + a minted
+# session (frontend/e2e/.auth/session.txt). Run by Playwright's webServer.
+set -e
+cd "$(dirname "$0")/../.."   # repo root
+export DATABASE_URL="sqlite:///$(pwd)/e2e.sqlite3"
+export REQUIRE_AUTH=False
+export DEBUG=True
+export SECRET_KEY="e2e-secret-key"
+export ALLOWED_HOSTS="localhost,127.0.0.1"
+rm -f e2e.sqlite3 frontend/e2e/.auth/session.txt
+uv run python manage.py migrate --noinput >/tmp/e2e-migrate.log 2>&1
+uv run python manage.py shell -c "exec(open('frontend/e2e/seed.py').read())"
+exec uv run uvicorn config.asgi:application --host 127.0.0.1 --port 8000

--- a/frontend/e2e/global-setup.ts
+++ b/frontend/e2e/global-setup.ts
@@ -1,0 +1,28 @@
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const dir = path.join(here, '.auth')
+const sessionFile = path.join(dir, 'session.txt')
+const stateFile = path.join(dir, 'state.json')
+
+// Wait for backend.sh to seed + mint the session, then write a Playwright
+// storageState carrying the session cookie so API calls are authenticated.
+export default async function globalSetup() {
+  for (let i = 0; i < 120; i++) {
+    if (fs.existsSync(sessionFile) && fs.readFileSync(sessionFile, 'utf8').trim()) break
+    await new Promise((r) => setTimeout(r, 1000))
+  }
+  const key = fs.readFileSync(sessionFile, 'utf8').trim()
+  if (!key) throw new Error('no session key minted by backend seed')
+  const state = {
+    cookies: [{
+      name: 'sessionid', value: key, domain: 'localhost', path: '/',
+      expires: Math.floor(Date.now() / 1000) + 86400,
+      httpOnly: true, secure: false, sameSite: 'Lax' as const,
+    }],
+    origins: [],
+  }
+  fs.writeFileSync(stateFile, JSON.stringify(state))
+}

--- a/frontend/e2e/seed.py
+++ b/frontend/e2e/seed.py
@@ -1,0 +1,73 @@
+"""E2E seed: a user + an authenticated session + the echo agent with a spread of
+tasks and one pending command. Writes the session key to .auth/session.txt for
+Playwright to use as a cookie. Run via `manage.py shell -c` from the repo root."""
+import datetime as dt
+import os
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.contrib.sessions.backends.db import SessionStore
+
+from apps.agents.models import (
+    Agent, AgentSkill, AgentSync, AgentTask, AgentTaskCommand, AgentWorkProduct,
+)
+
+User = get_user_model()
+user, _ = User.objects.get_or_create(username="e2e", defaults={"email": "e2e@dimagi.com"})
+
+a, _ = Agent.objects.update_or_create(slug="echo", defaults=dict(
+    name="Echo", email="echo@dimagi-ai.com", description="Marketing agent for Connect.",
+    persona="Email-driven marketing agent."))
+a.tasks.all().delete()
+a.commands.all().delete()
+
+
+def t(**k):
+    return AgentTask.objects.create(agent=a, **k)
+
+
+t(ext_id="t1", title="ZEGCAWIS polio AFP story", next_action="Get consent to interview the FLW",
+  status="suggested", owner="Matt", assigned="Matt", confidence="high",
+  rationale="Strong near-miss; timely AFP detection fed national surveillance.",
+  source_url="https://example.com/zegcawis", position=0)
+t(ext_id="t2", title="Brand-voice loop", next_action="Propose a draft to edits design",
+  status="suggested", owner="Amie", assigned="Echo", confidence="low",
+  rationale="Learn the house voice from edits.", position=1)
+t(ext_id="t3", title="PRIDE cholera story", next_action="Run the interview",
+  status="in_progress", owner="Matt", assigned="Sarvesh", position=2)
+t(ext_id="t4", title="Ideas backlog upkeep", next_action="Append new ideas",
+  status="in_progress", owner="Matt", assigned="Echo", position=3)
+t(ext_id="t5", title="Agent workspace shipped", next_action="", status="done",
+  owner="Jonathan", assigned="Echo", position=4)
+AgentTaskCommand.objects.create(agent=a, task=a.tasks.get(ext_id="t4"), kind="dispatch",
+                                status="pending", created_by="jonathan@dimagi.com")
+
+a.syncs.all().delete()
+a.work_products.all().delete()
+a.skills.all().delete()
+AgentSync.objects.create(
+    agent=a, period_start=dt.datetime(2026, 6, 3, tzinfo=dt.timezone.utc),
+    period_end=dt.datetime(2026, 6, 17, tzinfo=dt.timezone.utc), title="Manager sync 1",
+    summary="First two weeks.", doc_url="https://docs.google.com/document/d/syncdoc/edit",
+    self_grades={"work": "C+", "skills": "B-"}, source="manager-sync")
+AgentWorkProduct.objects.create(
+    agent=a, title="Demo story RUWOYD", kind="story",
+    url="https://docs.google.com/document/d/wp1/edit", description="A 5/5 demo story.",
+    tags=["story"], source="story-draft")
+AgentSkill.objects.create(
+    agent=a, name="email-communicator", description="Send and receive email as Echo.",
+    url="https://github.com/dimagi-internal/echo/blob/main/skills/email-communicator/SKILL.md")
+
+session = SessionStore()
+session["_auth_user_id"] = str(user.pk)
+session["_auth_user_backend"] = settings.AUTHENTICATION_BACKENDS[0]
+session["_auth_user_hash"] = user.get_session_auth_hash()
+session.set_expiry(24 * 3600)
+session.save()
+
+os.makedirs("frontend/e2e/.auth", exist_ok=True)
+with open("frontend/e2e/.auth/session.txt", "w") as f:
+    f.write(session.session_key)
+
+print(f"seeded: {a.tasks.count()} tasks, {a.commands.filter(status='pending').count()} pending; "
+      f"session {session.session_key[:8]}")

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -33,6 +33,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@playwright/test": "^1.61.0",
         "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.2.2",
         "@types/node": "^24.12.0",
@@ -1393,6 +1394,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
+      "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@redocly/ajv": {
@@ -7223,6 +7240,53 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pluralize": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,14 +9,17 @@
     "gen:api": "openapi-typescript http://localhost:8000/api/openapi.json --output src/api/generated.ts --immutable",
     "gen:api:local": "openapi-typescript openapi.json --output src/api/generated.ts --immutable",
     "lint": "eslint .",
+    "test:e2e": "playwright test",
     "preview": "vite preview",
     "test": "vitest run"
   },
-  "workspaces": ["packages/*"],
+  "workspaces": [
+    "packages/*"
+  ],
   "dependencies": {
-    "@canopy/workbench": "*",
     "@ai-sdk/react": "^3.0.143",
     "@base-ui/react": "^1.3.0",
+    "@canopy/workbench": "*",
     "@fontsource-variable/geist": "^5.2.8",
     "ai": "^6.0.141",
     "class-variance-authority": "^0.7.1",
@@ -36,6 +39,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@playwright/test": "^1.61.0",
     "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.2.2",
     "@types/node": "^24.12.0",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  reporter: [['list']],
+  globalSetup: './e2e/global-setup.ts',
+  use: {
+    baseURL: 'http://localhost:3000',
+    storageState: './e2e/.auth/state.json',
+    trace: 'retain-on-failure',
+  },
+  webServer: [
+    { command: 'bash e2e/backend.sh', url: 'http://127.0.0.1:8000/health/', timeout: 120_000, reuseExistingServer: false },
+    { command: 'npm run dev', url: 'http://localhost:3000', timeout: 60_000, reuseExistingServer: false },
+  ],
+})

--- a/frontend/src/api/agents.ts
+++ b/frontend/src/api/agents.ts
@@ -151,11 +151,31 @@ async function getJson<T>(path: string, what: string): Promise<T> {
   return (await res.json()) as T
 }
 
+function readCookie(name: string): string {
+  return document.cookie.match(new RegExp(`(?:^|;\\s*)${name}=([^;]+)`))?.[1] ?? ''
+}
+
+// Django's session auth (Ninja) enforces CSRF on unsafe methods. Read the
+// csrftoken cookie (bootstrapping it from /api/csrf/ if absent) and send it.
+async function csrfToken(): Promise<string> {
+  let token = readCookie('csrftoken')
+  if (!token) {
+    await fetch('/api/csrf/', { credentials: 'same-origin' })
+    token = readCookie('csrftoken')
+  }
+  return token ? decodeURIComponent(token) : ''
+}
+
 async function postJson<T>(path: string, body: unknown, what: string): Promise<T> {
+  const token = await csrfToken()
   const res = await fetch(path, {
     method: 'POST',
     credentials: 'same-origin',
-    headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      ...(token ? { 'X-CSRFToken': token } : {}),
+    },
     body: JSON.stringify(body),
   })
   if (res.status === 401 && !isPublicLinkRoute()) redirectToLogin()

--- a/frontend/src/components/TasksBoard.tsx
+++ b/frontend/src/components/TasksBoard.tsx
@@ -312,7 +312,8 @@ function TaskCard({
   const isDone = task.status === 'done'
 
   return (
-    <div className="rounded-lg border border-border bg-card p-3 transition-colors hover:border-primary/40">
+    <div data-testid={`task-${task.ext_id}`} data-status={task.status}
+         className="rounded-lg border border-border bg-card p-3 transition-colors hover:border-primary/40">
       <div className="flex items-start gap-2">
         {isSuggested && <ConfidenceDot confidence={task.confidence} />}
         <p className="min-w-0 flex-1 text-[13px] font-semibold leading-snug text-foreground">
@@ -503,6 +504,8 @@ export function TasksBoard({
             {declined.map((t) => (
               <div
                 key={t.id}
+                data-testid={`task-${t.ext_id}`}
+                data-status={t.status}
                 className="rounded-md border border-border bg-card/50 px-3 py-1.5 text-[11px] text-muted-foreground"
                 title={t.notes || undefined}
               >


### PR DESCRIPTION
Adds a Playwright suite (frontend/e2e, 11 specs) that boots a SQLite API + the SPA, mints a session, and exercises the workspace + action loop end-to-end. **It caught a real prod bug:** the board's action POSTs weren't sending X-CSRFToken (would 403 live) — fixed in agents.ts; plus dev CSRF trusted-origin. Run: `cd frontend && npm run test:e2e`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)