### PR TITLE
wave4: enrich canopy_runs read model (Artifact ref/path + decisions-log fields)

### DIFF
--- a/apps/agent_runs/stores.py
+++ b/apps/agent_runs/stores.py
@@ -331,6 +331,9 @@ def _artifact_to_schema(a, step_key: str) -> Artifact:
         mime_type=a.mime_type,
         size=a.size,
         role=a.role,
+        # The DB adapter has no Drive file id; the row pk is the stable handle.
+        # ``path`` has no DB-native source — default "". (No ORM column added.)
+        ref=str(a.pk),
     )
 
 

--- a/apps/agent_runs/tests/test_db_store.py
+++ b/apps/agent_runs/tests/test_db_store.py
@@ -56,9 +56,18 @@ def test_get_run_hydrates_full_read_model(run):
     assert [s.key for s in read.steps] == ["spec", "render"]
     assert len(read.artifacts) == 1 and read.artifacts[0].step_key == "render"
     assert read.artifacts[0].size == 1024
+    # The DB adapter has no Drive file id: ref defaults to the row pk, path "".
+    art = read.artifacts[0]
+    assert art.ref == str(AgentRunArtifact.objects.get(name="hero.mp4").pk)
+    assert art.path == ""
     assert len(read.verdicts) == 1 and read.verdicts[0].passed is True
     assert read.verdicts[0].criteria == {"structural": "pass"}
     assert len(read.decisions) == 1 and read.decisions[0].step_key == "spec"
+    # The enriched decisions-log fields have no DB columns — they default safely.
+    dec = read.decisions[0]
+    assert dec.id == "" and dec.phase == "" and dec.source == ""
+    assert dec.options_considered == [] and dec.conflict_signals == []
+    assert dec.override_reasoning == ""
     assert len(read.gates) == 1 and read.gates[0].is_open is True
 
 

--- a/packages/canopy_runs/canopy_runs/drive/store.py
+++ b/packages/canopy_runs/canopy_runs/drive/store.py
@@ -403,6 +403,10 @@ def _snapshot_to_schema(
             mime_type=a.mime_type or "",
             size=a.size_bytes,
             role=key,
+            # The Drive adapter already holds both during attribution: the Drive
+            # file id is the opaque stable handle; ``path`` is run-relative.
+            ref=a.drive_file_id or "",
+            path=a.path or "",
         )
         for a in snap.artifacts
     ]
@@ -458,6 +462,14 @@ def _decision_to_schema(d) -> Decision:
         status=d.status if d.status in ("ai-default", "overridden") else "ai-default",
         reasoning=d.notes or d.override_reasoning or "",
         evidence_basis=d.evidence_basis or "",
+        # The parsers.Decision dataclass already carries these (ported from ACE's
+        # decisions-schema); thread them through instead of dropping them.
+        id=d.id or "",
+        phase=d.phase or "",
+        options_considered=list(d.options_considered or []),
+        source=d.source or "",
+        override_reasoning=d.override_reasoning or "",
+        conflict_signals=list(d.conflict_signals or []),
     )
 
 

--- a/packages/canopy_runs/canopy_runs/schemas.py
+++ b/packages/canopy_runs/canopy_runs/schemas.py
@@ -66,6 +66,13 @@ class Artifact(StrictModel):
     mime_type: str = ""
     size: int | None = None
     role: str = ""
+    # ``ref`` is an opaque, adapter-defined stable handle: the Drive adapter sets
+    # it to the Drive file id; the DB adapter may set it to the row pk or leave
+    # "". ``path`` is the run-relative path (e.g. "1-design/pdd.md"). Both are
+    # populated from data each adapter already holds — surfaced so consumers
+    # (e.g. ace-web) need not re-derive them downstream.
+    ref: str = ""
+    path: str = ""
 
 
 class Decision(StrictModel):
@@ -78,6 +85,15 @@ class Decision(StrictModel):
     status: DecisionStatus = "ai-default"
     reasoning: str = ""
     evidence_basis: str = ""
