### PR TITLE
Fix mobile rendering across the canopy-web UI

### DIFF
--- a/frontend/packages/workbench/src/WorkbenchMain.tsx
+++ b/frontend/packages/workbench/src/WorkbenchMain.tsx
@@ -10,7 +10,7 @@ export const WorkbenchMain = forwardRef<
   ComponentPropsWithoutRef<'main'> & { children: ReactNode }
 >(function WorkbenchMain({ children, className, ...rest }, ref) {
   return (
-    <main ref={ref} className={cn('flex-1 overflow-y-auto', className)} {...rest}>
+    <main ref={ref} className={cn('min-h-0 min-w-0 flex-1 overflow-y-auto', className)} {...rest}>
       {children}
     </main>
   )

--- a/frontend/packages/workbench/src/WorkbenchRail.tsx
+++ b/frontend/packages/workbench/src/WorkbenchRail.tsx
@@ -6,7 +6,10 @@ import { cn } from './cn'
  * scrollable body that takes arbitrary children (a tree or a flat list).
  */
 export function WorkbenchRail({
-  width = 'w-64',
+  // `width` must be a md-prefixed Tailwind width (e.g. `md:w-64`): on phones the
+  // rail spans full width and stacks above the main column, so the width only
+  // applies once the layout goes side-by-side at md+.
+  width = 'md:w-64',
   header,
   children,
   className,
@@ -19,7 +22,10 @@ export function WorkbenchRail({
   return (
     <aside
       className={cn(
-        'flex shrink-0 flex-col border-r border-border bg-background',
+        'flex shrink-0 flex-col bg-background',
+        // Phone: full-width strip with a capped height so the main column below
+        // stays reachable. Desktop: fixed-width left rail with a right border.
+        'w-full max-h-[42vh] border-b border-border md:max-h-none md:border-b-0 md:border-r',
         width,
         className,
       )}

--- a/frontend/packages/workbench/src/WorkbenchShell.tsx
+++ b/frontend/packages/workbench/src/WorkbenchShell.tsx
@@ -18,7 +18,9 @@ export function WorkbenchShell({
   return (
     <div className={cn('flex h-full flex-col bg-background text-foreground', className)}>
       {header}
-      <div className="flex flex-1 overflow-hidden">{children}</div>
+      {/* Rail + main sit side-by-side on desktop; on phones they stack so the
+          main column gets full width instead of being crushed by the rail. */}
+      <div className="flex flex-1 flex-col overflow-hidden md:flex-row">{children}</div>
     </div>
   )
 }

--- a/frontend/src/components/AppLayout/AppLayout.tsx
+++ b/frontend/src/components/AppLayout/AppLayout.tsx
@@ -177,7 +177,7 @@ function UserChip() {
             {initials}
           </span>
         )}
-        <span className="text-xs text-stone-300 max-w-[12rem] truncate">{auth.user.email}</span>
+        <span className="hidden sm:inline text-xs text-stone-300 max-w-[12rem] truncate">{auth.user.email}</span>
       </button>
 
       {open && (
@@ -203,33 +203,86 @@ function UserChip() {
 
 export function AppLayout() {
   const location = useLocation()
+  const [mobileOpen, setMobileOpen] = useState(false)
+
+  // Collapse the mobile menu whenever the route changes (e.g. tapping a link).
+  useEffect(() => {
+    setMobileOpen(false)
+  }, [location.pathname])
+
+  function navLinkClass(path: string, block: boolean) {
+    const isActive =
+      location.pathname === path ||
+      (path !== '/' && location.pathname.startsWith(path))
+    return clsx(
+      'text-sm font-medium rounded transition-colors',
+      block ? 'block px-3 py-2' : 'px-3 py-1.5',
+      isActive
+        ? 'text-stone-100 bg-stone-900'
+        : 'text-stone-500 hover:text-stone-300 hover:bg-stone-900/50',
+    )
+  }
+
   return (
     <div className="min-h-screen bg-stone-950 text-stone-200">
       <header className="border-b border-stone-800 bg-stone-950 relative">
-        <div className="mx-auto max-w-7xl px-6 py-3 flex items-center justify-between">
-          <Link to="/" className="text-lg font-semibold text-stone-100">Canopy<span className="text-orange-400">.</span></Link>
-          <div className="flex items-center gap-6">
-            <nav className="flex gap-1">
-              {NAV_ITEMS.map((item) => {
-                const isActive =
-                  location.pathname === item.path ||
-                  (item.path !== '/' && location.pathname.startsWith(item.path))
-                return (
-                  <Link key={item.path} to={item.path}
-                    className={clsx('text-sm font-medium px-3 py-1.5 rounded transition-colors',
-                      isActive
-                        ? 'text-stone-100 bg-stone-900'
-                        : 'text-stone-500 hover:text-stone-300 hover:bg-stone-900/50'
-                    )}>
-                    {item.label}
-                  </Link>
-                )
-              })}
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 py-3 flex items-center justify-between gap-3">
+          <Link to="/" className="text-lg font-semibold text-stone-100 shrink-0">Canopy<span className="text-orange-400">.</span></Link>
+          <div className="flex items-center gap-3 xl:gap-6">
+            {/* Full inline nav only once all items fit (~xl); below that it
+                overflows the viewport, so we collapse it into the menu below. */}
+            <nav className="hidden xl:flex gap-1">
+              {NAV_ITEMS.map((item) => (
+                <Link key={item.path} to={item.path} className={navLinkClass(item.path, false)}>
+                  {item.label}
+                </Link>
+              ))}
             </nav>
             <AiStatusBadge />
             <UserChip />
+            <button
+              type="button"
+              onClick={() => setMobileOpen((o) => !o)}
+              aria-label="Toggle navigation menu"
+              aria-expanded={mobileOpen}
+              className="xl:hidden -mr-1 p-2 rounded text-stone-400 hover:text-stone-200 hover:bg-stone-900"
+            >
+              <svg className="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                {mobileOpen ? (
+                  <>
+                    <line x1="6" y1="6" x2="18" y2="18" />
+                    <line x1="6" y1="18" x2="18" y2="6" />
+                  </>
+                ) : (
+                  <>
+                    <line x1="3" y1="6" x2="21" y2="6" />
+                    <line x1="3" y1="12" x2="21" y2="12" />
+                    <line x1="3" y1="18" x2="21" y2="18" />
+                  </>
+                )}
+              </svg>
+            </button>
           </div>
         </div>
+        {mobileOpen && (
+          <>
+            {/* Backdrop: tap anywhere outside the panel to dismiss. */}
+            <button
+              type="button"
+              aria-hidden="true"
+              tabIndex={-1}
+              onClick={() => setMobileOpen(false)}
+              className="xl:hidden fixed inset-0 top-[53px] z-30 bg-stone-950/40 cursor-default"
+            />
+            <nav className="xl:hidden absolute left-0 right-0 top-full z-40 border-b border-stone-800 bg-stone-950 px-3 py-2 shadow-lg flex flex-col gap-1 max-h-[calc(100vh-53px)] overflow-y-auto">
+              {NAV_ITEMS.map((item) => (
+                <Link key={item.path} to={item.path} className={navLinkClass(item.path, true)}>
+                  {item.label}
+                </Link>
+              ))}
+            </nav>
+          </>
+        )}
       </header>
       {location.pathname.startsWith('/ddd') ||
       location.pathname.startsWith('/review') ||

--- a/frontend/src/components/ddd/DddLeftNav.tsx
+++ b/frontend/src/components/ddd/DddLeftNav.tsx
@@ -301,7 +301,7 @@ export function DddLeftNav({
   )
 
   return (
-    <WorkbenchRail width="w-72" header={header}>
+    <WorkbenchRail width="md:w-72" header={header}>
       <nav className="px-2 py-2">
         {error && <div className="px-3 py-2 text-xs text-destructive">{error}</div>}
         {!narratives && !error && (

--- a/frontend/src/components/ddd/NarrativeLanding.tsx
+++ b/frontend/src/components/ddd/NarrativeLanding.tsx
@@ -281,8 +281,8 @@ export function NarrativeLanding({ slug }: { slug: string }) {
   const currentVersion = detail.current_version?.version ?? null
 
   return (
-    <div className="mx-auto max-w-4xl px-8 py-6">
-      <header className="flex items-start justify-between gap-4">
+    <div className="mx-auto max-w-4xl px-4 py-6 sm:px-8">
+      <header className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
         <div className="min-w-0">
           <div className="text-[11px] uppercase tracking-wider text-stone-500">Narrative</div>
           <h1 className="text-2xl font-semibold text-stone-100">{detail.title || detail.slug}</h1>

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -97,13 +97,13 @@ function SectionNav({
   onSelect: (id: SectionId) => void
 }) {
   return (
-    <nav className="flex flex-col gap-0.5">
+    <nav className="flex flex-row gap-1 overflow-x-auto md:flex-col md:gap-0.5">
       {SECTIONS.map((s) => (
         <button
           key={s.id}
           type="button"
           onClick={() => onSelect(s.id)}
-          className={`rounded-md px-3 py-1.5 text-left text-sm transition-colors ${
+          className={`shrink-0 whitespace-nowrap rounded-md px-3 py-1.5 text-left text-sm transition-colors md:shrink ${
             active === s.id
               ? 'bg-orange-400/10 border border-orange-400/30 text-orange-400 font-medium'
               : 'border border-transparent text-stone-500 hover:text-stone-200 hover:bg-stone-900'
@@ -739,10 +739,10 @@ export function GuidePage() {
   }
 
   return (
-    <div className="flex gap-8">
-      {/* Sidebar nav */}
-      <div className="w-44 shrink-0">
-        <div className="sticky top-24">
+    <div className="flex flex-col gap-6 md:flex-row md:gap-8">
+      {/* Sidebar nav — stacks on top on phones, becomes a sticky rail on desktop */}
+      <div className="w-full md:w-44 md:shrink-0">
+        <div className="md:sticky md:top-24">
           <h3 className="mb-3 text-[10px] font-semibold uppercase tracking-wider text-stone-500">
             Guide
           </h3>

--- a/frontend/src/pages/SessionsPage.tsx
+++ b/frontend/src/pages/SessionsPage.tsx
@@ -64,7 +64,7 @@ export function SessionsPage() {
       ) : (
         <ul className="mt-6 divide-y divide-zinc-200 rounded-lg border border-zinc-200">
           {sessions.map((s) => (
-            <li key={s.slug} className="flex items-center gap-4 p-4">
+            <li key={s.slug} className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:gap-4">
               <div className="min-w-0 flex-1">
                 <div className="flex items-center gap-2">
                   <span className="truncate font-medium text-zinc-900">
@@ -91,7 +91,7 @@ export function SessionsPage() {
                   {s.project_slug ? ` · ${s.project_slug}` : ""}
                 </div>
               </div>
-              <div className="flex shrink-0 items-center gap-2 text-sm">
+              <div className="flex shrink-0 flex-wrap items-center gap-x-3 gap-y-1 text-sm">
                 {s.visibility === "link" && s.share_token && (
                   <>
                     <a

--- a/frontend/src/pages/ShareoutsPage.tsx
+++ b/frontend/src/pages/ShareoutsPage.tsx
@@ -236,7 +236,7 @@ function PeriodRail({
   return (
     <nav
       aria-label="Shareouts by date"
-      className="md:w-56 md:shrink-0 md:sticky md:top-6 self-start"
+      className="min-w-0 md:w-56 md:shrink-0 md:sticky md:top-6 md:self-start"
     >
       <div className="text-[10px] font-semibold uppercase tracking-wider text-stone-600 mb-2 px-2">
         By date

--- a/frontend/src/pages/WalkthroughsPage.tsx
+++ b/frontend/src/pages/WalkthroughsPage.tsx
@@ -118,7 +118,8 @@ export function WalkthroughsPage() {
         <div className="text-slate-500 text-sm">No walkthroughs match.</div>
       )}
       {items && items.length > 0 && (
-        <table className="w-full text-sm">
+        <div className="overflow-x-auto">
+        <table className="w-full min-w-[680px] text-sm">
           <thead className="text-left text-xs text-slate-500 border-b">
             <tr>
               <th className="py-2 pr-3">Title</th>
@@ -160,6 +161,7 @@ export function WalkthroughsPage() {
             ))}
           </tbody>
         </table>
+        </div>
       )}
     </div>
   )


### PR DESCRIPTION
## Summary
The global header rendered all 12 nav items inline with no breakpoint, forcing **every** page to ~1251px wide and horizontal-scrolling on a 375px phone. Several surfaces had their own mobile breakages on top of that. This PR makes the app render cleanly on phones.

- **AppLayout** — nav collapses into a hamburger menu below `xl` (with a tap-to-dismiss backdrop); user email hidden below `sm` so the header fits at 375px.
- **@canopy/workbench** (Shell/Rail/Main) + **DddLeftNav** — the left rail stacks above the main column on phones instead of crushing main to ~105px (fixes agent workspace, DDD, timeline). Rail width prop is now md-prefixed.
- **SessionsPage** — each card stacks and its actions wrap (were overlapping at mobile width).
- **NarrativeLanding** — header stacks on mobile so the narrative title isn't squeezed to 113px; tighter mobile padding.
- **GuidePage** — two-column layout stacks; the section sub-nav becomes a horizontal scroll strip.
- **WalkthroughsPage** — the wide 7-column `<table>` is wrapped in `overflow-x-auto` (was forcing the page to 738px).
- **ShareoutsPage** — the date TOC nav's `self-start` is gated to `md` so it stops sizing to content (was 538px).

## Verification
Audited every main route at a 375px viewport via a headless browser (authenticated). Each fixed route now reports `scrollWidth == 375` (no horizontal scroll), confirmed visually with screenshots.

- `npm run build` — green (only the pre-existing chunk-size warning)
- `vitest` — 45 pass (the 1 failed *file* is a pre-existing Playwright e2e spec mis-collected by vitest, unrelated to this change)

## Not included (flagged for follow-up)
- `SessionsPage` and `WalkthroughsPage` use light-theme classes (`text-zinc-900`, `text-slate-500`, `text-blue-700`) on the dark app, so some text is near-invisible — on desktop too. Out of scope here (not phone-specific); worth a follow-up to move to `stone-*`/semantic tokens.

## Test plan
- [x] Frontend builds + typechecks (`npm run build`)
- [x] Unit tests pass (`vitest`, 45)
- [x] Every audited route renders without horizontal scroll at 375px

🤖 Generated with [Claude Code](https://claude.com/claude-code)