### PR TITLE
Agent workspace: Needs-you inbox + command activity + token migration (#133, #134, #132)

### DIFF
--- a/apps/agents/api.py
+++ b/apps/agents/api.py
@@ -29,6 +29,7 @@ from .schemas import (
     AgentWorkProductOut,
     CommandResultOut,
     CountOut,
+    NeedsYouOut,
 )
 
 router = Router(auth=session_auth, tags=["agents"])
@@ -61,6 +62,14 @@ def upsert_agent(request: HttpRequest, payload: AgentIn) -> Status:
 def get_agent(request: HttpRequest, slug: str) -> AgentDetailOut:
     agent = _get_agent_or_404(slug)
     return AgentDetailOut.model_validate(services.agent_detail(agent))
+
+
+@router.get("/{slug}/needs-you", response=NeedsYouOut,
+            summary="What the human needs to act on — typed (review/question/notify) + ranked",
+            openapi_extra={"x-mcp-expose": True})
+def needs_you(request: HttpRequest, slug: str) -> NeedsYouOut:
+    agent = _get_agent_or_404(slug)
+    return NeedsYouOut.model_validate(services.needs_you(agent))
 
 
 # ---- syncs (Google-Doc backed) ----

--- a/apps/agents/schemas.py
+++ b/apps/agents/schemas.py
@@ -216,6 +216,23 @@ class CommandResultOut(StrictModel):
     task: AgentTaskOut | None = None
 
 
+# ---- "Needs you" supervisor inbox ----
+class NeedsYouItem(StrictModel):
+    type: str  # 'review' | 'question' | 'notify'
+    ref_kind: str  # 'task' | 'sync' | 'work_product'
+    ref_id: int
+    title: str
+    subtitle: str = ""
+    url: str = ""
+    created_at: dt.datetime
+
+
+class NeedsYouOut(StrictModel):
+    agent_slug: str
+    waiting_count: int  # gated (review + question) items — the "N waiting on you" badge
+    items: list[NeedsYouItem] = Field(default_factory=list)
+
+
 # ---- shared ----
 class CountOut(StrictModel):
     created: int = 0

--- a/apps/agents/services.py
+++ b/apps/agents/services.py
@@ -256,6 +256,71 @@ def list_commands(agent: Agent, status: str | None = None) -> list[AgentTaskComm
     return list(qs)
 
 
+# ---- "Needs you" supervisor inbox ----
+def _is_human(assigned: str) -> bool:
+    """The task's next action waits on a person, not the agent. Mirrors the
+    board's `isEcho` rule: empty or 'echo' (any case) means the agent."""
+    a = (assigned or "").strip().lower()
+    return a not in ("", "echo")
+
+
+def _task_item(item_type: str, task: AgentTask) -> dict:
+    subtitle = (task.next_action or "").strip()
+    if item_type == "question" and not subtitle:
+        subtitle = f"Echo is blocked, waiting on {task.assigned.strip()}"
+    return {
+        "type": item_type,
+        "ref_kind": "task",
+        "ref_id": task.id,
+        "title": (task.title or task.next_action or "").strip(),
+        "subtitle": subtitle,
+        "url": (task.source_url or "").strip(),
+        "created_at": task.updated_at,
+    }
+
+
+def needs_you(agent: Agent, notify_limit: int = 5) -> dict:
+    """The supervisor's "what does the agent need from me right now?" view.
+
+    Aggregates human-actionable items across the board, typed and ranked:
+      - review:   Suggested tasks awaiting validate/decline.
+      - question: In-progress tasks blocked on a human (Echo needs a decision).
+      - notify:   Recent FYI with no gate (a sync posted, a work product shipped).
+    Ranked Review → Question → Notify. `waiting_count` counts only the gated
+    (review + question) items — the "N waiting on you" badge."""
+    items: list[dict] = []
+
+    # Review — every suggestion needs a human to validate or decline it.
+    for t in agent.tasks.filter(status=AgentTask.SUGGESTED).order_by("position", "id"):
+        items.append(_task_item("review", t))
+
+    # Question — Echo is mid-task but the next step waits on a named person.
+    for t in agent.tasks.filter(status=AgentTask.IN_PROGRESS).order_by("position", "id"):
+        if _is_human(t.assigned):
+            items.append(_task_item("question", t))
+
+    waiting_count = len(items)  # review + question are the gated items
+
+    # Notify — recent FYI, newest first, capped. Merge syncs + work products.
+    notify: list[dict] = []
+    for s in agent.syncs.all()[:notify_limit]:
+        notify.append({
+            "type": "notify", "ref_kind": "sync", "ref_id": s.id,
+            "title": s.title, "subtitle": "Sync posted", "url": s.doc_url,
+            "created_at": s.created_at,
+        })
+    for w in agent.work_products.all()[:notify_limit]:
+        notify.append({
+            "type": "notify", "ref_kind": "work_product", "ref_id": w.id,
+            "title": w.title, "subtitle": w.kind or "Work product", "url": w.url,
+            "created_at": w.created_at,
+        })
+    notify.sort(key=lambda i: i["created_at"], reverse=True)
+    items.extend(notify[:notify_limit])
+
+    return {"agent_slug": agent.slug, "waiting_count": waiting_count, "items": items}
+
+
 def apply_command(cmd: AgentTaskCommand, result_note: str = "") -> AgentTaskCommand:
     cmd.status = AgentTaskCommand.APPLIED
     cmd.applied_at = timezone.now()

--- a/frontend/e2e/agents.spec.ts
+++ b/frontend/e2e/agents.spec.ts
@@ -15,6 +15,27 @@ test('workspace rail exposes the sections', async ({ page }) => {
   await expect(page.locator('a[href$="/agents/echo/skills"]')).toBeVisible()
 })
 
+test('needs-you is the default landing with typed, ranked actionable items', async ({ page }) => {
+  await page.goto('/agents/echo')
+  await expect(page).toHaveURL(/\/agents\/echo\/needs-you$/)
+  await expect(page.getByRole('heading', { name: 'Needs you' })).toBeVisible()
+  // review band: a suggested task awaiting validate/decline
+  await expect(page.getByTestId('needsyou-band-review')).toContainText('ZEGCAWIS polio AFP story')
+  // question band: the in-progress task blocked on a human
+  await expect(page.getByTestId('needsyou-band-question')).toContainText('PRIDE cholera story')
+  // notify band: a recent FYI (the sync)
+  await expect(page.getByTestId('needsyou-band-notify')).toContainText('Manager sync 1')
+  // nothing Echo is actively working appears in the inbox
+  await expect(page.getByText('Ideas backlog upkeep')).toHaveCount(0)
+  // the badge counts the gated items only (t1 + t2 suggested, t3 waiting = 3)
+  await expect(page.getByText(/3 waiting on you/)).toBeVisible()
+})
+
+test('the rail exposes the Needs you inbox', async ({ page }) => {
+  await page.goto('/agents/echo/tasks')
+  await expect(page.locator('a[href$="/agents/echo/needs-you"]')).toBeVisible()
+})
+
 test('overview shows the latest sync', async ({ page }) => {
   await page.goto('/agents/echo/overview')
   await expect(page.getByText('Manager sync 1')).toBeVisible()
@@ -45,6 +66,30 @@ test('task board groups by who has the ball, with context + queue badge', async 
   await expect(page.getByTestId('task-t3')).toHaveAttribute('data-status', 'in_progress')
   await expect(page.getByText(/Strong near-miss/)).toBeVisible() // rationale on the card
   await expect(page.getByText(/queued for Echo/i)).toBeVisible() // the seeded pending command
+})
+
+test('an applied command surfaces its result + timestamp on the task card', async ({ page }) => {
+  await page.goto('/agents/echo/tasks')
+  const card = page.getByTestId('task-t5') // done, with a seeded applied command
+  await expect(card.getByTestId('task-last-activity')).toContainText('Shipped the agent workspace board.')
+  await expect(card.getByTestId('task-last-activity')).toContainText(/Jun 17/)
+})
+
+test('the queue badge expands to the pending commands; activity stream lists history', async ({ page }) => {
+  await page.goto('/agents/echo/tasks')
+  // The badge starts as a count; clicking reveals which commands are pending.
+  await page.getByRole('button', { name: /queued for Echo/i }).click()
+  await expect(page.getByText(/dispatched/i).first()).toBeVisible()
+  // The activity disclosure lists recent commands across the agent.
+  await page.getByRole('button', { name: /^Activity/i }).click()
+  await expect(page.getByTestId('agent-activity')).toContainText('completed')
+})
+
+test('a suggested card links its grounded source next to the rationale', async ({ page }) => {
+  await page.goto('/agents/echo/tasks')
+  const card = page.getByTestId('task-t1')
+  const source = card.getByRole('link', { name: /source/i })
+  await expect(source).toHaveAttribute('href', 'https://example.com/zegcawis')
 })
 
 test('accept flips a suggested task to in progress and clears its Accept button', async ({ page }) => {

--- a/frontend/e2e/seed.py
+++ b/frontend/e2e/seed.py
@@ -41,6 +41,12 @@ t(ext_id="t5", title="Agent workspace shipped", next_action="", status="done",
   owner="Jonathan", assigned="Echo", position=4)
 AgentTaskCommand.objects.create(agent=a, task=a.tasks.get(ext_id="t4"), kind="dispatch",
                                 status="pending", created_by="jonathan@dimagi.com")
+# An applied command carries the outcome Echo recorded — surfaced on the card's
+# "last:" line and in the activity stream.
+AgentTaskCommand.objects.create(
+    agent=a, task=a.tasks.get(ext_id="t5"), kind="done", status="applied",
+    created_by="jonathan@dimagi.com", result_note="Shipped the agent workspace board.",
+    applied_at=dt.datetime(2026, 6, 17, 14, 30, tzinfo=dt.timezone.utc))
 
 a.syncs.all().delete()
 a.work_products.all().delete()

--- a/frontend/src/api/agents.ts
+++ b/frontend/src/api/agents.ts
@@ -114,17 +114,44 @@ export type AgentCommandKind =
 export interface AgentCommandOut {
   id: number
   agent_slug: string
-  task_id: number
+  task_id: number | null
+  task_ext_id: string // the task's stable sheet id ('' if the task was deleted)
+  task_title: string // the task's outcome, for activity rows
   kind: AgentCommandKind
   payload: Record<string, unknown>
-  status: string
-  created_by: string
+  status: string // 'pending' | 'applied' | 'dismissed'
+  created_by: string // who clicked it (email)
+  result_note: string // what Echo actually did, set when the command is applied
   created_at: string
+  applied_at: string | null // when Echo drained/applied it
 }
 
 export interface PostCommandResult {
   command: AgentCommandOut
   task: AgentTaskOut
+}
+
+// ── "Needs you" supervisor inbox ─────────────────────────────────────────────
+// The typed/ranked list of what the human must act on, computed server-side so
+// CLI agents / open claws can query "what needs the human" the same way the UI
+// does. Bands: review → question → notify.
+
+export type NeedsYouType = 'review' | 'question' | 'notify'
+
+export interface NeedsYouItem {
+  type: NeedsYouType
+  ref_kind: 'task' | 'sync' | 'work_product'
+  ref_id: number
+  title: string
+  subtitle: string
+  url: string
+  created_at: string
+}
+
+export interface NeedsYouOut {
+  agent_slug: string
+  waiting_count: number // gated (review + question) items — the "N waiting on you" badge
+  items: NeedsYouItem[]
 }
 
 // Mirrors client.v2's auth: anonymous 401s on a non-public route bounce to the
@@ -204,6 +231,14 @@ export async function getAgent(slug: string): Promise<AgentDetailOut> {
   return getJson<AgentDetailOut>(`/api/agents/${encodeURIComponent(slug)}/`, 'agent')
 }
 
+// The typed/ranked "what needs the human" list (review → question → notify).
+export async function getNeedsYou(slug: string): Promise<NeedsYouOut> {
+  return getJson<NeedsYouOut>(
+    `/api/agents/${encodeURIComponent(slug)}/needs-you`,
+    'needs-you inbox',
+  )
+}
+
 export async function listAgentSyncs(
   slug: string,
   params: ListAgentsParams = {},
@@ -255,10 +290,20 @@ export async function postTaskCommand(
   )
 }
 
+// List the agent's commands. Pass `status` to filter ('pending' for the queue
+// Echo will drain; omit for the full activity stream — newest first).
+export async function listAgentCommands(
+  slug: string,
+  status?: string,
+): Promise<AgentCommandOut[]> {
+  const q = status ? `?status=${encodeURIComponent(status)}` : ''
+  return getJson<AgentCommandOut[]>(
+    `/api/agents/${encodeURIComponent(slug)}/commands${q}`,
+    'agent commands',
+  )
+}
+
 // Pending commands queued for the agent to drain next turn.
 export async function listPendingCommands(slug: string): Promise<AgentCommandOut[]> {
-  return getJson<AgentCommandOut[]>(
-    `/api/agents/${encodeURIComponent(slug)}/commands?status=pending`,
-    'pending commands',
-  )
+  return listAgentCommands(slug, 'pending')
 }

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -1136,6 +1136,23 @@ export interface paths {
         readonly patch?: never;
         readonly trace?: never;
     };
+    readonly "/api/agents/{slug}/needs-you": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        /** What the human needs to act on — typed (review/question/notify) + ranked */
+        readonly get: operations["apps_agents_api_needs_you"];
+        readonly put?: never;
+        readonly post?: never;
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
     readonly "/api/agents/{slug}/syncs/": {
         readonly parameters: {
             readonly query?: never;
@@ -1200,7 +1217,8 @@ export interface paths {
         /** List the agent's tasks (board) */
         readonly get: operations["apps_agents_api_list_tasks"];
         readonly put?: never;
-        readonly post?: never;
+        /** Create a task */
+        readonly post: operations["apps_agents_api_create_task"];
         readonly delete?: never;
         readonly options?: never;
         readonly head?: never;
@@ -1216,8 +1234,76 @@ export interface paths {
         };
         readonly get?: never;
         readonly put?: never;
-        /** Sync (replace) the agent's task board from the source sheet */
+        /** Upsert the agent's tasks from the (legacy) source sheet */
         readonly post: operations["apps_agents_api_sync_tasks"];
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
+    readonly "/api/agents/{slug}/tasks/{task_id}/": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly get?: never;
+        readonly put?: never;
+        readonly post?: never;
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        /** Update a task */
+        readonly patch: operations["apps_agents_api_patch_task"];
+        readonly trace?: never;
+    };
+    readonly "/api/agents/{slug}/tasks/{task_id}/commands": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly get?: never;
+        readonly put?: never;
+        /** Post a board action (accept/decline/dispatch/…) on a task */
+        readonly post: operations["apps_agents_api_post_command"];
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
+    readonly "/api/agents/{slug}/commands": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        /** List commands (the agent reads ?status=pending) */
+        readonly get: operations["apps_agents_api_list_commands"];
+        readonly put?: never;
+        readonly post?: never;
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
+    readonly "/api/agents/{slug}/commands/{cmd_id}/apply": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly get?: never;
+        readonly put?: never;
+        /** Mark a command applied (the agent calls this after acting) */
+        readonly post: operations["apps_agents_api_apply_command"];
         readonly delete?: never;
         readonly options?: never;
         readonly head?: never;
@@ -3134,6 +3220,41 @@ export interface components {
             /** Latest Sync At */
             readonly latest_sync_at?: string | null;
         };
+        /** NeedsYouItem */
+        readonly NeedsYouItem: {
+            /** Type */
+            readonly type: string;
+            /** Ref Kind */
+            readonly ref_kind: string;
+            /** Ref Id */
+            readonly ref_id: number;
+            /** Title */
+            readonly title: string;
+            /**
+             * Subtitle
+             * @default
+             */
+            readonly subtitle: string;
+            /**
+             * Url
+             * @default
+             */
+            readonly url: string;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            readonly created_at: string;
+        };
+        /** NeedsYouOut */
+        readonly NeedsYouOut: {
+            /** Agent Slug */
+            readonly agent_slug: string;
+            /** Waiting Count */
+            readonly waiting_count: number;
+            /** Items */
+            readonly items?: readonly components["schemas"]["NeedsYouItem"][];
+        };
         /** AgentSyncOut */
         readonly AgentSyncOut: {
             /** Id */
@@ -3364,6 +3485,12 @@ export interface components {
             readonly assigned: string;
             /** Confidence */
             readonly confidence: string;
+            /** Rationale */
+            readonly rationale: string;
+            /** Source Url */
+            readonly source_url: string;
+            /** Plan */
+            readonly plan: string;
             /** Due */
             readonly due?: string | null;
             /** Links */
@@ -3409,6 +3536,21 @@ export interface components {
              * @default
              */
             readonly confidence: string;
+            /**
+             * Rationale
+             * @default
+             */
+            readonly rationale: string;
+            /**
+             * Source Url
+             * @default
+             */
+            readonly source_url: string;
+            /**
+             * Plan
+             * @default
+             */
+            readonly plan: string;
             /** Due */
             readonly due?: string | null;
             /** Links */
@@ -3436,6 +3578,101 @@ export interface components {
         readonly AgentTaskSyncIn: {
             /** Tasks */
             readonly tasks?: readonly components["schemas"]["AgentTaskIn"][];
+        };
+        /**
+         * AgentTaskPatch
+         * @description Partial update — only the fields sent are written.
+         */
+        readonly AgentTaskPatch: {
+            /** Title */
+            readonly title?: string | null;
+            /** Next Action */
+            readonly next_action?: string | null;
+            /** Status */
+            readonly status?: string | null;
+            /** Owner */
+            readonly owner?: string | null;
+            /** Assigned */
+            readonly assigned?: string | null;
+            /** Confidence */
+            readonly confidence?: string | null;
+            /** Rationale */
+            readonly rationale?: string | null;
+            /** Source Url */
+            readonly source_url?: string | null;
+            /** Plan */
+            readonly plan?: string | null;
+            /** Due */
+            readonly due?: string | null;
+            /** Notes */
+            readonly notes?: string | null;
+            /** Position */
+            readonly position?: number | null;
+            /** Links */
+            readonly links?: readonly components["schemas"]["AgentTaskLink"][] | null;
+        };
+        /** AgentTaskCommandOut */
+        readonly AgentTaskCommandOut: {
+            /** Id */
+            readonly id: number;
+            /** Agent Slug */
+            readonly agent_slug: string;
+            /** Task Id */
+            readonly task_id?: number | null;
+            /** Task Ext Id */
+            readonly task_ext_id: string;
+            /** Task Title */
+            readonly task_title: string;
+            /** Kind */
+            readonly kind: string;
+            /** Payload */
+            readonly payload?: {
+                readonly [key: string]: unknown;
+            };
+            /** Status */
+            readonly status: string;
+            /** Created By */
+            readonly created_by: string;
+            /** Result Note */
+            readonly result_note: string;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            readonly created_at: string;
+            /** Applied At */
+            readonly applied_at?: string | null;
+        };
+        /**
+         * CommandResultOut
+         * @description Returned when the UI posts a command: the queued command + the (maybe
+         *     immediately-updated) task.
+         */
+        readonly CommandResultOut: {
+            readonly command: components["schemas"]["AgentTaskCommandOut"];
+            readonly task?: components["schemas"]["AgentTaskOut"] | null;
+        };
+        /** AgentTaskCommandIn */
+        readonly AgentTaskCommandIn: {
+            /** Kind */
+            readonly kind: string;
+            /** Payload */
+            readonly payload?: {
+                readonly [key: string]: unknown;
+            };
+            /**
+             * Created By
+             * @default
+             */
+            readonly created_by: string;
+        };
+        /** AgentCommandApplyIn */
+        readonly AgentCommandApplyIn: {
+            /**
+             * Result Note
+             * @default
+             */
+            readonly result_note: string;
         };
         /**
          * SharedSessionOut
@@ -5305,6 +5542,28 @@ export interface operations {
             };
         };
     };
+    readonly apps_agents_api_needs_you: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path: {
+                readonly slug: string;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description OK */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["NeedsYouOut"];
+                };
+            };
+        };
+    };
     readonly apps_agents_api_list_syncs: {
         readonly parameters: {
             readonly query?: {
@@ -5475,6 +5734,32 @@ export interface operations {
             };
         };
     };
+    readonly apps_agents_api_create_task: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path: {
+                readonly slug: string;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody: {
+            readonly content: {
+                readonly "application/json": components["schemas"]["AgentTaskIn"];
+            };
+        };
+        readonly responses: {
+            /** @description Created */
+            readonly 201: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["AgentTaskOut"];
+                };
+            };
+        };
+    };
     readonly apps_agents_api_sync_tasks: {
         readonly parameters: {
             readonly query?: never;
@@ -5497,6 +5782,111 @@ export interface operations {
                 };
                 content: {
                     readonly "application/json": components["schemas"]["CountOut"];
+                };
+            };
+        };
+    };
+    readonly apps_agents_api_patch_task: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path: {
+                readonly slug: string;
+                readonly task_id: number;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody: {
+            readonly content: {
+                readonly "application/json": components["schemas"]["AgentTaskPatch"];
+            };
+        };
+        readonly responses: {
+            /** @description OK */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["AgentTaskOut"];
+                };
+            };
+        };
+    };
+    readonly apps_agents_api_post_command: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path: {
+                readonly slug: string;
+                readonly task_id: number;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody: {
+            readonly content: {
+                readonly "application/json": components["schemas"]["AgentTaskCommandIn"];
+            };
+        };
+        readonly responses: {
+            /** @description Created */
+            readonly 201: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["CommandResultOut"];
+                };
+            };
+        };
+    };
+    readonly apps_agents_api_list_commands: {
+        readonly parameters: {
+            readonly query?: {
+                readonly status?: string | null;
+            };
+            readonly header?: never;
+            readonly path: {
+                readonly slug: string;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description OK */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": readonly components["schemas"]["AgentTaskCommandOut"][];
+                };
+            };
+        };
+    };
+    readonly apps_agents_api_apply_command: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path: {
+                readonly slug: string;
+                readonly cmd_id: number;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody: {
+            readonly content: {
+                readonly "application/json": components["schemas"]["AgentCommandApplyIn"];
+            };
+        };
+        readonly responses: {
+            /** @description OK */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["AgentTaskCommandOut"];
                 };
             };
         };

