### PR TITLE
chore(canopy-ui): publish unscoped as canopy-ui

### DIFF
--- a/.github/workflows/publish-workbench.yml
+++ b/.github/workflows/publish-workbench.yml
@@ -1,15 +1,14 @@
-name: Publish @marshellis/canopy-ui
+name: Publish canopy-ui
 
-# Publishes the shared front-end workbench package to the PUBLIC npm registry
-# (npmjs.com) under the @marshellis scope. GitHub Packages can't host @marshellis from a
-# personal repo (its npm scope must equal the repo owner), so we use npmjs.
+# Publishes the shared front-end design system to the PUBLIC npm registry as the
+# UNSCOPED package `canopy-ui` (no org scope — portable, not tied to any account).
 #
 # Trigger by pushing a tag like `workbench-v0.2.0`, or manually via the Actions
 # tab (workflow_dispatch). Bump the version in
 # frontend/packages/workbench/package.json to match the tag before tagging.
 #
-# Requires repo secret NPM_TOKEN — an npm "Automation" token for an account that
-# can publish to the @marshellis org (claim @marshellis on npmjs first).
+# Requires repo secret NPM_TOKEN — an npm "Automation" token for an account with
+# publish rights to `canopy-ui`. (Or use OIDC Trusted Publishing instead.)
 on:
   push:
     tags: ['workbench-v*']
@@ -25,7 +24,6 @@ jobs:
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
-          scope: '@marshellis'
       - name: Publish
         run: npm publish --access public
         working-directory: frontend/packages/workbench

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,8 +14,8 @@
         "@ai-sdk/react": "^3.0.143",
         "@base-ui/react": "^1.3.0",
         "@fontsource-variable/geist": "^5.2.8",
-        "@marshellis/canopy-ui": "*",
         "ai": "^6.0.141",
