### PR TITLE
Team activity timeline at /timeline

### DIFF
--- a/apps/agents/timeline.py
+++ b/apps/agents/timeline.py
@@ -3,6 +3,9 @@
 Three ``kind``s merge under ``agents``: ``sync`` (a periodic manager sync),
 ``work_product`` (a deliverable — links off-site to the doc/form), and ``task``
 (a board task as it first appears).
+
+Returns *candidates* (newest ``limit`` per component plus cursor-instant ties);
+:func:`apps.timeline.sources.gather` does the final merge/order/slice.
 """
 from __future__ import annotations
 
@@ -12,14 +15,12 @@ from .models import AgentSync, AgentTask, AgentWorkProduct
 
 
 def recent_events(*, limit: int, before: dt.datetime | None, user) -> list:
-    from apps.timeline.types import ActivityEvent, truncate
+    from apps.timeline.types import ActivityEvent, cursor_page, truncate
 
     events: list[ActivityEvent] = []
 
     syncs = AgentSync.objects.select_related("agent").order_by("-period_end")
-    if before is not None:
-        syncs = syncs.filter(period_end__lt=before)
-    for s in syncs[:limit]:
+    for s in cursor_page(syncs, "period_end", before=before, limit=limit):
         events.append(
             ActivityEvent(
                 subsystem="agents",
@@ -34,9 +35,7 @@ def recent_events(*, limit: int, before: dt.datetime | None, user) -> list:
         )
 
     wps = AgentWorkProduct.objects.select_related("agent").order_by("-created_at")
-    if before is not None:
-        wps = wps.filter(created_at__lt=before)
-    for w in wps[:limit]:
+    for w in cursor_page(wps, "created_at", before=before, limit=limit):
         events.append(
             ActivityEvent(
                 subsystem="agents",
@@ -52,9 +51,7 @@ def recent_events(*, limit: int, before: dt.datetime | None, user) -> list:
         )
 
     tasks = AgentTask.objects.select_related("agent").order_by("-created_at")
-    if before is not None:
-        tasks = tasks.filter(created_at__lt=before)
-    for t in tasks[:limit]:
+    for t in cursor_page(tasks, "created_at", before=before, limit=limit):
         events.append(
             ActivityEvent(
                 subsystem="agents",
@@ -68,5 +65,4 @@ def recent_events(*, limit: int, before: dt.datetime | None, user) -> list:
             )
         )
 
-    events.sort(key=lambda e: e.at, reverse=True)
-    return events[:limit]
+    return events

--- a/apps/agents/timeline.py
+++ b/apps/agents/timeline.py
@@ -1,0 +1,72 @@
+"""Timeline source for the agents subsystem.
+
+Three ``kind``s merge under ``agents``: ``sync`` (a periodic manager sync),
+``work_product`` (a deliverable — links off-site to the doc/form), and ``task``
+(a board task as it first appears).
+"""
+from __future__ import annotations
+
+import datetime as dt
+
+from .models import AgentSync, AgentTask, AgentWorkProduct
+
+
+def recent_events(*, limit: int, before: dt.datetime | None, user) -> list:
+    from apps.timeline.types import ActivityEvent, truncate
+
+    events: list[ActivityEvent] = []
+
+    syncs = AgentSync.objects.select_related("agent").order_by("-period_end")
+    if before is not None:
+        syncs = syncs.filter(period_end__lt=before)
+    for s in syncs[:limit]:
+        events.append(
+            ActivityEvent(
+                subsystem="agents",
+                kind="sync",
+                at=s.period_end,
+                title=f"{s.agent.name}: {s.title}",
+                summary=truncate(s.summary),
+                href=f"/agents/{s.agent.slug}/syncs",
+                id=f"sync:{s.id}",
+                icon="sync",
+            )
+        )
+
+    wps = AgentWorkProduct.objects.select_related("agent").order_by("-created_at")
+    if before is not None:
+        wps = wps.filter(created_at__lt=before)
+    for w in wps[:limit]:
+        events.append(
+            ActivityEvent(
+                subsystem="agents",
+                kind="work_product",
+                at=w.created_at,
+                title=f"{w.agent.name}: {w.title}",
+                summary=w.kind or None,
+                href=w.url,
+                external=True,
+                id=f"workproduct:{w.id}",
+                icon="doc",
+            )
+        )
+
+    tasks = AgentTask.objects.select_related("agent").order_by("-created_at")
+    if before is not None:
+        tasks = tasks.filter(created_at__lt=before)
+    for t in tasks[:limit]:
+        events.append(
+            ActivityEvent(
+                subsystem="agents",
+                kind="task",
+                at=t.created_at,
+                title=f"{t.agent.name}: {t.title}",
+                summary=t.get_status_display(),
+                href=f"/agents/{t.agent.slug}/tasks",
+                id=f"task:{t.id}",
+                icon="task",
+            )
+        )
+
+    events.sort(key=lambda e: e.at, reverse=True)
+    return events[:limit]

--- a/apps/api/api.py
+++ b/apps/api/api.py
@@ -148,6 +148,7 @@ from apps.shareouts.api import router as shareouts_router  # noqa: E402
 from apps.sessions.api import router as sessions_router  # noqa: E402
 from apps.sessions.api import share_router as session_share_router  # noqa: E402
 from apps.agents.api import router as agents_router  # noqa: E402
+from apps.timeline.api import router as timeline_router  # noqa: E402
 
 api.add_router("/projects", projects_router)
 api.add_router("/insights", insights_router)
@@ -165,4 +166,5 @@ api.add_router("/ddd", runs_router)
 api.add_router("/shareouts", shareouts_router)
 api.add_router("/sessions", sessions_router)
 api.add_router("/agents", agents_router)
+api.add_router("/timeline", timeline_router)
 api.add_router("/share", session_share_router)

--- a/apps/projects/timeline.py
+++ b/apps/projects/timeline.py
@@ -1,0 +1,88 @@
+"""Timeline sources for the projects app.
+
+Two subsystems land here: ``insights`` (the cross-portfolio AI insight cards,
+stored as ``ProjectContext`` rows with ``context_type="insight"``) and
+``projects`` (the other context pushes + skill actions). They're separate filter
+keys, so they're separate callables.
+"""
+from __future__ import annotations
+
+import datetime as dt
+
+from .models import ProjectAction, ProjectContext
+
+
+def insight_events(*, limit: int, before: dt.datetime | None, user) -> list:
+    from apps.timeline.types import ActivityEvent, first_line
+
+    qs = (
+        ProjectContext.objects.filter(context_type="insight")
+        .select_related("project")
+        .order_by("-created_at")
+    )
+    if before is not None:
+        qs = qs.filter(created_at__lt=before)
+    return [
+        ActivityEvent(
+            subsystem="insights",
+            kind="insight",
+            at=c.created_at,
+            title=first_line(c.content) or "Insight",
+            summary=None,
+            project_slug=c.project.slug,
+            actor=c.source or None,
+            href="/insights",
+            id=f"insight:{c.id}",
+            icon="insight",
+        )
+        for c in qs[:limit]
+    ]
+
+
+def project_events(*, limit: int, before: dt.datetime | None, user) -> list:
+    from apps.timeline.types import ActivityEvent, first_line
+
+    events: list[ActivityEvent] = []
+
+    ctx = (
+        ProjectContext.objects.exclude(context_type="insight")
+        .select_related("project")
+        .order_by("-created_at")
+    )
+    if before is not None:
+        ctx = ctx.filter(created_at__lt=before)
+    for c in ctx[:limit]:
+        label = dict(ProjectContext.CONTEXT_TYPES).get(c.context_type, c.context_type)
+        events.append(
+            ActivityEvent(
+                subsystem="projects",
+                kind="context",
+                at=c.created_at,
+                title=f"{label}: {first_line(c.content) or '—'}",
+                project_slug=c.project.slug,
+                actor=c.source or None,
+                href="/",
+                id=f"context:{c.id}",
+                icon="note",
+            )
+        )
+
+    acts = ProjectAction.objects.select_related("project").order_by("-started_at")
+    if before is not None:
+        acts = acts.filter(started_at__lt=before)
+    for a in acts[:limit]:
+        events.append(
+            ActivityEvent(
+                subsystem="projects",
+                kind="action",
+                at=a.started_at,
+                title=f"{a.skill_name} · {a.status}",
+                project_slug=a.project.slug,
+                href="/",
+                id=f"action:{a.id}",
+                icon="skill",
+            )
+        )
+
+    events.sort(key=lambda e: e.at, reverse=True)
+    return events[:limit]

--- a/apps/projects/timeline.py
+++ b/apps/projects/timeline.py
@@ -4,6 +4,9 @@ Two subsystems land here: ``insights`` (the cross-portfolio AI insight cards,
 stored as ``ProjectContext`` rows with ``context_type="insight"``) and
 ``projects`` (the other context pushes + skill actions). They're separate filter
 keys, so they're separate callables.
+
+Each returns *candidates* (newest ``limit`` per component plus cursor-instant
+ties); :func:`apps.timeline.sources.gather` does the final merge/order/slice.
 """
 from __future__ import annotations
 
@@ -13,15 +16,13 @@ from .models import ProjectAction, ProjectContext
 
 
 def insight_events(*, limit: int, before: dt.datetime | None, user) -> list:
-    from apps.timeline.types import ActivityEvent, first_line
+    from apps.timeline.types import ActivityEvent, cursor_page, first_line
 
     qs = (
         ProjectContext.objects.filter(context_type="insight")
         .select_related("project")
         .order_by("-created_at")
     )
-    if before is not None:
-        qs = qs.filter(created_at__lt=before)
     return [
         ActivityEvent(
             subsystem="insights",
@@ -35,12 +36,12 @@ def insight_events(*, limit: int, before: dt.datetime | None, user) -> list:
             id=f"insight:{c.id}",
             icon="insight",
         )
-        for c in qs[:limit]
+        for c in cursor_page(qs, "created_at", before=before, limit=limit)
     ]
 
 
 def project_events(*, limit: int, before: dt.datetime | None, user) -> list:
-    from apps.timeline.types import ActivityEvent, first_line
+    from apps.timeline.types import ActivityEvent, cursor_page, first_line
 
     events: list[ActivityEvent] = []
 
@@ -49,9 +50,7 @@ def project_events(*, limit: int, before: dt.datetime | None, user) -> list:
         .select_related("project")
         .order_by("-created_at")
     )
