### PR TITLE
ci(workbench): publish @canopy/workbench to public npmjs

### DIFF
--- a/.github/workflows/publish-workbench.yml
+++ b/.github/workflows/publish-workbench.yml
@@ -1,9 +1,15 @@
 name: Publish @canopy/workbench
 
-# Publishes the shared front-end workbench package to GitHub Packages.
-# Trigger by pushing a tag like `workbench-v0.1.0`, or manually via the
-# Actions tab (workflow_dispatch). Bump the version in
+# Publishes the shared front-end workbench package to the PUBLIC npm registry
+# (npmjs.com) under the @canopy scope. GitHub Packages can't host @canopy from a
+# personal repo (its npm scope must equal the repo owner), so we use npmjs.
+#
+# Trigger by pushing a tag like `workbench-v0.2.0`, or manually via the Actions
+# tab (workflow_dispatch). Bump the version in
 # frontend/packages/workbench/package.json to match the tag before tagging.
+#
+# Requires repo secret NPM_TOKEN — an npm "Automation" token for an account that
+# can publish to the @canopy org (claim @canopy on npmjs first).
 on:
   push:
     tags: ['workbench-v*']
@@ -11,20 +17,17 @@ on:
 
 jobs:
   publish:
-    name: Publish to GitHub Packages
+    name: Publish to npmjs
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-          registry-url: 'https://npm.pkg.github.com'
+          registry-url: 'https://registry.npmjs.org'
           scope: '@canopy'
       - name: Publish
-        run: npm publish
+        run: npm publish --access public
         working-directory: frontend/packages/workbench
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/frontend/packages/workbench/package.json
+++ b/frontend/packages/workbench/package.json
@@ -12,7 +12,8 @@
     "./tokens/tokens.css": "./src/tokens/tokens.css"
   },
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
+    "registry": "https://registry.npmjs.org",
+    "access": "public"
   },
   "peerDependencies": {
     "@base-ui/react": "^1.3.0",


### PR DESCRIPTION
GitHub Packages can't host `@canopy` from a personal repo (scope must equal owner → 403). Repoints the publish workflow + `publishConfig` to **public npmjs** under `@canopy` (`--access public`), using a new repo secret `NPM_TOKEN`. This unblocks ace-web pinning `@canopy/workbench@<version>` with no auth needed to install.

**One-time setup needed (owner):** claim the `@canopy` org on npmjs + add an npm Automation token as repo secret `NPM_TOKEN`. Then re-tag `workbench-v0.2.0` to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)