### PR TITLE
Wave 3 / W1: workspaces REST API (create/list/get, member-scoped)

### DIFF
--- a/apps/api/api.py
+++ b/apps/api/api.py
@@ -149,6 +149,7 @@ from apps.sessions.api import router as sessions_router  # noqa: E402
 from apps.sessions.api import share_router as session_share_router  # noqa: E402
 from apps.agents.api import router as agents_router  # noqa: E402
 from apps.agent_runs.api import router as agent_runs_router  # noqa: E402
+from apps.workspaces.api import router as workspaces_router  # noqa: E402
 from apps.timeline.api import router as timeline_router  # noqa: E402
 from apps.system.api import router as system_router  # noqa: E402
 
@@ -169,6 +170,7 @@ api.add_router("/shareouts", shareouts_router)
 api.add_router("/sessions", sessions_router)
 api.add_router("/agents", agents_router)
 api.add_router("/agents", agent_runs_router)  # unified run lifecycle under the agents namespace
+api.add_router("/workspaces", workspaces_router)
 api.add_router("/timeline", timeline_router)
 api.add_router("/system", system_router)
 api.add_router("/share", session_share_router)

--- a/apps/workspaces/api.py
+++ b/apps/workspaces/api.py
@@ -1,0 +1,72 @@
+"""Django Ninja router for /api/workspaces — the multi-tenancy surface.
+
+Membership-scoped: a workspace is visible only to its members; a non-member
+gets 404 (no existence leak). Creating a workspace makes the creator its owner.
+RBAC for member/invite management lands in a follow-up increment.
+"""
+from __future__ import annotations
+
+from django.http import HttpRequest
+from ninja import Router, Status
+from ninja.errors import HttpError
+
+from apps.api.auth import session_auth
+
+from .models import Workspace, WorkspaceMembership
+from .schemas import WorkspaceCreateIn, WorkspaceOut
+
+router = Router(auth=session_auth, tags=["workspaces"])
+
+
+def _out(ws: Workspace, role: str) -> WorkspaceOut:
+    return WorkspaceOut(
+        slug=ws.slug,
+        display_name=ws.display_name,
+        auto_join_domains=ws.auto_join_domains,
+        role=role,
+        created_at=ws.created_at,
+    )
+
+
+def _membership_or_404(user, slug: str) -> WorkspaceMembership:
+    try:
+        return WorkspaceMembership.objects.select_related("workspace").get(
+            workspace_id=slug, user=user
+        )
+    except WorkspaceMembership.DoesNotExist:
+        raise HttpError(404, f"workspace '{slug}' not found")
+
+
+@router.post("/", response={201: WorkspaceOut}, summary="Create a workspace",
+             openapi_extra={"x-mcp-expose": True})
+def create_workspace(request: HttpRequest, payload: WorkspaceCreateIn) -> Status:
+    if Workspace.objects.filter(slug=payload.slug).exists():
+        raise HttpError(409, f"workspace '{payload.slug}' already exists")
+    ws = Workspace.objects.create(
+        slug=payload.slug,
+        display_name=payload.display_name,
+        created_by=request.user,
+        auto_join_domains=payload.auto_join_domains,
+    )
+    WorkspaceMembership.objects.create(
+        workspace=ws, user=request.user, role=WorkspaceMembership.OWNER
+    )
+    return Status(201, _out(ws, WorkspaceMembership.OWNER))
+
+
+@router.get("/", response=list[WorkspaceOut], summary="List my workspaces",
+            openapi_extra={"x-mcp-expose": True})
+def list_workspaces(request: HttpRequest) -> list[WorkspaceOut]:
+    memberships = (
+        WorkspaceMembership.objects.filter(user=request.user)
+        .select_related("workspace")
+        .order_by("-workspace__created_at")
+    )
+    return [_out(m.workspace, m.role) for m in memberships]
+
+
+@router.get("/{slug}/", response=WorkspaceOut, summary="Get a workspace (member-only)",
+            openapi_extra={"x-mcp-expose": True})
+def get_workspace(request: HttpRequest, slug: str) -> WorkspaceOut:
+    m = _membership_or_404(request.user, slug)
+    return _out(m.workspace, m.role)

--- a/apps/workspaces/schemas.py
+++ b/apps/workspaces/schemas.py
@@ -1,0 +1,22 @@
+"""Pydantic schemas for the /api/workspaces surface."""
+from __future__ import annotations
+
+import datetime as dt
+
+from pydantic import Field
+
+from apps.common.schemas import StrictModel
+
+
+class WorkspaceCreateIn(StrictModel):
+    slug: str = Field(min_length=1, max_length=64)
+    display_name: str = Field(min_length=1, max_length=200)
+    auto_join_domains: list[str] = Field(default_factory=list)
+
+
+class WorkspaceOut(StrictModel):
+    slug: str
+    display_name: str
+    auto_join_domains: list[str]
+    role: str  # the requesting user's role in this workspace
+    created_at: dt.datetime

