### PR TITLE
Wave 2 / P3a: run-step verdict recording + run-level eval aggregate

### DIFF
--- a/apps/agent_runs/api.py
+++ b/apps/agent_runs/api.py
@@ -21,7 +21,7 @@ from apps.api.pagination import Page, paginate
 from apps.common.schemas import StrictModel
 
 from . import resolver
-from .schemas import Gate, Run, RunMode, RunSummary, Step, StepStatus
+from .schemas import Gate, Run, RunMode, RunSummary, Step, StepStatus, Verdict, VerdictKind
 from .stores import RunStore
 
 router = Router(auth=session_auth, tags=["agent-runs"])
@@ -54,6 +54,17 @@ class GateDecisionIn(StrictModel):
     decision: str = Field(min_length=1, max_length=120)
     decided_by: str = ""
     note: str = ""
+
+
+class VerdictIn(StrictModel):
+    """Record a judge/QA verdict on a step. `kind=qa` is the binary gate;
+    `kind=judge` carries the 0-N quality score that the run aggregates."""
+
+    kind: VerdictKind
+    score: float | None = None
+    passed: bool | None = None
+    criteria: dict = Field(default_factory=dict)
+    rationale: str = ""
 
 
 class ForkIn(StrictModel):
@@ -147,6 +158,23 @@ def record_gate(request: HttpRequest, slug: str, run_id: str, step_key: str,
     except (ObjectDoesNotExist, KeyError):
         raise HttpError(404, f"step '{step_key}' not found in run '{run_id}'")
     return Status(201, gate)
+
+
+@router.post("/{slug}/runs/{run_id}/steps/{step_key}/verdict", response={201: Verdict},
+             summary="Record a judge/QA verdict on a step",
+             openapi_extra={"x-mcp-expose": True})
+def record_verdict(request: HttpRequest, slug: str, run_id: str, step_key: str,
+                   payload: VerdictIn) -> Status:
+    agent, store = _store_for(slug)
+    try:
+        verdict = store.record_verdict(
+            agent.slug, run_id, step_key,
+            kind=payload.kind, score=payload.score, passed=payload.passed,
+            criteria=payload.criteria, rationale=payload.rationale,
+        )
+    except (ObjectDoesNotExist, KeyError):
+        raise HttpError(404, f"step '{step_key}' not found in run '{run_id}'")
+    return Status(201, verdict)
 
 
 @router.post("/{slug}/runs/{run_id}/fork", response={201: RunSummary}, summary="Fork a run",

--- a/apps/agent_runs/stores.py
+++ b/apps/agent_runs/stores.py
@@ -169,6 +169,22 @@ class DbRunStore:
         decision = AgentRunDecision.objects.create(step=step, **fields)
         return _decision_to_schema(decision, step_key)
 
+    def record_verdict(
+        self, agent: str, run_id: str, step_key: str, *,
+        kind: str, score: float | None = None, passed: bool | None = None,
+        criteria: dict | None = None, rationale: str = "",
+        evaluated_at: dt.datetime | None = None,
+    ) -> Verdict:
+        from .models import AgentRunStep, AgentRunVerdict
+
+        step = AgentRunStep.objects.get(run__agent__slug=agent, run_id=run_id, key=step_key)
+        verdict = AgentRunVerdict.objects.create(
+            step=step, kind=kind, score=score, passed=passed,
+            criteria=criteria or {}, rationale=rationale,
+            evaluated_at=evaluated_at or dt.datetime.now(dt.timezone.utc),
+        )
+        return _verdict_to_schema(verdict, step_key)
+
     def fork(self, agent: str, run_id: str, at_step: str, mode: str = "keep-overrides-only", edits: dict | None = None) -> RunSummary:
         from django.db import transaction
 

--- a/apps/agent_runs/tests/test_api.py
+++ b/apps/agent_runs/tests/test_api.py
@@ -156,6 +156,31 @@ def test_gate_missing_step_404(agent):
     assert resp.status_code == 404
 
 
+def test_record_verdict_and_aggregate(agent):
+    c = _auth_client()
+    rid = _post(c, _base(), {
+        "steps": [{"key": "render", "ordinal": 0, "status": "running"}],
+    }).json()["id"]
+    resp = _post(c, f"{_base()}{rid}/steps/render/verdict", {
+        "kind": "judge", "score": 82.0, "rationale": "solid",
+    })
+    assert resp.status_code == 201, resp.content
+    v = resp.json()
+    assert v["kind"] == "judge" and v["score"] == 82.0 and v["step_key"] == "render"
+    # reflected in the run read model + the run-level aggregate
+    body = c.get(f"{_base()}{rid}/").json()
+    assert body["verdicts"][0]["score"] == 82.0
+    assert body["overall_score"] == 82.0
+    assert body["qa_gate_ok"] is True
+
+
+def test_verdict_missing_step_404(agent):
+    c = _auth_client()
+    rid = _post(c, _base(), {"steps": [{"key": "spec", "ordinal": 0}]}).json()["id"]
+    resp = _post(c, f"{_base()}{rid}/steps/nope/verdict", {"kind": "qa", "passed": True})
+    assert resp.status_code == 404
+
+
 # ---- fork ----
 def test_fork_run(agent):
     c = _auth_client()

--- a/apps/agent_runs/tests/test_db_store.py
+++ b/apps/agent_runs/tests/test_db_store.py
@@ -108,6 +108,20 @@ def test_record_gate_closes_it(run):
     assert read.gates[0].decided_by == "jj@x.com"
 
 
+def test_record_verdict_persists_and_aggregates(run):
+    store = DbRunStore()
+    rid = str(run.pk)
+    v = store.record_verdict("echo", rid, "render", kind="judge", score=82.0, rationale="solid")
+    assert v.kind == "judge" and v.score == 82.0 and v.step_key == "render"
+    assert v.evaluated_at is not None
+    read = store.get_run("echo", rid)
+    assert read.overall_score == 82.0       # weakest-link over the single judge verdict
+    assert read.qa_gate_ok is True          # fixture's qa verdict passed
+    # a second, lower judge verdict drives the weakest-link roll-up down
+    store.record_verdict("echo", rid, "spec", kind="judge", score=70.0)
+    assert store.get_run("echo", rid).overall_score == 70.0
+
+
 def test_forked_from_is_carried(agent):
     parent = AgentRun.objects.create(agent=agent, label="parent")
     child = AgentRun.objects.create(agent=agent, label="child", forked_from=parent)

--- a/docs/superpowers/specs/2026-06-29-wave2-3-harvest-execution.md
+++ b/docs/superpowers/specs/2026-06-29-wave2-3-harvest-execution.md
@@ -1,0 +1,67 @@
+# Wave 2 + Wave 3 Harvest — Execution Spec
+
+**Status:** Active build · **Date:** 2026-06-29 · **Owner:** Claude (driving)
+**Parent:** `2026-06-24-canopy-framework-harvest-design.md`
+**Branch:** `wave2-3/harvest` (canopy-web) + companion work in the canopy plugin.
+
+> Lean execution spec — built in verified increments, each TDD + green + committed.
+> Not for sign-off; it's the build's own tracking contract.
+
+## Corrected starting state (what Wave 1 already delivered)
+
+Wave 1 (`apps/agent_runs` + `packages/canopy_runs`) built more than its commits implied:
+- **Tables exist:** `AgentRunVerdict` (judge/qa, score, passed, per-dim `criteria`),
+  `AgentRunDecision` (P4 ✓), `AgentRunArtifact` (role-attributed, partial P2),
+  `AgentRunGate`.
+- **Read model** lives in the Django-free `canopy_runs` package; `RunStore` Protocol
+  has `record_gate` / `record_decision` / `fork` — **but NO `record_verdict`**, and the
+  `Run` read model has a `verdicts` list with **no run-level aggregate**.
+
+So P1 (run_state) and P4 (decisions) are done. The remaining harvest:
+
+## Scope (in priority order)
+
+**Wave 2 — plugin crown jewels (remaining):**
+- **P3a (web, THIS spec's first increments):** verdict recording + QA-gates-judge
+  enforcement + run-level eval aggregation on `agent_runs`/`canopy_runs`. The plumbing a
+  self-grading agent writes to.
+- **P3b (plugin):** the eval *runner* — a shared `canopy eval` lib/skill that grades an
+  artifact against a rubric and POSTs a verdict (the generic port of ACE's verdict-schema +
+  calibration discipline). Consumes P3a.
+- **P2 (plugin):** artifact-manifest registry primitive. (Partially covered by
+  `AgentRunArtifact.role`; remaining = the producer/consumer dependency graph.)
+- **P7 (plugin):** generic gdrive MCP — relocate ACE's `google-drive-server.ts`. *Defer
+  unless needed* (it already works in ACE).
+- **P8 (plugin):** video-engine single-package consolidation. *Defer* (lowest urgency;
+  both copies work).
+
+**Wave 3 — web substrate (untouched):**
+- **W1 (web, high value):** multi-tenant `workspaces` app + RBAC + invites + auto-join,
+  and scope `Agent`/runs to a workspace. The real blocker for onboarding more users.
+- **W3 (web):** `ingest` app — transcript upload + cost/structure rollup. Net-new.
+- **W7 (web):** `service_accounts` credential vault + impersonation. Net-new.
+- **W4 (web):** websocket chat sessions + presence (converge SSE). Larger; sequence after W1.
+- **W5/W8/W9:** AI-backend, workbench-shell, auth convergence. *Defer* — canopy-web already
+  has working versions; converge opportunistically.
+
+## Increment order (each = TDD, green, commit)
+
+1. **P3a-1** — `record_verdict` on `RunStore` (Protocol + InMemory + DB) + read-model
+   aggregate (`Run.overall_score` weakest-link over judge verdicts; `Run.qa_gate_ok`) +
+   `POST /{slug}/runs/{run_id}/steps/{step_key}/verdict`. Migration-free (uses existing
+   `AgentRunVerdict` columns). ← **building now**
+2. **P3a-2** — QA-gates-judge enforcement: recording a `judge` verdict on a step whose `qa`
+   verdict failed marks it gated; aggregate reflects it.
+3. **W1-1** — `workspaces` app: `Workspace`/`Membership`/`Invite` models + RBAC + REST.
+4. **W1-2** — scope `agents` + `agent_runs` to a workspace (nullable FK, default workspace,
+   non-member 404).
+5. **P3b** — plugin `canopy eval` runner lib/skill (consumes P3a verdict endpoint).
+6. **W3** — `ingest` app (transcript + cost rollup).
+7. **W7** — `service_accounts` vault.
+8. Remaining (W4, P2 graph, P7, P8) as pulled.
+
+## Invariant
+
+All new framework apps stay framework-tier: may FK `agents.Agent` / `workspaces.Workspace`;
+must not import product apps (`skills`, `collections`, `workspace`, `reviews`, `runs`).
+Enforced by the Wave 0 boundary check.

--- a/docs/superpowers/specs/2026-06-29-wave2-3-harvest-execution.md
+++ b/docs/superpowers/specs/2026-06-29-wave2-3-harvest-execution.md
@@ -44,21 +44,33 @@ So P1 (run_state) and P4 (decisions) are done. The remaining harvest:
 - **W5/W8/W9:** AI-backend, workbench-shell, auth convergence. *Defer* — canopy-web already
   has working versions; converge opportunistically.
 
+## Transcript-confirmed status (from the wave0 session + ace-web)
+
+The wave0/keystone agent did **Wave 0, Wave 1, and Wave 4** — Wave 4 is *further than
+first reported*: ace-web PR #660 (`wave4/run-reader-swap`, merged) swapped `apps/opps`
+onto the shared `canopy_runs` adapter; ace-web now depends on `canopy-runs`. The team
+chose **Option 2** (ace-web imports framework code, stays standalone), which the agent
+noted *removes Wave-3 multi-tenancy from ACE's critical path*. Per the user, multi-tenancy
+is still wanted — for the **non-ACE** agents (Echo + the new ones) — and then **multiplayer
+mode** (real-time collab) on top. So Wave 3 is back on, justified by the agent fleet, not ACE.
+
 ## Increment order (each = TDD, green, commit)
 
-1. **P3a-1** — `record_verdict` on `RunStore` (Protocol + InMemory + DB) + read-model
-   aggregate (`Run.overall_score` weakest-link over judge verdicts; `Run.qa_gate_ok`) +
-   `POST /{slug}/runs/{run_id}/steps/{step_key}/verdict`. Migration-free (uses existing
-   `AgentRunVerdict` columns). ← **building now**
-2. **P3a-2** — QA-gates-judge enforcement: recording a `judge` verdict on a step whose `qa`
-   verdict failed marks it gated; aggregate reflects it.
-3. **W1-1** — `workspaces` app: `Workspace`/`Membership`/`Invite` models + RBAC + REST.
-4. **W1-2** — scope `agents` + `agent_runs` to a workspace (nullable FK, default workspace,
+1. **P3a-1** ✅ — `record_verdict` on `RunStore` (Protocol + InMemory + DB) + read-model
+   aggregate (`Run.overall_score`, `Run.qa_gate_ok`). Migration-free. (commit aeef191)
+2. **P3a-2** ✅ — QA-gates-judge: judge score on a QA-failed step excluded from
+   `overall_score` (centralized in the read model) + `POST .../steps/{key}/verdict`.
+   181 tests green. (commit da72a2a)
+3. **P3b** — plugin `canopy eval` runner lib/skill (grades an artifact vs a rubric, POSTs a
+   verdict). The *scorer* the wave1 agent left out. ← **next**
+4. **W1-1** — `workspaces` app: `Workspace`/`Membership`/`Invite` + RBAC + REST (harvest
+   ace-web's `apps/workspaces`).
+5. **W1-2** — scope `agents` + `agent_runs` to a workspace (nullable FK, default workspace,
    non-member 404).
-5. **P3b** — plugin `canopy eval` runner lib/skill (consumes P3a verdict endpoint).
-6. **W3** — `ingest` app (transcript + cost rollup).
-7. **W7** — `service_accounts` vault.
-8. Remaining (W4, P2 graph, P7, P8) as pulled.
+6. **W4 (multiplayer)** — websocket sessions + presence (harvest ace-web's `apps/sessions`
+   consumer + Channels), scoped to a workspace.
+7. **W3** — `ingest` app (transcript + cost rollup); **W7** — `service_accounts` vault.
+8. Deferred tail (P2 manifest graph, P7 gdrive MCP, P8 video consolidation) as pulled.
 
 ## Invariant
 

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -1469,6 +1469,23 @@ export interface paths {
         readonly patch?: never;
         readonly trace?: never;
     };
+    readonly "/api/agents/{slug}/runs/{run_id}/steps/{step_key}/verdict": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly get?: never;
+        readonly put?: never;
+        /** Record a judge/QA verdict on a step */
+        readonly post: operations["apps_agent_runs_api_record_verdict"];
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
     readonly "/api/agents/{slug}/runs/{run_id}/fork": {
         readonly parameters: {
             readonly query?: never;
@@ -4349,6 +4366,16 @@ export interface components {
              * @default
              */
             readonly role: string;
+            /**
+             * Ref
+             * @default
+             */
+            readonly ref: string;
+            /**
+             * Path
+             * @default
+             */
+            readonly path: string;
         };
         /**
          * Decision
@@ -4385,6 +4412,30 @@ export interface components {
              * @default
              */
             readonly evidence_basis: string;
+            /**
+             * Id
+             * @default
+             */
+            readonly id: string;
+            /**
+             * Phase
+             * @default
+             */
+            readonly phase: string;
+            /** Options Considered */
+            readonly options_considered?: readonly string[];
+            /**
+             * Source
+             * @default
+             */
+            readonly source: string;
+            /**
+             * Override Reasoning
+             * @default
+             */
+            readonly override_reasoning: string;
+            /** Conflict Signals */
+            readonly conflict_signals?: readonly string[];
         };
         /**
          * Gate
@@ -4471,6 +4522,18 @@ export interface components {
             readonly decisions?: readonly components["schemas"]["Decision"][];
             /** Gates */
             readonly gates?: readonly components["schemas"]["Gate"][];
+            /**
+             * Overall Score
+             * @description Weakest-link (min) score across judge verdicts — the opp-eval roll-up.
+             *     QA gates the judge: a judge score on a step whose QA failed is excluded
+             *     (invalid). None when no qa-clean judge verdict carries a score.
+             */
+            readonly overall_score: number | null;
+            /**
+             * Qa Gate Ok
+             * @description False iff any QA verdict explicitly failed (QA gates the judge).
+             */
+            readonly qa_gate_ok: boolean;
         };
         /**
          * Step
@@ -4550,6 +4613,31 @@ export interface components {
              * @default
              */
             readonly note: string;
+        };
+        /**
+         * VerdictIn
+         * @description Record a judge/QA verdict on a step. `kind=qa` is the binary gate;
+         *     `kind=judge` carries the 0-N quality score that the run aggregates.
+         */
+        readonly VerdictIn: {
+            /**
+             * Kind
+             * @enum {string}
+             */
+            readonly kind: "judge" | "qa";
+            /** Score */
+            readonly score?: number | null;
+            /** Passed */
+            readonly passed?: boolean | null;
+            /** Criteria */
+            readonly criteria?: {
+                readonly [key: string]: unknown;
+            };
+            /**
+             * Rationale
+             * @default
+             */
+            readonly rationale: string;
         };
         /**
          * ForkIn
@@ -7317,6 +7405,34 @@ export interface operations {
                 };
                 content: {
                     readonly "application/json": components["schemas"]["Gate"];
+                };
+            };
+        };
+    };
+    readonly apps_agent_runs_api_record_verdict: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path: {
+                readonly slug: string;
+                readonly run_id: string;
+                readonly step_key: string;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody: {
+            readonly content: {
+                readonly "application/json": components["schemas"]["VerdictIn"];
+            };
+        };
+        readonly responses: {
+            /** @description Created */
+            readonly 201: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["Verdict"];
                 };
             };
         };

--- a/packages/canopy_runs/canopy_runs/drive/store.py
+++ b/packages/canopy_runs/canopy_runs/drive/store.py
@@ -861,6 +861,21 @@ class DriveRunStore:
         return self.get_run(agent, run_id).verdicts
 
     # -- RunStore: writes --
+    def record_verdict(
+        self, agent: str, run_id: str, step_key: str, *,
+        kind: str, score: float | None = None, passed: bool | None = None,
+        criteria: dict | None = None, rationale: str = "",
+        evaluated_at: dt.datetime | None = None,
+    ) -> Verdict:
+        """Not supported: the Drive adapter is read-through for verdicts. ACE
+        writes its own ``verdicts/*.yaml`` (and new-layout per-phase verdicts);
+        `list_verdicts` reads them. Canopy-hosted agents record verdicts through
+        the DB store (`DbRunStore.record_verdict`)."""
+        raise NotImplementedError(
+            "DriveRunStore is read-through for verdicts: ACE writes verdicts to "
+            "Drive directly; record them via the DB store for canopy-hosted agents."
+        )
+
     def record_gate(
         self,
         agent: str,

--- a/packages/canopy_runs/canopy_runs/schemas.py
+++ b/packages/canopy_runs/canopy_runs/schemas.py
@@ -170,8 +170,13 @@ class Run(StrictModel):
     @property
     def overall_score(self) -> float | None:
         """Weakest-link (min) score across judge verdicts — the opp-eval roll-up.
-        None when no judge verdict carries a score."""
-        scores = [v.score for v in self.verdicts if v.kind == "judge" and v.score is not None]
+        QA gates the judge: a judge score on a step whose QA failed is excluded
+        (invalid). None when no qa-clean judge verdict carries a score."""
+        qa_failed = {v.step_key for v in self.verdicts if v.kind == "qa" and v.passed is False}
+        scores = [
+            v.score for v in self.verdicts
+            if v.kind == "judge" and v.score is not None and v.step_key not in qa_failed
+        ]
         return min(scores) if scores else None
 
     @computed_field

--- a/packages/canopy_runs/canopy_runs/schemas.py
+++ b/packages/canopy_runs/canopy_runs/schemas.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import datetime as dt
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, computed_field
 
 
 class StrictModel(BaseModel):
@@ -165,6 +165,20 @@ class Run(StrictModel):
     verdicts: list[Verdict] = Field(default_factory=list)
     decisions: list[Decision] = Field(default_factory=list)
     gates: list[Gate] = Field(default_factory=list)
+
+    @computed_field
+    @property
+    def overall_score(self) -> float | None:
+        """Weakest-link (min) score across judge verdicts — the opp-eval roll-up.
+        None when no judge verdict carries a score."""
+        scores = [v.score for v in self.verdicts if v.kind == "judge" and v.score is not None]
+        return min(scores) if scores else None
+
+    @computed_field
+    @property
+    def qa_gate_ok(self) -> bool:
+        """False iff any QA verdict explicitly failed (QA gates the judge)."""
+        return all(v.passed is not False for v in self.verdicts if v.kind == "qa")
 
     def status_from_steps(self) -> RunStatus:
         """Derive run status from the steps map (load-bearing per spec §3)."""

--- a/packages/canopy_runs/canopy_runs/stores.py
+++ b/packages/canopy_runs/canopy_runs/stores.py
@@ -96,6 +96,16 @@ class RunStore(Protocol):
     def list_verdicts(self, agent: str, run_id: str) -> list[Verdict]:
         ...
 
+    def record_verdict(
+        self, agent: str, run_id: str, step_key: str, *,
+        kind: str, score: float | None = None, passed: bool | None = None,
+        criteria: dict | None = None, rationale: str = "",
+        evaluated_at: dt.datetime | None = None,
+    ) -> Verdict:
+        """Attach a judge/QA verdict to a step. A write. `evaluated_at` defaults
+        to now. The run's `overall_score` / `qa_gate_ok` aggregate recomputes."""
+        ...
+
     def record_gate(self, agent: str, run_id: str, step_key: str, decision: str, decided_by: str = "", note: str = "") -> Gate:
         """Record (close) a gate decision on a step. A write."""
         ...
@@ -226,6 +236,23 @@ class InMemoryRunStore:
         self._cursor += 1
         self._changed.append((self._cursor, agent, run_id))
         return decision
+
+    def record_verdict(
+        self, agent: str, run_id: str, step_key: str, *,
+        kind: str, score: float | None = None, passed: bool | None = None,
+        criteria: dict | None = None, rationale: str = "",
+        evaluated_at: dt.datetime | None = None,
+    ) -> Verdict:
+        run = self._require(agent, run_id)
+        verdict = Verdict(
+            step_key=step_key, kind=kind, score=score, passed=passed,
+            criteria=criteria or {}, rationale=rationale,
+            evaluated_at=evaluated_at or dt.datetime.now(dt.timezone.utc),
+        )
+        run.verdicts.append(verdict)
+        self._cursor += 1
+        self._changed.append((self._cursor, agent, run_id))
+        return verdict
 
     def fork(self, agent: str, run_id: str, at_step: str, mode: str = "keep-overrides-only", edits: dict | None = None) -> RunSummary:
         if mode not in FORK_MODES:

--- a/packages/canopy_runs/tests/test_drive_store.py
+++ b/packages/canopy_runs/tests/test_drive_store.py
@@ -133,6 +133,13 @@ def test_drive_store_satisfies_runstore_protocol():
     assert isinstance(_store(), RunStore)
 
 
+def test_record_verdict_is_read_through_only():
+    """ACE writes its own verdicts/*.yaml; the Drive adapter does not write them.
+    Canopy-hosted agents record verdicts via the DB store instead."""
+    with pytest.raises(NotImplementedError, match="read-through"):
+        _store().record_verdict(AGENT, "any-run", "render", kind="judge", score=80.0)
+
+
 # --- get_run: the full read model ---
 
 

--- a/packages/canopy_runs/tests/test_inmemory_store.py
+++ b/packages/canopy_runs/tests/test_inmemory_store.py
@@ -98,6 +98,28 @@ def test_changed_ids_tracks_writes():
     assert ids3 == ["r1"]
 
 
+def test_record_verdict_appends_and_aggregates():
+    store = InMemoryRunStore()
+    store.put_run(_sample_run())
+    v = store.record_verdict("echo", "r1", "render", kind="judge", score=82.0, rationale="solid")
+    assert isinstance(v, Verdict)
+    assert (v.kind, v.score, v.step_key) == ("judge", 82.0, "render")
+    assert v.evaluated_at is not None
+    run = store.get_run("echo", "r1")
+    assert run.verdicts[-1].score == 82.0
+    assert run.overall_score == 82.0          # weakest-link over the single judge verdict
+    assert run.qa_gate_ok is True             # the sample's qa verdict passed
+
+
+def test_record_verdict_tracked_as_write():
+    store = InMemoryRunStore()
+    store.put_run(_sample_run("r1"))
+    _, cursor = store.changed_ids("echo")
+    store.record_verdict("echo", "r1", "render", kind="qa", passed=False)
+    ids, _ = store.changed_ids("echo", cursor)
+    assert ids == ["r1"]
+
+
 def test_missing_run_raises():
     store = InMemoryRunStore()
     with pytest.raises(KeyError):

--- a/packages/canopy_runs/tests/test_run_aggregate.py
+++ b/packages/canopy_runs/tests/test_run_aggregate.py
@@ -52,6 +52,29 @@ def test_qa_gate_ok_false_when_any_qa_failed():
     assert run.qa_gate_ok is False
 
 
+def test_qa_failed_step_judge_score_excluded_from_overall():
+    # s1 was judged a LOW 40 but its QA failed → that score is invalid and must
+    # be excluded; without the rule weakest-link would wrongly report 40. With
+    # it, only the qa-clean s2 (70) counts → overall 70, gate red.
+    run = _run([
+        Verdict(step_key="s1", kind="judge", score=40.0),
+        Verdict(step_key="s1", kind="qa", passed=False),
+        Verdict(step_key="s2", kind="judge", score=70.0),
+        Verdict(step_key="s2", kind="qa", passed=True),
+    ])
+    assert run.overall_score == 70.0
+    assert run.qa_gate_ok is False
+
+
+def test_overall_none_when_only_judged_step_failed_qa():
+    run = _run([
+        Verdict(step_key="s1", kind="judge", score=95.0),
+        Verdict(step_key="s1", kind="qa", passed=False),
+    ])
+    assert run.overall_score is None
+    assert run.qa_gate_ok is False
+
+
 def test_aggregate_fields_are_serialized():
     run = _run([Verdict(step_key="s1", kind="judge", score=80.0)])
     dumped = run.model_dump()

--- a/packages/canopy_runs/tests/test_run_aggregate.py
+++ b/packages/canopy_runs/tests/test_run_aggregate.py
@@ -1,0 +1,59 @@
+"""Run-level eval aggregate over a run's verdicts (the opp-eval analogue).
+
+`overall_score` is weakest-link (min) across judge verdicts; `qa_gate_ok` is
+False iff any QA verdict explicitly failed. Both are computed (serialized) fields
+so the REST read model surfaces them without a stored column.
+"""
+from canopy_runs.schemas import Run, Step, Verdict
+
+
+def _run(verdicts):
+    return Run(
+        id="r1", agent_slug="echo",
+        steps=[Step(key="s1", ordinal=0)],
+        verdicts=verdicts,
+    )
+
+
+def test_overall_score_is_weakest_link_over_judge_verdicts():
+    run = _run([
+        Verdict(step_key="s1", kind="judge", score=88.0),
+        Verdict(step_key="s2", kind="judge", score=72.0),
+    ])
+    assert run.overall_score == 72.0
+
+
+def test_overall_score_ignores_qa_and_unscored_verdicts():
+    run = _run([
+        Verdict(step_key="s1", kind="judge", score=90.0),
+        Verdict(step_key="s1", kind="qa", passed=True),        # qa excluded
+        Verdict(step_key="s2", kind="judge", score=None),       # unscored excluded
+    ])
+    assert run.overall_score == 90.0
+
+
+def test_overall_score_none_when_no_judge_scores():
+    assert _run([Verdict(step_key="s1", kind="qa", passed=True)]).overall_score is None
+
+
+def test_qa_gate_ok_true_when_no_qa_failed():
+    run = _run([
+        Verdict(step_key="s1", kind="qa", passed=True),
+        Verdict(step_key="s2", kind="judge", score=50.0),
+    ])
+    assert run.qa_gate_ok is True
+
+
+def test_qa_gate_ok_false_when_any_qa_failed():
+    run = _run([
+        Verdict(step_key="s1", kind="qa", passed=True),
+        Verdict(step_key="s2", kind="qa", passed=False),
+    ])
+    assert run.qa_gate_ok is False
+
+
+def test_aggregate_fields_are_serialized():
+    run = _run([Verdict(step_key="s1", kind="judge", score=80.0)])
+    dumped = run.model_dump()
+    assert dumped["overall_score"] == 80.0
+    assert dumped["qa_gate_ok"] is True


### PR DESCRIPTION
Web-side half of Wave 2's eval engine — completes the hook the wave1 keystone left (verdict *tables* existed; the record path + roll-up did not).

## What
- `RunStore.record_verdict` on the Protocol + `DbRunStore` + `InMemoryRunStore`; `DriveRunStore` guards it as **read-through** (ACE writes its own `verdicts/*.yaml`).
- `POST /api/agents/{slug}/runs/{run_id}/steps/{step_key}/verdict`.
- Run-level roll-up (computed, serialized): `Run.overall_score` (weakest-link over judge verdicts) + `Run.qa_gate_ok`, with **ACE's "QA gates eval" rule** — a judge score on a QA-failed step is excluded — centralized in the `canopy_runs` read model so both the DB and Drive adapters inherit it.

## Coordination
Rebased onto `#156` (wave4 canopy_runs enrichment) — clean auto-merge (disjoint hunks). Pairs with canopy plugin #250 (the eval runner that POSTs here).

## Tests
**183 pass** across `packages/canopy_runs` + `apps/agent_runs` (incl. the enrichment's tests); architecture-boundary invariant passes (framework imports no product). TDD throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)