--- a/frontend/src/components/TasksBoard.tsx
+++ b/frontend/src/components/TasksBoard.tsx
@@ -1,7 +1,8 @@
-import { useState, type JSX, type ReactNode } from 'react'
+import { useMemo, useState, type JSX, type ReactNode } from 'react'
 import {
   postTaskCommand,
   type AgentCommandKind,
+  type AgentCommandOut,
   type AgentTaskOut,
 } from '@/api/agents'
 
@@ -24,6 +25,33 @@ function formatDue(s: string): string {
     month: 'short',
     day: 'numeric',
   })
+}
+
+// A short, human "when" for command timestamps: "Jun 17, 2:30 PM".
+function formatWhen(s: string): string {
+  const d = new Date(s)
+  if (Number.isNaN(d.getTime())) return ''
+  return d.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  })
+}
+
+// A command's kind read as a past-tense verb for activity rows.
+const KIND_VERB: Record<string, string> = {
+  accept: 'accepted',
+  decline: 'declined',
+  dispatch: 'dispatched',
+  reassign: 'reassigned',
+  edit: 'edited',
+  comment: 'commented on',
+  done: 'completed',
+}
+
+function kindVerb(kind: string): string {
+  return KIND_VERB[kind] ?? kind
 }
 
 function isPastDue(due: string): boolean {
@@ -141,9 +169,17 @@ function SourceChip({ url }: { url: string }): JSX.Element | null {
 }
 
 // A muted "Why: …" rationale line — expandable when long. Lets a human validate
-// a suggested task before accepting it.
-function RationaleLine({ rationale }: { rationale: string }): JSX.Element | null {
+// a suggested task before accepting it. When `sourceUrl` is set, the grounded
+// source Echo read is linked inline right after the rationale — the trust signal.
+function RationaleLine({
+  rationale,
+  sourceUrl,
+}: {
+  rationale: string
+  sourceUrl?: string
+}): JSX.Element | null {
   const text = (rationale || '').trim()
+  const source = (sourceUrl || '').trim()
   const [expanded, setExpanded] = useState(false)
   if (!text) return null
   const long = text.length > 120
@@ -160,6 +196,34 @@ function RationaleLine({ rationale }: { rationale: string }): JSX.Element | null
           {expanded ? 'less' : 'more'}
         </button>
       )}
+      {source && (
+        <a
+          href={source}
+          target="_blank"
+          rel="noreferrer"
+          className="ml-1.5 whitespace-nowrap font-medium text-primary/80 hover:text-primary"
+          title={source}
+        >
+          source <span className="text-primary/70">↗</span>
+        </a>
+      )}
+    </p>
+  )
+}
+
+// The outcome of the most recent command Echo applied to this task — surfaces
+// `result_note` + `applied_at` that the API already stores but nothing rendered.
+function LastActivityLine({ command }: { command: AgentCommandOut }): JSX.Element {
+  const note = (command.result_note || '').trim() || `${kindVerb(command.kind)}`
+  const when = command.applied_at ? formatWhen(command.applied_at) : ''
+  return (
+    <p
+      className="mt-1.5 text-[11px] leading-snug text-muted-foreground/90"
+      data-testid="task-last-activity"
+    >
+      <span className="text-muted-foreground/70">last: </span>
+      {note}
+      {when && <span className="text-muted-foreground/60"> · {when}</span>}
     </p>
   )
 }
