### PR TITLE
fix(deploy): restore CANOPY_DRIVE_ROOT_FOLDER_ID in AWS task def

### DIFF
--- a/deploy/aws/canopy-web.cfn.yaml
+++ b/deploy/aws/canopy-web.cfn.yaml
@@ -146,6 +146,11 @@ Resources:
             - { Name: ALLOWED_HOSTS, Value: labs.connect.dimagi.com }
             - { Name: AWS_REGION, Value: !Ref "AWS::Region" }
             - { Name: PORT, Value: !Ref ContainerPort }
+            # Google Drive root folder for walkthrough storage. Not a secret
+            # (folder ID isn't sensitive) — plain env var, matching the retired
+            # GCP deploy. The matching SA key is the CANOPY_DRIVE_SA_KEY_JSON
+            # secret below.
+            - { Name: CANOPY_DRIVE_ROOT_FOLDER_ID, Value: 1cUv7wQXOvVwuZ86PdhkxpFcuB4Lm9fPz }
           Secrets:
             - { Name: DJANGO_SECRET_KEY, ValueFrom: !Ref DjangoSecretKey }
             - { Name: DATABASE_URL, ValueFrom: !Ref DatabaseUrl }


### PR DESCRIPTION
## What

The GCP→AWS migration dropped `CANOPY_DRIVE_ROOT_FOLDER_ID` from the CloudFormation task definition. The old GCP `deploy.sh` set it as a plain env var (`1cUv7wQXOvVwuZ86PdhkxpFcuB4Lm9fPz`); the new `deploy/aws/canopy-web.cfn.yaml` omitted it entirely. Without it, walkthrough Drive storage fails with `code=drive-not-configured`.

This adds it back as a plain `Environment` var (a folder ID isn't a secret), matching the retired `deploy.sh`.

## Notes

- `CANOPY_DRIVE_SA_KEY_JSON` was **not** affected — its secret (`canopy-web/drive-sa-key-json`) was already wired and already held the real service-account key.
- Already applied to the live labs service out-of-band as task-def **rev 7** (verified `/canopy/health/` → 200). This PR keeps the source-of-truth template in sync so future CloudFormation updates and workflow-sourced deploys carry the value forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)