### PR TITLE
feat(canopy-ui): rename to @marshellis/canopy-ui + solid variants

### DIFF
--- a/.github/workflows/publish-workbench.yml
+++ b/.github/workflows/publish-workbench.yml
@@ -1,4 +1,4 @@
-name: Publish @marshellis/workbench
+name: Publish @marshellis/canopy-ui
 
 # Publishes the shared front-end workbench package to the PUBLIC npm registry
 # (npmjs.com) under the @marshellis scope. GitHub Packages can't host @marshellis from a

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,7 +14,7 @@
         "@ai-sdk/react": "^3.0.143",
         "@base-ui/react": "^1.3.0",
         "@fontsource-variable/geist": "^5.2.8",
-        "@marshellis/workbench": "*",
+        "@marshellis/canopy-ui": "*",
         "ai": "^6.0.141",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -1181,7 +1181,7 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@marshellis/workbench": {
+    "node_modules/@marshellis/canopy-ui": {
       "resolved": "packages/workbench",
       "link": true
     },
@@ -9348,7 +9348,7 @@
       }
     },
     "packages/workbench": {
-      "name": "@marshellis/workbench",
+      "name": "@marshellis/canopy-ui",
       "version": "0.2.0",
       "peerDependencies": {
         "@base-ui/react": "^1.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@ai-sdk/react": "^3.0.143",
     "@base-ui/react": "^1.3.0",
-    "@marshellis/workbench": "*",
+    "@marshellis/canopy-ui": "*",
     "@fontsource-variable/geist": "^5.2.8",
     "ai": "^6.0.141",
     "class-variance-authority": "^0.7.1",

--- a/frontend/packages/workbench/package.json
+++ b/frontend/packages/workbench/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@marshellis/workbench",
+  "name": "@marshellis/canopy-ui",
   "version": "0.2.0",
   "type": "module",
   "exports": {

--- a/frontend/packages/workbench/src/index.ts
+++ b/frontend/packages/workbench/src/index.ts
@@ -1,5 +1,5 @@
-// The full @marshellis/workbench surface, re-exported from the subpath modules.
-// Prefer the subpath imports (@marshellis/workbench/ui, /shell, /lib) in app code;
+// The full @marshellis/canopy-ui surface, re-exported from the subpath modules.
+// Prefer the subpath imports (@marshellis/canopy-ui/ui, /shell, /lib) in app code;
 // this barrel keeps the convenience top-level entry working.
 export * from './lib'
 export * from './shell'

--- a/frontend/packages/workbench/src/tokens/index.ts
+++ b/frontend/packages/workbench/src/tokens/index.ts
@@ -1,9 +1,9 @@
 /**
- * @marshellis/workbench/tokens — the shared token contract.
+ * @marshellis/canopy-ui/tokens — the shared token contract.
  *
  * The substance of the token system is CSS, imported directly:
- *   import "@marshellis/workbench/tokens/preset.css"   // Tailwind v4 @theme name → var mapping
- *   import "@marshellis/workbench/tokens/tokens.css"    // default :root / .dark VALUES
+ *   import "@marshellis/canopy-ui/tokens/preset.css"   // Tailwind v4 @theme name → var mapping
+ *   import "@marshellis/canopy-ui/tokens/tokens.css"    // default :root / .dark VALUES
  *
  * This module exposes the canonical list of token names so tooling/tests can
  * assert an app's palette covers the contract.

--- a/frontend/packages/workbench/src/tokens/preset.css
+++ b/frontend/packages/workbench/src/tokens/preset.css
@@ -1,5 +1,5 @@
 /**
- * @marshellis/workbench — Tailwind v4 token PRESET.
+ * @marshellis/canopy-ui — Tailwind v4 token PRESET.
  *
  * This is the shared CONTRACT: it maps Tailwind color/radius utilities
  * (`bg-primary`, `text-muted-foreground`, `border-border`, `rounded-lg`, …)
@@ -11,8 +11,8 @@
  * default values, which an app may import then override).
  *
  * Usage (in an app's index.css, after `@import "tailwindcss";`):
- *   @import "@marshellis/workbench/tokens/preset.css";
- *   @import "@marshellis/workbench/tokens/tokens.css";   // optional defaults
+ *   @import "@marshellis/canopy-ui/tokens/preset.css";
+ *   @import "@marshellis/canopy-ui/tokens/tokens.css";   // optional defaults
  *   :root { --primary: <app palette>; ... }           // override values
  */
 @theme inline {

--- a/frontend/packages/workbench/src/tokens/tokens.css
+++ b/frontend/packages/workbench/src/tokens/tokens.css
@@ -1,5 +1,5 @@
 /**
- * @marshellis/workbench — DEFAULT token VALUES (the palette baseline).
+ * @marshellis/canopy-ui — DEFAULT token VALUES (the palette baseline).
  *
  * These are the default values for the CSS-variable names declared by the
  * preset (preset.css). They are a complete, working "Warm Earth" palette so a

--- a/frontend/packages/workbench/src/ui/badge.tsx
+++ b/frontend/packages/workbench/src/ui/badge.tsx
@@ -9,17 +9,16 @@ const badgeVariants = cva(
   {
     variants: {
       variant: {
-        default:
-          "bg-primary/10 border border-primary/30 text-primary [a]:hover:bg-primary/20",
+        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
         secondary:
-          "bg-muted border border-input text-foreground-secondary [a]:hover:bg-input",
+          "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
         destructive:
-          "bg-destructive/10 border border-destructive/30 text-destructive [a]:hover:bg-destructive/20",
+          "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
         outline:
-          "border border-input text-foreground-secondary [a]:hover:bg-muted [a]:hover:text-foreground",
+          "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
         ghost:
-          "text-foreground-secondary hover:bg-muted hover:text-foreground-secondary",
-        link: "text-primary underline-offset-4 hover:text-primary hover:underline",
+          "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
+        link: "text-primary underline-offset-4 hover:underline",
       },
     },
     defaultVariants: {

--- a/frontend/packages/workbench/src/ui/button.tsx
+++ b/frontend/packages/workbench/src/ui/button.tsx
@@ -8,17 +8,16 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default:
-          "bg-primary/10 border border-primary/30 text-primary hover:bg-primary/20 hover:border-primary/40 aria-expanded:bg-primary/20",
+        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
         outline:
-          "border-input bg-card text-foreground-secondary hover:bg-muted hover:border-input hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground",
+          "border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
         secondary:
-          "bg-card border border-input text-foreground-secondary hover:bg-muted hover:border-input aria-expanded:bg-muted aria-expanded:text-foreground",
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
         ghost:
-          "text-foreground-secondary hover:bg-card hover:text-foreground aria-expanded:bg-card aria-expanded:text-foreground",
+          "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
         destructive:
-          "bg-destructive/10 border border-destructive/30 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20",
-        link: "text-primary underline-offset-4 hover:text-primary hover:underline",
+          "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
+        link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
         default:

--- a/frontend/packages/workbench/src/ui/input.tsx
+++ b/frontend/packages/workbench/src/ui/input.tsx
@@ -9,7 +9,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "h-8 w-full min-w-0 rounded-lg border border-input bg-background px-2.5 py-1 text-sm text-foreground-secondary transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground-secondary placeholder:text-muted-foreground focus-visible:border-primary/50 focus-visible:ring-2 focus-visible:ring-primary/20 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-card disabled:opacity-60 aria-invalid:border-destructive/50 aria-invalid:ring-2 aria-invalid:ring-destructive/20",
+        "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
         className
       )}
       {...props}

--- a/frontend/packages/workbench/src/ui/skeleton.tsx
+++ b/frontend/packages/workbench/src/ui/skeleton.tsx
@@ -6,7 +6,7 @@ function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="skeleton"
-      className={cn("animate-pulse rounded-md bg-muted/60", className)}
+      className={cn("animate-pulse rounded-md bg-muted", className)}
       {...props}
     />
   )

--- a/frontend/packages/workbench/src/ui/textarea.tsx
+++ b/frontend/packages/workbench/src/ui/textarea.tsx
@@ -7,7 +7,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
     <textarea
       data-slot="textarea"
       className={cn(
-        "flex field-sizing-content min-h-16 w-full rounded-lg border border-input bg-background px-2.5 py-2 text-sm text-foreground-secondary transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-primary/50 focus-visible:ring-2 focus-visible:ring-primary/20 disabled:cursor-not-allowed disabled:bg-card disabled:opacity-60 aria-invalid:border-destructive/50 aria-invalid:ring-2 aria-invalid:ring-destructive/20",
+        "flex field-sizing-content min-h-16 w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-base transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
         className
       )}
       {...props}

--- a/frontend/src/components/Workspace/SourcePanel.tsx
+++ b/frontend/src/components/Workspace/SourcePanel.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { cn } from '@/lib/utils'
-import { Badge } from '@marshellis/workbench/ui'
+import { Badge } from '@marshellis/canopy-ui/ui'
 
 interface Source {
   id?: number

--- a/frontend/src/components/agents/AgentLeftNav.tsx
+++ b/frontend/src/components/agents/AgentLeftNav.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { Link, NavLink } from 'react-router-dom'
-import { WorkbenchRail, WorkbenchNavItem } from '@marshellis/workbench'
+import { WorkbenchRail, WorkbenchNavItem } from '@marshellis/canopy-ui'
 import { getNeedsYou, type AgentDetailOut } from '@/api/agents'
 
 type NavItem = { to: string; label: string; count?: number }

--- a/frontend/src/components/ddd/DddLeftNav.tsx
+++ b/frontend/src/components/ddd/DddLeftNav.tsx
@@ -8,7 +8,7 @@ import {
   type DddNarrativeListItem,
 } from '@/api/ddd'
 import { listReviews, type ReviewListItem } from '@/api/reviews'
-import { WorkbenchRail, WorkbenchNavItem } from '@marshellis/workbench'
+import { WorkbenchRail, WorkbenchNavItem } from '@marshellis/canopy-ui'
 import { useRunSectionNav } from './runSectionNav'
 
 /**

--- a/frontend/src/components/ddd/DddShell.tsx
+++ b/frontend/src/components/ddd/DddShell.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react'
-import { WorkbenchShell, WorkbenchMain } from '@marshellis/workbench'
+import { WorkbenchShell, WorkbenchMain } from '@marshellis/canopy-ui'
 import { DddLeftNav } from './DddLeftNav'
 import { RunSectionNavProvider } from './runSectionNav'
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,13 +3,13 @@
 @import "shadcn/tailwind.css";
 @import "@fontsource-variable/geist";
 
-/* Shared @marshellis/workbench token CONTRACT: maps Tailwind color/radius utilities
+/* Shared @marshellis/canopy-ui token CONTRACT: maps Tailwind color/radius utilities
    (bg-primary, text-muted-foreground, border-border, rounded-lg, …) onto the
    canonical CSS-var NAMES (--primary, --muted-foreground, --border, --radius, …).
    The preset owns the NAMES; this app owns the VALUES — the :root / .dark
    palette below. ace-web imports this same preset with its own palette. Keep in
    lockstep with packages/workbench/src/tokens/preset.css. */
-@import "@marshellis/workbench/tokens/preset.css";
+@import "@marshellis/canopy-ui/tokens/preset.css";
 
 @source "../packages/workbench/src";
 

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,3 +1,3 @@
 // Canonical `cn` now lives in the shared package; re-export so existing
 // `@/lib/utils` imports keep resolving to the one implementation.
-export { cn } from "@marshellis/workbench/lib"
+export { cn } from "@marshellis/canopy-ui/lib"

--- a/frontend/src/pages/AgentWorkspacePage.tsx
+++ b/frontend/src/pages/AgentWorkspacePage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { Link, Outlet, useParams } from 'react-router-dom'
 import { getAgent, type AgentDetailOut } from '@/api/agents'
 import { AgentLeftNav } from '@/components/agents/AgentLeftNav'
-import { WorkbenchShell, WorkbenchMain } from '@marshellis/workbench'
+import { WorkbenchShell, WorkbenchMain } from '@marshellis/canopy-ui'
 
 /** Context the section sub-routes read via useOutletContext. */
 export interface AgentOutletContext {

--- a/frontend/src/pages/DiscoveryPage.tsx
+++ b/frontend/src/pages/DiscoveryPage.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useState, useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { listSkills } from '@/api/skills'
-import { Button } from '@marshellis/workbench/ui'
-import { Input } from '@marshellis/workbench/ui'
-import { Badge } from '@marshellis/workbench/ui'
-import { Skeleton } from '@marshellis/workbench/ui'
+import { Button } from '@marshellis/canopy-ui/ui'
+import { Input } from '@marshellis/canopy-ui/ui'
+import { Badge } from '@marshellis/canopy-ui/ui'
+import { Skeleton } from '@marshellis/canopy-ui/ui'
 import {
   Table,
   TableBody,
@@ -12,7 +12,7 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from '@marshellis/workbench/ui'
+} from '@marshellis/canopy-ui/ui'
 
 interface Skill {
   id: number

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
-import { Badge } from '@marshellis/workbench/ui'
+import { Badge } from '@marshellis/canopy-ui/ui'
 
 const SECTIONS = [
   { id: 'try-it', label: 'Try It Now' },

--- a/frontend/src/pages/NewCollectionPage.tsx
+++ b/frontend/src/pages/NewCollectionPage.tsx
@@ -1,10 +1,10 @@
 import { useState, useCallback } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { createCollection, addSource } from '@/api/collections'
-import { Button } from '@marshellis/workbench/ui'
-import { Input } from '@marshellis/workbench/ui'
-import { Textarea } from '@marshellis/workbench/ui'
-import { Badge } from '@marshellis/workbench/ui'
+import { Button } from '@marshellis/canopy-ui/ui'
+import { Input } from '@marshellis/canopy-ui/ui'
+import { Textarea } from '@marshellis/canopy-ui/ui'
+import { Badge } from '@marshellis/canopy-ui/ui'
 
 const SOURCE_TYPES = ['transcript', 'slack', 'document', 'text'] as const
 type SourceType = (typeof SOURCE_TYPES)[number]

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState, useRef, useCallback } from 'react'
 import { mintDebugSession, type MintDebugSessionResponse } from '@/api/debug'
 import { aiStatus as fetchAiStatus, aiAuthStart, aiAuthComplete, aiAuthPoll } from '@/api/ai'
-import { Button } from '@marshellis/workbench/ui'
-import { Input } from '@marshellis/workbench/ui'
+import { Button } from '@marshellis/canopy-ui/ui'
+import { Input } from '@marshellis/canopy-ui/ui'
 
 type Step = 'idle' | 'loading' | 'awaiting_code' | 'submitting' | 'complete' | 'error'
 

--- a/frontend/src/pages/SkillDetailPage.tsx
+++ b/frontend/src/pages/SkillDetailPage.tsx
@@ -2,10 +2,10 @@ import { useEffect, useState, useCallback } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { getSkill, generateAdapter } from '@/api/skills'
 import { getEvalSuite, runEval, getEvalHistory, editEvalCase, deleteEvalCase } from '@/api/evals'
-import { Button } from '@marshellis/workbench/ui'
-import { Badge } from '@marshellis/workbench/ui'
-import { Input } from '@marshellis/workbench/ui'
-import { Skeleton } from '@marshellis/workbench/ui'
+import { Button } from '@marshellis/canopy-ui/ui'
+import { Badge } from '@marshellis/canopy-ui/ui'
+import { Input } from '@marshellis/canopy-ui/ui'
+import { Skeleton } from '@marshellis/canopy-ui/ui'
 import {
   Table,
   TableBody,
@@ -13,7 +13,7 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from '@marshellis/workbench/ui'
+} from '@marshellis/canopy-ui/ui'
 
 // ---------------------------------------------------------------------------
 // Types

--- a/frontend/src/pages/TimelinePage.tsx
+++ b/frontend/src/pages/TimelinePage.tsx
@@ -9,7 +9,7 @@ import {
   EmptyState,
   ErrorState,
   LoadingSpinner,
-} from '@marshellis/workbench'
+} from '@marshellis/canopy-ui'
 import {
   listTimeline,
   type TimelineEvent,

--- a/frontend/src/pages/agents/AgentOverviewSection.tsx
+++ b/frontend/src/pages/agents/AgentOverviewSection.tsx
@@ -9,7 +9,7 @@ import {
 } from '@/api/agents'
 import type { AgentOutletContext } from '@/pages/AgentWorkspacePage'
 import { CountStat, SyncCard } from '@/components/agents/cards'
-import { WorkbenchSubHeader, WorkbenchSkeleton } from '@marshellis/workbench'
+import { WorkbenchSubHeader, WorkbenchSkeleton } from '@marshellis/canopy-ui'
 
 const TASK_COLUMNS: { status: AgentTaskStatus; label: string; dot: string }[] = [
   { status: 'suggested', label: 'Suggested', dot: 'bg-muted-foreground' },

--- a/frontend/src/pages/agents/AgentSkillsSection.tsx
+++ b/frontend/src/pages/agents/AgentSkillsSection.tsx
@@ -3,7 +3,7 @@ import { useOutletContext } from 'react-router-dom'
 import { listAgentSkills, type AgentSkillOut } from '@/api/agents'
 import type { AgentOutletContext } from '@/pages/AgentWorkspacePage'
 import { SkillCard } from '@/components/agents/cards'
-import { WorkbenchSubHeader, WorkbenchSkeleton } from '@marshellis/workbench'
+import { WorkbenchSubHeader, WorkbenchSkeleton } from '@marshellis/canopy-ui'
 
 export function AgentSkillsSection() {
   const { agent } = useOutletContext<AgentOutletContext>()

--- a/frontend/src/pages/agents/AgentSyncsSection.tsx
+++ b/frontend/src/pages/agents/AgentSyncsSection.tsx
@@ -3,7 +3,7 @@ import { useOutletContext } from 'react-router-dom'
 import { listAgentSyncs, type AgentSyncOut } from '@/api/agents'
 import type { AgentOutletContext } from '@/pages/AgentWorkspacePage'
 import { SyncCard } from '@/components/agents/cards'
-import { WorkbenchSubHeader, WorkbenchSkeleton } from '@marshellis/workbench'
+import { WorkbenchSubHeader, WorkbenchSkeleton } from '@marshellis/canopy-ui'
 
 export function AgentSyncsSection() {
   const { agent } = useOutletContext<AgentOutletContext>()

--- a/frontend/src/pages/agents/AgentTasksSection.tsx
+++ b/frontend/src/pages/agents/AgentTasksSection.tsx
@@ -3,7 +3,7 @@ import { useOutletContext } from 'react-router-dom'
 import { listAgentTasks, listAgentCommands, type AgentCommandOut, type AgentTaskOut } from '@/api/agents'
 import type { AgentOutletContext } from '@/pages/AgentWorkspacePage'
 import { TasksBoard } from '@/components/TasksBoard'
-import { WorkbenchSubHeader, WorkbenchSkeleton } from '@marshellis/workbench'
+import { WorkbenchSubHeader, WorkbenchSkeleton } from '@marshellis/canopy-ui'
 
 export function AgentTasksSection() {
   const { agent } = useOutletContext<AgentOutletContext>()

--- a/frontend/src/pages/agents/AgentWorkProductsSection.tsx
+++ b/frontend/src/pages/agents/AgentWorkProductsSection.tsx
@@ -3,7 +3,7 @@ import { useOutletContext } from 'react-router-dom'
 import { listAgentWorkProducts, type AgentWorkProductOut } from '@/api/agents'
 import type { AgentOutletContext } from '@/pages/AgentWorkspacePage'
 import { WorkProductCard } from '@/components/agents/cards'
-import { WorkbenchSubHeader, WorkbenchSkeleton } from '@marshellis/workbench'
+import { WorkbenchSubHeader, WorkbenchSkeleton } from '@marshellis/canopy-ui'
 
 export function AgentWorkProductsSection() {
   const { agent } = useOutletContext<AgentOutletContext>()

--- a/frontend/src/pages/agents/NeedsYouSection.tsx
+++ b/frontend/src/pages/agents/NeedsYouSection.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/api/agents'
 import type { AgentOutletContext } from '@/pages/AgentWorkspacePage'
 import { TaskCard } from '@/components/TasksBoard'
-import { WorkbenchSubHeader, WorkbenchSkeleton } from '@marshellis/workbench'
+import { WorkbenchSubHeader, WorkbenchSkeleton } from '@marshellis/canopy-ui'
 
 // The three bands, in rank order. Each is a distinct kind of human attention:
 // a decision to make (review), an answer Echo is blocked on (question), or an


### PR DESCRIPTION
Final scope/name: **`@marshellis/canopy-ui`** (npm `@canopy` taken). Also adopts the **solid** default Button/Badge (ace's conventional variant) as canonical instead of the AI-generated tint — both apps converge on the cleaner look. Build green; 45 unit tests pass (lone failing suite is the pre-existing vitest/Playwright baseline). Dir/tag keep the `workbench` label (cosmetic; npm uses the package name).