### PR TITLE
chore(workbench): rename scope @canopy -> @marshellis

### DIFF
--- a/.github/workflows/publish-workbench.yml
+++ b/.github/workflows/publish-workbench.yml
@@ -1,7 +1,7 @@
-name: Publish @canopy/workbench
+name: Publish @marshellis/workbench
 
 # Publishes the shared front-end workbench package to the PUBLIC npm registry
-# (npmjs.com) under the @canopy scope. GitHub Packages can't host @canopy from a
+# (npmjs.com) under the @marshellis scope. GitHub Packages can't host @marshellis from a
 # personal repo (its npm scope must equal the repo owner), so we use npmjs.
 #
 # Trigger by pushing a tag like `workbench-v0.2.0`, or manually via the Actions
@@ -9,7 +9,7 @@ name: Publish @canopy/workbench
 # frontend/packages/workbench/package.json to match the tag before tagging.
 #
 # Requires repo secret NPM_TOKEN — an npm "Automation" token for an account that
-# can publish to the @canopy org (claim @canopy on npmjs first).
+# can publish to the @marshellis org (claim @marshellis on npmjs first).
 on:
   push:
     tags: ['workbench-v*']
@@ -25,7 +25,7 @@ jobs:
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
-          scope: '@canopy'
+          scope: '@marshellis'
       - name: Publish
         run: npm publish --access public
         working-directory: frontend/packages/workbench

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,8 +13,8 @@
       "dependencies": {
         "@ai-sdk/react": "^3.0.143",
         "@base-ui/react": "^1.3.0",
-        "@canopy/workbench": "*",
         "@fontsource-variable/geist": "^5.2.8",
+        "@marshellis/workbench": "*",
         "ai": "^6.0.141",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -582,10 +582,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/@canopy/workbench": {
-      "resolved": "packages/workbench",
-      "link": true
     },
     "node_modules/@dotenvx/dotenvx": {
       "version": "1.58.0",
@@ -1184,6 +1180,10 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@marshellis/workbench": {
+      "resolved": "packages/workbench",
+      "link": true
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.28.0",
@@ -9348,9 +9348,11 @@
       }
     },
     "packages/workbench": {
-      "name": "@canopy/workbench",
-      "version": "0.1.0",
+      "name": "@marshellis/workbench",
+      "version": "0.2.0",
       "peerDependencies": {
+        "@base-ui/react": "^1.3.0",
+        "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@ai-sdk/react": "^3.0.143",
     "@base-ui/react": "^1.3.0",
-    "@canopy/workbench": "*",
+    "@marshellis/workbench": "*",
     "@fontsource-variable/geist": "^5.2.8",
     "ai": "^6.0.141",
     "class-variance-authority": "^0.7.1",

--- a/frontend/packages/workbench/package.json
+++ b/frontend/packages/workbench/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@canopy/workbench",
+  "name": "@marshellis/workbench",
   "version": "0.2.0",
   "type": "module",
   "exports": {

--- a/frontend/packages/workbench/src/index.ts
+++ b/frontend/packages/workbench/src/index.ts
@@ -1,5 +1,5 @@
-// The full @canopy/workbench surface, re-exported from the subpath modules.
-// Prefer the subpath imports (@canopy/workbench/ui, /shell, /lib) in app code;
+// The full @marshellis/workbench surface, re-exported from the subpath modules.
+// Prefer the subpath imports (@marshellis/workbench/ui, /shell, /lib) in app code;
 // this barrel keeps the convenience top-level entry working.
 export * from './lib'
 export * from './shell'

--- a/frontend/packages/workbench/src/tokens/index.ts
+++ b/frontend/packages/workbench/src/tokens/index.ts
@@ -1,9 +1,9 @@
 /**
- * @canopy/workbench/tokens — the shared token contract.
+ * @marshellis/workbench/tokens — the shared token contract.
  *
  * The substance of the token system is CSS, imported directly:
- *   import "@canopy/workbench/tokens/preset.css"   // Tailwind v4 @theme name → var mapping
- *   import "@canopy/workbench/tokens/tokens.css"    // default :root / .dark VALUES
+ *   import "@marshellis/workbench/tokens/preset.css"   // Tailwind v4 @theme name → var mapping
+ *   import "@marshellis/workbench/tokens/tokens.css"    // default :root / .dark VALUES
  *
  * This module exposes the canonical list of token names so tooling/tests can
  * assert an app's palette covers the contract.

--- a/frontend/packages/workbench/src/tokens/preset.css
+++ b/frontend/packages/workbench/src/tokens/preset.css
@@ -1,5 +1,5 @@
 /**
- * @canopy/workbench — Tailwind v4 token PRESET.
+ * @marshellis/workbench — Tailwind v4 token PRESET.
  *
  * This is the shared CONTRACT: it maps Tailwind color/radius utilities
  * (`bg-primary`, `text-muted-foreground`, `border-border`, `rounded-lg`, …)
@@ -11,8 +11,8 @@
  * default values, which an app may import then override).
  *
  * Usage (in an app's index.css, after `@import "tailwindcss";`):
- *   @import "@canopy/workbench/tokens/preset.css";
- *   @import "@canopy/workbench/tokens/tokens.css";   // optional defaults
+ *   @import "@marshellis/workbench/tokens/preset.css";
+ *   @import "@marshellis/workbench/tokens/tokens.css";   // optional defaults
  *   :root { --primary: <app palette>; ... }           // override values
  */
 @theme inline {

--- a/frontend/packages/workbench/src/tokens/tokens.css
+++ b/frontend/packages/workbench/src/tokens/tokens.css
@@ -1,5 +1,5 @@
 /**
- * @canopy/workbench — DEFAULT token VALUES (the palette baseline).
+ * @marshellis/workbench — DEFAULT token VALUES (the palette baseline).
  *
  * These are the default values for the CSS-variable names declared by the
  * preset (preset.css). They are a complete, working "Warm Earth" palette so a

--- a/frontend/src/components/Workspace/SourcePanel.tsx
+++ b/frontend/src/components/Workspace/SourcePanel.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { cn } from '@/lib/utils'
-import { Badge } from '@canopy/workbench/ui'
+import { Badge } from '@marshellis/workbench/ui'
 
 interface Source {
   id?: number

--- a/frontend/src/components/agents/AgentLeftNav.tsx
+++ b/frontend/src/components/agents/AgentLeftNav.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { Link, NavLink } from 'react-router-dom'
-import { WorkbenchRail, WorkbenchNavItem } from '@canopy/workbench'
+import { WorkbenchRail, WorkbenchNavItem } from '@marshellis/workbench'
 import { getNeedsYou, type AgentDetailOut } from '@/api/agents'
 
 type NavItem = { to: string; label: string; count?: number }

--- a/frontend/src/components/ddd/DddLeftNav.tsx
+++ b/frontend/src/components/ddd/DddLeftNav.tsx
@@ -8,7 +8,7 @@ import {
   type DddNarrativeListItem,
 } from '@/api/ddd'
 import { listReviews, type ReviewListItem } from '@/api/reviews'
-import { WorkbenchRail, WorkbenchNavItem } from '@canopy/workbench'
+import { WorkbenchRail, WorkbenchNavItem } from '@marshellis/workbench'
 import { useRunSectionNav } from './runSectionNav'
 
 /**

--- a/frontend/src/components/ddd/DddShell.tsx
+++ b/frontend/src/components/ddd/DddShell.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react'
-import { WorkbenchShell, WorkbenchMain } from '@canopy/workbench'
+import { WorkbenchShell, WorkbenchMain } from '@marshellis/workbench'
 import { DddLeftNav } from './DddLeftNav'
 import { RunSectionNavProvider } from './runSectionNav'
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,13 +3,13 @@
 @import "shadcn/tailwind.css";
 @import "@fontsource-variable/geist";
 
-/* Shared @canopy/workbench token CONTRACT: maps Tailwind color/radius utilities
+/* Shared @marshellis/workbench token CONTRACT: maps Tailwind color/radius utilities
    (bg-primary, text-muted-foreground, border-border, rounded-lg, …) onto the
    canonical CSS-var NAMES (--primary, --muted-foreground, --border, --radius, …).
    The preset owns the NAMES; this app owns the VALUES — the :root / .dark
    palette below. ace-web imports this same preset with its own palette. Keep in
    lockstep with packages/workbench/src/tokens/preset.css. */
-@import "@canopy/workbench/tokens/preset.css";
+@import "@marshellis/workbench/tokens/preset.css";
 
 @source "../packages/workbench/src";
 

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,3 +1,3 @@
 // Canonical `cn` now lives in the shared package; re-export so existing
 // `@/lib/utils` imports keep resolving to the one implementation.
-export { cn } from "@canopy/workbench/lib"
+export { cn } from "@marshellis/workbench/lib"

--- a/frontend/src/pages/AgentWorkspacePage.tsx
+++ b/frontend/src/pages/AgentWorkspacePage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { Link, Outlet, useParams } from 'react-router-dom'
 import { getAgent, type AgentDetailOut } from '@/api/agents'
 import { AgentLeftNav } from '@/components/agents/AgentLeftNav'
-import { WorkbenchShell, WorkbenchMain } from '@canopy/workbench'
+import { WorkbenchShell, WorkbenchMain } from '@marshellis/workbench'
 
 /** Context the section sub-routes read via useOutletContext. */
 export interface AgentOutletContext {

--- a/frontend/src/pages/DiscoveryPage.tsx
+++ b/frontend/src/pages/DiscoveryPage.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useState, useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { listSkills } from '@/api/skills'
-import { Button } from '@canopy/workbench/ui'
-import { Input } from '@canopy/workbench/ui'
-import { Badge } from '@canopy/workbench/ui'
-import { Skeleton } from '@canopy/workbench/ui'
+import { Button } from '@marshellis/workbench/ui'
+import { Input } from '@marshellis/workbench/ui'
+import { Badge } from '@marshellis/workbench/ui'
+import { Skeleton } from '@marshellis/workbench/ui'
 import {
   Table,
   TableBody,
@@ -12,7 +12,7 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from '@canopy/workbench/ui'
+} from '@marshellis/workbench/ui'
 
 interface Skill {
   id: number

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
-import { Badge } from '@canopy/workbench/ui'
+import { Badge } from '@marshellis/workbench/ui'
 
 const SECTIONS = [
   { id: 'try-it', label: 'Try It Now' },

--- a/frontend/src/pages/NewCollectionPage.tsx
+++ b/frontend/src/pages/NewCollectionPage.tsx
@@ -1,10 +1,10 @@
 import { useState, useCallback } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { createCollection, addSource } from '@/api/collections'
-import { Button } from '@canopy/workbench/ui'
-import { Input } from '@canopy/workbench/ui'
-import { Textarea } from '@canopy/workbench/ui'
-import { Badge } from '@canopy/workbench/ui'
+import { Button } from '@marshellis/workbench/ui'
+import { Input } from '@marshellis/workbench/ui'
+import { Textarea } from '@marshellis/workbench/ui'
+import { Badge } from '@marshellis/workbench/ui'
 
 const SOURCE_TYPES = ['transcript', 'slack', 'document', 'text'] as const
 type SourceType = (typeof SOURCE_TYPES)[number]

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState, useRef, useCallback } from 'react'
 import { mintDebugSession, type MintDebugSessionResponse } from '@/api/debug'
 import { aiStatus as fetchAiStatus, aiAuthStart, aiAuthComplete, aiAuthPoll } from '@/api/ai'
-import { Button } from '@canopy/workbench/ui'
-import { Input } from '@canopy/workbench/ui'
+import { Button } from '@marshellis/workbench/ui'
+import { Input } from '@marshellis/workbench/ui'
 
 type Step = 'idle' | 'loading' | 'awaiting_code' | 'submitting' | 'complete' | 'error'
 

--- a/frontend/src/pages/SkillDetailPage.tsx
+++ b/frontend/src/pages/SkillDetailPage.tsx
@@ -2,10 +2,10 @@ import { useEffect, useState, useCallback } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { getSkill, generateAdapter } from '@/api/skills'
 import { getEvalSuite, runEval, getEvalHistory, editEvalCase, deleteEvalCase } from '@/api/evals'
-import { Button } from '@canopy/workbench/ui'
-import { Badge } from '@canopy/workbench/ui'
-import { Input } from '@canopy/workbench/ui'
-import { Skeleton } from '@canopy/workbench/ui'
+import { Button } from '@marshellis/workbench/ui'
+import { Badge } from '@marshellis/workbench/ui'
+import { Input } from '@marshellis/workbench/ui'
+import { Skeleton } from '@marshellis/workbench/ui'
 import {
   Table,
   TableBody,
@@ -13,7 +13,7 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from '@canopy/workbench/ui'
+} from '@marshellis/workbench/ui'
 
 // ---------------------------------------------------------------------------
 // Types

--- a/frontend/src/pages/TimelinePage.tsx
+++ b/frontend/src/pages/TimelinePage.tsx
@@ -9,7 +9,7 @@ import {
   EmptyState,
   ErrorState,
   LoadingSpinner,
-} from '@canopy/workbench'
+} from '@marshellis/workbench'
 import {
   listTimeline,
   type TimelineEvent,

--- a/frontend/src/pages/agents/AgentOverviewSection.tsx
+++ b/frontend/src/pages/agents/AgentOverviewSection.tsx
@@ -9,7 +9,7 @@ import {
 } from '@/api/agents'
 import type { AgentOutletContext } from '@/pages/AgentWorkspacePage'
 import { CountStat, SyncCard } from '@/components/agents/cards'
-import { WorkbenchSubHeader, WorkbenchSkeleton } from '@canopy/workbench'
+import { WorkbenchSubHeader, WorkbenchSkeleton } from '@marshellis/workbench'
 
 const TASK_COLUMNS: { status: AgentTaskStatus; label: string; dot: string }[] = [
   { status: 'suggested', label: 'Suggested', dot: 'bg-muted-foreground' },

--- a/frontend/src/pages/agents/AgentSkillsSection.tsx
+++ b/frontend/src/pages/agents/AgentSkillsSection.tsx
@@ -3,7 +3,7 @@ import { useOutletContext } from 'react-router-dom'
 import { listAgentSkills, type AgentSkillOut } from '@/api/agents'
 import type { AgentOutletContext } from '@/pages/AgentWorkspacePage'
 import { SkillCard } from '@/components/agents/cards'
-import { WorkbenchSubHeader, WorkbenchSkeleton } from '@canopy/workbench'
+import { WorkbenchSubHeader, WorkbenchSkeleton } from '@marshellis/workbench'
 
 export function AgentSkillsSection() {
   const { agent } = useOutletContext<AgentOutletContext>()

--- a/frontend/src/pages/agents/AgentSyncsSection.tsx
+++ b/frontend/src/pages/agents/AgentSyncsSection.tsx
@@ -3,7 +3,7 @@ import { useOutletContext } from 'react-router-dom'
 import { listAgentSyncs, type AgentSyncOut } from '@/api/agents'
 import type { AgentOutletContext } from '@/pages/AgentWorkspacePage'
 import { SyncCard } from '@/components/agents/cards'
-import { WorkbenchSubHeader, WorkbenchSkeleton } from '@canopy/workbench'
+import { WorkbenchSubHeader, WorkbenchSkeleton } from '@marshellis/workbench'
 
 export function AgentSyncsSection() {
   const { agent } = useOutletContext<AgentOutletContext>()

--- a/frontend/src/pages/agents/AgentTasksSection.tsx
+++ b/frontend/src/pages/agents/AgentTasksSection.tsx
@@ -3,7 +3,7 @@ import { useOutletContext } from 'react-router-dom'
 import { listAgentTasks, listAgentCommands, type AgentCommandOut, type AgentTaskOut } from '@/api/agents'
 import type { AgentOutletContext } from '@/pages/AgentWorkspacePage'
 import { TasksBoard } from '@/components/TasksBoard'
-import { WorkbenchSubHeader, WorkbenchSkeleton } from '@canopy/workbench'
+import { WorkbenchSubHeader, WorkbenchSkeleton } from '@marshellis/workbench'
 
 export function AgentTasksSection() {
   const { agent } = useOutletContext<AgentOutletContext>()

--- a/frontend/src/pages/agents/AgentWorkProductsSection.tsx
+++ b/frontend/src/pages/agents/AgentWorkProductsSection.tsx
@@ -3,7 +3,7 @@ import { useOutletContext } from 'react-router-dom'
 import { listAgentWorkProducts, type AgentWorkProductOut } from '@/api/agents'
 import type { AgentOutletContext } from '@/pages/AgentWorkspacePage'
 import { WorkProductCard } from '@/components/agents/cards'
-import { WorkbenchSubHeader, WorkbenchSkeleton } from '@canopy/workbench'
+import { WorkbenchSubHeader, WorkbenchSkeleton } from '@marshellis/workbench'
 
 export function AgentWorkProductsSection() {
   const { agent } = useOutletContext<AgentOutletContext>()

--- a/frontend/src/pages/agents/NeedsYouSection.tsx
+++ b/frontend/src/pages/agents/NeedsYouSection.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/api/agents'
 import type { AgentOutletContext } from '@/pages/AgentWorkspacePage'
 import { TaskCard } from '@/components/TasksBoard'
-import { WorkbenchSubHeader, WorkbenchSkeleton } from '@canopy/workbench'
+import { WorkbenchSubHeader, WorkbenchSkeleton } from '@marshellis/workbench'
 
 // The three bands, in rank order. Each is a distinct kind of human attention:
 // a decision to make (review), an answer Echo is blocked on (question), or an


### PR DESCRIPTION
npm @canopy is taken; publish under @marshellis. Renames the package, publish workflow scope, and all canopy-web app imports. Build green.