### PR TITLE
fix(walkthroughs): clip stream broken by /w/ reclaim — frontend URL + legacy redirect

### DIFF
--- a/apps/common/middleware.py
+++ b/apps/common/middleware.py
@@ -4,6 +4,8 @@ Authenticated callers (via session cookie OR Personal Access Token via
 `apps.tokens.middleware.BearerTokenAuthMiddleware`) bypass this gate
 automatically — `request.user.is_authenticated` becomes True for both.
 """
+import re
+
 from django.conf import settings
 from django.http import JsonResponse
 from django.shortcuts import redirect
@@ -46,15 +48,25 @@ def _is_review_link(path: str) -> bool:
     return path.startswith("/api/reviews/") and path != "/api/reviews/"
 
 
+# Pre-reclaim content-stream URL, baked into already-rendered artifacts
+# (DDD decks, review embeds). UUID-shaped only — workspace slugs never match.
+_LEGACY_W_CONTENT = re.compile(
+    r"^/w/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/content$"
+)
+
+
 def _is_walkthrough_link(request) -> bool:
     # The public walkthrough viewer SPA shell (/walkthrough/<uuid>) and the
     # content stream (/walkthrough/<uuid>/content), plus the per-walkthrough
     # detail GET, self-enforce tokenless public access, so let anonymous callers
     # through the middleware. /w/ now means "workspace" (the authed tenant shell)
-    # and is NOT allowlisted. The bare collection (/api/walkthroughs/) is NOT
-    # included — list/upload still require auth.
+    # and is NOT allowlisted — except the legacy /w/<uuid>/content path, which
+    # must reach its back-compat redirect. The bare collection
+    # (/api/walkthroughs/) is NOT included — list/upload still require auth.
     path = request.path
     if path.startswith("/walkthrough/"):
+        return True
+    if _LEGACY_W_CONTENT.match(path):
         return True
     return (
         request.method == "GET"

--- a/apps/common/tests/test_walkthrough_reclaim.py
+++ b/apps/common/tests/test_walkthrough_reclaim.py
@@ -21,6 +21,17 @@ def test_bare_w_prefix_is_no_longer_public():
     assert _is_walkthrough_link(_Req("/w/dimagi/agents")) is False
 
 
+def test_legacy_w_uuid_content_is_public():
+    # Old rendered artifacts (DDD decks, review embeds) have
+    # /w/<uuid>/content baked in; the anon holder must reach the
+    # back-compat redirect. Only the UUID-shaped content path — a
+    # workspace slug doesn't match.
+    uuid = "2f9a1c34-5b6d-4e7f-8a9b-0c1d2e3f4a5b"
+    assert _is_walkthrough_link(_Req(f"/w/{uuid}/content")) is True
+    assert _is_walkthrough_link(_Req(f"/w/{uuid}")) is False
+    assert _is_walkthrough_link(_Req("/w/dimagi/content")) is False
+
+
 def test_walkthrough_detail_get_still_public():
     assert _is_walkthrough_link(_Req("/api/walkthroughs/abc/")) is True
     # the collection stays auth'd (list/upload)

--- a/config/urls.py
+++ b/config/urls.py
@@ -3,6 +3,7 @@ URL configuration for canopy-web project.
 """
 from django.contrib import admin
 from django.urls import include, path, re_path
+from django.views.generic import RedirectView
 
 from apps.api.api import api as api_v2
 from apps.api.views import redoc_docs, scalar_docs
