### PR TITLE
Bump GitHub Actions to Node 24 majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
     name: Backend tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
 
@@ -38,9 +38,9 @@ jobs:
     name: Frontend build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
 

--- a/.github/workflows/contract-nightly.yml
+++ b/.github/workflows/contract-nightly.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
 

--- a/.github/workflows/contract-nightly.yml
+++ b/.github/workflows/contract-nightly.yml
@@ -28,10 +28,10 @@ jobs:
         ports: ["5432:5432"]
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
 

--- a/.github/workflows/deploy-labs.yml
+++ b/.github/workflows/deploy-labs.yml
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: guard
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Vendor the private canopy plugin into the build context so apps.system
       # can render the /system catalog. Absent → /system degrades to an empty
@@ -87,17 +87,17 @@ jobs:
             echo "::warning::CANOPY_PLUGIN_TOKEN not set — /system will show an empty catalog."
           fi
 
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - uses: aws-actions/amazon-ecr-login@v2
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile
@@ -114,7 +114,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/publish-canopy-ui.yml
+++ b/.github/workflows/publish-canopy-ui.yml
@@ -25,8 +25,8 @@ jobs:
     name: Publish to npmjs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/regen-openapi.yml
+++ b/.github/workflows/regen-openapi.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: write  # push the regenerated generated.ts back to the PR branch
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           # Push with a PAT when one is configured (secret REGEN_TOKEN) so the
@@ -24,7 +24,7 @@ jobs:
           # set you can safely enforce branch protection on admins too.
           # Falls back to GITHUB_TOKEN when the secret is absent.
           token: ${{ secrets.REGEN_TOKEN || secrets.GITHUB_TOKEN }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
       - name: Install uv


### PR DESCRIPTION
Clears the `Node.js 20 is deprecated` warnings surfaced during the labs deploy. Version bumps only — no workflow logic changes.

| Action | From | To |
|---|---|---|
| actions/checkout | v4 | v5 |
| actions/setup-node | v4 | v6 |
| astral-sh/setup-uv | v3 | v8 |
| aws-actions/configure-aws-credentials | v4 | v6 |
| docker/setup-buildx-action | v3 | v4 |
| docker/build-push-action | v6 | v7 |
| aws-actions/amazon-ecr-login | v2 | v2 (already Node 24) |

Applied across all five workflows (ci, deploy-labs, contract-nightly, publish-canopy-ui, regen-openapi). `configure-aws-credentials@v6` matches what ace-web's labs deploy already runs. CI exercises the `ci.yml` actions live on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)