### PR TITLE
feat(auth): allow dimagi-associate.com Google Workspace logins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,8 +21,8 @@ ANTHROPIC_API_KEY=sk-ant-your-key-here
 GOOGLE_OAUTH_CLIENT_ID=
 GOOGLE_OAUTH_CLIENT_SECRET=
 
-# Email domain allowlist for Google login. Empty = allow any Google account.
-AUTH_ALLOWED_EMAIL_DOMAIN=dimagi.com
+# Email domain allowlist for Google login (comma-separated). Empty = allow any Google account.
+AUTH_ALLOWED_EMAIL_DOMAIN=dimagi.com,dimagi-ai.com,dimagi-associate.com
 
 # Whether LoginRequiredMiddleware enforces auth. Set False during local rollout only.
 REQUIRE_AUTH=True

--- a/deploy.sh
+++ b/deploy.sh
@@ -105,7 +105,7 @@ gcloud run deploy "${SERVICE_NAME}" \
   --add-cloudsql-instances="${SQL_INSTANCE}" \
   --set-env-vars="DJANGO_SETTINGS_MODULE=config.settings.production" \
   --set-env-vars="AI_BACKEND=api" \
-  --set-env-vars="^|^AUTH_ALLOWED_EMAIL_DOMAIN=dimagi.com,dimagi-ai.com" \
+  --set-env-vars="^|^AUTH_ALLOWED_EMAIL_DOMAIN=dimagi.com,dimagi-ai.com,dimagi-associate.com" \
   --set-env-vars="REQUIRE_AUTH=${REQUIRE_AUTH_FLAG}" \
   --set-env-vars="CANOPY_DRIVE_ROOT_FOLDER_ID=1cUv7wQXOvVwuZ86PdhkxpFcuB4Lm9fPz" \
   --set-secrets="SECRET_KEY=django-secret-key:latest,ANTHROPIC_API_KEY=anthropic-api-key:latest,DATABASE_URL=canopy-db-url:latest,GOOGLE_OAUTH_CLIENT_ID=google-oauth-client-id:latest,GOOGLE_OAUTH_CLIENT_SECRET=google-oauth-client-secret:latest,CANOPY_DRIVE_SA_KEY_JSON=canopy-web-drive-sa:latest" \


### PR DESCRIPTION
## What

Add `dimagi-associate.com` to the `AUTH_ALLOWED_EMAIL_DOMAIN` allowlist so users on the dimagi-associate.com Google Workspace can sign in to canopy-web.

## Why

dimagi-associate.com is a separate Google Workspace domain. The Google OAuth app is generic (no `hd` hosted-domain lock), so Google will authenticate any Workspace account; the only gate is the app-level allowlist in `apps/common/auth_domains.py`, which is already comma-separated and multi-domain capable.

## Changes

- `deploy.sh` — production Cloud Run allowlist now `dimagi.com,dimagi-ai.com,dimagi-associate.com` (the value that actually gates prod login)
- `.env.example` — local-dev sample updated to match + noted it's comma-separated

Config-only: no code, migration, or OAuth-app change. Takes effect on next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)