### PR TITLE
fix(reviews): enforce CSRF on session-cookie review submit

### DIFF
--- a/apps/common/csrf.py
+++ b/apps/common/csrf.py
@@ -1,0 +1,23 @@
+"""Manual CSRF enforcement for Ninja routes that opt out of auth classes.
+
+Django Ninja marks its views ``csrf_exempt`` for Django's middleware and only
+re-runs the CSRF check inside cookie-based auth classes (``APIKeyCookie``).
+A route declared with ``auth=None`` that still mutates state on behalf of a
+session-cookie caller therefore gets NO CSRF check anywhere — it must re-run
+Django's check itself via this helper.
+
+PAT/bearer callers are skipped automatically: ``BearerTokenAuthMiddleware``
+sets ``request._dont_enforce_csrf_checks``, which Django's middleware honors.
+"""
+from django.http import HttpRequest
+from django.middleware.csrf import CsrfViewMiddleware
+
+
+def _noop_view(request):  # pragma: no cover - never actually called
+    return None
+
+
+def csrf_rejected(request: HttpRequest) -> bool:
+    """Run Django's CSRF check on ``request``; True if it would be rejected."""
+    mw = CsrfViewMiddleware(get_response=_noop_view)
+    return mw.process_view(request, _noop_view, (), {}) is not None

--- a/apps/common/middleware.py
+++ b/apps/common/middleware.py
@@ -59,8 +59,8 @@ _LEGACY_W_CONTENT = re.compile(
 def _is_walkthrough_link(request) -> bool:
     # The public walkthrough viewer SPA shell (/walkthrough/<uuid>) and the
     # content stream (/walkthrough/<uuid>/content), plus the per-walkthrough
-    # detail GET, self-enforce tokenless public access, so let anonymous callers
-    # through the middleware. /w/ now means "workspace" (the authed tenant shell)
+    # detail GET, self-enforce token-gated public access (?t=<share_token>),
+    # so let anonymous callers through the middleware. /w/ now means "workspace" (the authed tenant shell)
     # and is NOT allowlisted — except the legacy /w/<uuid>/content path, which
     # must reach its back-compat redirect. The bare collection
     # (/api/walkthroughs/) is NOT included — list/upload still require auth.

--- a/apps/reviews/api.py
+++ b/apps/reviews/api.py
@@ -27,6 +27,7 @@ from ninja import Router, Status
 
 from apps.api.auth import session_auth
 from apps.api.errors import TYPE_FORBIDDEN, TYPE_NOT_FOUND, ProblemError
+from apps.common.csrf import csrf_rejected
 from apps.common.ddd import narrative_slug_from_run_id
 from apps.workspaces import services as wsvc
 
@@ -326,7 +327,7 @@ def get_review(request: HttpRequest, rid: UUID) -> ReviewRequestOut:
 @router.post(
     "/{rid}/submit/",
     response=ReviewRequestOut,
-    auth=None,  # handler enforces _can_write (auth required); 403 not 401 for readable-but-anonymous
+    auth=None,  # handler enforces _can_write (auth required) + CSRF; 403 not 401 for readable-but-anonymous
     summary="Submit decisions + narration edits (human → server)",
 )
 def submit_review(request: HttpRequest, rid: UUID, payload: ReviewSubmitIn) -> ReviewRequestOut:
@@ -345,6 +346,12 @@ def submit_review(request: HttpRequest, rid: UUID, payload: ReviewSubmitIn) -> R
         raise ProblemError(404, "Review request not found", type_=TYPE_NOT_FOUND)
     if not _can_write(request, review):
         raise ProblemError(403, "Authentication required to submit a review", type_=TYPE_FORBIDDEN)
+
+    # auth=None means Ninja never runs a CSRF check for session-cookie writers;
+    # re-run Django's. PAT callers skip it (BearerTokenAuthMiddleware sets
+    # _dont_enforce_csrf_checks).
+    if csrf_rejected(request):
+        raise ProblemError(403, "CSRF verification failed", type_=TYPE_FORBIDDEN)
 
     if review.status == ReviewRequest.STATUS_RESOLVED:
         raise ProblemError(

--- a/tests/test_visibility_reviews.py
+++ b/tests/test_visibility_reviews.py
@@ -62,3 +62,36 @@ def test_review_submit_allowed_for_authenticated(owner):
         content_type="application/json",
     )
     assert resp.status_code == 200
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_review_submit_rejects_session_caller_without_csrf(owner):
+    """auth=None routes get no CSRF check from Ninja — the handler re-runs it."""
+    r = _review(owner, visibility="link")
+    client = Client(enforce_csrf_checks=True)
+    client.force_login(owner)
+    resp = client.post(
+        f"/api/reviews/{r.id}/submit/",
+        data={"response_json": {}},
+        content_type="application/json",
+    )
+    assert resp.status_code == 403
+    r.refresh_from_db()
+    assert r.status != ReviewRequest.STATUS_RESOLVED
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_review_submit_allows_session_caller_with_csrf(owner):
+    r = _review(owner, visibility="link")
+    client = Client(enforce_csrf_checks=True)
+    client.force_login(owner)
+    # Bootstrap the CSRF cookie the way the SPA does (/api/csrf/).
+    client.get("/api/csrf/")
+    token = client.cookies["csrftoken"].value
+    resp = client.post(
+        f"/api/reviews/{r.id}/submit/",
+        data={"response_json": {}},
+        content_type="application/json",
+        headers={"X-CSRFToken": token},
+    )
+    assert resp.status_code == 200

--- a/tests/test_visibility_walkthroughs.py
+++ b/tests/test_visibility_walkthroughs.py
@@ -1,4 +1,4 @@
-"""Tokenless visibility behaviour for the walkthrough content stream + detail."""
+"""Token-gated visibility behaviour for the walkthrough content stream + detail."""
 from unittest.mock import patch
 
 import pytest


### PR DESCRIPTION
Follow-up flagged in #194's final review: the review-submit POST (`auth=None`) is csrf_exempt end to end in Ninja, so session-cookie writers got no CSRF check — same class of issue as the walkthrough rotate-token fix.

## Changes
- New `apps/common/csrf.py::csrf_rejected` — re-runs Django's `CsrfViewMiddleware` check for Ninja routes that opt out of auth classes.
- `submit_review` enforces it after the `_can_write` gate, preserving the designed contract (anonymous-readable → friendly 403; non-readable → 404). PAT/bearer callers skip it (`BearerTokenAuthMiddleware` sets `_dont_enforce_csrf_checks`); the SPA already sends `X-CSRFToken`.
- Sweeps two stale "tokenless" comments left by the share-token revival (test module docstring, middleware allowlist comment).

## Testing
- New: session-cookie submit without CSRF token → 403 + review unresolved; with token (bootstrapped via `/api/csrf/`) → 200.
- Full suite: 517 passed / 1 skipped.

No migrations — deploy with `run_migrations=false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)