-    if before is not None:
-        ctx = ctx.filter(created_at__lt=before)
-    for c in ctx[:limit]:
+    for c in cursor_page(ctx, "created_at", before=before, limit=limit):
         label = dict(ProjectContext.CONTEXT_TYPES).get(c.context_type, c.context_type)
         events.append(
             ActivityEvent(
@@ -68,9 +67,7 @@ def project_events(*, limit: int, before: dt.datetime | None, user) -> list:
         )
 
     acts = ProjectAction.objects.select_related("project").order_by("-started_at")
-    if before is not None:
-        acts = acts.filter(started_at__lt=before)
-    for a in acts[:limit]:
+    for a in cursor_page(acts, "started_at", before=before, limit=limit):
         events.append(
             ActivityEvent(
                 subsystem="projects",
@@ -84,5 +81,4 @@ def project_events(*, limit: int, before: dt.datetime | None, user) -> list:
             )
         )
 
-    events.sort(key=lambda e: e.at, reverse=True)
-    return events[:limit]
+    return events

--- a/apps/runs/timeline.py
+++ b/apps/runs/timeline.py
@@ -1,0 +1,110 @@
+"""Timeline source for DDD: rendered runs + narrative-review checkpoints.
+
+Two ``kind``s under the ``ddd`` subsystem:
+
+- ``run`` — a render (a ``run_id`` with artifacts). Sorted by the latest
+  artifact/review timestamp in the run; links to the run package.
+- ``narrative_review`` — a story-bearing review version (the narrative-agreement
+  gate). Sorted by ``resolved_at`` (when decided) else ``created_at``; links to
+  the review surface.
+
+Reuses the read-time join helpers in :mod:`apps.runs.aggregate` so this stays
+consistent with the /ddd views.
+"""
+from __future__ import annotations
+
+import datetime as dt
+
+from apps.reviews.models import ReviewRequest
+from apps.walkthroughs.models import Walkthrough
+
+from . import aggregate as agg
+
+
+def _run_stamp(run_id: str) -> str:
+    """'microplans-2026-06-02-001' -> '2026-06-02-001' (falls back to the id)."""
+    import re
+
+    m = re.search(r"(\d{4}-\d{2}-\d{2}-\d+)$", run_id or "")
+    return m.group(1) if m else (run_id or "")
+
+
+def recent_events(*, limit: int, before: dt.datetime | None, user) -> list:
+    from apps.timeline.types import ActivityEvent, actor_name
+
+    wts = list(
+        Walkthrough.objects.exclude(run_id__isnull=True)
+        .exclude(run_id="")
+        .select_related("owner")
+    )
+    revs = list(ReviewRequest.objects.all())
+    feature_map = agg._narrative_slug_map(wts)
+
+    # Latest story-bearing review per narrative drives the run title.
+    title_by_narrative: dict[str, tuple[dt.datetime, str | None]] = {}
+    for r in revs:
+        if not agg._review_has_narrative(r):
+            continue
+        slug = agg.narrative_for_run_id(r.run_id, feature_map)
+        prev = title_by_narrative.get(slug)
+        if prev is None or r.created_at > prev[0]:
+            title_by_narrative[slug] = (r.created_at, agg._title_from_review(r))
+
+    wts_by_run: dict[str, list[Walkthrough]] = {}
+    for w in wts:
+        wts_by_run.setdefault(w.run_id, []).append(w)
+    revs_by_run: dict[str, list[ReviewRequest]] = {}
+    for r in revs:
+        revs_by_run.setdefault(r.run_id, []).append(r)
+
+    events: list[ActivityEvent] = []
+
+    # Run events — one per run_id that has artifacts.
+    for run_id, run_wts in wts_by_run.items():
+        run_revs = revs_by_run.get(run_id, [])
+        timestamps = [w.created_at for w in run_wts] + [r.created_at for r in run_revs]
+        latest = max(timestamps)
+        narrative = agg.narrative_of_walkthrough(run_wts[0])
+        title = (title_by_narrative.get(narrative) or (None, None))[1] or narrative
+        project_slug = next((w.project_slug for w in run_wts if w.project_slug), None)
+        events.append(
+            ActivityEvent(
+                subsystem="ddd",
+                kind="run",
+                at=latest,
+                title=f"Run · {title}",
+                summary=_run_stamp(run_id),
+                project_slug=project_slug,
+                actor=None,
+                href=f"/ddd/{narrative}/{run_id}",
+                id=f"run:{run_id}",
+                icon="video" if any(agg._is_video(w) for w in run_wts) else "deck",
+            )
+        )
+
+    # Narrative-version review events.
+    for r in revs:
+        if not agg._is_narrative_version(r):
+            continue
+        at = r.resolved_at or r.created_at
+        narrative = agg.narrative_of_review(r)
+        label = agg._title_from_review(r) or narrative
+        events.append(
+            ActivityEvent(
+                subsystem="ddd",
+                kind="narrative_review",
+                at=at,
+                title=f"Narrative v{r.version} · {label}",
+                summary=f"{r.gate} · {r.status}",
+                project_slug=None,
+                actor=actor_name(r.owner),
+                href=f"/review/{r.id}",
+                id=f"review:{r.id}",
+                icon="narrative",
+            )
+        )
+
+    if before is not None:
+        events = [e for e in events if e.at < before]
+    events.sort(key=lambda e: e.at, reverse=True)
+    return events[:limit]

--- a/apps/runs/timeline.py
+++ b/apps/runs/timeline.py
@@ -32,6 +32,11 @@ def _run_stamp(run_id: str) -> str:
 def recent_events(*, limit: int, before: dt.datetime | None, user) -> list:
     from apps.timeline.types import ActivityEvent, actor_name
 
+    # Full rollup over both tables, exactly like apps.runs.aggregate (the /ddd
+    # views load the same way). A run's timeline timestamp is max(artifact,
+    # review) so it can't be pushed to a per-row `before` filter without
+    # splitting a run across the boundary; we filter run events by `before` in
+    # Python below. Bounded by the team's DDD history (tens–hundreds of runs).
     wts = list(
         Walkthrough.objects.exclude(run_id__isnull=True)
         .exclude(run_id="")
@@ -40,10 +45,13 @@ def recent_events(*, limit: int, before: dt.datetime | None, user) -> list:
     revs = list(ReviewRequest.objects.all())
     feature_map = agg._narrative_slug_map(wts)
 
-    # Latest story-bearing review per narrative drives the run title.
+    # Latest narrative-version review per narrative drives the run title. Gated on
+    # _is_narrative_version (not _review_has_narrative) so a product_findings /
+    # external_release review can't hijack the run title — same guard the /ddd
+    # views use (aggregate._NON_NARRATIVE_GATES).
     title_by_narrative: dict[str, tuple[dt.datetime, str | None]] = {}
     for r in revs:
-        if not agg._review_has_narrative(r):
+        if not agg._is_narrative_version(r):
             continue
         slug = agg.narrative_for_run_id(r.run_id, feature_map)
         prev = title_by_narrative.get(slug)
@@ -104,7 +112,15 @@ def recent_events(*, limit: int, before: dt.datetime | None, user) -> list:
             )
         )
 
-    if before is not None:
-        events = [e for e in events if e.at < before]
-    events.sort(key=lambda e: e.at, reverse=True)
-    return events[:limit]
+    # Return candidates (newest `limit` strictly-older + all cursor-instant ties);
+    # sources.gather applies the exact (at, id) cursor and the final slice.
+    if before is None:
+        events.sort(key=lambda e: (e.at, e.id), reverse=True)
+        return events[:limit]
+    older = sorted(
+        (e for e in events if e.at < before),
+        key=lambda e: (e.at, e.id),
+        reverse=True,
+    )
+    ties = [e for e in events if e.at == before]
+    return older[:limit] + ties

--- a/apps/sessions/timeline.py
+++ b/apps/sessions/timeline.py
@@ -8,22 +8,31 @@ from __future__ import annotations
 
 import datetime as dt
 
-from .models import Session
+from django.db.models import Prefetch
+
+from .models import Session, ShareToken
 
 
 def recent_events(*, limit: int, before: dt.datetime | None, user) -> list:
-    from apps.timeline.types import ActivityEvent, actor_name
+    from apps.timeline.types import ActivityEvent, actor_name, cursor_page
 
-    qs = Session.objects.select_related("owner").order_by("-created_at")
-    if before is not None:
-        qs = qs.filter(created_at__lt=before)
+    # Prefetch active share tokens (newest first) so the link-out href doesn't
+    # fire a per-row active_token() query — one extra query for the whole page.
+    active_tokens = Prefetch(
+        "share_tokens",
+        queryset=ShareToken.objects.filter(revoked_at__isnull=True).order_by("-created_at"),
+        to_attr="active_tokens",
+    )
+    qs = (
+        Session.objects.select_related("owner")
+        .prefetch_related(active_tokens)
+        .order_by("-created_at")
+    )
     out: list[ActivityEvent] = []
-    for s in qs[:limit]:
+    for s in cursor_page(qs, "created_at", before=before, limit=limit):
         href = "/sessions"
