### PR TITLE
fix(auth): login redirect ?next drops the /canopy prefix + query string

### DIFF
--- a/apps/common/middleware.py
+++ b/apps/common/middleware.py
@@ -5,6 +5,7 @@ Authenticated callers (via session cookie OR Personal Access Token via
 automatically — `request.user.is_authenticated` becomes True for both.
 """
 import re
+from urllib.parse import urlencode
 
 from django.conf import settings
 from django.http import JsonResponse
@@ -108,4 +109,9 @@ class LoginRequiredMiddleware:
         if request.path.startswith("/api/"):
             return JsonResponse({"detail": "Authentication required"}, status=401)
 
-        return redirect(f"{settings.LOGIN_URL}?next={request.path}")
+        # Build the post-login target from SCRIPT_NAME + path_info so it works
+        # both locally (no prefix) and on the labs sub-path deployment, where
+        # request.path is prefix-stripped by the StripScriptName ASGI wrapper —
+        # a bare request.path would bounce the user to a sibling tenant's path.
+        next_target = request.META.get("SCRIPT_NAME", "") + request.get_full_path_info()
+        return redirect(f"{settings.LOGIN_URL}?{urlencode({'next': next_target})}")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -43,7 +43,28 @@ def test_page_requires_auth_redirects_to_login(db):
     resp = client.get("/some-spa-route")
     assert resp.status_code == 302
     assert resp["Location"].startswith("/accounts/google/login/")
-    assert "next=/some-spa-route" in resp["Location"]
+    assert "next=%2Fsome-spa-route" in resp["Location"]
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_login_redirect_next_preserves_query_string(db):
+    resp = Client().get("/some-spa-route?tab=syncs")
+    assert resp.status_code == 302
+    assert "next=%2Fsome-spa-route%3Ftab%3Dsyncs" in resp["Location"]
+
+
+@override_settings(
+    REQUIRE_AUTH=True,
+    FORCE_SCRIPT_NAME="/canopy",
+    LOGIN_URL="/canopy/accounts/google/login/",
+)
+def test_login_redirect_next_carries_script_prefix(db):
+    # On the labs sub-path deployment the post-login bounce must land back
+    # on /canopy/..., not on the root tenant's path.
+    resp = Client().get("/w/dimagi/agents")
+    assert resp.status_code == 302
+    assert resp["Location"].startswith("/canopy/accounts/google/login/")
+    assert "next=%2Fcanopy%2Fw%2Fdimagi%2Fagents" in resp["Location"]
 
 
 @override_settings(REQUIRE_AUTH=True)


### PR DESCRIPTION
Follow-up to #186 — the pre-existing quirk noticed while verifying that fix.

`LoginRequiredMiddleware` built the post-login target as `?next={request.path}`. On the labs sub-path deployment, `StripScriptName` strips `/canopy` from the scope before Django builds the request, so `request.path` lacks the prefix and an anonymous deep link (e.g. `/canopy/w/dimagi/agents`) bounced, after login, to `/w/dimagi/agents` at the origin root — the connect-labs tenant. It also dropped the query string and never URL-encoded the value.

Fix: build the target from `SCRIPT_NAME + request.get_full_path_info()` — correct under both WSGI (`request.path` includes the prefix, `path_info` doesn't) and the deployed ASGI setup — preserve the query string, and `urlencode` it.

Tests: prefix-carrying `next` under `FORCE_SCRIPT_NAME`, query-string preservation, and the updated encoded assertion in the existing redirect test. Full suite: 486 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)