### PR TITLE
feat(ddd): clickable narrative version rows in left nav + active highlight

### DIFF
--- a/frontend/src/components/ddd/DddLeftNav.tsx
+++ b/frontend/src/components/ddd/DddLeftNav.tsx
@@ -167,19 +167,42 @@ function NarrativeRuns({
       {versions.map((v) => {
         const isCurrent = v.version != null && v.version === currentVersion
         const label = v.version != null ? `v${v.version}` : 'no narrative'
+        // The version's edit/review page — same destination as the "Edit
+        // narrative" button on the narrative landing page. The null/"no
+        // narrative" bucket has no review_id and stays non-clickable.
+        const isVersionActive = v.review_id != null && activeReviewId === v.review_id
         const runs = [...v.runs].sort((a, b) =>
           (b.latest_at || '').localeCompare(a.latest_at || ''),
         )
+        const versionRow = (
+          <>
+            <span className="font-mono text-[11px] font-medium">{label}</span>
+            {isCurrent && (
+              <span className="rounded bg-primary/10 px-1 py-px text-[9px] font-medium uppercase tracking-wide text-primary">
+                current
+              </span>
+            )}
+          </>
+        )
         return (
           <div key={v.review_id ?? `v${v.version ?? 'none'}`} className="flex flex-col gap-0.5">
-            <div className="flex items-center gap-1.5 px-3 py-0.5">
-              <span className="font-mono text-[11px] font-medium text-foreground">{label}</span>
-              {isCurrent && (
-                <span className="rounded bg-primary/10 px-1 py-px text-[9px] font-medium uppercase tracking-wide text-primary">
-                  current
-                </span>
-              )}
-            </div>
+            {v.review_id != null ? (
+              <Link
+                to={`/review/${encodeURIComponent(v.review_id)}`}
+                className={clsx(
+                  'flex items-center gap-1.5 rounded-md px-3 py-0.5 transition-colors',
+                  isVersionActive
+                    ? 'bg-primary/10 text-primary border border-primary/30'
+                    : 'text-foreground hover:bg-accent border border-transparent',
+                )}
+              >
+                {versionRow}
+              </Link>
+            ) : (
+              <div className="flex items-center gap-1.5 px-3 py-0.5 text-foreground">
+                {versionRow}
+              </div>
+            )}
             {runs.length === 0 ? (
               <div className="px-3 py-0.5 pl-5 text-[11px] text-muted-foreground">No runs</div>
             ) : (


### PR DESCRIPTION
## Summary
In the DDD left nav (`frontend/src/components/ddd/DddLeftNav.tsx`), the **run** rows were clickable links but the **version** rows (`v12`, `v11`, …) were plain non-clickable `<div>`s, and there was no indication of which version you were viewing. This makes version rows clickable and highlights the active one.

- **Version rows are links → `/review/<review_id>`** — the same destination as the narrative landing page's "Edit narrative" button. The label + `current` badge are factored into a shared `versionRow` fragment used by both the link and non-link branches.
- **Active version highlight** — reuses the existing `activeReviewId` (derived from `window.location.pathname.match(/^\/review\/([^/]+)/)`) already computed in this component for findings-review entries, applying the same active styling the run rows use (`bg-primary/10 text-primary border border-primary/30`), with `hover:bg-accent` + a transparent border on the inactive state so there's no layout shift.
- **Null bucket stays non-clickable** — versions with no `review_id` (the "no narrative" bucket) render as a plain `<div>`.

Closes #129

## Test Coverage
Frontend-only presentational change. Verified via `tsc -b` typecheck + `vite build` (both pass). No new code paths beyond render-time conditional link wrapping; existing component has no unit tests.

## Pre-Landing Review
Small single-file diff (31 insertions, 8 deletions). Mirrors the established `FindingsReviewEntry` / run-row link patterns in the same file. No data, auth, or trust-boundary surface touched.

## Design Review
Matches existing rail styling — same active-state classes as run rows, monospace version label, unchanged `current` badge. No new visual idiom introduced.

## Test plan
- [x] `tsc -b` typecheck passes
- [x] `vite build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)