-        if s.visibility == Session.VISIBILITY_LINK:
-            token = s.active_token()
-            if token is not None:
-                href = f"/share/{token.token}"
+        if s.visibility == Session.VISIBILITY_LINK and s.active_tokens:
+            href = f"/share/{s.active_tokens[0].token}"
         out.append(
             ActivityEvent(
                 subsystem="sessions",

--- a/apps/sessions/timeline.py
+++ b/apps/sessions/timeline.py
@@ -1,0 +1,40 @@
+"""Timeline source for shared Claude Code sessions.
+
+Link-visible sessions deep-link to the public ``/share/<token>`` viewer; private
+(dimagi-only) sessions fall back to the ``/sessions`` list (there's no per-session
+owner route).
+"""
+from __future__ import annotations
+
+import datetime as dt
+
+from .models import Session
+
+
+def recent_events(*, limit: int, before: dt.datetime | None, user) -> list:
+    from apps.timeline.types import ActivityEvent, actor_name
+
+    qs = Session.objects.select_related("owner").order_by("-created_at")
+    if before is not None:
+        qs = qs.filter(created_at__lt=before)
+    out: list[ActivityEvent] = []
+    for s in qs[:limit]:
+        href = "/sessions"
+        if s.visibility == Session.VISIBILITY_LINK:
+            token = s.active_token()
+            if token is not None:
+                href = f"/share/{token.token}"
+        out.append(
+            ActivityEvent(
+                subsystem="sessions",
+                kind="session",
+                at=s.created_at,
+                title=s.title or "(untitled session)",
+                project_slug=s.project_slug,
+                actor=actor_name(s.owner),
+                href=href,
+                id=f"session:{s.slug}",
+                icon="session",
+            )
+        )
+    return out

--- a/apps/shareouts/timeline.py
+++ b/apps/shareouts/timeline.py
@@ -1,0 +1,56 @@
+"""Timeline source for shareouts (teammate-facing work briefings)."""
+from __future__ import annotations
+
+import datetime as dt
+from urllib.parse import quote
+
+from .models import Shareout
+
+
+def _ymd(d: dt.datetime) -> str:
+    return f"{d.year:04d}-{d.month:02d}-{d.day:02d}"
+
+
+def _period_slug(start: dt.datetime, end: dt.datetime) -> str:
+    """Mirror the frontend ``periodSlug`` (ShareoutsPage) so the permalink resolves.
+
+    Day-aligned windows (00:00:00→23:59:59 UTC) slug as a date or ``start_end``;
+    a precise mid-day run slugs as ``YYYY-MM-DD-HHMM``. Built from UTC so it's
+    identical for every viewer.
+    """
+    s = start.astimezone(dt.UTC)
+    e = end.astimezone(dt.UTC)
+    day_aligned = (
+        s.hour == 0
+        and s.minute == 0
+        and s.second == 0
+        and e.hour == 23
+        and e.minute == 59
+        and e.second == 59
+    )
+    if day_aligned:
+        return _ymd(s) if _ymd(s) == _ymd(e) else f"{_ymd(s)}_{_ymd(e)}"
+    return f"{_ymd(s)}-{s.hour:02d}{s.minute:02d}"
+
+
+def recent_events(*, limit: int, before: dt.datetime | None, user) -> list:
+    from apps.timeline.types import ActivityEvent, truncate
+
+    qs = Shareout.objects.select_related("project").order_by("-period_end")
+    if before is not None:
+        qs = qs.filter(period_end__lt=before)
+    return [
+        ActivityEvent(
+            subsystem="shareouts",
+            kind="shareout",
+            at=s.period_end,
+            title=s.title,
+            summary=truncate(s.summary),
+            project_slug=s.project.slug if s.project_id else None,
+            actor=s.author or s.source or None,
+            href=f"/shareouts/{quote(_period_slug(s.period_start, s.period_end))}",
+            id=f"shareout:{s.id}",
+            icon="doc",
+        )
+        for s in qs[:limit]
+    ]

--- a/apps/shareouts/timeline.py
+++ b/apps/shareouts/timeline.py
@@ -34,11 +34,9 @@ def _period_slug(start: dt.datetime, end: dt.datetime) -> str:
 
 
 def recent_events(*, limit: int, before: dt.datetime | None, user) -> list:
-    from apps.timeline.types import ActivityEvent, truncate
+    from apps.timeline.types import ActivityEvent, cursor_page, truncate
 
     qs = Shareout.objects.select_related("project").order_by("-period_end")
-    if before is not None:
-        qs = qs.filter(period_end__lt=before)
     return [
         ActivityEvent(
             subsystem="shareouts",
@@ -52,5 +50,5 @@ def recent_events(*, limit: int, before: dt.datetime | None, user) -> list:
             id=f"shareout:{s.id}",
             icon="doc",
         )
-        for s in qs[:limit]
+        for s in cursor_page(qs, "period_end", before=before, limit=limit)
     ]

--- a/apps/skills/timeline.py
+++ b/apps/skills/timeline.py
@@ -7,11 +7,9 @@ from .models import Skill
 
 
 def recent_events(*, limit: int, before: dt.datetime | None, user) -> list:
-    from apps.timeline.types import ActivityEvent, truncate
+    from apps.timeline.types import ActivityEvent, cursor_page, truncate
 
     qs = Skill.objects.order_by("-created_at")
-    if before is not None:
-        qs = qs.filter(created_at__lt=before)
     return [
         ActivityEvent(
             subsystem="skills",
@@ -23,5 +21,5 @@ def recent_events(*, limit: int, before: dt.datetime | None, user) -> list:
             id=f"skill:{sk.id}",
             icon="skill",
         )
-        for sk in qs[:limit]
+        for sk in cursor_page(qs, "created_at", before=before, limit=limit)
     ]

--- a/apps/skills/timeline.py
+++ b/apps/skills/timeline.py
@@ -1,0 +1,27 @@
+"""Timeline source for the skill catalog."""
+from __future__ import annotations
+
+import datetime as dt
+
+from .models import Skill
+
+
+def recent_events(*, limit: int, before: dt.datetime | None, user) -> list:
+    from apps.timeline.types import ActivityEvent, truncate
+
+    qs = Skill.objects.order_by("-created_at")
+    if before is not None:
+        qs = qs.filter(created_at__lt=before)
+    return [
+        ActivityEvent(
+            subsystem="skills",
+            kind="skill",
+            at=sk.created_at,
+            title=sk.name,
+            summary=truncate(sk.description),
+            href=f"/skills/{sk.id}",
+            id=f"skill:{sk.id}",
+            icon="skill",
+        )
+        for sk in qs[:limit]
+    ]

--- a/apps/timeline/api.py
+++ b/apps/timeline/api.py
@@ -17,6 +17,7 @@ from apps.api.auth import session_auth
 
 from . import sources
 from .schemas import ActivityEventOut, SubsystemOut, TimelineOut
+from .types import ActivityEvent
 
 router = Router(auth=session_auth, tags=["timeline"])
 
@@ -24,24 +25,45 @@ _MAX_LIMIT = 200
 _DEFAULT_LIMIT = 50
 
 
+def _encode_cursor(event: ActivityEvent) -> str:
+    """Opaque ``"<iso8601>|<id>"`` cursor — a compound (at, id) keyset."""
+    return f"{event.at.isoformat()}|{event.id}"
+
+
+def _parse_cursor(raw: str | None) -> tuple[dt.datetime, str] | None:
+    """Decode the opaque cursor; ``None`` (or anything malformed) → first page."""
+    if not raw:
+        return None
+    at_str, sep, event_id = raw.partition("|")
+    if not sep:
+        return None
+    try:
+        at = dt.datetime.fromisoformat(at_str)
+    except ValueError:
+        return None
+    return (at, event_id)
+
+
 @router.get("/", response=TimelineOut, summary="Team activity timeline")
 def list_timeline(
     request: HttpRequest,
     subsystem: str | None = None,
     limit: int = _DEFAULT_LIMIT,
-    before: dt.datetime | None = None,
+    before: str | None = None,
 ) -> TimelineOut:
     """Recent activity across all subsystems, newest first.
 
     - ``subsystem``: restrict to one filter key (unknown keys → all).
     - ``limit``: page size, clamped to 1..200.
-    - ``before``: cursor — return only events older than this timestamp.
+    - ``before``: opaque cursor from a prior page's ``next_before`` — return only
+      events older than it.
     """
     limit = max(1, min(limit, _MAX_LIMIT))
     sub = sources.valid_subsystem(subsystem)
-    events = sources.gather(subsystem=sub, limit=limit, before=before, user=request.user)
-    # A full page means there may be more; the tail's timestamp is the next cursor.
-    next_before = events[-1].at if len(events) == limit else None
+    cursor = _parse_cursor(before)
+    events = sources.gather(subsystem=sub, limit=limit, before=cursor, user=request.user)
+    # A full page means there may be more; the tail event seeds the next cursor.
+    next_before = _encode_cursor(events[-1]) if len(events) == limit else None
     return TimelineOut(
         events=[ActivityEventOut(**dataclasses.asdict(e)) for e in events],
         subsystems=[SubsystemOut(**s) for s in sources.subsystem_catalog()],

--- a/apps/timeline/api.py
+++ b/apps/timeline/api.py
@@ -1,0 +1,49 @@
+"""GET /api/timeline/ — one merged, filterable, team-wide activity feed.
+
+Read-only aggregator over every subsystem (see :mod:`apps.timeline.sources`).
+Session-authed like the rest of /api/; since "private" means "dimagi-only" (the
+whole app is OAuth-gated), every authenticated user sees the full team feed —
+no owner filtering.
+"""
+from __future__ import annotations
+
+import dataclasses
+import datetime as dt
+
+from django.http import HttpRequest
+from ninja import Router
+
+from apps.api.auth import session_auth
+
+from . import sources
+from .schemas import ActivityEventOut, SubsystemOut, TimelineOut
+
+router = Router(auth=session_auth, tags=["timeline"])
+
+_MAX_LIMIT = 200
+_DEFAULT_LIMIT = 50
+
+
+@router.get("/", response=TimelineOut, summary="Team activity timeline")
+def list_timeline(
+    request: HttpRequest,
+    subsystem: str | None = None,
+    limit: int = _DEFAULT_LIMIT,
+    before: dt.datetime | None = None,
+) -> TimelineOut:
+    """Recent activity across all subsystems, newest first.
+
+    - ``subsystem``: restrict to one filter key (unknown keys → all).
+    - ``limit``: page size, clamped to 1..200.
+    - ``before``: cursor — return only events older than this timestamp.
+    """
+    limit = max(1, min(limit, _MAX_LIMIT))
+    sub = sources.valid_subsystem(subsystem)
+    events = sources.gather(subsystem=sub, limit=limit, before=before, user=request.user)
+    # A full page means there may be more; the tail's timestamp is the next cursor.
+    next_before = events[-1].at if len(events) == limit else None
+    return TimelineOut(
+        events=[ActivityEventOut(**dataclasses.asdict(e)) for e in events],
+        subsystems=[SubsystemOut(**s) for s in sources.subsystem_catalog()],
+        next_before=next_before,
+    )

--- a/apps/timeline/apps.py
+++ b/apps/timeline/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class TimelineConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.timeline"

--- a/apps/timeline/schemas.py
+++ b/apps/timeline/schemas.py
@@ -1,0 +1,33 @@
+"""Pydantic schemas for the /api/timeline surface (read-only aggregator)."""
+from __future__ import annotations
+
+import datetime as dt
+
+from apps.common.schemas import StrictModel
+
+
+class ActivityEventOut(StrictModel):
+    subsystem: str
+    kind: str
+    at: dt.datetime
+    title: str
+    summary: str | None = None
+    project_slug: str | None = None
+    actor: str | None = None
+    href: str
+    external: bool = False
+    icon: str | None = None
+    id: str
+
+
+class SubsystemOut(StrictModel):
+    key: str
+    label: str
+
+
+class TimelineOut(StrictModel):
+    events: list[ActivityEventOut]
+    # The filter catalog for the rail (stable order, labels live server-side).
+    subsystems: list[SubsystemOut]
+    # Cursor for "show more": pass back as ?before=. Null when the page is the tail.
+    next_before: dt.datetime | None = None

--- a/apps/timeline/schemas.py
+++ b/apps/timeline/schemas.py
@@ -29,5 +29,6 @@ class TimelineOut(StrictModel):
     events: list[ActivityEventOut]
     # The filter catalog for the rail (stable order, labels live server-side).
     subsystems: list[SubsystemOut]
-    # Cursor for "show more": pass back as ?before=. Null when the page is the tail.
-    next_before: dt.datetime | None = None
+    # Opaque compound cursor for "show more": pass back verbatim as ?before=.
+    # Null when the page is the tail.
+    next_before: str | None = None

--- a/apps/timeline/sources.py
+++ b/apps/timeline/sources.py
@@ -53,17 +53,28 @@ def gather(
     *,
     subsystem: str | None,
     limit: int,
-    before: dt.datetime | None,
+    before: tuple[dt.datetime, str] | None,
     user,
 ) -> list[ActivityEvent]:
-    """Merged, newest-first events across the enabled sources, capped at ``limit``."""
+    """Merged, newest-first events across the enabled sources, capped at ``limit``.
+
+    ``before`` is a compound ``(at, id)`` cursor. Sources fetch inclusively
+    (``at <= before_at``) so events whose timestamps tie at the cursor aren't
+    lost; the aggregator then applies the exact ``(at, id)`` tuple bound. This
+    keeps "show more" from silently skipping events that share a timestamp (e.g.
+    two day-aligned shareouts both stamped 23:59:59).
+    """
+    before_at = before[0] if before else None
     entries = [e for e in _REGISTRY if subsystem is None or e[0] == subsystem]
     events: list[ActivityEvent] = []
     for key, _label, module_path, attr in entries:
         try:
             fn = _resolve(module_path, attr)
-            events.extend(fn(limit=limit, before=before, user=user) or [])
+            events.extend(fn(limit=limit, before=before_at, user=user) or [])
         except Exception:  # one bad source must not blank the feed
             logger.exception("timeline source %r failed", key)
-    events.sort(key=lambda ev: ev.at, reverse=True)
+    # Total order with id as the tiebreak so the compound cursor is exact.
+    events.sort(key=lambda ev: (ev.at, ev.id), reverse=True)
+    if before is not None:
+        events = [ev for ev in events if (ev.at, ev.id) < before]
     return events[:limit]

--- a/apps/timeline/sources.py
+++ b/apps/timeline/sources.py
@@ -1,0 +1,69 @@
+"""Registry + merge for the team activity timeline.
+
+Each entry points at a ``recent_events(*, limit, before, user)`` callable living
+in a subsystem's own ``timeline.py``. The aggregator calls the enabled sources,
+merges their events, sorts newest-first, and slices to ``limit``. A source that
+raises is logged and skipped — one broken subsystem never blanks the whole feed.
+
+No new tables: every source reads live models at request time. Each source
+returns at most ``limit`` events (and only events older than ``before`` when a
+cursor is given), so worst-case work is ``len(sources) * limit`` rows.
+"""
+from __future__ import annotations
+
+import datetime as dt
+import logging
+from collections.abc import Callable
+from importlib import import_module
+
+from .types import ActivityEvent
+
+logger = logging.getLogger(__name__)
+
+#: (key, label, "module.path", "callable_name"). Order is the rail order.
+_REGISTRY: list[tuple[str, str, str, str]] = [
+    ("ddd", "DDD", "apps.runs.timeline", "recent_events"),
+    ("insights", "Insights", "apps.projects.timeline", "insight_events"),
+    ("walkthroughs", "Walkthroughs", "apps.walkthroughs.timeline", "recent_events"),
+    ("shareouts", "Shareouts", "apps.shareouts.timeline", "recent_events"),
+    ("agents", "Agents", "apps.agents.timeline", "recent_events"),
+    ("sessions", "Sessions", "apps.sessions.timeline", "recent_events"),
+    ("projects", "Projects", "apps.projects.timeline", "project_events"),
+    ("skills", "Skills", "apps.skills.timeline", "recent_events"),
+    ("workspace", "Workspace", "apps.workspace.timeline", "recent_events"),
+]
+
+
+def subsystem_catalog() -> list[dict[str, str]]:
+    """[{key, label}] for the filter rail, in registry order."""
+    return [{"key": key, "label": label} for key, label, _, _ in _REGISTRY]
+
+
+def valid_subsystem(key: str | None) -> str | None:
+    """Return ``key`` if it's a known subsystem, else ``None`` (→ all)."""
+    known = {k for k, _, _, _ in _REGISTRY}
+    return key if key in known else None
+
+
+def _resolve(module_path: str, attr: str) -> Callable[..., list[ActivityEvent]]:
+    return getattr(import_module(module_path), attr)
+
+
+def gather(
+    *,
+    subsystem: str | None,
+    limit: int,
+    before: dt.datetime | None,
+    user,
+) -> list[ActivityEvent]:
+    """Merged, newest-first events across the enabled sources, capped at ``limit``."""
+    entries = [e for e in _REGISTRY if subsystem is None or e[0] == subsystem]
+    events: list[ActivityEvent] = []
+    for key, _label, module_path, attr in entries:
+        try:
+            fn = _resolve(module_path, attr)
+            events.extend(fn(limit=limit, before=before, user=user) or [])
+        except Exception:  # one bad source must not blank the feed
+            logger.exception("timeline source %r failed", key)
+    events.sort(key=lambda ev: ev.at, reverse=True)
+    return events[:limit]

--- a/apps/timeline/tests/test_timeline.py
+++ b/apps/timeline/tests/test_timeline.py
@@ -1,0 +1,183 @@
+"""Contract + source tests for the /api/timeline aggregator."""
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+from django.test import Client
+from django.utils import timezone
+
+from apps.agents.models import Agent, AgentSync
+from apps.projects.models import Project, ProjectContext
+from apps.runs.tests.factories import make_review, make_user, make_walkthrough
+from apps.shareouts.models import Shareout
+from apps.shareouts.timeline import _period_slug
+
+pytestmark = pytest.mark.django_db
+
+BASE = "/api/timeline/"
+
+
+@pytest.fixture
+def owner(db):
+    return make_user()
+
+
+@pytest.fixture
+def client(owner):
+    c = Client()
+    c.force_login(owner)
+    return c
+
+
+def _at(model_cls, pk, when, field="created_at"):
+    """Force an auto_now_add timestamp for deterministic ordering."""
+    model_cls.objects.filter(pk=pk).update(**{field: when})
+
+
+def _aware(y, mo, d, h=12):
+    return timezone.make_aware(dt.datetime(y, mo, d, h, 0, 0))
+
+
+# --- merge + shape -----------------------------------------------------------
+
+
+def test_requires_auth():
+    assert Client().get(BASE).status_code == 401
+
+
+def test_merges_across_subsystems(client, owner):
+    project = Project.objects.create(name="Reef", slug="reef")
+    ins = ProjectContext.objects.create(
+        project=project, context_type="insight", content="[ship_gap] ship it", source="x"
+    )
+    _at(ProjectContext, ins.pk, _aware(2026, 6, 10))
+    Shareout.objects.create(
+        project=project,
+        period_start=_aware(2026, 6, 11, 0),
+        period_end=_aware(2026, 6, 11, 23),
+        title="Week of June 11",
+        summary="shipped things",
+        content="body",
+        source="canopy:shareout",
+    )
+    wt = make_walkthrough(owner, kind="video")  # standalone (no run_id)
+    _at(type(wt), wt.pk, _aware(2026, 6, 12))
+
+    body = client.get(BASE).json()
+    by_sub = {e["subsystem"] for e in body["events"]}
+    assert {"insights", "shareouts", "walkthroughs"} <= by_sub
+    # newest first
+    ats = [e["at"] for e in body["events"]]
+    assert ats == sorted(ats, reverse=True)
+    # catalog present for the rail
+    keys = {s["key"] for s in body["subsystems"]}
+    assert {"ddd", "insights", "walkthroughs", "shareouts", "agents", "sessions"} <= keys
+
+
+def test_subsystem_filter(client, owner):
+    project = Project.objects.create(name="Reef", slug="reef")
+    ProjectContext.objects.create(
+        project=project, context_type="insight", content="an insight", source="x"
+    )
+    make_walkthrough(owner, kind="video")  # standalone walkthrough
+
+    body = client.get(BASE, {"subsystem": "insights"}).json()
+    assert body["events"]
+    assert all(e["subsystem"] == "insights" for e in body["events"])
+
+
+def test_unknown_subsystem_falls_back_to_all(client, owner):
+    project = Project.objects.create(name="Reef", slug="reef")
+    ProjectContext.objects.create(
+        project=project, context_type="insight", content="an insight", source="x"
+    )
+    body = client.get(BASE, {"subsystem": "bogus"}).json()
+    assert body["events"]  # not an empty/error result
+
+
+def test_before_cursor_paginates(client, owner):
+    project = Project.objects.create(name="Reef", slug="reef")
+    for i, day in enumerate((10, 11, 12)):
+        Shareout.objects.create(
+            project=project,
+            period_start=_aware(2026, 6, day, 0),
+            period_end=_aware(2026, 6, day, 23),
+            title=f"so-{i}",
+            content="body",
+            source="canopy:shareout",
+        )
+    page1 = client.get(BASE, {"subsystem": "shareouts", "limit": 2}).json()
+    assert len(page1["events"]) == 2
+    assert page1["next_before"] is not None
+    page2 = client.get(
+        BASE, {"subsystem": "shareouts", "limit": 2, "before": page1["next_before"]}
+    ).json()
+    titles1 = {e["title"] for e in page1["events"]}
+    titles2 = {e["title"] for e in page2["events"]}
+    assert titles1 == {"so-2", "so-1"}
+    assert titles2 == {"so-0"}
+    assert titles1.isdisjoint(titles2)
+
+
+# --- DDD source --------------------------------------------------------------
+
+
+def test_ddd_run_and_narrative_review(client, owner):
+    rid = "reef-2026-06-02-001"
+    make_walkthrough(owner, kind="video", run_id=rid, narrative_slug="reef", role="hero_video")
+    rev = make_review(
+        owner,
+        run_id=rid,
+        gate="concept_change",
+        narrative_slug="reef",
+        version=1,
+        request_json={"run_id": rid, "narrative": "Reef demo\nmore"},
+    )
+    body = client.get(BASE, {"subsystem": "ddd"}).json()
+    kinds = {e["kind"]: e for e in body["events"]}
+    assert "run" in kinds and "narrative_review" in kinds
+    assert kinds["run"]["href"] == f"/ddd/reef/{rid}"
+    assert kinds["narrative_review"]["href"] == f"/review/{rev.id}"
+
+
+def test_ddd_excludes_standalone_walkthrough_from_walkthroughs(client, owner):
+    # A walkthrough tied to a run must NOT appear under the walkthroughs subsystem.
+    make_walkthrough(owner, kind="video", run_id="reef-2026-06-02-001", narrative_slug="reef")
+    body = client.get(BASE, {"subsystem": "walkthroughs"}).json()
+    assert body["events"] == []
+
+
+# --- agents ------------------------------------------------------------------
+
+
+def test_agent_sync_event(client, owner):
+    agent = Agent.objects.create(slug="echo", name="Echo", owner=owner)
+    AgentSync.objects.create(
+        agent=agent,
+        period_start=_aware(2026, 6, 10, 0),
+        period_end=_aware(2026, 6, 10, 23),
+        title="Weekly sync",
+        summary="did stuff",
+        doc_url="https://docs.example/echo",
+        source="echo",
+    )
+    body = client.get(BASE, {"subsystem": "agents"}).json()
+    ev = body["events"][0]
+    assert ev["kind"] == "sync"
+    assert ev["href"] == "/agents/echo/syncs"
+
+
+# --- period slug -------------------------------------------------------------
+
+
+def _utc(y, mo, d, h, mi, s):
+    return dt.datetime(y, mo, d, h, mi, s, tzinfo=dt.UTC)
+
+
+def test_period_slug_day_aligned():
+    assert _period_slug(_utc(2026, 6, 11, 0, 0, 0), _utc(2026, 6, 11, 23, 59, 59)) == "2026-06-11"
+
+
+def test_period_slug_midday_run():
+    assert _period_slug(_utc(2026, 6, 11, 14, 30, 0), _utc(2026, 6, 11, 16, 0, 0)) == "2026-06-11-1430"

--- a/apps/timeline/tests/test_timeline.py
+++ b/apps/timeline/tests/test_timeline.py
@@ -120,6 +120,34 @@ def test_before_cursor_paginates(client, owner):
     assert titles1.isdisjoint(titles2)
 
 
+def test_cursor_no_loss_on_tied_timestamps(client, owner):
+    # Two shareouts stamped at the exact same instant — a strict `< at` cursor
+    # would drop one when paging. The compound (at, id) cursor must surface both.
+    project = Project.objects.create(name="Reef", slug="reef")
+    same = _aware(2026, 6, 11, 12)
+    for i in range(2):
+        Shareout.objects.create(
+            project=project,
+            period_start=same,
+            period_end=same,
+            title=f"tie-{i}",
+            content="body",
+            source="canopy:shareout",
+        )
+    seen: list[str] = []
+    before = None
+    for _ in range(4):  # page one-at-a-time; loop-guard well above 2 events
+        params = {"subsystem": "shareouts", "limit": 1}
+        if before:
+            params["before"] = before
+        body = client.get(BASE, params).json()
+        seen.extend(e["title"] for e in body["events"])
+        before = body["next_before"]
+        if not before:
+            break
+    assert sorted(seen) == ["tie-0", "tie-1"]
+
+
 # --- DDD source --------------------------------------------------------------
 
 

--- a/apps/timeline/types.py
+++ b/apps/timeline/types.py
@@ -54,6 +54,29 @@ def truncate(text: str | None, *, limit: int = 160) -> str | None:
     return s[:limit] or None
 
 
+def cursor_page(qs, ts_field: str, *, before, limit: int) -> list:
+    """Candidate rows for one timeline page from a single-timestamp queryset.
+
+    ``qs`` must already be ordered newest-first on ``ts_field``. Returns the
+    newest ``limit`` rows at-or-older than the cursor, **plus every row tied at
+    the page's boundary timestamp**. The boundary ties matter because SQL's own
+    tiebreak need not match the aggregator's global ``(at, id)`` order — without
+    them, the globally-newest of a tied set can be sliced off before
+    :func:`apps.timeline.sources.gather` re-sorts, and then the cursor skips it
+    forever (e.g. many projects' day-aligned shareouts all stamped ``23:59:59``).
+    The aggregator applies the exact ``(at, id)`` cursor and the final slice, so a
+    source returns candidates, not a finished page.
+    """
+    if before is not None:
+        qs = qs.filter(**{f"{ts_field}__lte": before})
+    rows = list(qs[:limit])
+    if rows:
+        boundary = getattr(rows[-1], ts_field)
+        seen = {r.pk for r in rows}
+        rows += [r for r in qs.filter(**{ts_field: boundary}) if r.pk not in seen]
+    return rows
+
+
 def actor_name(user) -> str | None:
     """Human label for an owner FK (may be ``None``)."""
     if user is None:

--- a/apps/timeline/types.py
+++ b/apps/timeline/types.py
@@ -1,0 +1,66 @@
+"""The common event shape every timeline source emits.
+
+A subsystem "source" (``apps/<app>/timeline.py``) queries its own models and
+maps each user-visible happening to an :class:`ActivityEvent`. The aggregator
+(:mod:`apps.timeline.sources`) merges events from every source, sorts by ``at``
+descending, and slices to the page size — so sources never need to know about
+each other.
+"""
+from __future__ import annotations
+
+import dataclasses
+import datetime as dt
+
+
+@dataclasses.dataclass(frozen=True)
+class ActivityEvent:
+    """One row on the timeline.
+
+    ``subsystem`` is the filter key (also a UI chip); ``kind`` is the verb within
+    that subsystem. ``id`` is ``"<kind>:<pk>"`` — unique per event, used for
+    React keys and as the seed for a future canonical object address.
+    ``href`` is the real in-app URL to open (``external=True`` for off-site URLs
+    like an agent work product, which open in a new tab).
+    """
+
+    subsystem: str
+    kind: str
+    at: dt.datetime
+    title: str
+    href: str
+    id: str
+    summary: str | None = None
+    project_slug: str | None = None
+    actor: str | None = None
+    external: bool = False
+    icon: str | None = None
+
+
+# --- small mapping helpers shared by sources ---------------------------------
+
+
+def first_line(text: str | None, *, limit: int = 140) -> str:
+    """First non-empty line of ``text``, trimmed to ``limit`` chars."""
+    for line in (text or "").splitlines():
+        line = line.strip()
+        if line:
+            return line[:limit]
+    return ""
+
+
+def truncate(text: str | None, *, limit: int = 160) -> str | None:
+    """A single trimmed line, or ``None`` when empty (so the field is omitted)."""
+    s = (text or "").strip().replace("\n", " ")
+    return s[:limit] or None
+
+
+def actor_name(user) -> str | None:
+    """Human label for an owner FK (may be ``None``)."""
+    if user is None:
+        return None
+    return (
+        getattr(user, "email", "")
+        or getattr(user, "get_full_name", lambda: "")()
+        or getattr(user, "username", "")
+        or None
+    )

--- a/apps/walkthroughs/timeline.py
+++ b/apps/walkthroughs/timeline.py
@@ -14,7 +14,7 @@ from .models import Walkthrough
 
 
 def recent_events(*, limit: int, before: dt.datetime | None, user) -> list:
-    from apps.timeline.types import ActivityEvent, actor_name, truncate
+    from apps.timeline.types import ActivityEvent, actor_name, cursor_page, truncate
 
     qs = (
         Walkthrough.objects.filter(Q(run_id__isnull=True) | Q(run_id=""))
@@ -22,8 +22,6 @@ def recent_events(*, limit: int, before: dt.datetime | None, user) -> list:
         .select_related("owner")
         .order_by("-created_at")
     )
-    if before is not None:
-        qs = qs.filter(created_at__lt=before)
     return [
         ActivityEvent(
             subsystem="walkthroughs",
@@ -37,5 +35,5 @@ def recent_events(*, limit: int, before: dt.datetime | None, user) -> list:
             id=f"walkthrough:{w.id}",
             icon="video" if w.kind == Walkthrough.KIND_VIDEO else "deck",
         )
-        for w in qs[:limit]
+        for w in cursor_page(qs, "created_at", before=before, limit=limit)
     ]

--- a/apps/walkthroughs/timeline.py
+++ b/apps/walkthroughs/timeline.py
@@ -1,0 +1,41 @@
+"""Timeline source for standalone walkthrough uploads.
+
+Walkthroughs tied to a DDD run (they carry a ``run_id``/``narrative_slug``) are
+surfaced by the ``ddd`` source instead — this emits only one-off uploads so the
+two subsystems don't double-count the same artifact.
+"""
+from __future__ import annotations
+
+import datetime as dt
+
+from django.db.models import Q
+
+from .models import Walkthrough
+
+
+def recent_events(*, limit: int, before: dt.datetime | None, user) -> list:
+    from apps.timeline.types import ActivityEvent, actor_name, truncate
+
+    qs = (
+        Walkthrough.objects.filter(Q(run_id__isnull=True) | Q(run_id=""))
+        .filter(Q(narrative_slug__isnull=True) | Q(narrative_slug=""))
+        .select_related("owner")
+        .order_by("-created_at")
+    )
+    if before is not None:
+        qs = qs.filter(created_at__lt=before)
+    return [
+        ActivityEvent(
+            subsystem="walkthroughs",
+            kind="walkthrough",
+            at=w.created_at,
+            title=w.title,
+            summary=truncate(w.description),
+            project_slug=w.project_slug,
+            actor=actor_name(w.owner),
+            href=f"/w/{w.id}",
+            id=f"walkthrough:{w.id}",
+            icon="video" if w.kind == Walkthrough.KIND_VIDEO else "deck",
+        )
+        for w in qs[:limit]
+    ]

--- a/apps/workspace/timeline.py
+++ b/apps/workspace/timeline.py
@@ -1,0 +1,30 @@
+"""Timeline source for workspace sessions (published skills)."""
+from __future__ import annotations
+
+import datetime as dt
+
+from .models import WorkspaceSession
+
+
+def recent_events(*, limit: int, before: dt.datetime | None, user) -> list:
+    from apps.timeline.types import ActivityEvent
+
+    qs = WorkspaceSession.objects.filter(status="published").order_by("-updated_at")
+    if before is not None:
+        qs = qs.filter(updated_at__lt=before)
+    out: list[ActivityEvent] = []
+    for ws in qs[:limit]:
+        draft = ws.skill_draft if isinstance(ws.skill_draft, dict) else {}
+        name = (draft.get("name") or "").strip() or "skill"
+        out.append(
+            ActivityEvent(
+                subsystem="workspace",
+                kind="workspace",
+                at=ws.updated_at,
+                title=f"Published: {name}",
+                href=f"/workspace/{ws.id}",
+                id=f"workspace:{ws.id}",
+                icon="skill",
+            )
+        )
+    return out

--- a/apps/workspace/timeline.py
+++ b/apps/workspace/timeline.py
@@ -7,13 +7,11 @@ from .models import WorkspaceSession
 
 
 def recent_events(*, limit: int, before: dt.datetime | None, user) -> list:
-    from apps.timeline.types import ActivityEvent
+    from apps.timeline.types import ActivityEvent, cursor_page
 
     qs = WorkspaceSession.objects.filter(status="published").order_by("-updated_at")
-    if before is not None:
-        qs = qs.filter(updated_at__lt=before)
     out: list[ActivityEvent] = []
-    for ws in qs[:limit]:
+    for ws in cursor_page(qs, "updated_at", before=before, limit=limit):
         draft = ws.skill_draft if isinstance(ws.skill_draft, dict) else {}
         name = (draft.get("name") or "").strip() or "skill"
         out.append(

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -66,6 +66,7 @@ INSTALLED_APPS = [
     "apps.mcp",
     "apps.sessions",
     "apps.agents",
+    "apps.timeline",
 ]
 
 MIDDLEWARE = [

--- a/docs/superpowers/specs/2026-06-19-team-activity-timeline-design.md
+++ b/docs/superpowers/specs/2026-06-19-team-activity-timeline-design.md
@@ -1,0 +1,209 @@
+# Team Activity Timeline — Design Spec
+
+**Date:** 2026-06-19
+**Status:** Approved (brainstorm) → ready for implementation plan
+**Scope:** One spec. Link-out only. In-panel rendering and object-URL standardization are explicitly deferred.
+
+## Problem
+
+Work now happens in parallel across many subsystems — DDD runs, narrative
+reviews, insights, walkthroughs, shareouts, agent syncs, sessions, project
+context. There is no single place to see "what has been completed recently"
+across the whole workspace. Today you must visit `/ddd`, `/insights`,
+`/shareouts`, `/agents/:slug`, etc. one at a time to reconstruct a mental
+timeline.
+
+## Goal
+
+A single `/timeline` page: a reverse-chronological, team-wide activity feed
+across **every** subsystem, **filterable** down to one subsystem so you can see
+just that subsystem's timeline. Each row links out to the object's real URL.
+Read-only.
+
+## Non-goals (deferred)
+
+- **In-panel object rendering** — selecting a row does not render the object in
+  a main panel; it navigates to the object's existing page.
+- **Renderer registry / embeddable detail components** — not built. No consumer
+  exists yet; designing the embedding contract before the panel UI exists would
+  guess the contract wrong.
+- **Canonical `/o/<type>/<id>` URLs / workbench URL standardization** — not
+  built. There is exactly one link generator (the aggregator), so retrofitting
+  to a canonical address layer later is cheap. Each event preserves explicit
+  identity (`subsystem` + `kind` + `id`) so that layer can be introduced
+  **non-destructively** in a future spec without re-instrumenting adapters.
+
+## Architecture
+
+### Read-time aggregator (no new tables, no backfill, no write instrumentation)
+
+A new `apps/timeline/` Django app exposes one endpoint. It does **not** own
+models. It holds a **registry** of per-subsystem "source" functions. Each
+participating app owns a small `timeline.py` exporting:
+
+```python
+def recent_events(*, limit: int, before: datetime | None, user) -> list[ActivityEvent]: ...
+```
+
+This keeps each subsystem's event-mapping knowledge inside that subsystem's app
+(no cross-app model reaching from the aggregator) and makes adding a subsystem a
+one-file change plus one registry line.
+
+The endpoint:
+
+```
+GET /api/timeline/?subsystem=<key>&limit=<n>&before=<iso8601>
+```
+
+1. Resolve the set of sources: all registered, or just `subsystem` if given.
+2. Call each source with `limit` + `before` (so each returns at most `limit`
+   rows newer than the cursor — bounds the work per source).
+3. Merge, sort by `at` descending, slice to `limit`.
+4. Return events + the subsystem catalog + the next cursor.
+
+Default `limit` = 50 (team-wide stream is busier than a single subsystem).
+Sources are bounded by `limit`, so worst-case work is `len(sources) * limit`
+rows fetched then merged — fine for a "recent" window. A written activity-log
+table can replace the aggregator later if deep pagination is ever needed; the
+endpoint contract would not change.
+
+### Event shape
+
+`apps/timeline/schemas.py`:
+
+```python
+class ActivityEventOut(Schema):
+    subsystem: str          # filter key: "ddd" | "insights" | "walkthroughs" | ...
+    kind: str               # verb within subsystem: "run" | "narrative_review" | "insight" | "shareout" | "sync" | "work_product" | "task" | "session" | "context" | "skill" | "workspace"
+    at: datetime            # sort timestamp
+    title: str              # headline (e.g. narrative title, insight one-liner)
+    summary: str | None     # one supporting line
+    project_slug: str | None
+    actor: str | None       # owner display name/email, if known
+    href: str               # real in-app URL to open (or external URL for work products)
+    external: bool = False  # true → open in new tab (e.g. AgentWorkProduct.url)
+    icon: str | None         # chip hint for the frontend (e.g. "video", "deck", "doc")
+    id: str                 # stable id for React keys + future canonical addressing
+```
+
+`ActivityEvent` is a plain dataclass internally (what sources return);
+`ActivityEventOut` is the Ninja/Pydantic response schema. The list endpoint
+returns:
+
+```python
+class TimelineOut(Schema):
+    events: list[ActivityEventOut]
+    subsystems: list[SubsystemOut]   # [{key, label}] catalog for the rail
+    next_before: datetime | None     # cursor for "show more"; null when exhausted
+```
+
+### Cursor pagination
+
+`before` is the `at` of the last event already shown. Each source filters
+`<ts> < before`; the merged result's last `at` becomes `next_before`. `null`
+when fewer than `limit` events come back.
+
+## Subsystem catalog
+
+Each subsystem is a filter key. "All" (no `subsystem` param) merges every
+source. Visibility-gated sources (walkthroughs, reviews, sessions) honor their
+`visibility` field against the requesting user.
+
+| Subsystem (`key`) | Label | Source model(s) | Sort ts | Link-out href |
+|---|---|---|---|---|
+| `ddd` | DDD | runs (Walkthrough grouped by `run_id`, via `apps/runs/aggregate.py`) + narrative `ReviewRequest` (narrative gates only) | run `latest_at`; review `resolved_at` or `created_at` | run → `/ddd/{narrative}/{runId}`; review → `/review/{id}` |
+| `insights` | Insights | `ProjectContext` where `context_type="insight"` | `created_at` | `/insights` |
+| `walkthroughs` | Walkthroughs | standalone `Walkthrough` (no `narrative_slug`) | `created_at` | `/w/{id}` |
+| `shareouts` | Shareouts | `Shareout` | `period_end` | `/shareouts/{period}` |
+| `agents` | Agents | `AgentSync` + `AgentWorkProduct` + `AgentTask` | sync `period_end`; others `created_at` | sync → `/agents/{slug}/syncs`; work_product → `url` (external); task → `/agents/{slug}/tasks` |
+| `sessions` | Sessions | `Session` | `created_at` | `/share/{token}` if `visibility="link"`, else `/sessions` |
+| `projects` | Projects | `ProjectContext` (non-insight types) + `ProjectAction` | context `created_at`; action `started_at` | `/` (workbench) |
+| `skills` | Skills | `Skill` | `created_at` | `/skills/{id}` |
+| `workspace` | Workspace | `WorkspaceSession` (status `published`) | `updated_at` | `/workspace/{id}` |
+
+**DDD source** reuses the existing read-time join in `apps/runs/aggregate.py`.
+Runs and narrative reviews are two `kind`s under the one `ddd` subsystem.
+Non-narrative review gates (`external_release`, `product_findings`) are excluded
+(already filtered by `_NON_NARRATIVE_GATES` in aggregate).
+
+**Walkthroughs vs DDD:** a `Walkthrough` with a `narrative_slug`/`run_id`
+belongs to a DDD run and is surfaced via the `ddd` source. The `walkthroughs`
+source only emits standalone uploads (`narrative_slug` is null) to avoid double
+counting.
+
+## Frontend: `/timeline`
+
+- New route `/timeline` in `frontend/src/router.tsx` + a top-nav entry.
+- `frontend/src/pages/TimelinePage.tsx` uses the `@canopy/workbench` shell (same
+  chrome as DDD/Agents):
+  - **Left rail:** "All activity" + one entry per subsystem from the returned
+    catalog. Single-select. Selecting sets `?subsystem=<key>` in the URL so a
+    filtered view is a shareable link. `/timeline` (no param) = All.
+  - **Main:** dense vertical feed grouped by day (Today / Yesterday / `MMM D`).
+    Each row: relative time · subsystem chip · project badge (if `project_slug`)
+    · `title` · `summary` · `actor`. Whole row navigates to `href` (internal →
+    router navigation; `external` → `window.open`/`target=_blank`).
+  - **Show more:** appends the next page using `next_before`; hides when null.
+- `frontend/src/api/timeline.ts`: `listTimeline({ subsystem?, limit?, before? })`
+  returning the typed `TimelineOut`, following the existing `frontend/src/api/ddd.ts`
+  fetch-wrapper pattern (`credentials: 'same-origin'`).
+- Styling: semantic tokens only (`bg-card`, `border-border`, `text-foreground`,
+  `text-muted-foreground`, `text-primary`). Table-dense, no card soup.
+
+## Auth & visibility
+
+- Endpoint is session-authed (`session_auth`), like the rest of the API; also
+  PAT-resolvable via the bearer middleware.
+- Each source filters by the requesting user where the model is owner- or
+  visibility-scoped:
+  - `Walkthrough` / `ReviewRequest` / `Session`: include if `visibility="link"`
+    OR `owner == user`.
+  - Owner-scoped-only models (e.g. `Session` private) excluded for non-owners.
+- Org-wide models (projects, insights, shareouts, skills) are visible to any
+  authenticated user (single-tenant V1, consistent with existing endpoints).
+
+## Testing
+
+- **Per-source unit tests** (`apps/timeline/tests/` or each app's tests): given
+  fixture rows, `recent_events` returns correctly-shaped, correctly-ordered,
+  visibility-filtered events with resolving hrefs.
+- **Endpoint tests:** merge ordering across sources; `subsystem` filter
+  restricts to one source; `before` cursor paginates; `limit` honored;
+  anonymous/cross-user visibility filtering; empty state.
+- **Frontend:** `npm run build` type-checks against regenerated OpenAPI types.
+
+## Files
+
+**Backend (new):**
+- `apps/timeline/__init__.py`, `apps/timeline/api.py`, `apps/timeline/schemas.py`,
+  `apps/timeline/sources.py` (registry + merge/sort/slice), `apps/timeline/types.py`
+  (the `ActivityEvent` dataclass), `apps/timeline/tests/`.
+
+**Backend (one small file per participating app):**
+- `apps/projects/timeline.py` (insights + projects sources)
+- `apps/walkthroughs/timeline.py`
+- `apps/shareouts/timeline.py`
+- `apps/agents/timeline.py`
+- `apps/sessions/timeline.py`
+- `apps/skills/timeline.py`
+- `apps/workspace/timeline.py`
+- `apps/runs/timeline.py` (DDD runs + narrative reviews; reuses `aggregate.py`)
+
+**Backend (edit):**
+- `apps/api/api.py` — register `api.add_router("/timeline", timeline_router)`.
+- `config/settings/*` — add `apps.timeline` to `INSTALLED_APPS` if app config is
+  required (no models, so may not be necessary; include for discoverability).
+
+**Frontend (new):**
+- `frontend/src/api/timeline.ts`, `frontend/src/pages/TimelinePage.tsx`,
+  timeline row/rail components under `frontend/src/components/timeline/`.
+
+**Frontend (edit):**
+- `frontend/src/router.tsx` — add `/timeline` route.
+- top-nav component — add the Timeline entry.
+- `frontend/src/api/generated.ts` — regenerated from OpenAPI.
+
+## Rollout
+
+Additive. No migrations (read-time aggregator, no new tables). No changes to
+existing endpoints. Ships behind no flag; the page is simply a new route.

--- a/docs/superpowers/specs/2026-06-19-team-activity-timeline-design.md
+++ b/docs/superpowers/specs/2026-06-19-team-activity-timeline-design.md
@@ -154,13 +154,15 @@ counting.
 
 - Endpoint is session-authed (`session_auth`), like the rest of the API; also
   PAT-resolvable via the bearer middleware.
-- Each source filters by the requesting user where the model is owner- or
-  visibility-scoped:
-  - `Walkthrough` / `ReviewRequest` / `Session`: include if `visibility="link"`
-    OR `owner == user`.
-  - Owner-scoped-only models (e.g. `Session` private) excluded for non-owners.
-- Org-wide models (projects, insights, shareouts, skills) are visible to any
-  authenticated user (single-tenant V1, consistent with existing endpoints).
+- **No owner/visibility filtering.** In this codebase `visibility="private"`
+  means "dimagi-only" (the whole app is dimagi-OAuth-gated), not "owner-only" —
+  so every authenticated user already sees all `private` content, exactly as the
+  existing `/ddd`, `/walkthroughs`, and `/insights` list endpoints do. This is
+  what makes it a genuine *team* timeline: sources query and map without an owner
+  filter. (`visibility="link"` only changes link-out targets, e.g. a session
+  deep-links to its public `/share/<token>` viewer.) An earlier draft proposed
+  `link`-OR-`owner` filtering; that was dropped once the "private = dimagi-only"
+  semantics were confirmed.
 
 ## Testing
 

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -1310,6 +1310,31 @@ export interface paths {
         readonly patch?: never;
         readonly trace?: never;
     };
+    readonly "/api/timeline/": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        /**
+         * Team activity timeline
+         * @description Recent activity across all subsystems, newest first.
+         *
+         *     - ``subsystem``: restrict to one filter key (unknown keys → all).
+         *     - ``limit``: page size, clamped to 1..200.
+         *     - ``before``: opaque cursor from a prior page's ``next_before`` — return only
+         *       events older than it.
+         */
+        readonly get: operations["apps_timeline_api_list_timeline"];
+        readonly put?: never;
+        readonly post?: never;
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
     readonly "/api/share/{token}": {
         readonly parameters: {
             readonly query?: never;
@@ -3674,6 +3699,53 @@ export interface components {
              */
             readonly result_note: string;
         };
+        /** ActivityEventOut */
+        readonly ActivityEventOut: {
+            /** Subsystem */
+            readonly subsystem: string;
+            /** Kind */
+            readonly kind: string;
+            /**
+             * At
+             * Format: date-time
+             */
+            readonly at: string;
+            /** Title */
+            readonly title: string;
+            /** Summary */
+            readonly summary?: string | null;
+            /** Project Slug */
+            readonly project_slug?: string | null;
+            /** Actor */
+            readonly actor?: string | null;
+            /** Href */
+            readonly href: string;
+            /**
+             * External
+             * @default false
+             */
+            readonly external: boolean;
+            /** Icon */
+            readonly icon?: string | null;
+            /** Id */
+            readonly id: string;
+        };
+        /** SubsystemOut */
+        readonly SubsystemOut: {
+            /** Key */
+            readonly key: string;
+            /** Label */
+            readonly label: string;
+        };
+        /** TimelineOut */
+        readonly TimelineOut: {
+            /** Events */
+            readonly events: readonly components["schemas"]["ActivityEventOut"][];
+            /** Subsystems */
+            readonly subsystems: readonly components["schemas"]["SubsystemOut"][];
+            /** Next Before */
+            readonly next_before?: string | null;
+        };
         /**
          * SharedSessionOut
          * @description Public, read-only payload for /api/share/{token}. No owner identity.
@@ -5887,6 +5959,30 @@ export interface operations {
                 };
                 content: {
                     readonly "application/json": components["schemas"]["AgentTaskCommandOut"];
+                };
+            };
+        };
+    };
+    readonly apps_timeline_api_list_timeline: {
+        readonly parameters: {
+            readonly query?: {
+                readonly subsystem?: string | null;
+                readonly limit?: number;
+                readonly before?: string | null;
+            };
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description OK */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["TimelineOut"];
                 };
             };
         };

--- a/frontend/src/api/timeline.ts
+++ b/frontend/src/api/timeline.ts
@@ -1,0 +1,60 @@
+/**
+ * API client for the /api/timeline surface (team-wide activity aggregator).
+ *
+ * Not in the generated OpenAPI types yet — raw fetch with the same credential
+ * conventions as api/ddd.ts. Run `npm run gen:api` to migrate to openapi-fetch.
+ */
+
+export interface TimelineEvent {
+  subsystem: string
+  kind: string
+  at: string
+  title: string
+  summary: string | null
+  project_slug: string | null
+  actor: string | null
+  href: string
+  external: boolean
+  icon: string | null
+  id: string
+}
+
+export interface TimelineSubsystem {
+  key: string
+  label: string
+}
+
+export interface TimelineResponse {
+  events: TimelineEvent[]
+  subsystems: TimelineSubsystem[]
+  next_before: string | null
+}
+
+export interface ListTimelineParams {
+  subsystem?: string
+  limit?: number
+  before?: string
+}
+
+async function getJson<T>(url: string): Promise<T> {
+  const resp = await fetch(url, { credentials: 'same-origin' })
+  if (!resp.ok) {
+    let detail = ''
+    try {
+      detail = (await resp.json())?.detail ?? ''
+    } catch {
+      /* ignore */
+    }
+    throw new Error(detail || `Request failed (${resp.status})`)
+  }
+  return resp.json() as Promise<T>
+}
+
+export function listTimeline(params: ListTimelineParams = {}): Promise<TimelineResponse> {
+  const q = new URLSearchParams()
+  if (params.subsystem) q.set('subsystem', params.subsystem)
+  if (params.limit) q.set('limit', String(params.limit))
+  if (params.before) q.set('before', params.before)
+  const suffix = q.toString() ? `?${q.toString()}` : ''
+  return getJson(`/api/timeline/${suffix}`)
+}

--- a/frontend/src/components/AppLayout/AppLayout.tsx
+++ b/frontend/src/components/AppLayout/AppLayout.tsx
@@ -6,6 +6,7 @@ import { useAuth } from '@/auth/AuthProvider'
 
 const NAV_ITEMS = [
   { path: '/', label: 'Projects' },
+  { path: '/timeline', label: 'Timeline' },
   { path: '/insights', label: 'Insights' },
   { path: '/shareouts', label: 'Shareouts' },
   { path: '/skills', label: 'Skills' },
@@ -232,6 +233,7 @@ export function AppLayout() {
       </header>
       {location.pathname.startsWith('/ddd') ||
       location.pathname.startsWith('/review') ||
+      location.pathname.startsWith('/timeline') ||
       // An individual Agent Workspace (/agents/<slug>) is a full-bleed workbench
       // like DDD; the bare /agents LIST stays in the standard container.
       /^\/agents\/[^/]+/.test(location.pathname) ? (

--- a/frontend/src/pages/TimelinePage.tsx
+++ b/frontend/src/pages/TimelinePage.tsx
@@ -70,7 +70,7 @@ function groupByDay(events: TimelineEvent[]): Array<{ day: string; events: Timel
   return groups
 }
 
-function EventRow({ ev }: { ev: TimelineEvent }) {
+function EventRow({ ev, label }: { ev: TimelineEvent; label: string }) {
   const navigate = useNavigate()
   const glyph = (ev.icon && ICON[ev.icon]) || '•'
 
@@ -87,8 +87,8 @@ function EventRow({ ev }: { ev: TimelineEvent }) {
       </div>
       <div className="min-w-0 flex-1">
         <div className="flex items-baseline gap-2">
-          <span className="rounded bg-accent px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">
-            {ev.subsystem}
+          <span className="rounded bg-accent px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+            {label}
           </span>
           <span className="truncate text-[13px] font-medium text-foreground">{ev.title}</span>
         </div>
@@ -164,6 +164,12 @@ export function TimelinePage() {
   const [loading, setLoading] = useState(true)
   const [loadingMore, setLoadingMore] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [moreError, setMoreError] = useState<string | null>(null)
+
+  const labelOf = useCallback(
+    (key: string) => subsystems.find((s) => s.key === key)?.label ?? key,
+    [subsystems],
+  )
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -187,6 +193,7 @@ export function TimelinePage() {
   async function loadMore() {
     if (!nextBefore) return
     setLoadingMore(true)
+    setMoreError(null)
     try {
       const data = await listTimeline({
         subsystem: subsystem || undefined,
@@ -195,8 +202,8 @@ export function TimelinePage() {
       })
       setEvents((prev) => [...prev, ...data.events])
       setNextBefore(data.next_before)
-    } catch {
-      /* keep what we have */
+    } catch (e) {
+      setMoreError(e instanceof Error ? e.message : 'Failed to load more')
     } finally {
       setLoadingMore(false)
     }
@@ -230,11 +237,11 @@ export function TimelinePage() {
                     {g.day}
                   </div>
                   {g.events.map((ev) => (
-                    <EventRow key={ev.id} ev={ev} />
+                    <EventRow key={ev.id} ev={ev} label={labelOf(ev.subsystem)} />
                   ))}
                 </section>
               ))}
-              <div className="flex justify-center p-4">
+              <div className="flex flex-col items-center gap-2 p-4">
                 {nextBefore ? (
                   <button
                     type="button"
@@ -245,11 +252,12 @@ export function TimelinePage() {
                       loadingMore && 'opacity-60',
                     )}
                   >
-                    {loadingMore ? 'Loading…' : 'Show more'}
+                    {loadingMore ? 'Loading…' : moreError ? 'Retry' : 'Show more'}
                   </button>
                 ) : (
                   <span className="text-[11px] text-muted-foreground">End of recent activity</span>
                 )}
+                {moreError && <span className="text-[11px] text-destructive">{moreError}</span>}
               </div>
             </>
           )}

--- a/frontend/src/pages/TimelinePage.tsx
+++ b/frontend/src/pages/TimelinePage.tsx
@@ -1,0 +1,260 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Link, useNavigate, useSearchParams } from 'react-router-dom'
+import { clsx } from 'clsx'
+import {
+  WorkbenchShell,
+  WorkbenchMain,
+  WorkbenchRail,
+  WorkbenchNavItem,
+  EmptyState,
+  ErrorState,
+  LoadingSpinner,
+} from '@canopy/workbench'
+import {
+  listTimeline,
+  type TimelineEvent,
+  type TimelineSubsystem,
+} from '@/api/timeline'
+
+const PAGE_SIZE = 50
+
+// A glyph per icon hint the backend stamps — a quiet visual anchor per row.
+const ICON: Record<string, string> = {
+  video: '▶',
+  deck: '◫',
+  doc: '⎘',
+  insight: '✦',
+  narrative: '✎',
+  note: '·',
+  sync: '⟳',
+  task: '◆',
+  session: '⌘',
+  skill: '✧',
+}
+
+function relativeTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime()
+  const m = Math.floor(diff / 60000)
+  if (m < 1) return 'now'
+  if (m < 60) return `${m}m ago`
+  const h = Math.floor(m / 60)
+  if (h < 24) return `${h}h ago`
+  const d = Math.floor(h / 24)
+  if (d < 7) return `${d}d ago`
+  return new Date(iso).toLocaleDateString()
+}
+
+function dayLabel(iso: string): string {
+  const d = new Date(iso)
+  const today = new Date()
+  const yesterday = new Date()
+  yesterday.setDate(today.getDate() - 1)
+  const sameDay = (a: Date, b: Date) =>
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  if (sameDay(d, today)) return 'Today'
+  if (sameDay(d, yesterday)) return 'Yesterday'
+  return d.toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' })
+}
+
+/** Group consecutive (already newest-first) events under their day label. */
+function groupByDay(events: TimelineEvent[]): Array<{ day: string; events: TimelineEvent[] }> {
+  const groups: Array<{ day: string; events: TimelineEvent[] }> = []
+  for (const ev of events) {
+    const day = dayLabel(ev.at)
+    const last = groups[groups.length - 1]
+    if (last && last.day === day) last.events.push(ev)
+    else groups.push({ day, events: [ev] })
+  }
+  return groups
+}
+
+function EventRow({ ev }: { ev: TimelineEvent }) {
+  const navigate = useNavigate()
+  const glyph = (ev.icon && ICON[ev.icon]) || '•'
+
+  const inner = (
+    <>
+      <div className="w-14 shrink-0 pt-0.5 text-right text-[11px] tabular-nums text-muted-foreground">
+        {relativeTime(ev.at)}
+      </div>
+      <div
+        aria-hidden
+        className="w-4 shrink-0 pt-0.5 text-center text-xs text-muted-foreground"
+      >
+        {glyph}
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-baseline gap-2">
+          <span className="rounded bg-accent px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">
+            {ev.subsystem}
+          </span>
+          <span className="truncate text-[13px] font-medium text-foreground">{ev.title}</span>
+        </div>
+        {ev.summary && (
+          <div className="mt-0.5 truncate text-[12px] text-muted-foreground">{ev.summary}</div>
+        )}
+        <div className="mt-0.5 flex items-center gap-2 text-[11px] text-muted-foreground">
+          {ev.project_slug && (
+            <span className="rounded border border-border px-1 py-px text-muted-foreground">
+              {ev.project_slug}
+            </span>
+          )}
+          {ev.actor && <span className="truncate">{ev.actor}</span>}
+        </div>
+      </div>
+    </>
+  )
+
+  const rowClass =
+    'flex w-full gap-3 border-b border-border/60 px-4 py-2.5 text-left transition-colors hover:bg-accent'
+
+  if (ev.external) {
+    return (
+      <a href={ev.href} target="_blank" rel="noopener noreferrer" className={rowClass}>
+        {inner}
+      </a>
+    )
+  }
+  return (
+    <button type="button" onClick={() => navigate(ev.href)} className={rowClass}>
+      {inner}
+    </button>
+  )
+}
+
+function TimelineRail({
+  subsystems,
+  active,
+}: {
+  subsystems: TimelineSubsystem[]
+  active: string | null
+}) {
+  return (
+    <WorkbenchRail
+      header={
+        <div className="px-4 py-3">
+          <div className="text-sm font-semibold text-foreground">Activity</div>
+          <div className="text-[11px] text-muted-foreground">Across the workspace</div>
+        </div>
+      }
+    >
+      <nav className="flex flex-col gap-0.5 p-2">
+        <WorkbenchNavItem asChild active={active === null}>
+          <Link to="/timeline">All activity</Link>
+        </WorkbenchNavItem>
+        {subsystems.map((s) => (
+          <WorkbenchNavItem key={s.key} asChild active={active === s.key}>
+            <Link to={`/timeline?subsystem=${s.key}`}>{s.label}</Link>
+          </WorkbenchNavItem>
+        ))}
+      </nav>
+    </WorkbenchRail>
+  )
+}
+
+export function TimelinePage() {
+  const [searchParams] = useSearchParams()
+  const subsystem = searchParams.get('subsystem')
+
+  const [events, setEvents] = useState<TimelineEvent[]>([])
+  const [subsystems, setSubsystems] = useState<TimelineSubsystem[]>([])
+  const [nextBefore, setNextBefore] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [loadingMore, setLoadingMore] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const data = await listTimeline({ subsystem: subsystem || undefined, limit: PAGE_SIZE })
+      setEvents(data.events)
+      setSubsystems(data.subsystems)
+      setNextBefore(data.next_before)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load activity')
+    } finally {
+      setLoading(false)
+    }
+  }, [subsystem])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  async function loadMore() {
+    if (!nextBefore) return
+    setLoadingMore(true)
+    try {
+      const data = await listTimeline({
+        subsystem: subsystem || undefined,
+        limit: PAGE_SIZE,
+        before: nextBefore,
+      })
+      setEvents((prev) => [...prev, ...data.events])
+      setNextBefore(data.next_before)
+    } catch {
+      /* keep what we have */
+    } finally {
+      setLoadingMore(false)
+    }
+  }
+
+  const groups = groupByDay(events)
+
+  return (
+    <WorkbenchShell>
+      <TimelineRail subsystems={subsystems} active={subsystem} />
+      <WorkbenchMain>
+        <div className="mx-auto max-w-3xl">
+          {loading ? (
+            <LoadingSpinner label="Loading activity…" />
+          ) : error ? (
+            <div className="p-4">
+              <ErrorState message={error} onRetry={() => void load()} />
+            </div>
+          ) : events.length === 0 ? (
+            <EmptyState
+              title="No activity yet"
+              description={
+                subsystem ? 'Nothing in this subsystem yet.' : 'Activity will show up here as work happens.'
+              }
+            />
+          ) : (
+            <>
+              {groups.map((g) => (
+                <section key={g.day}>
+                  <div className="sticky top-0 z-10 bg-background/95 px-4 py-1.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground backdrop-blur">
+                    {g.day}
+                  </div>
+                  {g.events.map((ev) => (
+                    <EventRow key={ev.id} ev={ev} />
+                  ))}
+                </section>
+              ))}
+              <div className="flex justify-center p-4">
+                {nextBefore ? (
+                  <button
+                    type="button"
+                    onClick={() => void loadMore()}
+                    disabled={loadingMore}
+                    className={clsx(
+                      'rounded-md border border-border px-3 py-1.5 text-[13px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground',
+                      loadingMore && 'opacity-60',
+                    )}
+                  >
+                    {loadingMore ? 'Loading…' : 'Show more'}
+                  </button>
+                ) : (
+                  <span className="text-[11px] text-muted-foreground">End of recent activity</span>
+                )}
+              </div>
+            </>
+          )}
+        </div>
+      </WorkbenchMain>
+    </WorkbenchShell>
+  )
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -15,6 +15,7 @@ import { WalkthroughsPage } from './pages/WalkthroughsPage'
 import { WalkthroughViewerPage } from './pages/WalkthroughViewerPage'
 import { ReviewPage } from './pages/ReviewPage'
 import { DddPage } from './pages/DddPage'
+import { TimelinePage } from './pages/TimelinePage'
 import { SessionsPage } from './pages/SessionsPage'
 import { AgentsPage } from './pages/AgentsPage'
 import { AgentWorkspacePage } from './pages/AgentWorkspacePage'
@@ -60,6 +61,7 @@ export const router = createBrowserRouter([
     element: <AppLayout />,
     children: [
       { path: '/', element: <ProjectsPage /> },
+      { path: '/timeline', element: <TimelinePage /> },
       { path: '/insights', element: <InsightsPage /> },
       { path: '/shareouts', element: <ShareoutsPage /> },
       { path: '/shareouts/:period', element: <ShareoutsPage /> },


### PR DESCRIPTION
## What

A team-wide **activity timeline at `/timeline`** — one reverse-chronological feed across every subsystem, filterable down to any single one, with each row linking out to the object's real page. Built to make it easy to see "what's been completed recently" across parallel work (DDD and everything else).

## How it works

**Backend** — a new `apps/timeline/` read-time aggregator (no new tables, no backfill):
- `GET /api/timeline/?subsystem=&limit=&before=` merges per-subsystem adapters, orders newest-first, and returns an opaque cursor for "show more".
- Each subsystem owns a small `timeline.py` emitting a common `ActivityEvent`, registered in `sources.py` — adding a subsystem is a one-file change.
- Sources: **DDD** (runs + narrative reviews, reusing `apps/runs/aggregate.py`), insights, standalone walkthroughs, shareouts, agents (syncs/work-products/tasks), sessions, projects, skills, workspace.
- A broken source is logged and skipped — it never blanks the feed.

**Frontend** — `/timeline` on the `@canopy/workbench` shell: left rail = "All activity" + one filter per subsystem (selection lives in `?subsystem=`, so a filtered view is a shareable URL); main = a dense day-grouped feed (Today / Yesterday / date) with "Show more".

## Pagination correctness

`before` is a compound `(at, id)` keyset cursor. Sources return *candidates* (newest `limit` plus every row tied at the page's boundary timestamp, via `cursor_page`); the aggregator applies the exact `(at, id)` bound and the final slice. This prevents silent event loss on "show more" when timestamps tie — e.g. many projects' day-aligned shareouts all stamped `23:59:59`. Locked by a regression test.

## Scope

Link-out only. In-panel object rendering, the renderer registry, and canonical `/o/<type>/<id>` URLs are **explicitly deferred** — the event shape (`subsystem`+`kind`+`id`) already preserves the identity those need, so they can be added non-destructively later. Rationale captured in the design spec.

## Auth

Since `private` means "dimagi-only" (the whole app is OAuth-gated), the feed is genuinely team-wide with **no owner filtering** — consistent with how `/ddd`, `/walkthroughs`, and `/insights` already list content.

## Tests

- Backend: full suite **437 passed, 1 skipped**; 11 new timeline tests (merge, subsystem filter, compound-cursor pagination, tied-timestamp no-loss regression, DDD run/review hrefs, double-count exclusion, period-slug parity with the frontend).
- Frontend: `tsc -b && vite build` clean.
- OpenAPI schema builds with `/api/timeline/`; ruff clean.

Design spec: `docs/superpowers/specs/2026-06-19-team-activity-timeline-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)