+    # Generic decisions-log fields the Drive adapter already parses (ported from
+    # ACE's decisions-schema). Storage-agnostic with safe defaults: the DB
+    # adapter leaves them at their defaults.
+    id: str = ""
+    phase: str = ""
+    options_considered: list[str] = Field(default_factory=list)
+    source: str = ""
+    override_reasoning: str = ""
+    conflict_signals: list[str] = Field(default_factory=list)
 
 
 class Gate(StrictModel):

--- a/packages/canopy_runs/tests/test_drive_store.py
+++ b/packages/canopy_runs/tests/test_drive_store.py
@@ -73,6 +73,7 @@ decisions:
     question: Which archetype?
     ai-default: atomic-visit
     options: [atomic-visit, focus-group]
+    source: idea-pack
     status: ai-default
 """
 
@@ -180,6 +181,23 @@ def test_artifacts_attributed_to_producing_skill():
     assert "idea-to-pdd-qa_result.yaml" not in [a.name for a in run.artifacts]
 
 
+def test_artifact_ref_and_path_populated_from_drive_data():
+    # The Drive adapter surfaces the Drive file id (opaque stable handle) as
+    # Artifact.ref and the run-relative path as Artifact.path — both from data
+    # it already holds during attribution. ace-web reads these instead of
+    # re-deriving them.
+    run = _store().get_run(AGENT, RUN_ID)
+    pdd = next(a for a in run.artifacts if a.name == "pdd.md")
+    assert pdd.path == "1-design/pdd.md"
+    assert pdd.ref  # non-empty Drive file id
+    assert pdd.url.endswith(pdd.ref)  # url is https://fake/<ref> for this client
+    summary = next(
+        a for a in run.artifacts if a.name == "pdd-to-learn-app_summary.md"
+    )
+    assert summary.path == "2-build/pdd-to-learn-app_summary.md"
+    assert summary.ref
+
+
 def test_judge_and_qa_verdicts_attached_to_step():
     run = _store().get_run(AGENT, RUN_ID)
     judges = [v for v in run.verdicts if v.kind == "judge"]
@@ -205,6 +223,14 @@ def test_decisions_log_parsed_through():
     assert d.question == "Which archetype?"
     assert d.ai_default == "atomic-visit"
     assert d.status == "ai-default"
+    # Generic decisions-log fields the Drive adapter already parses are now
+    # threaded through to the read model (previously dropped).
+    assert d.id == "archetype-selection"
+    assert d.phase == "1-design"
+    assert d.options_considered == ["atomic-visit", "focus-group"]
+    assert d.source == "idea-pack"
+    assert d.override_reasoning == ""
+    assert d.conflict_signals == []
 
 
 def test_gates_parsed_from_run_state():

--- a/packages/canopy_runs/tests/test_inmemory_store.py
+++ b/packages/canopy_runs/tests/test_inmemory_store.py
@@ -102,3 +102,24 @@ def test_missing_run_raises():
     store = InMemoryRunStore()
     with pytest.raises(KeyError):
         store.get_run("echo", "nope")
+
+
+def test_new_artifact_and_decision_fields_default_safely():
+    # Storage-agnostic adapters (in-memory, DB) that don't carry the enriched
+    # Drive provenance construct the read model fine — the new fields take their
+    # safe defaults (empty string / empty list), never required.
+    store = InMemoryRunStore()
+    store.put_run(_sample_run())
+    run = store.get_run("echo", "r1")
+
+    art = run.artifacts[0]
+    assert art.ref == ""
+    assert art.path == ""
+
+    dec = run.decisions[0]
+    assert dec.id == ""
+    assert dec.phase == ""
+    assert dec.options_considered == []
+    assert dec.source == ""
+    assert dec.override_reasoning == ""
+    assert dec.conflict_signals == []


### PR DESCRIPTION
Additive, read-model-only enrichment so ace-web can become a *true* single reader — dropping its parallel artifact re-attribution + decisions re-load.

- `Artifact` += `ref` (opaque adapter handle: Drive→drive_file_id, DB→row pk) + `path`.
- `Decision` += `id`/`phase`/`options_considered`/`source`/`override_reasoning`/`conflict_signals` (the generic decisions-log contract).
- DriveRunStore populates all from data its parsers already computed; DbRunStore defaults them safely. **No migration** (read-model-only); Django-free preserved.

131 (lib) + 505 (Django) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)