@@ -18,6 +19,13 @@ urlpatterns = [
     path("api/debug/", include("apps.common.urls_debug")),
     path("auth/cli/authorize/", views_cli_authorize, name="cli_authorize"),
     path("walkthrough/<uuid:wid>/content", views_walkthrough_content, name="walkthrough-content"),
+    # Back-compat: the pre-reclaim stream URL is baked into already-rendered
+    # artifacts (DDD decks, review embeds). Redirect, don't fall to the SPA.
+    path(
+        "w/<uuid:wid>/content",
+        RedirectView.as_view(pattern_name="walkthrough-content", query_string=True),
+        name="walkthrough-content-legacy",
+    ),
     path("api/", api_v2.urls),
     path("api/docs/", scalar_docs, name="api_docs_scalar"),
     path("api/redoc/", redoc_docs, name="api_docs_redoc"),

--- a/frontend/src/api/walkthroughs.ts
+++ b/frontend/src/api/walkthroughs.ts
@@ -94,6 +94,6 @@ export async function uploadWalkthrough(
 
 export function walkthroughContentUrl(id: string): string {
   // Base-aware so the `<video>`/`<iframe>` src resolves under the deployed
-  // sub-path (e.g. `/canopy/w/<id>/content`), not the origin root.
-  return withBase(`/w/${id}/content`);
+  // sub-path (e.g. `/canopy/walkthrough/<id>/content`), not the origin root.
+  return withBase(`/walkthrough/${id}/content`);
 }

--- a/frontend/src/lib/basePath.ts
+++ b/frontend/src/lib/basePath.ts
@@ -3,10 +3,10 @@
  *
  * canopy-web can be served under a sub-path (e.g. `https://labs.connect.dimagi.com/canopy/`).
  * Vite builds the SPA with `base=/canopy/`, so assets and the router resolve
- * correctly — but content URLs like `/w/<id>/content` (built by
+ * correctly — but content URLs like `/walkthrough/<id>/content` (built by
  * `walkthroughContentUrl`, or returned by the run-package API as
  * `content_url`) are ROOT-relative. As a `<video>`/`<iframe>` `src` those
- * resolve against the origin (`/w/<id>/content`), bypassing the `/canopy`
+ * resolve against the origin (`/walkthrough/<id>/content`), bypassing the `/canopy`
  * prefix, so the reverse proxy never routes them to canopy-web → 404 and the
  * video never loads.
  *

--- a/tests/test_visibility_walkthroughs.py
+++ b/tests/test_visibility_walkthroughs.py
@@ -119,3 +119,14 @@ def test_walkthrough_collection_still_gated(db):
     # The list/upload collection must NOT be public.
     resp = Client().get("/api/walkthroughs/")
     assert resp.status_code == 401
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_legacy_w_content_path_redirects_to_walkthrough(owner):
+    # /w/<id>/content was the pre-reclaim stream URL; old artifacts have it
+    # baked in. Anonymous holders must get redirected to the new route, not
+    # bounced to login or handed the SPA shell.
+    w = _make(owner, visibility="link")
+    resp = Client().get(f"/w/{w.id}/content")
+    assert resp.status_code in (301, 302)
+    assert resp.headers["Location"] == f"/walkthrough/{w.id}/content"


### PR DESCRIPTION
## Root cause (corrects the analysis in #185)

The `/w/` → `/walkthrough/` reclaim (4500bfe, shipped in #183, deployed 2026-07-01 14:28Z) moved the content-stream route, the login-middleware allowlist, and the backend-generated URLs — but **not the frontend**. `walkthroughContentUrl` still built `/w/<id>/content`, which since the reclaim matches nothing but the SPA catch-all:

- **authed / PAT**: 200 `text/html` — the SPA shell instead of video bytes
- **anon**: 302 to login (`/w/` is now the auth'd workspace shell, not allowlisted)

This is exactly the evidence table in #185. It is **not** a `FORCE_SCRIPT_NAME` / `StripScriptName` / `raw_path` problem: the strip wrapper removes `/canopy` from the scope before Django builds the request, so `request.path` never carries the prefix on labs (verified empirically against Django 5.2 `ASGIRequest`). The two deploys earlier that day (02:26Z / 03:17Z) contained the strip wrapper but **not** the reclaim — which is why clips streamed 206 "earlier this session" and broke after the 14:28Z deploy.

## Fix

- `frontend/src/api/walkthroughs.ts`: `walkthroughContentUrl` → `/walkthrough/<id>/content` (used by the viewer page and review clip embeds)
- `config/urls.py`: back-compat redirect `w/<uuid>/content` → `walkthrough/<uuid>/content` — the old URL is baked into already-rendered artifacts (DDD decks, review embeds)
- `apps/common/middleware.py`: allowlist the legacy UUID-shaped content path only, so anonymous link-holders reach the redirect (workspace slugs never match)

## Tests

- middleware unit tests: legacy `/w/<uuid>/content` public; `/w/<uuid>` and `/w/<slug>/content` still gated
- integration test: anon GET on the legacy path 302s to `/walkthrough/<id>/content`
- full suite: 484 backend + 58 frontend pass; `npm run build` clean

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)