### PR TITLE
fix(labs): pass VITE build-args in deploy workflow (broken /canopy assets)

### DIFF
--- a/.github/workflows/deploy-labs.yml
+++ b/.github/workflows/deploy-labs.yml
@@ -103,6 +103,13 @@ jobs:
           file: Dockerfile
           push: true
           provenance: false
+          # canopy-web serves under the /canopy path prefix on the shared ALB.
+          # These MUST be passed or the SPA builds with base "/" (assets 404 at
+          # /assets/… instead of /canopy/assets/…) and reads the wrong CSRF
+          # cookie (writes 403). Mirrors config/settings/connectlabs.py.
+          build-args: |
+            VITE_BASE_PATH=/canopy/
+            VITE_CSRF_COOKIE_NAME=csrftoken_canopy
           tags: |
             ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPO }}:latest
             ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPO }}:${{ github.sha }}


### PR DESCRIPTION
**The live site is currently broken.** The `deploy-labs.yml` build step (added in #179) calls `docker/build-push-action` **without `build-args`**, so the image builds with the Dockerfile defaults:
- `VITE_BASE_PATH=/` → the SPA's `index.html` references `/assets/…`, which **404s at the root tenant** (the real files are at `/canopy/assets/…`) → white screen.
- `VITE_CSRF_COOKIE_NAME=csrftoken` → frontend reads the wrong cookie → writes 403.

Fix: pass `VITE_BASE_PATH=/canopy/` and `VITE_CSRF_COOKIE_NAME=csrftoken_canopy` (mirrors `config/settings/connectlabs.py`).

After merge, re-run **Deploy to Labs (AWS)** to ship a correct image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)