### PR TITLE
fix(agents): /turns/ handlers pass (request, slug) to _get_agent_or_404

### DIFF
--- a/apps/agents/api.py
+++ b/apps/agents/api.py
@@ -128,7 +128,7 @@ def create_sync(request: HttpRequest, slug: str, payload: AgentSyncIn) -> Status
             openapi_extra={"x-mcp-expose": True})
 def list_turns(request: HttpRequest, slug: str, limit: int = 100) -> Page[AgentTurnOut]:
     limit = min(limit, 500)
-    agent = _get_agent_or_404(slug)
+    agent = _get_agent_or_404(request, slug)
     items = [AgentTurnOut.model_validate(t) for t in services.list_turns(agent, limit=limit)]
     return paginate(items, offset=0, limit=limit)
 
@@ -137,7 +137,7 @@ def list_turns(request: HttpRequest, slug: str, limit: int = 100) -> Page[AgentT
              summary="Package a turn (idempotent per cli_session_id)",
              openapi_extra={"x-mcp-expose": True})
 def create_turn(request: HttpRequest, slug: str, payload: AgentTurnIn) -> Status:
-    agent = _get_agent_or_404(slug)
+    agent = _get_agent_or_404(request, slug)
     turn = services.upsert_turn(agent, payload)
     return Status(201, AgentTurnOut.model_validate(turn))
 

--- a/tests/test_agents_turns_api.py
+++ b/tests/test_agents_turns_api.py
@@ -1,0 +1,45 @@
+"""API-level (ninja route) tests for the agent turns endpoints — reproduces the
+live 500 the service-level tests missed."""
+from __future__ import annotations
+
+import pytest
+
+from apps.agents import services
+from apps.agents.models import Agent
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture()
+def authed_client(client, django_user_model):
+    u = django_user_model.objects.create_user(username="dev", email="dev@dimagi.com", password="pw")
+    client.force_login(u)
+    return client
+
+
+def _echo() -> Agent:
+    from types import SimpleNamespace
+    return services.upsert_agent(
+        SimpleNamespace(slug="echo", name="Echo", description="", persona="", email="", avatar_url="")
+    )
+
+
+def test_list_turns_empty(authed_client):
+    _echo()
+    resp = authed_client.get("/api/agents/echo/turns/?limit=1")
+    assert resp.status_code == 200, resp.content
+    assert resp.json()["items"] == []
+
+
+def test_post_then_list_turn(authed_client):
+    _echo()
+    resp = authed_client.post(
+        "/api/agents/echo/turns/",
+        data={"cli_session_id": "s1", "title": "Did a thing", "task_ext_ids": ["t1"],
+              "work_product_urls": [], "source": "turn"},
+        content_type="application/json",
+    )
+    assert resp.status_code == 201, resp.content
+    resp2 = authed_client.get("/api/agents/echo/turns/?limit=10")
+    assert resp2.status_code == 200, resp2.content
+    assert resp2.json()["items"][0]["task_ext_ids"] == ["t1"]


### PR DESCRIPTION
Follow-up to #188. The turns list/create handlers called `_get_agent_or_404(slug)` (old one-arg signature); current main's helper is `_get_agent_or_404(request, slug)` and does workspace-membership gating. Every `/api/agents/<slug>/turns/` call 500'd, and the routes skipped workspace gating.

Root cause: I wrote the handlers against the one-arg signature I read early in the session, before rebasing onto the newer origin/main. Phase 1's tests were service-level and never hit the ninja route, so it reached prod (caught by a live smoke test).

Fix both calls + add **API-level** tests (empty-list + post-then-list) that exercise the route so this can't regress. Verified: 14 passed.