### PR TITLE
agents: explicit workspace homing on register

### DIFF
--- a/apps/agents/api.py
+++ b/apps/agents/api.py
@@ -73,10 +73,20 @@ def list_agents(request: HttpRequest, limit: int = 100) -> Page[AgentOut]:
              openapi_extra={"x-mcp-expose": True})
 def upsert_agent(request: HttpRequest, payload: AgentIn) -> Status:
     agent = services.upsert_agent(payload)
-    # Scope to the request's workspace (from the /w/{ws} prefix or the compat
-    # shim's default); fall back to the org default so an unchanged register()
-    # (e.g. Echo's) keeps working.
-    if agent.workspace_id is None:
+    explicit = (payload.workspace or "").strip()
+    if explicit and agent.workspace_id != explicit:
+        # Explicit home: may MOVE an already-homed agent. Membership-gated; a
+        # missing workspace and a non-member get the same 404 (no existence leak).
+        wsvc.auto_join_workspaces(request.user)
+        ws = wsvc.Workspace.objects.filter(slug=explicit).first()
+        if ws is None or not wsvc.is_member(request.user, explicit):
+            raise HttpError(404, f"workspace '{explicit}' not found")
+        agent.workspace = ws
+        agent.save(update_fields=["workspace"])
+    elif agent.workspace_id is None:
+        # Scope to the request's workspace (from the /w/{ws} prefix or the compat
+        # shim's default); fall back to the org default so an unchanged register()
+        # (e.g. Echo's) keeps working.
         pinned = getattr(request, "workspace_slug", None)
         ws = (
             wsvc.Workspace.objects.filter(slug=pinned).first() if pinned else None

--- a/apps/agents/schemas.py
+++ b/apps/agents/schemas.py
@@ -18,6 +18,10 @@ class AgentIn(StrictModel):
     persona: str = ""
     email: str = Field(default="", max_length=254)
     avatar_url: str = Field(default="", max_length=500)
+    # Optional explicit home: a workspace slug. Setting it on an already-homed
+    # agent MOVES it (caller must be a member of the target). Empty → legacy
+    # behavior (default workspace for unhomed agents).
+    workspace: str = Field(default="", max_length=64)
 
 
 class AgentOut(StrictModel):

--- a/apps/agents/tests/test_workspace_scoping.py
+++ b/apps/agents/tests/test_workspace_scoping.py
@@ -68,3 +68,49 @@ def test_outsider_gets_404_and_empty_list():
     assert _client(outsider).get("/api/agents/echo/").status_code == 404
     items = _client(outsider).get("/api/agents/").json()["items"]
     assert all(a["slug"] != "echo" for a in items)
+
+
+# ---- explicit homing (payload.workspace) — the "move echo to connect" path ----
+
+def _make_ws(slug, owner, auto_join=()):
+    from apps.workspaces.models import Workspace
+    return Workspace.objects.create(
+        slug=slug, display_name=slug.title(), created_by=owner,
+        auto_join_domains=list(auto_join),
+    )
+
+
+def test_register_with_workspace_moves_an_already_homed_agent():
+    from apps.workspaces import services as wsvc
+
+    jj = _user("jj@dimagi.com", is_superuser=True)
+    c = _client(jj)
+    _register_echo(c)  # homed in the default workspace
+    connect = _make_ws("connect", jj)
+    wsvc.ensure_member(connect, jj)
+    r = _post(c, "/api/agents/", {"slug": "echo", "name": "Echo", "workspace": "connect"})
+    assert r.status_code == 201
+    assert Agent.objects.get(slug="echo").workspace_id == "connect"
+    # scoped reads follow the agent: new tenant 200, old tenant 404
+    assert c.get("/api/w/connect/agents/echo/").status_code == 200
+    assert c.get(f"/api/w/{DEFAULT_WORKSPACE_SLUG}/agents/echo/").status_code == 404
+
+
+def test_register_with_unknown_workspace_404s_and_does_not_move():
+    jj = _user("jj@dimagi.com", is_superuser=True)
+    c = _client(jj)
+    _register_echo(c)
+    r = _post(c, "/api/agents/", {"slug": "echo", "name": "Echo", "workspace": "nope"})
+    assert r.status_code == 404
+    assert Agent.objects.get(slug="echo").workspace_id == DEFAULT_WORKSPACE_SLUG
+
+
+def test_register_with_nonmember_workspace_404s_and_does_not_move():
+    jj = _user("jj@dimagi.com", is_superuser=True)
+    other = _user("owner@other.com")
+    _make_ws("private", other)  # exists, but jj is not a member (no auto-join)
+    c = _client(jj)
+    _register_echo(c)
+    r = _post(c, "/api/agents/", {"slug": "echo", "name": "Echo", "workspace": "private"})
+    assert r.status_code == 404
+    assert Agent.objects.get(slug="echo").workspace_id == DEFAULT_WORKSPACE_SLUG

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -3154,6 +3154,11 @@ export interface components {
              * @default
              */
             readonly avatar_url: string;
+            /**
+             * Workspace
+             * @default
+             */
+            readonly workspace: string;
         };
         /** AgentDetailOut */
         readonly AgentDetailOut: {


### PR DESCRIPTION
Adds an optional `workspace` field to `AgentIn`. When set, the register/upsert call homes the agent in that workspace — including moving an already-homed agent — gated on the caller's membership of the target (unknown workspace and non-member workspace both return the same 404, no existence leak). When empty, behavior is unchanged (tenant-pin or org default, unhomed agents only).

Motivation: the tenancy backfill homed all pre-tenancy agents (echo, ace) in `dimagi`, and `upsert_agent` only assigned a workspace when the agent had none — so there was no way to move an agent, and `/w/connect/agents/echo` 404s for anyone whose active workspace is `connect`. After deploy, Echo re-registers itself with `workspace: connect` and the scoped URL works.

Tests: 3 new cases in `test_workspace_scoping.py` (move-when-member, unknown-404-no-move, non-member-404-no-move); full `apps/agents apps/api tests` suite green locally (121 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)