### PR TITLE
Wave 3 / W1: workspace member + invite management (owner RBAC)

### DIFF
--- a/apps/workspaces/api.py
+++ b/apps/workspaces/api.py
@@ -2,20 +2,32 @@
 
 Membership-scoped: a workspace is visible only to its members; a non-member
 gets 404 (no existence leak). Creating a workspace makes the creator its owner.
-RBAC for member/invite management lands in a follow-up increment.
+Owners manage members + invites (RBAC via `_require_role`); invites are accepted
+by token, only by the addressed email.
 """
 from __future__ import annotations
 
+import datetime as dt
+
 from django.http import HttpRequest
+from django.utils import timezone
 from ninja import Router, Status
 from ninja.errors import HttpError
 
 from apps.api.auth import session_auth
 
-from .models import Workspace, WorkspaceMembership
-from .schemas import WorkspaceCreateIn, WorkspaceOut
+from .models import Workspace, WorkspaceInvite, WorkspaceMembership
+from .schemas import (
+    InviteCreateIn,
+    InviteOut,
+    MemberOut,
+    WorkspaceCreateIn,
+    WorkspaceOut,
+)
 
 router = Router(auth=session_auth, tags=["workspaces"])
+
+INVITE_TTL_DAYS = 14
 
 
 def _out(ws: Workspace, role: str) -> WorkspaceOut:
@@ -35,6 +47,20 @@ def _membership_or_404(user, slug: str) -> WorkspaceMembership:
         )
     except WorkspaceMembership.DoesNotExist:
         raise HttpError(404, f"workspace '{slug}' not found")
+
+
+def _require_role(user, slug: str, *allowed: str) -> WorkspaceMembership:
+    m = _membership_or_404(user, slug)  # 404 first — a non-member can't probe roles
+    if m.role not in allowed:
+        raise HttpError(403, f"requires one of roles {list(allowed)}")
+    return m
+
+
+def _invite_out(inv: WorkspaceInvite) -> InviteOut:
+    return InviteOut(
+        id=inv.id, email=inv.email, role=inv.role, token=inv.token,
+        expires_at=inv.expires_at, accepted_at=inv.accepted_at, revoked_at=inv.revoked_at,
+    )
 
 
 @router.post("/", response={201: WorkspaceOut}, summary="Create a workspace",
@@ -70,3 +96,90 @@ def list_workspaces(request: HttpRequest) -> list[WorkspaceOut]:
 def get_workspace(request: HttpRequest, slug: str) -> WorkspaceOut:
     m = _membership_or_404(request.user, slug)
     return _out(m.workspace, m.role)
+
+
+# ---- members ----
+@router.get("/{slug}/members/", response=list[MemberOut], summary="List members (member-only)",
+            openapi_extra={"x-mcp-expose": True})
+def list_members(request: HttpRequest, slug: str) -> list[MemberOut]:
+    _membership_or_404(request.user, slug)
+    members = (
+        WorkspaceMembership.objects.filter(workspace_id=slug)
+        .select_related("user").order_by("joined_at")
+    )
+    return [
+        MemberOut(user_id=m.user_id, email=m.user.email, role=m.role, joined_at=m.joined_at)
+        for m in members
+    ]
+
+
+@router.delete("/{slug}/members/{user_id}/", response={204: None},
+               summary="Remove a member (owner-only)", openapi_extra={"x-mcp-expose": True})
+def remove_member(request: HttpRequest, slug: str, user_id: int):
+    _require_role(request.user, slug, WorkspaceMembership.OWNER)
+    try:
+        m = WorkspaceMembership.objects.get(workspace_id=slug, user_id=user_id)
+    except WorkspaceMembership.DoesNotExist:
+        raise HttpError(404, "member not found")
+    if m.role == WorkspaceMembership.OWNER and (
+        WorkspaceMembership.objects.filter(
+            workspace_id=slug, role=WorkspaceMembership.OWNER
+        ).count() == 1
+    ):
+        raise HttpError(400, "cannot remove the last owner")
+    m.delete()
+    return Status(204, None)
+
+
+# ---- invites ----
+@router.post("/{slug}/invites/", response={201: InviteOut}, summary="Invite by email (owner-only)",
+             openapi_extra={"x-mcp-expose": True})
+def create_invite(request: HttpRequest, slug: str, payload: InviteCreateIn) -> Status:
+    _require_role(request.user, slug, WorkspaceMembership.OWNER)
+    inv = WorkspaceInvite.objects.create(
+        workspace_id=slug, email=payload.email, role=payload.role,
+        invited_by=request.user,
+        expires_at=timezone.now() + dt.timedelta(days=INVITE_TTL_DAYS),
+    )
+    return Status(201, _invite_out(inv))
+
+
+@router.get("/{slug}/invites/", response=list[InviteOut], summary="List invites (member-only)",
+            openapi_extra={"x-mcp-expose": True})
+def list_invites(request: HttpRequest, slug: str) -> list[InviteOut]:
+    _membership_or_404(request.user, slug)
+    return [_invite_out(i) for i in WorkspaceInvite.objects.filter(workspace_id=slug).order_by("-created_at")]
+
+
+@router.post("/{slug}/invites/{invite_id}/revoke", response={204: None},
+             summary="Revoke an invite (owner-only)", openapi_extra={"x-mcp-expose": True})
+def revoke_invite(request: HttpRequest, slug: str, invite_id: int):
+    _require_role(request.user, slug, WorkspaceMembership.OWNER)
+    try:
+        inv = WorkspaceInvite.objects.get(workspace_id=slug, id=invite_id)
+    except WorkspaceInvite.DoesNotExist:
+        raise HttpError(404, "invite not found")
+    if inv.accepted_at is None and inv.revoked_at is None:
+        inv.revoked_at = timezone.now()
+        inv.save(update_fields=["revoked_at"])
+    return Status(204, None)
+
+
+@router.post("/invites/{token}/accept", response=WorkspaceOut,
+             summary="Accept an invite by token", openapi_extra={"x-mcp-expose": True})
+def accept_invite(request: HttpRequest, token: str) -> WorkspaceOut:
+    try:
+        inv = WorkspaceInvite.objects.select_related("workspace").get(token=token)
+    except WorkspaceInvite.DoesNotExist:
+        raise HttpError(404, "invite not found")
+    if not inv.is_pending():
+        raise HttpError(410, "invite is expired, revoked, or already accepted")
+    if inv.email and (request.user.email or "").lower() != inv.email.lower():
+        raise HttpError(403, "this invite is addressed to a different email")
+    m, _ = WorkspaceMembership.objects.get_or_create(
+        workspace=inv.workspace, user=request.user,
+        defaults={"role": inv.role, "invited_by": inv.invited_by},
+    )
+    inv.accepted_at = timezone.now()
+    inv.save(update_fields=["accepted_at"])
+    return _out(inv.workspace, m.role)

--- a/apps/workspaces/schemas.py
+++ b/apps/workspaces/schemas.py
@@ -2,10 +2,13 @@
 from __future__ import annotations
 
 import datetime as dt
+from typing import Literal
 
 from pydantic import Field
 
 from apps.common.schemas import StrictModel
+
+Role = Literal["owner", "editor", "viewer"]
 
 
 class WorkspaceCreateIn(StrictModel):
@@ -20,3 +23,25 @@ class WorkspaceOut(StrictModel):
     auto_join_domains: list[str]
     role: str  # the requesting user's role in this workspace
     created_at: dt.datetime
+
+
+class MemberOut(StrictModel):
+    user_id: int
+    email: str
+    role: str
+    joined_at: dt.datetime
+
+
+class InviteCreateIn(StrictModel):
+    email: str = Field(min_length=3, max_length=200)
+    role: Role = "editor"
+
+
+class InviteOut(StrictModel):
+    id: int
+    email: str
+    role: str
+    token: str
+    expires_at: dt.datetime
+    accepted_at: dt.datetime | None = None
+    revoked_at: dt.datetime | None = None

--- a/apps/workspaces/tests/test_members.py
+++ b/apps/workspaces/tests/test_members.py
@@ -1,0 +1,103 @@
+"""Member + invite management with owner RBAC.
+
+Owners manage members and invites; editors/viewers cannot. Invites are accepted
+by token, but only by the user whose email the invite names. The last owner
+can't be removed.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import Client
+
+from apps.workspaces.models import WorkspaceMembership
+
+pytestmark = pytest.mark.django_db
+User = get_user_model()
+
+
+def _user(email):
+    return User.objects.create(username=email, email=email)
+
+
+def _client(u):
+    c = Client()
+    c.force_login(u)
+    return c
+
+
+def _post(c, url, data=None):
+    return c.post(url, data=json.dumps(data or {}), content_type="application/json")
+
+
+def _ws(owner, slug="acme"):
+    _post(_client(owner), "/api/workspaces/", {"slug": slug, "display_name": slug.title()})
+    return slug
+
+
+def _invite(owner, slug, email, role="editor"):
+    return _post(_client(owner), f"/api/workspaces/{slug}/invites/", {"email": email, "role": role}).json()
+
+
+def test_list_members_is_member_only():
+    a = _user("a@dimagi.com")
+    _ws(a)
+    members = _client(a).get("/api/workspaces/acme/members/").json()
+    assert len(members) == 1
+    assert members[0]["email"] == "a@dimagi.com" and members[0]["role"] == "owner"
+    b = _user("b@dimagi.com")
+    assert _client(b).get("/api/workspaces/acme/members/").status_code == 404
+
+
+def test_owner_invites_and_invitee_accepts():
+    a = _user("a@dimagi.com")
+    _ws(a)
+    inv = _invite(a, "acme", "b@dimagi.com", "editor")
+    assert inv["role"] == "editor" and inv["email"] == "b@dimagi.com" and inv["token"]
+    b = _user("b@dimagi.com")
+    r = _post(_client(b), f"/api/workspaces/invites/{inv['token']}/accept")
+    assert r.status_code == 200, r.content
+    assert r.json()["role"] == "editor"
+    assert WorkspaceMembership.objects.get(workspace_id="acme", user=b).role == "editor"
+
+
+def test_accept_requires_matching_email():
+    a = _user("a@dimagi.com")
+    _ws(a)
+    inv = _invite(a, "acme", "b@dimagi.com")
+    c = _user("c@dimagi.com")
+    assert _post(_client(c), f"/api/workspaces/invites/{inv['token']}/accept").status_code == 403
+
+
+def test_revoked_invite_cannot_be_accepted():
+    a = _user("a@dimagi.com")
+    _ws(a)
+    inv = _invite(a, "acme", "b@dimagi.com")
+    assert _post(_client(a), f"/api/workspaces/acme/invites/{inv['id']}/revoke").status_code == 204
+    b = _user("b@dimagi.com")
+    assert _post(_client(b), f"/api/workspaces/invites/{inv['token']}/accept").status_code == 410
+
+
+def test_non_owner_cannot_invite():
+    a = _user("a@dimagi.com")
+    _ws(a)
+    inv = _invite(a, "acme", "b@dimagi.com", "editor")
+    b = _user("b@dimagi.com")
+    _post(_client(b), f"/api/workspaces/invites/{inv['token']}/accept")  # b is now an editor
+    assert _post(_client(b), "/api/workspaces/acme/invites/", {"email": "d@dimagi.com"}).status_code == 403
+
+
+def test_remove_member_owner_only_and_protects_last_owner():
+    a = _user("a@dimagi.com")
+    _ws(a)
+    inv = _invite(a, "acme", "b@dimagi.com", "editor")
+    b = _user("b@dimagi.com")
+    _post(_client(b), f"/api/workspaces/invites/{inv['token']}/accept")
+    # an editor can't remove anyone
+    assert _client(b).delete(f"/api/workspaces/acme/members/{a.id}/").status_code == 403
+    # the owner can remove the editor
+    assert _client(a).delete(f"/api/workspaces/acme/members/{b.id}/").status_code == 204
+    # the last owner can't be removed
+    assert _client(a).delete(f"/api/workspaces/acme/members/{a.id}/").status_code == 400

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -1405,6 +1405,92 @@ export interface paths {
         readonly patch?: never;
         readonly trace?: never;
     };