@@ -300,9 +364,11 @@ function TaskActions({
 function TaskCard({
   task,
   onChanged,
+  lastApplied,
 }: {
   task: AgentTaskOut
   onChanged?: () => void
+  lastApplied?: AgentCommandOut
 }): JSX.Element {
   const head = headline(task)
   const outcome = (task.title || '').trim()
@@ -310,6 +376,7 @@ function TaskCard({
   const echo = isEcho(task.assigned)
   const isSuggested = task.status === 'suggested'
   const isDone = task.status === 'done'
+  const hasRationale = Boolean((task.rationale || '').trim())
 
   return (
     <div data-testid={`task-${task.ext_id}`} data-status={task.status}
@@ -333,17 +400,22 @@ function TaskCard({
         <p className="mt-1.5 text-[11px] leading-snug text-muted-foreground">{outcome}</p>
       )}
 
-      {/* Context: why this is here (esp. for validating suggested tasks). */}
-      <RationaleLine rationale={task.rationale} />
+      {/* Context: why this is here (esp. for validating suggested tasks). The
+          grounded source links inline with the rationale when both are present. */}
+      <RationaleLine rationale={task.rationale} sourceUrl={task.source_url} />
+
+      {/* What Echo last did on this task — the stored command outcome. */}
+      {lastApplied && <LastActivityLine command={lastApplied} />}
 
       {(task.owner ||
         task.due ||
-        task.source_url ||
+        (!hasRationale && task.source_url) ||
         (task.links && task.links.length > 0)) && (
         <div className="mt-2 flex flex-wrap items-center gap-1.5">
           <OwnerTag owner={task.owner} />
           {task.due && <DueChip due={task.due} done={isDone} />}
-          <SourceChip url={task.source_url} />
+          {/* Source rides the rationale line when there is one; otherwise show a chip. */}
+          {!hasRationale && <SourceChip url={task.source_url} />}
           {task.links?.map((l, i) => (
             <TaskLinkChip key={`${l.url}-${i}`} label={l.label} url={l.url} />
           ))}
@@ -399,31 +471,114 @@ function SectionHeader({
 function CardGrid({
   tasks,
   onChanged,
+  lastByTask,
 }: {
   tasks: AgentTaskOut[]
   onChanged?: () => void
+  lastByTask?: Map<number, AgentCommandOut>
 }): JSX.Element {
   return (
     <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
       {tasks.map((t) => (
-        <TaskCard key={t.id} task={t} onChanged={onChanged} />
+        <TaskCard
+          key={t.id}
+          task={t}
+          onChanged={onChanged}
+          lastApplied={lastByTask?.get(t.id)}
+        />
       ))}
     </div>
   )
 }
 
-// Subtle "N queued for Echo" indicator — accept/dispatch commands Echo will
-// drain on its next turn.
-function QueuedForEcho({ count }: { count: number }): JSX.Element | null {
-  if (count <= 0) return null
+// One pending command, shown when the "N queued for Echo" badge is expanded:
+// what's actually waiting (kind · task · who · when) rather than just a count.
+function PendingCommandRow({ command }: { command: AgentCommandOut }): JSX.Element {
+  const who = (command.created_by || '').split('@')[0] || 'someone'
   return (
-    <span
-      className="inline-flex items-center gap-1.5 rounded border border-primary/30 bg-primary/10 px-2 py-0.5 text-[11px] font-medium text-primary"
-      title="Commands queued for Echo to act on next turn"
-    >
-      <span className="h-1.5 w-1.5 rounded-full bg-primary" />
-      {count} queued for Echo
-    </span>
+    <li className="flex flex-wrap items-baseline gap-x-1.5 gap-y-0.5 text-[11px] text-muted-foreground">
+      <span className="font-medium text-foreground">{kindVerb(command.kind)}</span>
+      {command.task_title && <span className="truncate text-muted-foreground/90">{command.task_title}</span>}
+      <span className="text-muted-foreground/60">· {who}</span>
+      <span className="text-muted-foreground/60">· {formatWhen(command.created_at)}</span>
+    </li>
+  )
+}
+
+// "N queued for Echo" — accept/dispatch commands Echo will drain on its next
+// turn. Click to reveal *which* commands are pending, not just the number.
+function QueuedForEcho({ pending }: { pending: AgentCommandOut[] }): JSX.Element | null {
+  const [open, setOpen] = useState(false)
+  if (pending.length === 0) return null
+  return (
+    <div className="flex flex-col items-end gap-1.5">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="inline-flex items-center gap-1.5 rounded border border-primary/30 bg-primary/10 px-2 py-0.5 text-[11px] font-medium text-primary transition-colors hover:border-primary/50 hover:bg-primary/15"
+        title="Commands queued for Echo to act on next turn"
+      >
+        <span className="h-1.5 w-1.5 rounded-full bg-primary" />
+        {pending.length} queued for Echo
+        <span aria-hidden className="text-primary/70">{open ? '▾' : '▸'}</span>
+      </button>
+      {open && (
+        <ul className="w-full max-w-sm space-y-1 rounded-md border border-border bg-card p-2.5">
+          {pending.map((c) => (
+            <PendingCommandRow key={c.id} command={c} />
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+// A compact, collapsible activity stream of recent commands across the agent —
+// reuses the commands the board already fetched. Newest first (API order).
+function AgentActivity({ commands }: { commands: AgentCommandOut[] }): JSX.Element | null {
+  const [open, setOpen] = useState(false)
+  if (commands.length === 0) return null
+  const recent = commands.slice(0, 12)
+  return (
+    <section className="border-t border-border/60 pt-4">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="flex items-center gap-1.5 text-[11px] font-bold uppercase tracking-[0.06em] text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <span aria-hidden className="text-muted-foreground/70">{open ? '▾' : '▸'}</span>
+        Activity
+        <span className="font-normal lowercase tracking-normal text-muted-foreground/70">
+          {commands.length}
+        </span>
+      </button>
+      {open && (
+        <ul className="mt-2.5 space-y-1.5" data-testid="agent-activity">
+          {recent.map((c) => {
+            const who = (c.created_by || '').split('@')[0] || 'someone'
+            const when = c.applied_at || c.created_at
+            return (
+              <li key={c.id} className="flex flex-wrap items-baseline gap-x-1.5 text-[11px] leading-snug">
+                <span className="text-muted-foreground/60">{formatWhen(when)}</span>
+                <span className="font-medium text-foreground">{who}</span>
+                <span className="text-muted-foreground">{kindVerb(c.kind)}</span>
+                {c.task_title && <span className="truncate text-muted-foreground/90">{c.task_title}</span>}
+                {c.status === 'pending' && (
+                  <span className="rounded bg-primary/10 px-1 text-[10px] font-medium text-primary">queued</span>
+                )}
+                {c.result_note && (
+                  <span className="basis-full truncate pl-1 text-muted-foreground/80" title={c.result_note}>
+                    → {c.result_note}
+                  </span>
+                )}
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </section>
   )
 }
 
@@ -434,11 +589,11 @@ function byPosition(a: AgentTaskOut, b: AgentTaskOut): number {
 export function TasksBoard({
   tasks,
   onChanged,
-  pendingCount = 0,
+  commands = [],
 }: {
   tasks: AgentTaskOut[]
   onChanged?: () => void
-  pendingCount?: number
+  commands?: AgentCommandOut[]
 }): JSX.Element {
   const suggested = tasks.filter((t) => t.status === 'suggested').sort(byPosition)
   const inProgress = tasks.filter((t) => t.status === 'in_progress')
@@ -446,6 +601,19 @@ export function TasksBoard({
   const echoWorking = inProgress.filter((t) => isEcho(t.assigned)).sort(byPosition)
   const done = tasks.filter((t) => t.status === 'done').sort(byPosition)
   const declined = tasks.filter((t) => t.status === 'declined').sort(byPosition)
+
+  const pending = useMemo(() => commands.filter((c) => c.status === 'pending'), [commands])
+  // Latest applied command per task — `commands` arrives newest-first, so the
+  // first applied one we see for a task is its most recent outcome.
+  const lastByTask = useMemo(() => {
+    const m = new Map<number, AgentCommandOut>()
+    for (const c of commands) {
+      if (c.status === 'applied' && c.task_id != null && !m.has(c.task_id)) {
+        m.set(c.task_id, c)
+      }
+    }
+    return m
+  }, [commands])
 
   if (tasks.length === 0) {
     return (
@@ -455,9 +623,9 @@ export function TasksBoard({
 
   return (
     <div className="space-y-7">
-      {pendingCount > 0 && (
+      {pending.length > 0 && (
         <div className="flex justify-end">
-          <QueuedForEcho count={pendingCount} />
+          <QueuedForEcho pending={pending} />
         </div>
       )}
 
@@ -468,14 +636,14 @@ export function TasksBoard({
             count={suggested.length}
             dotClass="bg-muted-foreground"
           />
-          <CardGrid tasks={suggested} onChanged={onChanged} />
+          <CardGrid tasks={suggested} onChanged={onChanged} lastByTask={lastByTask} />
         </section>
       )}
 
       {waitingHuman.length > 0 && (
         <section className="rounded-xl border border-amber-500/25 bg-amber-500/5 p-3">
           <SectionHeader label="Waiting on a human" count={waitingHuman.length} accent />
-          <CardGrid tasks={waitingHuman} onChanged={onChanged} />
+          <CardGrid tasks={waitingHuman} onChanged={onChanged} lastByTask={lastByTask} />
         </section>
       )}
 
@@ -486,14 +654,14 @@ export function TasksBoard({
             count={echoWorking.length}
             dotClass="bg-primary"
           />
-          <CardGrid tasks={echoWorking} onChanged={onChanged} />
+          <CardGrid tasks={echoWorking} onChanged={onChanged} lastByTask={lastByTask} />
         </section>
       )}
 
       {done.length > 0 && (
         <section>
           <SectionHeader label="Done" count={done.length} dotClass="bg-primary/40" />
-          <CardGrid tasks={done} onChanged={onChanged} />
+          <CardGrid tasks={done} onChanged={onChanged} lastByTask={lastByTask} />
         </section>
       )}
 
@@ -518,6 +686,8 @@ export function TasksBoard({
           </div>
         </section>
       )}
+
+      <AgentActivity commands={commands} />
     </div>
   )
 }

--- a/frontend/src/components/agents/AgentLeftNav.tsx
+++ b/frontend/src/components/agents/AgentLeftNav.tsx
@@ -1,11 +1,26 @@
+import { useEffect, useState } from 'react'
 import { Link, NavLink } from 'react-router-dom'
 import { WorkbenchRail, WorkbenchNavItem } from '@canopy/workbench'
-import type { AgentDetailOut } from '@/api/agents'
+import { getNeedsYou, type AgentDetailOut } from '@/api/agents'
 
 type NavItem = { to: string; label: string; count?: number }
 
 export function AgentLeftNav({ agent }: { agent: AgentDetailOut }) {
+  // The "N waiting on you" count for the inbox badge — computed server-side.
+  const [waiting, setWaiting] = useState<number | undefined>(undefined)
+  useEffect(() => {
+    let cancelled = false
+    setWaiting(undefined)
+    getNeedsYou(agent.slug)
+      .then((d) => !cancelled && setWaiting(d.waiting_count))
+      .catch(() => !cancelled && setWaiting(undefined))
+    return () => {
+      cancelled = true
+    }
+  }, [agent.slug])
+
   const items: NavItem[] = [
+    { to: 'needs-you', label: 'Needs you', count: waiting },
     { to: 'overview', label: 'Overview' },
     { to: 'tasks', label: 'Tasks', count: agent.task_count },
     { to: 'syncs', label: 'Syncs', count: agent.sync_count },

--- a/frontend/src/components/agents/cards.tsx
+++ b/frontend/src/components/agents/cards.tsx
@@ -26,8 +26,8 @@ export function formatPeriod(start: string, end: string): string {
 export function CountStat({ value, label }: { value: number; label: string }) {
   return (
     <div className="flex flex-col">
-      <span className="text-lg font-semibold text-stone-100 leading-none">{value}</span>
-      <span className="text-[10px] uppercase tracking-wide text-stone-600 mt-1">{label}</span>
+      <span className="text-lg font-semibold text-foreground leading-none">{value}</span>
+      <span className="text-[10px] uppercase tracking-wide text-muted-foreground mt-1">{label}</span>
     </div>
   )
 }
@@ -35,8 +35,8 @@ export function CountStat({ value, label }: { value: number; label: string }) {
 export function SectionHeading({ label, count }: { label: string; count?: number }) {
   return (
     <div className="flex items-baseline gap-2 mb-3 mt-8 first:mt-0">
-      <h2 className="text-[11px] font-bold uppercase tracking-[0.08em] text-orange-300">{label}</h2>
-      {count !== undefined && <span className="text-[11px] text-stone-600">{count}</span>}
+      <h2 className="text-[11px] font-bold uppercase tracking-[0.08em] text-primary">{label}</h2>
+      {count !== undefined && <span className="text-[11px] text-muted-foreground">{count}</span>}
     </div>
   )
 }
@@ -44,9 +44,9 @@ export function SectionHeading({ label, count }: { label: string; count?: number
 // "work: C+" → an outlined badge. Generic so any grade dimension renders.
 function GradeBadge({ dimension, grade }: { dimension: string; grade: string }) {
   return (
-    <span className="inline-flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wide text-stone-300 bg-stone-950/80 border border-stone-700/60 px-2 py-0.5 rounded">
-      <span className="text-stone-500">{dimension}:</span>
-      <span className="text-orange-300">{grade}</span>
+    <span className="inline-flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wide text-foreground bg-muted border border-border px-2 py-0.5 rounded">
+      <span className="text-muted-foreground">{dimension}:</span>
+      <span className="text-primary">{grade}</span>
     </span>
   )
 }
@@ -58,9 +58,9 @@ function OpenDocChip({ url, label }: { url: string; label: string }) {
       href={url}
       target="_blank"
       rel="noreferrer"
-      className="inline-flex items-center gap-1 text-[11px] font-medium text-stone-300 hover:text-orange-300 bg-stone-950/80 border border-stone-700/60 hover:border-orange-400/50 px-2.5 py-1 rounded-md transition-colors"
+      className="inline-flex items-center gap-1 text-[11px] font-medium text-muted-foreground hover:text-primary bg-muted border border-border hover:border-primary/50 px-2.5 py-1 rounded-md transition-colors"
     >
-      <span className="text-orange-400/70">↗</span>
+      <span className="text-primary/70">↗</span>
       {label}
     </a>
   )
@@ -69,16 +69,16 @@ function OpenDocChip({ url, label }: { url: string; label: string }) {
 export function SyncCard({ sync }: { sync: AgentSyncOut }) {
   const grades = Object.entries(sync.self_grades ?? {})
   return (
-    <div className="bg-stone-900/70 border border-stone-800 rounded-xl p-5">
+    <div className="bg-card border border-border rounded-xl p-5">
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
-          <p className="text-[11px] text-stone-500">{formatPeriod(sync.period_start, sync.period_end)}</p>
-          <h3 className="text-[15px] font-semibold text-stone-100 mt-0.5 leading-snug">{sync.title}</h3>
+          <p className="text-[11px] text-muted-foreground">{formatPeriod(sync.period_start, sync.period_end)}</p>
+          <h3 className="text-[15px] font-semibold text-foreground mt-0.5 leading-snug">{sync.title}</h3>
         </div>
         <OpenDocChip url={sync.doc_url} label="Open in Google Docs" />
       </div>
       {sync.summary && (
-        <p className="text-[13px] text-stone-400 leading-relaxed mt-2">{sync.summary}</p>
+        <p className="text-[13px] text-muted-foreground leading-relaxed mt-2">{sync.summary}</p>
       )}
       {grades.length > 0 && (
         <div className="flex flex-wrap gap-1.5 mt-3">
@@ -97,26 +97,26 @@ export function WorkProductCard({ wp }: { wp: AgentWorkProductOut }) {
       href={wp.url}
       target="_blank"
       rel="noreferrer"
-      className="group block bg-stone-900/70 border border-stone-800 rounded-xl p-4 hover:border-orange-400/40 hover:bg-stone-900 transition-colors"
+      className="group block bg-card border border-border rounded-xl p-4 hover:border-primary/40 hover:bg-accent transition-colors"
     >
       <div className="flex items-start gap-2">
-        <h3 className="text-[14px] font-semibold text-stone-100 leading-snug group-hover:text-orange-300 transition-colors min-w-0 flex-1">
+        <h3 className="text-[14px] font-semibold text-foreground leading-snug group-hover:text-primary transition-colors min-w-0 flex-1">
           {wp.title}
         </h3>
-        <span className="text-orange-400/70 text-xs shrink-0">↗</span>
+        <span className="text-primary/70 text-xs shrink-0">↗</span>
       </div>
       {wp.kind && (
-        <span className="inline-block mt-2 text-[10px] font-semibold uppercase tracking-wide text-stone-400 bg-stone-800 px-1.5 py-0.5 rounded">
+        <span className="inline-block mt-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
           {wp.kind}
         </span>
       )}
       {wp.description && (
-        <p className="text-[12px] text-stone-400 leading-relaxed mt-2 line-clamp-3">{wp.description}</p>
+        <p className="text-[12px] text-muted-foreground leading-relaxed mt-2 line-clamp-3">{wp.description}</p>
       )}
       {wp.tags && wp.tags.length > 0 && (
         <div className="flex flex-wrap gap-1 mt-2">
           {wp.tags.map((t) => (
-            <span key={t} className="text-[10px] text-stone-500 bg-stone-950/60 border border-stone-800 px-1.5 py-0.5 rounded">
+            <span key={t} className="text-[10px] text-muted-foreground bg-muted border border-border px-1.5 py-0.5 rounded">
               {t}
             </span>
           ))}
@@ -128,17 +128,17 @@ export function WorkProductCard({ wp }: { wp: AgentWorkProductOut }) {
 
 export function SkillCard({ skill }: { skill: AgentSkillOut }) {
   return (
-    <div className="bg-stone-900/70 border border-stone-800 rounded-xl p-4">
+    <div className="bg-card border border-border rounded-xl p-4">
       <div className="flex items-start justify-between gap-2">
-        <h3 className="text-[14px] font-semibold text-stone-100 leading-snug min-w-0">{skill.name}</h3>
+        <h3 className="text-[14px] font-semibold text-foreground leading-snug min-w-0">{skill.name}</h3>
         <OpenDocChip url={skill.url} label="SKILL.md" />
       </div>
       {skill.description && (
-        <p className="text-[12px] text-stone-400 leading-relaxed mt-2">{skill.description}</p>
+        <p className="text-[12px] text-muted-foreground leading-relaxed mt-2">{skill.description}</p>
       )}
       {skill.improvement_note && (
-        <p className="text-[12px] text-stone-300 leading-relaxed mt-2 pl-3 border-l-2 border-orange-400/40">
-          <span className="text-[10px] font-semibold uppercase tracking-wide text-orange-300/80 mr-1">
+        <p className="text-[12px] text-foreground leading-relaxed mt-2 pl-3 border-l-2 border-primary/40">
+          <span className="text-[10px] font-semibold uppercase tracking-wide text-primary/80 mr-1">
             Improvement
           </span>
           {skill.improvement_note}

--- a/frontend/src/pages/AgentWorkspacePage.tsx
+++ b/frontend/src/pages/AgentWorkspacePage.tsx
@@ -68,10 +68,10 @@ export function AgentWorkspacePage() {
   if (error || !agent) {
     return (
       <div className="px-6 py-8 max-w-4xl">
-        <Link to="/agents" className="text-[12px] text-stone-500 hover:text-orange-400 transition-colors">
+        <Link to="/agents" className="text-[12px] text-muted-foreground hover:text-primary transition-colors">
           ← Agents
         </Link>
-        <div className="flex items-center justify-center h-48 text-red-400 text-sm">
+        <div className="flex items-center justify-center h-48 text-destructive text-sm">
           {error ?? 'Agent not found'}
         </div>
       </div>

--- a/frontend/src/pages/agents/AgentOverviewSection.tsx
+++ b/frontend/src/pages/agents/AgentOverviewSection.tsx
@@ -70,16 +70,16 @@ export function AgentOverviewSection() {
       {(agent.persona || agent.description) && (
         <div className="mb-6">
           {agent.persona && (
-            <p className="text-[14px] text-stone-300 leading-relaxed">{agent.persona}</p>
+            <p className="text-[14px] text-foreground leading-relaxed">{agent.persona}</p>
           )}
           {agent.description && (
-            <p className="text-[13px] text-stone-400 leading-relaxed mt-2">{agent.description}</p>
+            <p className="text-[13px] text-muted-foreground leading-relaxed mt-2">{agent.description}</p>
           )}
         </div>
       )}
 
       {/* Counts row */}
-      <div className="flex flex-wrap gap-6 pb-6 mb-6 border-b border-stone-800">
+      <div className="flex flex-wrap gap-6 pb-6 mb-6 border-b border-border">
         <CountStat value={agent.task_count} label="Tasks" />
         <CountStat value={agent.sync_count} label="Syncs" />
         <CountStat value={agent.work_product_count} label="Work" />
@@ -89,12 +89,12 @@ export function AgentOverviewSection() {
       {/* Task summary — counts per board column */}
       <div className="mb-8">
         <div className="flex items-baseline justify-between mb-3">
-          <h2 className="text-[11px] font-bold uppercase tracking-[0.08em] text-orange-300">
+          <h2 className="text-[11px] font-bold uppercase tracking-[0.08em] text-primary">
             Tasks
           </h2>
           <Link
             to="../tasks"
-            className="text-[11px] text-stone-500 hover:text-orange-400 transition-colors"
+            className="text-[11px] text-muted-foreground hover:text-primary transition-colors"
           >
             Open board →
           </Link>
@@ -102,7 +102,7 @@ export function AgentOverviewSection() {
         {tasksLoading ? (
           <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
             {TASK_COLUMNS.map((c) => (
-              <div key={c.status} className="h-16 rounded-lg bg-stone-900 border border-stone-800 animate-pulse" />
+              <div key={c.status} className="h-16 rounded-lg bg-muted border border-border animate-pulse" />
             ))}
           </div>
         ) : (
@@ -110,15 +110,15 @@ export function AgentOverviewSection() {
             {TASK_COLUMNS.map((c) => (
               <div
                 key={c.status}
-                className="rounded-lg bg-stone-900/70 border border-stone-800 px-3 py-3"
+                className="rounded-lg bg-card border border-border px-3 py-3"
               >
                 <div className="flex items-center gap-2">
                   <span className={`h-1.5 w-1.5 rounded-full ${c.dot}`} />
-                  <span className="text-[10px] font-semibold uppercase tracking-[0.06em] text-stone-400">
+                  <span className="text-[10px] font-semibold uppercase tracking-[0.06em] text-muted-foreground">
                     {c.label}
                   </span>
                 </div>
-                <span className="block text-lg font-semibold text-stone-100 leading-none mt-2">
+                <span className="block text-lg font-semibold text-foreground leading-none mt-2">
                   {countFor(c.status)}
                 </span>
               </div>
@@ -130,12 +130,12 @@ export function AgentOverviewSection() {
       {/* Latest sync */}
       <div className="mb-8">
         <div className="flex items-baseline justify-between mb-3">
-          <h2 className="text-[11px] font-bold uppercase tracking-[0.08em] text-orange-300">
+          <h2 className="text-[11px] font-bold uppercase tracking-[0.08em] text-primary">
             Latest sync
           </h2>
           <Link
             to="../syncs"
-            className="text-[11px] text-stone-500 hover:text-orange-400 transition-colors"
+            className="text-[11px] text-muted-foreground hover:text-primary transition-colors"
           >
             All syncs →
           </Link>
@@ -145,7 +145,7 @@ export function AgentOverviewSection() {
         ) : latestSync ? (
           <SyncCard sync={latestSync} />
         ) : (
-          <p className="text-[13px] text-stone-600">No syncs yet.</p>
+          <p className="text-[13px] text-muted-foreground">No syncs yet.</p>
         )}
       </div>
 
@@ -155,10 +155,10 @@ export function AgentOverviewSection() {
           <Link
             key={l.to}
             to={l.to}
-            className="inline-flex items-center gap-1 text-[12px] font-medium text-stone-300 hover:text-orange-300 bg-stone-900/70 border border-stone-800 hover:border-orange-400/40 px-3 py-1.5 rounded-md transition-colors"
+            className="inline-flex items-center gap-1 text-[12px] font-medium text-muted-foreground hover:text-primary bg-card border border-border hover:border-primary/40 px-3 py-1.5 rounded-md transition-colors"
           >
             {l.label}
-            <span className="text-orange-400/70">→</span>
+            <span className="text-primary/70">→</span>
           </Link>
         ))}
       </div>

--- a/frontend/src/pages/agents/AgentSkillsSection.tsx
+++ b/frontend/src/pages/agents/AgentSkillsSection.tsx
@@ -26,7 +26,7 @@ export function AgentSkillsSection() {
       {skills === null ? (
         <WorkbenchSkeleton />
       ) : skills.length === 0 ? (
-        <p className="text-[13px] text-stone-600">No skills yet.</p>
+        <p className="text-[13px] text-muted-foreground">No skills yet.</p>
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
           {skills.map((sk) => (

--- a/frontend/src/pages/agents/AgentSyncsSection.tsx
+++ b/frontend/src/pages/agents/AgentSyncsSection.tsx
@@ -26,7 +26,7 @@ export function AgentSyncsSection() {
       {syncs === null ? (
         <WorkbenchSkeleton />
       ) : syncs.length === 0 ? (
-        <p className="text-[13px] text-stone-600">No syncs yet.</p>
+        <p className="text-[13px] text-muted-foreground">No syncs yet.</p>
       ) : (
         <div className="space-y-3">
           {syncs.map((s) => (

--- a/frontend/src/pages/agents/AgentTasksSection.tsx
+++ b/frontend/src/pages/agents/AgentTasksSection.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 import { useOutletContext } from 'react-router-dom'
-import { listAgentTasks, listPendingCommands, type AgentTaskOut } from '@/api/agents'
+import { listAgentTasks, listAgentCommands, type AgentCommandOut, type AgentTaskOut } from '@/api/agents'
 import type { AgentOutletContext } from '@/pages/AgentWorkspacePage'
 import { TasksBoard } from '@/components/TasksBoard'
 import { WorkbenchSubHeader, WorkbenchSkeleton } from '@canopy/workbench'
@@ -8,18 +8,19 @@ import { WorkbenchSubHeader, WorkbenchSkeleton } from '@canopy/workbench'
 export function AgentTasksSection() {
   const { agent } = useOutletContext<AgentOutletContext>()
   const [tasks, setTasks] = useState<AgentTaskOut[] | null>(null)
-  const [pendingCount, setPendingCount] = useState(0)
+  const [commands, setCommands] = useState<AgentCommandOut[]>([])
 
-  // Refetch tasks + the pending-command count. Passed to the board as
-  // `onChanged` so an Accept/Decline/Dispatch/Done refreshes the whole board.
+  // Refetch tasks + the full command stream (queue + applied history). Passed to
+  // the board as `onChanged` so an Accept/Decline/Dispatch/Done refreshes both
+  // the cards and the activity surfaces.
   const reload = useCallback(() => {
     let cancelled = false
     listAgentTasks(agent.slug)
       .then((list) => !cancelled && setTasks(list))
       .catch(() => !cancelled && setTasks([]))
-    listPendingCommands(agent.slug)
-      .then((cmds) => !cancelled && setPendingCount(cmds.length))
-      .catch(() => !cancelled && setPendingCount(0))
+    listAgentCommands(agent.slug)
+      .then((cmds) => !cancelled && setCommands(cmds))
+      .catch(() => !cancelled && setCommands([]))
     return () => {
       cancelled = true
     }
@@ -27,7 +28,7 @@ export function AgentTasksSection() {
 
   useEffect(() => {
     setTasks(null)
-    setPendingCount(0)
+    setCommands([])
     const cleanup = reload()
     return cleanup
   }, [reload])
@@ -38,7 +39,7 @@ export function AgentTasksSection() {
       {tasks === null ? (
         <WorkbenchSkeleton />
       ) : (
-        <TasksBoard tasks={tasks} onChanged={reload} pendingCount={pendingCount} />
+        <TasksBoard tasks={tasks} onChanged={reload} commands={commands} />
       )}
     </div>
   )

--- a/frontend/src/pages/agents/AgentWorkProductsSection.tsx
+++ b/frontend/src/pages/agents/AgentWorkProductsSection.tsx
@@ -26,7 +26,7 @@ export function AgentWorkProductsSection() {
       {items === null ? (
         <WorkbenchSkeleton />
       ) : items.length === 0 ? (
-        <p className="text-[13px] text-stone-600">No work products yet.</p>
+        <p className="text-[13px] text-muted-foreground">No work products yet.</p>
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
           {items.map((wp) => (

--- a/frontend/src/pages/agents/NeedsYouSection.tsx
+++ b/frontend/src/pages/agents/NeedsYouSection.tsx
@@ -1,0 +1,149 @@
+import { useEffect, useState, type JSX } from 'react'
+import { Link, useOutletContext } from 'react-router-dom'
+import { getNeedsYou, type NeedsYouItem, type NeedsYouOut, type NeedsYouType } from '@/api/agents'
+import type { AgentOutletContext } from '@/pages/AgentWorkspacePage'
+import { WorkbenchSubHeader, WorkbenchSkeleton } from '@canopy/workbench'
+
+// The three bands, in rank order. Each is a distinct kind of human attention:
+// a decision to make (review), an answer Echo is blocked on (question), or an
+// FYI with no gate (notify).
+const BANDS: { type: NeedsYouType; label: string; blurb: string; dot: string }[] = [
+  { type: 'review', label: 'Review', blurb: 'Suggestions awaiting your validate / decline', dot: 'bg-muted-foreground' },
+  { type: 'question', label: 'Question', blurb: 'Echo is blocked and needs a decision', dot: 'bg-amber-400' },
+  { type: 'notify', label: 'Notify', blurb: 'Recent work — no action needed', dot: 'bg-primary/50' },
+]
+
+// The "N waiting on you" badge — mirrors the board's "N queued for Echo".
+function WaitingBadge({ count }: { count: number }): JSX.Element {
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 rounded border border-primary/30 bg-primary/10 px-2 py-0.5 text-[11px] font-medium text-primary"
+      title="Items waiting on you to act"
+    >
+      <span className="h-1.5 w-1.5 rounded-full bg-primary" />
+      {count} waiting on you
+    </span>
+  )
+}
+
+function ItemRow({ item }: { item: NeedsYouItem }): JSX.Element {
+  const isTask = item.ref_kind === 'task'
+  // Task items route to the board where the human can act; FYI items link out
+  // to the artifact (the doc / work product) directly.
+  const inner = (
+    <>
+      <div className="flex items-start gap-2">
+        <p className="min-w-0 flex-1 text-[13px] font-semibold leading-snug text-foreground">
+          {item.title}
+        </p>
+        {!isTask && item.url && <span aria-hidden className="shrink-0 text-primary/70">↗</span>}
+      </div>
+      {item.subtitle && (
+        <p className="mt-1 text-[11px] leading-snug text-muted-foreground">{item.subtitle}</p>
+      )}
+      {isTask && item.url && (
+        <span className="mt-1.5 inline-flex items-center gap-1 text-[10px] font-medium text-muted-foreground">
+          source <span className="text-primary/70">↗</span>
+        </span>
+      )}
+    </>
+  )
+
+  const className =
+    'block rounded-lg border border-border bg-card p-3 text-left transition-colors hover:border-primary/40'
+
+  if (isTask) {
+    return (
+      <Link to="../tasks" data-testid={`needsyou-${item.ref_kind}-${item.ref_id}`} className={className}>
+        {inner}
+      </Link>
+    )
+  }
+  return (
+    <a
+      href={item.url || undefined}
+      target="_blank"
+      rel="noreferrer"
+      data-testid={`needsyou-${item.ref_kind}-${item.ref_id}`}
+      className={className}
+    >
+      {inner}
+    </a>
+  )
+}
+
+function Band({
+  type,
+  label,
+  blurb,
+  dot,
+  items,
+}: {
+  type: NeedsYouType
+  label: string
+  blurb: string
+  dot: string
+  items: NeedsYouItem[]
+}): JSX.Element | null {
+  const mine = items.filter((i) => i.type === type)
+  if (mine.length === 0) return null
+  return (
+    <section data-testid={`needsyou-band-${type}`}>
+      <div className="mb-2 flex items-center gap-2 border-b border-border pb-1.5">
+        <span className={`h-1.5 w-1.5 rounded-full ${dot}`} />
+        <span className="text-[11px] font-bold uppercase tracking-[0.06em] text-foreground">{label}</span>
+        <span className="text-[11px] text-muted-foreground">{blurb}</span>
+        <span className="ml-auto text-[11px] text-muted-foreground">{mine.length}</span>
+      </div>
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        {mine.map((i) => (
+          <ItemRow key={`${i.ref_kind}-${i.ref_id}`} item={i} />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+/**
+ * The supervisor's home screen: "what does Echo need from me right now?" in one
+ * scan. Aggregates the human-actionable items across the board, typed and
+ * ranked Review → Question → Notify. Consumes GET /api/agents/{slug}/needs-you
+ * (the durable shape CLI agents query too).
+ */
+export function NeedsYouSection() {
+  const { agent } = useOutletContext<AgentOutletContext>()
+  const [data, setData] = useState<NeedsYouOut | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setData(null)
+    getNeedsYou(agent.slug)
+      .then((d) => !cancelled && setData(d))
+      .catch(() => !cancelled && setData({ agent_slug: agent.slug, waiting_count: 0, items: [] }))
+    return () => {
+      cancelled = true
+    }
+  }, [agent.slug])
+
+  return (
+    <div className="max-w-4xl px-6 py-8">
+      <WorkbenchSubHeader
+        title="Needs you"
+        action={data && data.waiting_count > 0 ? <WaitingBadge count={data.waiting_count} /> : undefined}
+      />
+      {data === null ? (
+        <WorkbenchSkeleton />
+      ) : data.items.length === 0 ? (
+        <p className="text-[13px] text-muted-foreground">
+          Nothing needs you right now — Echo has the ball.
+        </p>
+      ) : (
+        <div className="space-y-7">
+          {BANDS.map((b) => (
+            <Band key={b.type} {...b} items={data.items} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -22,6 +22,9 @@ import SessionSharePage from './pages/SessionSharePage'
 
 // Agent Workspace sections are lazy-loaded — each owns its data fetch and only
 // the active section's bundle is pulled in.
+const NeedsYouSection = lazy(() =>
+  import('./pages/agents/NeedsYouSection').then((m) => ({ default: m.NeedsYouSection })),
+)
 const AgentOverviewSection = lazy(() =>
   import('./pages/agents/AgentOverviewSection').then((m) => ({ default: m.AgentOverviewSection })),
 )
@@ -69,7 +72,8 @@ export const router = createBrowserRouter([
         path: '/agents/:slug',
         element: <AgentWorkspacePage />,
         children: [
-          { index: true, element: <Navigate to="overview" replace /> },
+          { index: true, element: <Navigate to="needs-you" replace /> },
+          { path: 'needs-you', element: <LazySection><NeedsYouSection /></LazySection> },
           { path: 'overview', element: <LazySection><AgentOverviewSection /></LazySection> },
           { path: 'tasks', element: <LazySection><AgentTasksSection /></LazySection> },
           { path: 'syncs', element: <LazySection><AgentSyncsSection /></LazySection> },

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -95,6 +95,39 @@ def test_sync_tasks_upserts_and_normalizes_status():
     assert AgentTask.objects.get(agent=agent, ext_id="t1").title == "PRIDE story v2"
 
 
+def test_needs_you_types_ranks_and_excludes_echo():
+    agent = _agent()
+    # review: a suggested task — the human must validate/decline it
+    services.create_task(agent, _task(ext_id="r1", title="Polio story", status="suggested",
+                                      owner="Matt", assigned="Matt", position=0))
+    # question: an in-progress task blocked on a human (Echo needs a decision)
+    services.create_task(agent, _task(ext_id="q1", title="Cholera story", status="in_progress",
+                                      owner="Matt", assigned="Sarvesh", position=1))
+    # excluded: in-progress assigned to Echo — Echo has the ball, not the human
+    services.create_task(agent, _task(ext_id="e1", title="Backlog upkeep", status="in_progress",
+                                      owner="Matt", assigned="Echo", position=2))
+    # excluded: a done task is no longer actionable
+    services.create_task(agent, _task(ext_id="d1", title="Shipped", status="done", position=3))
+    # notify: a recent FYI sync (no gate)
+    services.upsert_sync(agent, SimpleNamespace(
+        period_start=dt.datetime(2026, 6, 3, tzinfo=dt.timezone.utc),
+        period_end=dt.datetime(2026, 6, 17, tzinfo=dt.timezone.utc),
+        title="Sync 1", summary="", doc_url="https://d/sync", self_grades={}, source="manager-sync"))
+
+    res = services.needs_you(agent)
+    pairs = [(i["type"], i["title"]) for i in res["items"]]
+    assert pairs[0] == ("review", "Polio story")        # review band leads
+    assert ("question", "Cholera story") in pairs
+    assert ("notify", "Sync 1") in pairs
+    titles = [t for _, t in pairs]
+    assert "Backlog upkeep" not in titles               # nothing Echo is working
+    assert "Shipped" not in titles                       # nothing done
+    rank = {"review": 0, "question": 1, "notify": 2}
+    order = [rank[i["type"]] for i in res["items"]]
+    assert order == sorted(order)                        # typed bands, ranked
+    assert res["waiting_count"] == 2                      # gated (review+question) only
+
+
 def test_command_flow_accept_then_apply_and_decline():
     agent = _agent()
     t = services.create_task(agent, _task(ext_id="t1", title="ZEGCAWIS story", next_action="Get consent",


### PR DESCRIPTION
Three cohesive improvements to the agent workspace, surfaced by `/canopy:pm-scout`. They share files (`agents.ts`, the e2e spec, the router/nav), so they ship together.

## #133 — "Needs you" supervisor inbox + `/needs-you` API
- New `GET /api/agents/{slug}/needs-you` (service + schema + endpoint, `x-mcp-expose`d) returning a typed/ranked **review → question → notify** list plus `waiting_count`, so CLI agents/open claws can query "what needs the human" the same way the UI does.
- New `NeedsYouSection` view with the **"N waiting on you"** badge and a rail nav item. Now the workspace **default landing** (was overview — easy to revert if undesired).
- Excludes anything Echo is actively working (in-progress + Echo) and done/declined tasks.

## #134 — surface command activity + outcomes
The API already stored `result_note` + `applied_at` on `AgentTaskCommand` but nothing rendered them. No backend change:
- Per-task **"last: … · timestamp"** line (the latest applied command's outcome).
- The **"N queued for Echo"** badge expands to *which* commands are pending (kind · task · who · when).
- A collapsible **Activity** stream of recent commands across the agent.
- The grounded **source ↗** link now rides inline with the rationale on Suggested cards.

## #132 — semantic-token migration
- `components/agents/cards.tsx` + the four section panels (and the workspace error state) moved off raw `stone-*`/`orange-*` onto `bg-card` / `border-border` / `text-foreground` / `text-muted-foreground` / `text-primary`, mirroring `TasksBoard.tsx`. `grep -rE "stone-[0-9]|orange-[0-9]"` over the agents dirs is clean.

## Verification
- `cd frontend && npm run build` — passes (tsc + vite)
- `uv run pytest` — **426 passed, 1 skipped** (incl. new `services.needs_you` unit test, written TDD)
- `npm run test:e2e` — **16 passed** (5 new specs across #133/#134)

Note: `apps/agents/api.py` + `schemas.py` changed, so the `regen-openapi.yml` workflow will auto-commit regenerated `generated.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)