### PR TITLE
Make the Needs-you inbox actionable inline (stop bouncing to the board)

### DIFF
--- a/frontend/e2e/agents.spec.ts
+++ b/frontend/e2e/agents.spec.ts
@@ -31,6 +31,17 @@ test('needs-you is the default landing with typed, ranked actionable items', asy
   await expect(page.getByText(/3 waiting on you/)).toBeVisible()
 })
 
+test('needs-you cards are the actionable board card, not a bounce link', async ({ page }) => {
+  await page.goto('/agents/echo/needs-you')
+  const review = page.getByTestId('needsyou-band-review')
+  // The real board card (rationale + inline Accept/Decline), so you act here...
+  await expect(review.getByText(/Why:/).first()).toBeVisible()
+  await expect(review.getByRole('button', { name: /^Accept$/ }).first()).toBeVisible()
+  await expect(review.getByRole('button', { name: /^Decline$/ }).first()).toBeVisible()
+  // ...and NOT a bare link that dumps you to the generic board.
+  await expect(review.locator('a[href$="/tasks"]')).toHaveCount(0)
+})
+
 test('the rail exposes the Needs you inbox', async ({ page }) => {
   await page.goto('/agents/echo/tasks')
   await expect(page.locator('a[href$="/agents/echo/needs-you"]')).toBeVisible()

--- a/frontend/src/components/TasksBoard.tsx
+++ b/frontend/src/components/TasksBoard.tsx
@@ -361,7 +361,7 @@ function TaskActions({
 
 // ── Card ────────────────────────────────────────────────────────────────────
 
-function TaskCard({
+export function TaskCard({
   task,
   onChanged,
   lastApplied,

--- a/frontend/src/pages/agents/NeedsYouSection.tsx
+++ b/frontend/src/pages/agents/NeedsYouSection.tsx
@@ -1,7 +1,15 @@
-import { useEffect, useState, type JSX } from 'react'
-import { Link, useOutletContext } from 'react-router-dom'
-import { getNeedsYou, type NeedsYouItem, type NeedsYouOut, type NeedsYouType } from '@/api/agents'
+import { useCallback, useEffect, useState, type JSX } from 'react'
+import { useOutletContext } from 'react-router-dom'
+import {
+  getNeedsYou,
+  listAgentTasks,
+  type AgentTaskOut,
+  type NeedsYouItem,
+  type NeedsYouOut,
+  type NeedsYouType,
+} from '@/api/agents'
 import type { AgentOutletContext } from '@/pages/AgentWorkspacePage'
+import { TaskCard } from '@/components/TasksBoard'
 import { WorkbenchSubHeader, WorkbenchSkeleton } from '@canopy/workbench'
 
 // The three bands, in rank order. Each is a distinct kind of human attention:
@@ -26,48 +34,21 @@ function WaitingBadge({ count }: { count: number }): JSX.Element {
   )
 }
 
-function ItemRow({ item }: { item: NeedsYouItem }): JSX.Element {
-  const isTask = item.ref_kind === 'task'
-  // Task items route to the board where the human can act; FYI items link out
-  // to the artifact (the doc / work product) directly.
-  const inner = (
-    <>
-      <div className="flex items-start gap-2">
-        <p className="min-w-0 flex-1 text-[13px] font-semibold leading-snug text-foreground">
-          {item.title}
-        </p>
-        {!isTask && item.url && <span aria-hidden className="shrink-0 text-primary/70">↗</span>}
-      </div>
-      {item.subtitle && (
-        <p className="mt-1 text-[11px] leading-snug text-muted-foreground">{item.subtitle}</p>
-      )}
-      {isTask && item.url && (
-        <span className="mt-1.5 inline-flex items-center gap-1 text-[10px] font-medium text-muted-foreground">
-          source <span className="text-primary/70">↗</span>
-        </span>
-      )}
-    </>
-  )
-
-  const className =
-    'block rounded-lg border border-border bg-card p-3 text-left transition-colors hover:border-primary/40'
-
-  if (isTask) {
-    return (
-      <Link to="../tasks" data-testid={`needsyou-${item.ref_kind}-${item.ref_id}`} className={className}>
-        {inner}
-      </Link>
-    )
-  }
+// FYI items (a posted sync / shipped work product) link out to the artifact.
+function NotifyRow({ item }: { item: NeedsYouItem }): JSX.Element {
   return (
     <a
       href={item.url || undefined}
       target="_blank"
       rel="noreferrer"
       data-testid={`needsyou-${item.ref_kind}-${item.ref_id}`}
-      className={className}
+      className="block rounded-lg border border-border bg-card p-3 transition-colors hover:border-primary/40"
     >
-      {inner}
+      <div className="flex items-start gap-2">
+        <p className="min-w-0 flex-1 text-[13px] font-semibold leading-snug text-foreground">{item.title}</p>
+        {item.url && <span aria-hidden className="shrink-0 text-primary/70">↗</span>}
+      </div>
+      {item.subtitle && <p className="mt-1 text-[11px] leading-snug text-muted-foreground">{item.subtitle}</p>}
     </a>
   )
 }
@@ -78,12 +59,16 @@ function Band({
   blurb,
   dot,
   items,
+  tasksById,
+  reload,
 }: {
   type: NeedsYouType
   label: string
   blurb: string
   dot: string
   items: NeedsYouItem[]
+  tasksById: Map<number, AgentTaskOut>
+  reload: () => void
 }): JSX.Element | null {
   const mine = items.filter((i) => i.type === type)
   if (mine.length === 0) return null
@@ -96,9 +81,20 @@ function Band({
         <span className="ml-auto text-[11px] text-muted-foreground">{mine.length}</span>
       </div>
       <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-        {mine.map((i) => (
-          <ItemRow key={`${i.ref_kind}-${i.ref_id}`} item={i} />
-        ))}
+        {mine.map((i) => {
+          // Task items render the SAME actionable board card — you accept /
+          // decline / dispatch right here, no bounce to the board.
+          if (i.ref_kind === 'task') {
+            const task = tasksById.get(i.ref_id)
+            if (!task) return null
+            return (
+              <div key={`task-${i.ref_id}`} data-testid={`needsyou-task-${i.ref_id}`}>
+                <TaskCard task={task} onChanged={reload} />
+              </div>
+            )
+          }
+          return <NotifyRow key={`${i.ref_kind}-${i.ref_id}`} item={i} />
+        })}
       </div>
     </section>
   )
@@ -106,24 +102,35 @@ function Band({
 
 /**
  * The supervisor's home screen: "what does Echo need from me right now?" in one
- * scan. Aggregates the human-actionable items across the board, typed and
- * ranked Review → Question → Notify. Consumes GET /api/agents/{slug}/needs-you
- * (the durable shape CLI agents query too).
+ * scan. Renders the actionable board card for each task that needs you (act
+ * inline — accept/decline/dispatch — without bouncing to the board), plus
+ * link-out rows for FYI items. Ranked Review → Question → Notify. Consumes
+ * GET /api/agents/{slug}/needs-you (the durable shape CLI agents query too) +
+ * the full tasks so the cards are fully actionable.
  */
 export function NeedsYouSection() {
   const { agent } = useOutletContext<AgentOutletContext>()
   const [data, setData] = useState<NeedsYouOut | null>(null)
+  const [tasks, setTasks] = useState<AgentTaskOut[]>([])
+
+  const reload = useCallback(() => {
+    void Promise.all([getNeedsYou(agent.slug), listAgentTasks(agent.slug)])
+      .then(([d, t]) => {
+        setData(d)
+        setTasks(t)
+      })
+      .catch(() => {
+        setData({ agent_slug: agent.slug, waiting_count: 0, items: [] })
+        setTasks([])
+      })
+  }, [agent.slug])
 
   useEffect(() => {
-    let cancelled = false
     setData(null)
-    getNeedsYou(agent.slug)
-      .then((d) => !cancelled && setData(d))
-      .catch(() => !cancelled && setData({ agent_slug: agent.slug, waiting_count: 0, items: [] }))
-    return () => {
-      cancelled = true
-    }
-  }, [agent.slug])
+    reload()
+  }, [agent.slug, reload])
+
+  const tasksById = new Map(tasks.map((t) => [t.id, t]))
 
   return (
     <div className="max-w-4xl px-6 py-8">
@@ -140,7 +147,7 @@ export function NeedsYouSection() {
       ) : (
         <div className="space-y-7">
           {BANDS.map((b) => (
-            <Band key={b.type} {...b} items={data.items} />
+            <Band key={b.type} {...b} items={data.items} tasksById={tasksById} reload={reload} />
           ))}
         </div>
       )}


### PR DESCRIPTION
Needs-you task cards used to bounce you to the generic /tasks board and were a redundant, stripped-down mirror of it. Now they render the actual actionable board card (rationale + Accept/Decline/dispatch/done) so you act inline. Reuses TaskCard; e2e locks it in. Frontend-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)