### PR TITLE
fix(canopy-ui): add repository field for npm provenance

### DIFF
--- a/frontend/packages/canopy-ui/package.json
+++ b/frontend/packages/canopy-ui/package.json
@@ -2,6 +2,11 @@
   "name": "canopy-ui",
   "version": "0.3.0",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jjackson/canopy-web.git",
+    "directory": "frontend/packages/canopy-ui"
+  },
   "exports": {
     ".": "./src/index.ts",
     "./lib": "./src/lib/index.ts",


### PR DESCRIPTION
Trusted Publishing OIDC auth succeeded; the publish only failed the `--provenance` check, which requires `repository.url` in package.json. Adds it.