+        "canopy-ui": "*",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "framer-motion": "^12.38.0",
@@ -1180,10 +1180,6 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
-    },
-    "node_modules/@marshellis/canopy-ui": {
-      "resolved": "packages/workbench",
-      "link": true
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.28.0",
@@ -3090,6 +3086,10 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canopy-ui": {
+      "resolved": "packages/workbench",
+      "link": true
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -9348,7 +9348,7 @@
       }
     },
     "packages/workbench": {
-      "name": "@marshellis/canopy-ui",
+      "name": "canopy-ui",
       "version": "0.2.0",
       "peerDependencies": {
         "@base-ui/react": "^1.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@ai-sdk/react": "^3.0.143",
     "@base-ui/react": "^1.3.0",
-    "@marshellis/canopy-ui": "*",
+    "canopy-ui": "*",
     "@fontsource-variable/geist": "^5.2.8",
     "ai": "^6.0.141",
     "class-variance-authority": "^0.7.1",

--- a/frontend/packages/workbench/package.json
+++ b/frontend/packages/workbench/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@marshellis/canopy-ui",
+  "name": "canopy-ui",
   "version": "0.2.0",
   "type": "module",
   "exports": {

--- a/frontend/packages/workbench/src/index.ts
+++ b/frontend/packages/workbench/src/index.ts
@@ -1,5 +1,5 @@
-// The full @marshellis/canopy-ui surface, re-exported from the subpath modules.
-// Prefer the subpath imports (@marshellis/canopy-ui/ui, /shell, /lib) in app code;
+// The full canopy-ui surface, re-exported from the subpath modules.
+// Prefer the subpath imports (canopy-ui/ui, /shell, /lib) in app code;
 // this barrel keeps the convenience top-level entry working.
 export * from './lib'
 export * from './shell'

--- a/frontend/packages/workbench/src/tokens/index.ts
+++ b/frontend/packages/workbench/src/tokens/index.ts
@@ -1,9 +1,9 @@
 /**
- * @marshellis/canopy-ui/tokens — the shared token contract.
+ * canopy-ui/tokens — the shared token contract.
  *
  * The substance of the token system is CSS, imported directly:
- *   import "@marshellis/canopy-ui/tokens/preset.css"   // Tailwind v4 @theme name → var mapping
- *   import "@marshellis/canopy-ui/tokens/tokens.css"    // default :root / .dark VALUES
+ *   import "canopy-ui/tokens/preset.css"   // Tailwind v4 @theme name → var mapping
+ *   import "canopy-ui/tokens/tokens.css"    // default :root / .dark VALUES
  *
  * This module exposes the canonical list of token names so tooling/tests can
  * assert an app's palette covers the contract.

--- a/frontend/packages/workbench/src/tokens/preset.css
+++ b/frontend/packages/workbench/src/tokens/preset.css
@@ -1,5 +1,5 @@
 /**
- * @marshellis/canopy-ui — Tailwind v4 token PRESET.
+ * canopy-ui — Tailwind v4 token PRESET.
  *
  * This is the shared CONTRACT: it maps Tailwind color/radius utilities
  * (`bg-primary`, `text-muted-foreground`, `border-border`, `rounded-lg`, …)
@@ -11,8 +11,8 @@
  * default values, which an app may import then override).
  *
  * Usage (in an app's index.css, after `@import "tailwindcss";`):
- *   @import "@marshellis/canopy-ui/tokens/preset.css";
- *   @import "@marshellis/canopy-ui/tokens/tokens.css";   // optional defaults
+ *   @import "canopy-ui/tokens/preset.css";
+ *   @import "canopy-ui/tokens/tokens.css";   // optional defaults
  *   :root { --primary: <app palette>; ... }           // override values
  */
 @theme inline {

--- a/frontend/packages/workbench/src/tokens/tokens.css
+++ b/frontend/packages/workbench/src/tokens/tokens.css
@@ -1,5 +1,5 @@
 /**
- * @marshellis/canopy-ui — DEFAULT token VALUES (the palette baseline).
+ * canopy-ui — DEFAULT token VALUES (the palette baseline).
  *
  * These are the default values for the CSS-variable names declared by the
  * preset (preset.css). They are a complete, working "Warm Earth" palette so a

--- a/frontend/src/components/Workspace/SourcePanel.tsx
+++ b/frontend/src/components/Workspace/SourcePanel.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { cn } from '@/lib/utils'
-import { Badge } from '@marshellis/canopy-ui/ui'
+import { Badge } from 'canopy-ui/ui'
 
 interface Source {
   id?: number

--- a/frontend/src/components/agents/AgentLeftNav.tsx
+++ b/frontend/src/components/agents/AgentLeftNav.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { Link, NavLink } from 'react-router-dom'
-import { WorkbenchRail, WorkbenchNavItem } from '@marshellis/canopy-ui'
+import { WorkbenchRail, WorkbenchNavItem } from 'canopy-ui'
 import { getNeedsYou, type AgentDetailOut } from '@/api/agents'
 
 type NavItem = { to: string; label: string; count?: number }

--- a/frontend/src/components/ddd/DddLeftNav.tsx
+++ b/frontend/src/components/ddd/DddLeftNav.tsx
@@ -8,7 +8,7 @@ import {
   type DddNarrativeListItem,
 } from '@/api/ddd'
 import { listReviews, type ReviewListItem } from '@/api/reviews'
-import { WorkbenchRail, WorkbenchNavItem } from '@marshellis/canopy-ui'
+import { WorkbenchRail, WorkbenchNavItem } from 'canopy-ui'
 import { useRunSectionNav } from './runSectionNav'
 
 /**

--- a/frontend/src/components/ddd/DddShell.tsx
+++ b/frontend/src/components/ddd/DddShell.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react'
-import { WorkbenchShell, WorkbenchMain } from '@marshellis/canopy-ui'
+import { WorkbenchShell, WorkbenchMain } from 'canopy-ui'
 import { DddLeftNav } from './DddLeftNav'
 import { RunSectionNavProvider } from './runSectionNav'
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,13 +3,13 @@
 @import "shadcn/tailwind.css";
 @import "@fontsource-variable/geist";
 
-/* Shared @marshellis/canopy-ui token CONTRACT: maps Tailwind color/radius utilities
+/* Shared canopy-ui token CONTRACT: maps Tailwind color/radius utilities
    (bg-primary, text-muted-foreground, border-border, rounded-lg, …) onto the
    canonical CSS-var NAMES (--primary, --muted-foreground, --border, --radius, …).
    The preset owns the NAMES; this app owns the VALUES — the :root / .dark
    palette below. ace-web imports this same preset with its own palette. Keep in
    lockstep with packages/workbench/src/tokens/preset.css. */
-@import "@marshellis/canopy-ui/tokens/preset.css";
+@import "canopy-ui/tokens/preset.css";
 
 @source "../packages/workbench/src";
 

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,3 +1,3 @@
 // Canonical `cn` now lives in the shared package; re-export so existing
 // `@/lib/utils` imports keep resolving to the one implementation.
-export { cn } from "@marshellis/canopy-ui/lib"
+export { cn } from "canopy-ui/lib"

--- a/frontend/src/pages/AgentWorkspacePage.tsx
+++ b/frontend/src/pages/AgentWorkspacePage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { Link, Outlet, useParams } from 'react-router-dom'
 import { getAgent, type AgentDetailOut } from '@/api/agents'
 import { AgentLeftNav } from '@/components/agents/AgentLeftNav'
-import { WorkbenchShell, WorkbenchMain } from '@marshellis/canopy-ui'
+import { WorkbenchShell, WorkbenchMain } from 'canopy-ui'
 
 /** Context the section sub-routes read via useOutletContext. */
 export interface AgentOutletContext {

--- a/frontend/src/pages/DiscoveryPage.tsx
+++ b/frontend/src/pages/DiscoveryPage.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useState, useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { listSkills } from '@/api/skills'
-import { Button } from '@marshellis/canopy-ui/ui'
-import { Input } from '@marshellis/canopy-ui/ui'
-import { Badge } from '@marshellis/canopy-ui/ui'
-import { Skeleton } from '@marshellis/canopy-ui/ui'
+import { Button } from 'canopy-ui/ui'
+import { Input } from 'canopy-ui/ui'
+import { Badge } from 'canopy-ui/ui'
+import { Skeleton } from 'canopy-ui/ui'
 import {
   Table,
   TableBody,
@@ -12,7 +12,7 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from '@marshellis/canopy-ui/ui'
+} from 'canopy-ui/ui'
 
 interface Skill {
   id: number

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
-import { Badge } from '@marshellis/canopy-ui/ui'
+import { Badge } from 'canopy-ui/ui'
 
 const SECTIONS = [
   { id: 'try-it', label: 'Try It Now' },

--- a/frontend/src/pages/NewCollectionPage.tsx
+++ b/frontend/src/pages/NewCollectionPage.tsx
@@ -1,10 +1,10 @@
 import { useState, useCallback } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { createCollection, addSource } from '@/api/collections'
-import { Button } from '@marshellis/canopy-ui/ui'
-import { Input } from '@marshellis/canopy-ui/ui'
-import { Textarea } from '@marshellis/canopy-ui/ui'
-import { Badge } from '@marshellis/canopy-ui/ui'
+import { Button } from 'canopy-ui/ui'
+import { Input } from 'canopy-ui/ui'
+import { Textarea } from 'canopy-ui/ui'
+import { Badge } from 'canopy-ui/ui'
 
 const SOURCE_TYPES = ['transcript', 'slack', 'document', 'text'] as const
 type SourceType = (typeof SOURCE_TYPES)[number]

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState, useRef, useCallback } from 'react'
 import { mintDebugSession, type MintDebugSessionResponse } from '@/api/debug'
 import { aiStatus as fetchAiStatus, aiAuthStart, aiAuthComplete, aiAuthPoll } from '@/api/ai'
-import { Button } from '@marshellis/canopy-ui/ui'
-import { Input } from '@marshellis/canopy-ui/ui'
+import { Button } from 'canopy-ui/ui'
+import { Input } from 'canopy-ui/ui'
 
 type Step = 'idle' | 'loading' | 'awaiting_code' | 'submitting' | 'complete' | 'error'
 

--- a/frontend/src/pages/SkillDetailPage.tsx
+++ b/frontend/src/pages/SkillDetailPage.tsx
@@ -2,10 +2,10 @@ import { useEffect, useState, useCallback } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { getSkill, generateAdapter } from '@/api/skills'
 import { getEvalSuite, runEval, getEvalHistory, editEvalCase, deleteEvalCase } from '@/api/evals'
-import { Button } from '@marshellis/canopy-ui/ui'
-import { Badge } from '@marshellis/canopy-ui/ui'
-import { Input } from '@marshellis/canopy-ui/ui'
-import { Skeleton } from '@marshellis/canopy-ui/ui'
+import { Button } from 'canopy-ui/ui'
+import { Badge } from 'canopy-ui/ui'
+import { Input } from 'canopy-ui/ui'
+import { Skeleton } from 'canopy-ui/ui'
 import {
   Table,
   TableBody,
@@ -13,7 +13,7 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from '@marshellis/canopy-ui/ui'
+} from 'canopy-ui/ui'
 
 // ---------------------------------------------------------------------------
 // Types

--- a/frontend/src/pages/TimelinePage.tsx
+++ b/frontend/src/pages/TimelinePage.tsx
@@ -9,7 +9,7 @@ import {
   EmptyState,
   ErrorState,
   LoadingSpinner,
-} from '@marshellis/canopy-ui'
+} from 'canopy-ui'
 import {
   listTimeline,
   type TimelineEvent,

--- a/frontend/src/pages/agents/AgentOverviewSection.tsx
+++ b/frontend/src/pages/agents/AgentOverviewSection.tsx
@@ -9,7 +9,7 @@ import {
 } from '@/api/agents'
 import type { AgentOutletContext } from '@/pages/AgentWorkspacePage'
 import { CountStat, SyncCard } from '@/components/agents/cards'
-import { WorkbenchSubHeader, WorkbenchSkeleton } from '@marshellis/canopy-ui'
+import { WorkbenchSubHeader, WorkbenchSkeleton } from 'canopy-ui'
 
 const TASK_COLUMNS: { status: AgentTaskStatus; label: string; dot: string }[] = [
   { status: 'suggested', label: 'Suggested', dot: 'bg-muted-foreground' },

--- a/frontend/src/pages/agents/AgentSkillsSection.tsx
+++ b/frontend/src/pages/agents/AgentSkillsSection.tsx
@@ -3,7 +3,7 @@ import { useOutletContext } from 'react-router-dom'
 import { listAgentSkills, type AgentSkillOut } from '@/api/agents'
 import type { AgentOutletContext } from '@/pages/AgentWorkspacePage'
 import { SkillCard } from '@/components/agents/cards'
-import { WorkbenchSubHeader, WorkbenchSkeleton } from '@marshellis/canopy-ui'
+import { WorkbenchSubHeader, WorkbenchSkeleton } from 'canopy-ui'
 
 export function AgentSkillsSection() {
   const { agent } = useOutletContext<AgentOutletContext>()

--- a/frontend/src/pages/agents/AgentSyncsSection.tsx
+++ b/frontend/src/pages/agents/AgentSyncsSection.tsx
@@ -3,7 +3,7 @@ import { useOutletContext } from 'react-router-dom'
 import { listAgentSyncs, type AgentSyncOut } from '@/api/agents'
 import type { AgentOutletContext } from '@/pages/AgentWorkspacePage'
 import { SyncCard } from '@/components/agents/cards'
-import { WorkbenchSubHeader, WorkbenchSkeleton } from '@marshellis/canopy-ui'
+import { WorkbenchSubHeader, WorkbenchSkeleton } from 'canopy-ui'
 
 export function AgentSyncsSection() {
   const { agent } = useOutletContext<AgentOutletContext>()

--- a/frontend/src/pages/agents/AgentTasksSection.tsx
+++ b/frontend/src/pages/agents/AgentTasksSection.tsx
@@ -3,7 +3,7 @@ import { useOutletContext } from 'react-router-dom'
 import { listAgentTasks, listAgentCommands, type AgentCommandOut, type AgentTaskOut } from '@/api/agents'
 import type { AgentOutletContext } from '@/pages/AgentWorkspacePage'
 import { TasksBoard } from '@/components/TasksBoard'
-import { WorkbenchSubHeader, WorkbenchSkeleton } from '@marshellis/canopy-ui'
+import { WorkbenchSubHeader, WorkbenchSkeleton } from 'canopy-ui'
 
 export function AgentTasksSection() {
   const { agent } = useOutletContext<AgentOutletContext>()

--- a/frontend/src/pages/agents/AgentWorkProductsSection.tsx
+++ b/frontend/src/pages/agents/AgentWorkProductsSection.tsx
@@ -3,7 +3,7 @@ import { useOutletContext } from 'react-router-dom'
 import { listAgentWorkProducts, type AgentWorkProductOut } from '@/api/agents'
 import type { AgentOutletContext } from '@/pages/AgentWorkspacePage'
 import { WorkProductCard } from '@/components/agents/cards'
-import { WorkbenchSubHeader, WorkbenchSkeleton } from '@marshellis/canopy-ui'
+import { WorkbenchSubHeader, WorkbenchSkeleton } from 'canopy-ui'
 
 export function AgentWorkProductsSection() {
   const { agent } = useOutletContext<AgentOutletContext>()

--- a/frontend/src/pages/agents/NeedsYouSection.tsx
+++ b/frontend/src/pages/agents/NeedsYouSection.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/api/agents'
 import type { AgentOutletContext } from '@/pages/AgentWorkspacePage'
 import { TaskCard } from '@/components/TasksBoard'
-import { WorkbenchSubHeader, WorkbenchSkeleton } from '@marshellis/canopy-ui'
+import { WorkbenchSubHeader, WorkbenchSkeleton } from 'canopy-ui'
 
 // The three bands, in rank order. Each is a distinct kind of human attention:
 // a decision to make (review), an answer Echo is blocked on (question), or an


### PR DESCRIPTION
Drops the placeholder `@marshellis` scope — the shared design system publishes as the **unscoped `canopy-ui`** (name is available on npm). Every import is now just `canopy-ui/ui` etc., not tied to any org, so it can move freely later. Build green; lockfile churn is the 6 workspace-name lines only.