+    readonly "/api/workspaces/{slug}/members/": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        /** List members (member-only) */
+        readonly get: operations["apps_workspaces_api_list_members"];
+        readonly put?: never;
+        readonly post?: never;
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
+    readonly "/api/workspaces/{slug}/members/{user_id}/": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly get?: never;
+        readonly put?: never;
+        readonly post?: never;
+        /** Remove a member (owner-only) */
+        readonly delete: operations["apps_workspaces_api_remove_member"];
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
+    readonly "/api/workspaces/{slug}/invites/": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        /** List invites (member-only) */
+        readonly get: operations["apps_workspaces_api_list_invites"];
+        readonly put?: never;
+        /** Invite by email (owner-only) */
+        readonly post: operations["apps_workspaces_api_create_invite"];
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
+    readonly "/api/workspaces/{slug}/invites/{invite_id}/revoke": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly get?: never;
+        readonly put?: never;
+        /** Revoke an invite (owner-only) */
+        readonly post: operations["apps_workspaces_api_revoke_invite"];
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
+    readonly "/api/workspaces/invites/{token}/accept": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly get?: never;
+        readonly put?: never;
+        /** Accept an invite by token */
+        readonly post: operations["apps_workspaces_api_accept_invite"];
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
     readonly "/api/timeline/": {
         readonly parameters: {
             readonly query?: never;
@@ -4474,6 +4560,51 @@ export interface components {
             /** Auto Join Domains */
             readonly auto_join_domains?: readonly string[];
         };
+        /** MemberOut */
+        readonly MemberOut: {
+            /** User Id */
+            readonly user_id: number;
+            /** Email */
+            readonly email: string;
+            /** Role */
+            readonly role: string;
+            /**
+             * Joined At
+             * Format: date-time
+             */
+            readonly joined_at: string;
+        };
+        /** InviteOut */
+        readonly InviteOut: {
+            /** Id */
+            readonly id: number;
+            /** Email */
+            readonly email: string;
+            /** Role */
+            readonly role: string;
+            /** Token */
+            readonly token: string;
+            /**
+             * Expires At
+             * Format: date-time
+             */
+            readonly expires_at: string;
+            /** Accepted At */
+            readonly accepted_at?: string | null;
+            /** Revoked At */
+            readonly revoked_at?: string | null;
+        };
+        /** InviteCreateIn */
+        readonly InviteCreateIn: {
+            /** Email */
+            readonly email: string;
+            /**
+             * Role
+             * @default editor
+             * @enum {string}
+             */
+            readonly role: "owner" | "editor" | "viewer";
+        };
         /** ActivityEventOut */
         readonly ActivityEventOut: {
             /** Subsystem */
@@ -7192,6 +7323,140 @@ export interface operations {
             readonly header?: never;
             readonly path: {
                 readonly slug: string;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description OK */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["WorkspaceOut"];
+                };
+            };
+        };
+    };
+    readonly apps_workspaces_api_list_members: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path: {
+                readonly slug: string;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description OK */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": readonly components["schemas"]["MemberOut"][];
+                };
+            };
+        };
+    };
+    readonly apps_workspaces_api_remove_member: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path: {
+                readonly slug: string;
+                readonly user_id: number;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description No Content */
+            readonly 204: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    readonly apps_workspaces_api_list_invites: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path: {
+                readonly slug: string;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description OK */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": readonly components["schemas"]["InviteOut"][];
+                };
+            };
+        };
+    };
+    readonly apps_workspaces_api_create_invite: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path: {
+                readonly slug: string;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody: {
+            readonly content: {
+                readonly "application/json": components["schemas"]["InviteCreateIn"];
+            };
+        };
+        readonly responses: {
+            /** @description Created */
+            readonly 201: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["InviteOut"];
+                };
+            };
+        };
+    };
+    readonly apps_workspaces_api_revoke_invite: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path: {
+                readonly slug: string;
+                readonly invite_id: number;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description No Content */
+            readonly 204: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    readonly apps_workspaces_api_accept_invite: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path: {
+                readonly token: string;
             };
             readonly cookie?: never;
         };


### PR DESCRIPTION
Completes the workspaces management surface (on top of #159 models + #160 CRUD).

- `GET /{slug}/members/` (member-only) · `DELETE /{slug}/members/{user_id}/` (owner-only; **protects the last owner**)
- `POST /{slug}/invites/` (owner-only) · `GET /{slug}/invites/` · `POST /{slug}/invites/{id}/revoke`
- `POST /invites/{token}/accept` — by token, **only by the addressed email**; creates the membership with the invite's role; **410** if expired/revoked/already-accepted

RBAC centralized in `_require_role`. **Full suite 499 passed**; OpenAPI types regenerated locally (CI `regen` no-op).

**Remaining in W1:** scope `agents`/`agent_runs` to a workspace (the enforcement piece — needs a deliberate migration plan since Echo is live on `/api/agents`). Then W4 multiplayer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)