--- a/apps/workspaces/tests/test_api.py
+++ b/apps/workspaces/tests/test_api.py
@@ -1,0 +1,69 @@
+"""Workspaces REST API — create/list/get with membership-scoped RBAC.
+A workspace is visible only to its members; a non-member gets 404 (no existence
+leak), mirroring the tokenless-visibility discipline elsewhere."""
+from __future__ import annotations
+
+import json
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import Client
+
+from apps.workspaces.models import WorkspaceMembership
+
+pytestmark = pytest.mark.django_db
+User = get_user_model()
+
+
+def _user(email):
+    return User.objects.create(username=email, email=email)
+
+
+def _client(user):
+    c = Client()
+    c.force_login(user)
+    return c
+
+
+def _post(c, url, data):
+    return c.post(url, data=json.dumps(data), content_type="application/json")
+
+
+def test_list_requires_auth():
+    assert Client().get("/api/workspaces/").status_code in (401, 403)
+
+
+def test_create_makes_creator_an_owner():
+    u = _user("a@dimagi.com")
+    r = _post(_client(u), "/api/workspaces/", {
+        "slug": "acme", "display_name": "Acme", "auto_join_domains": ["acme.com"],
+    })
+    assert r.status_code == 201, r.content
+    body = r.json()
+    assert body["slug"] == "acme"
+    assert body["role"] == "owner"
+    assert body["auto_join_domains"] == ["acme.com"]
+    assert WorkspaceMembership.objects.get(workspace_id="acme", user=u).role == "owner"
+
+
+def test_list_is_member_scoped():
+    a, b = _user("a@dimagi.com"), _user("b@dimagi.com")
+    _post(_client(a), "/api/workspaces/", {"slug": "acme", "display_name": "Acme"})
+    _post(_client(b), "/api/workspaces/", {"slug": "beta", "display_name": "Beta"})
+    a_slugs = {w["slug"] for w in _client(a).get("/api/workspaces/").json()}
+    assert a_slugs == {"acme"}
+
+
+def test_get_is_member_only_else_404():
+    a, b = _user("a@dimagi.com"), _user("b@dimagi.com")
+    _post(_client(a), "/api/workspaces/", {"slug": "acme", "display_name": "Acme"})
+    assert _client(a).get("/api/workspaces/acme/").json()["role"] == "owner"
+    # a non-member can't even tell it exists
+    assert _client(b).get("/api/workspaces/acme/").status_code == 404
+
+
+def test_duplicate_slug_conflicts():
+    a = _user("a@dimagi.com")
+    _post(_client(a), "/api/workspaces/", {"slug": "acme", "display_name": "Acme"})
+    dup = _post(_client(a), "/api/workspaces/", {"slug": "acme", "display_name": "Dup"})
+    assert dup.status_code == 409

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -1370,6 +1370,41 @@ export interface paths {
         readonly patch?: never;
         readonly trace?: never;
     };
+    readonly "/api/workspaces/": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        /** List my workspaces */
+        readonly get: operations["apps_workspaces_api_list_workspaces"];
+        readonly put?: never;
+        /** Create a workspace */
+        readonly post: operations["apps_workspaces_api_create_workspace"];
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
+    readonly "/api/workspaces/{slug}/": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        /** Get a workspace (member-only) */
+        readonly get: operations["apps_workspaces_api_get_workspace"];
+        readonly put?: never;
+        readonly post?: never;
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
     readonly "/api/timeline/": {
         readonly parameters: {
             readonly query?: never;
@@ -4414,6 +4449,31 @@ export interface components {
                 readonly [key: string]: unknown;
             };
         };
+        /** WorkspaceOut */
+        readonly WorkspaceOut: {
+            /** Slug */
+            readonly slug: string;
+            /** Display Name */
+            readonly display_name: string;
+            /** Auto Join Domains */
+            readonly auto_join_domains: readonly string[];
+            /** Role */
+            readonly role: string;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            readonly created_at: string;
+        };
+        /** WorkspaceCreateIn */
+        readonly WorkspaceCreateIn: {
+            /** Slug */
+            readonly slug: string;
+            /** Display Name */
+            readonly display_name: string;
+            /** Auto Join Domains */
+            readonly auto_join_domains?: readonly string[];
+        };
         /** ActivityEventOut */
         readonly ActivityEventOut: {
             /** Subsystem */
@@ -7078,6 +7138,72 @@ export interface operations {
                 };
                 content: {
                     readonly "application/json": components["schemas"]["RunSummary"];
+                };
+            };
+        };
+    };
+    readonly apps_workspaces_api_list_workspaces: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description OK */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": readonly components["schemas"]["WorkspaceOut"][];
+                };
+            };
+        };
+    };
+    readonly apps_workspaces_api_create_workspace: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly requestBody: {
+            readonly content: {
+                readonly "application/json": components["schemas"]["WorkspaceCreateIn"];
+            };
+        };
+        readonly responses: {
+            /** @description Created */
+            readonly 201: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["WorkspaceOut"];
+                };
+            };
+        };
+    };
+    readonly apps_workspaces_api_get_workspace: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path: {
+                readonly slug: string;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description OK */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["WorkspaceOut"];
                 };
             };
         };


### PR DESCRIPTION
Next W1 increment on top of #159 (the workspaces models). Adds the REST surface.

- `POST /api/workspaces/` — create; the creator becomes an **owner** member.
- `GET /api/workspaces/` — lists only **my** workspaces (membership-scoped).
- `GET /api/workspaces/{slug}/` — member-only; a non-member gets **404** (no existence leak), mirroring the tokenless-visibility discipline.

Schemas in `apps/workspaces/schemas.py`, router registered under `/api/workspaces`, OpenAPI types regenerated locally (CI `regen` is a no-op).

**Verification:** full suite **493 passed**; framework→product boundary invariant clean.

**Follow-ups (rest of W1):** member add/remove + invite create/accept/revoke + RBAC; then scope `agents`/`agent_runs` to a workspace. Then W4 multiplayer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)