### PR TITLE
feat(runner): click-to-open agent panel + per-agent pause/resume

### DIFF
--- a/apps/harness/api.py
+++ b/apps/harness/api.py
@@ -89,9 +89,14 @@ def runner_heartbeat(request: HttpRequest, runner_id: uuid.UUID, payload: Heartb
 
 
 @router.post("/runners/{runner_id}/claim", response={200: TurnOut, 204: None})
-def claim_turn(request: HttpRequest, runner_id: uuid.UUID):
+def claim_turn(request: HttpRequest, runner_id: uuid.UUID, paused: str = ""):
+    """Claim the next eligible turn. `paused` is an optional comma-separated list of
+    agent slugs the caller has locally paused (per-agent pause) — the server skips
+    their queued turns so nothing is claimed-then-released. Omitted by older runners
+    (backward-compatible: no exclusions)."""
     runner = _runner_or_404(runner_id)
-    turn = services.claim_next_turn(runner)
+    exclude = [s for s in (p.strip() for p in paused.split(",")) if s]
+    turn = services.claim_next_turn(runner, exclude_slugs=exclude or None)
     if turn is None:
         return 204, None
     return 200, turn

--- a/apps/harness/services.py
+++ b/apps/harness/services.py
@@ -99,11 +99,16 @@ def _kind_allows(runner: Runner, routing: str) -> bool:
 EXECUTING = [Turn.CLAIMED, Turn.RUNNING, Turn.NEEDS_HUMAN]
 
 
-def claim_next_turn(runner: Runner, *, lease_seconds: int = DEFAULT_LEASE_SECONDS) -> Turn | None:
+def claim_next_turn(runner: Runner, *, lease_seconds: int = DEFAULT_LEASE_SECONDS,
+                    exclude_slugs: list[str] | None = None) -> Turn | None:
     if runner.status != Runner.ONLINE:
         return None
     sweep_expired_leases()
     slugs = runner.agent_slugs()
+    if exclude_slugs:
+        # Per-agent pause: the runner locally paused these agents; never claim their
+        # queued turns (they stay QUEUED, resumed the moment the pause is lifted).
+        slugs = [s for s in slugs if s not in set(exclude_slugs)]
     if not slugs:
         return None
     routing_q = Q(routing__in=[Turn.PREFER_LOCAL, Turn.LOCAL_ONLY, Turn.ANY])

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -1461,7 +1461,13 @@ export interface paths {
         };
         readonly get?: never;
         readonly put?: never;
-        /** Claim Turn */
+        /**
+         * Claim Turn
+         * @description Claim the next eligible turn. `paused` is an optional comma-separated list of
+         *     agent slugs the caller has locally paused (per-agent pause) — the server skips
+         *     their queued turns so nothing is claimed-then-released. Omitted by older runners
+         *     (backward-compatible: no exclusions).
+         */
         readonly post: operations["apps_harness_api_claim_turn"];
         readonly delete?: never;
         readonly options?: never;
@@ -7472,7 +7478,9 @@ export interface operations {
     };
     readonly apps_harness_api_claim_turn: {
         readonly parameters: {
-            readonly query?: never;
+            readonly query?: {
+                readonly paused?: string;
+            };
             readonly header?: never;
             readonly path: {
                 readonly runner_id: string;

--- a/packages/canopy_runner/canopy_runner/client.py
+++ b/packages/canopy_runner/canopy_runner/client.py
@@ -70,8 +70,13 @@ class Client:
         )
         return payload or {}
 
-    def claim(self, runner_id: str) -> dict | None:
-        status, payload = self._call("POST", f"/runners/{runner_id}/claim")
+    def claim(self, runner_id: str, paused_agents: list[str] | None = None) -> dict | None:
+        # paused_agents (per-agent pause) → server skips those agents' queued turns.
+        path = f"/runners/{runner_id}/claim"
+        if paused_agents:
+            from urllib.parse import urlencode
+            path += "?" + urlencode({"paused": ",".join(sorted(paused_agents))})
+        status, payload = self._call("POST", path)
         return payload if status == 200 else None
 
     def post_events(self, turn_id: str, events: list[dict]) -> None:

--- a/packages/canopy_runner/canopy_runner/main.py
+++ b/packages/canopy_runner/canopy_runner/main.py
@@ -100,10 +100,24 @@ def _fail_and_evict(cfg: Config, client: Client, state: dict, turn_id: str, note
     return f"failed:{turn_id}"
 
 
-def _maybe_check_inboxes(cfg: Config, client: Client, now_fn=time.time) -> None:
+def _paused_agents(cfg: Config) -> set[str]:
+    """Per-agent pause: agent slugs with a `PAUSED.<slug>` sentinel next to the state
+    file (dropped by the menu-bar app). Distinct from the global `PAUSED` file, which
+    halts everything. A paused agent's inbox is skipped and its queued turns are not
+    claimed (the server excludes them), so its work simply waits until resumed."""
+    d = Path(cfg.state_path).parent if cfg.state_path else Path.home() / ".canopy"
+    try:
+        return {p.name[len("PAUSED."):] for p in d.glob("PAUSED.*")}
+    except OSError:
+        return set()
+
+
+def _maybe_check_inboxes(cfg: Config, client: Client, now_fn=time.time,
+                         paused: set[str] | None = None) -> None:
     """Deterministic email trigger: at most every inbox_poll_seconds, poll each
     configured mailbox and enqueue email-origin turns. Best-effort — a failing inbox
-    (auth expired) logs and is skipped, never crashes the loop."""
+    (auth expired) logs and is skipped, never crashes the loop. Paused agents are
+    skipped so no new email turns are enqueued for them."""
     if not getattr(cfg, "mailboxes", None):
         return
     stamp = Path(cfg.state_path).with_name("inbox-last.txt") if cfg.state_path else Path("inbox-last.txt")
@@ -116,6 +130,8 @@ def _maybe_check_inboxes(cfg: Config, client: Client, now_fn=time.time) -> None:
     from . import inbox as inbox_mod
     cap = getattr(cfg, "inbox_max_threads", 8)
     for agent, box in cfg.mailboxes.items():
+        if paused and agent in paused:
+            continue
         try:
             ids = inbox_mod.check_inbox(
                 client, agent, mailbox=box["account"], gog_client=box["client"],
@@ -141,9 +157,10 @@ def _run_once_cdp(cfg: Config, client: Client) -> str:
     from .cdp_control import host_id
 
     client.heartbeat(cfg.runner_id, [], host=host_id())
-    _maybe_check_inboxes(cfg, client)
+    paused = _paused_agents(cfg)
+    _maybe_check_inboxes(cfg, client, paused=paused)
     try:
-        turn = client.claim(cfg.runner_id)
+        turn = client.claim(cfg.runner_id, paused_agents=sorted(paused))
     except ClientError as exc:
         logger.warning("claim failed: %s", exc)
         return "idle"

--- a/packages/canopy_runner/canopy_runner/menubar.py
+++ b/packages/canopy_runner/canopy_runner/menubar.py
@@ -1,39 +1,52 @@
-"""Canopy Runner — a lightweight macOS menu-bar app to watch + control the runner.
+"""Canopy Runner — a macOS menu-bar app with a click-to-open panel.
 
-It is a *thin control surface* over the launchd-managed runner daemon; it holds no
-state of its own. Everything it shows is read live from the runner's own files:
+The menu-bar shows just a status dot; clicking it opens a rich panel (an NSPopover
+hosting a WKWebView) styled to canopy-web's Warm Earth palette — think Google Drive's
+menu-bar UI rather than a plain text menu. The panel shows:
 
-  * pause      → presence of the PAUSED sentinel (sibling of runner.json)
-  * alive      → `launchctl print` for the LaunchAgent + freshness of runner.log
-  * activity   → today's CREATE / REUSE / cycle lines tail-parsed from runner.log
+  * runner status + today's CREATE/REUSE tally, with Pause/Resume + Start/Stop controls
+  * every agent (fetched live from canopy-web) as a card with its details; clicking a
+    card opens that agent's home page on canopy-web in the browser
 
-Controls:
-  * Pause / Resume        → create / remove the PAUSED sentinel (instant, token-safe)
-  * Start / Stop daemon   → launchctl bootstrap / bootout (the nuclear option)
-  * Quick links           → open the relevant canopy-web pages in the browser
-  * Open runner log        → reveal ~/.canopy/runner.log
+It is a thin control surface — no state of its own. Runner state is read from the
+runner's own files (PAUSED sentinel, runner.log, launchctl); agent data is read from
+the canopy-web API with the runner's bearer token. Pure stdlib + pyobjc (Cocoa+WebKit).
 
 Run standalone: `python -m canopy_runner.menubar`. Packaged as "Canopy Runner.app"
-(LSUIElement, so menu-bar-only, no dock icon) by menubar/build_app.sh — Spotlight-
-launchable like "Emdash CDP".
-
-Config is discovered from CANOPY_RUNNER_CONFIG (default ~/.canopy/runner.json); the
-log path from CANOPY_RUNNER_LOG (default alongside it). Pure stdlib + rumps.
+by menubar/build_app.sh (Spotlight-launchable, menu-bar-only).
 """
 from __future__ import annotations
 
 import datetime as dt
+import html
 import json
 import os
 import re
 import subprocess
+import threading
+import urllib.error
+import urllib.request
 import webbrowser
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
-import rumps
-from AppKit import NSApplication, NSApplicationActivationPolicyAccessory
+import objc
+from AppKit import (
+    NSApplication,
+    NSApplicationActivationPolicyAccessory,
+    NSMakeRect,
+    NSMakeSize,
+    NSMinYEdge,
+    NSPopover,
+    NSPopoverBehaviorTransient,
+    NSStatusBar,
+    NSVariableStatusItemLength,
+    NSViewController,
+)
+from Foundation import NSObject, NSTimer
+from WebKit import WKWebView, WKWebViewConfiguration, WKUserContentController
 
-LABEL = "com.canopy.runner"                      # the LaunchAgent label
+# ── config discovery (shared source of truth with the daemon) ───────────────────
 CONFIG = Path(os.environ.get("CANOPY_RUNNER_CONFIG", "~/.canopy/runner.json")).expanduser()
 LOG = Path(os.environ.get("CANOPY_RUNNER_LOG", str(CONFIG.with_name("runner.log")))).expanduser()
 PLIST = Path(os.environ.get(
@@ -41,11 +54,19 @@ PLIST = Path(os.environ.get(
     "~/emdash-projects/canopy-web/packages/canopy_runner/launchd/com.canopy.runner.plist",
 )).expanduser()
 PAUSE_FILE = CONFIG.with_name("PAUSED")
+LABEL = "com.canopy.runner"
 
-# Menu-bar glyphs — status legible at a glance from the top of the screen.
 GLYPH = {"running": "🟢", "paused": "🟡", "stopped": "🔴", "stale": "🟠"}
+CARD_ACCENTS = [  # oklch categorical tokens, cycled per-agent for the initials avatar
+    "oklch(0.757 0.161 53.57)",   # primary / orange
+    "oklch(0.765 0.177 163.22)",  # success / emerald
+    "oklch(0.746 0.16 232.66)",   # info / sky
+    "oklch(0.828 0.189 84.43)",   # warning / amber
+    "oklch(0.72 0.15 300)",       # special / violet
+]
 
 
+# ── config / status helpers (stdlib) ────────────────────────────────────────────
 def _load_cfg() -> dict:
     try:
         return json.loads(CONFIG.read_text())
@@ -53,18 +74,28 @@ def _load_cfg() -> dict:
         return {}
 
 
-def _links(cfg: dict) -> list[tuple[str, str]]:
-    """Quick links → canopy-web. Flat paths (/, /agents, /timeline …) 302 into the
-    caller's active workspace, so we don't need to know the workspace slug here."""
-    base = (cfg.get("base_url") or "https://labs.connect.dimagi.com/canopy").rstrip("/")
-    return [
-        ("🌲  Workbench", f"{base}/"),
-        ("🤖  Agents (turns & needs-you)", f"{base}/agents"),
-        ("📰  Timeline", f"{base}/timeline"),
-        ("💡  Insights", f"{base}/insights"),
-        ("🧵  Shared sessions", f"{base}/sessions"),
-        ("⚙️  Settings (AI backend)", f"{base}/settings"),
-    ]
+def _token(cfg: dict) -> str:
+    tok = cfg.get("token", "")
+    if tok.startswith("@"):
+        try:
+            return Path(tok[1:]).expanduser().read_text().strip()
+        except Exception:  # noqa: BLE001
+            return ""
+    return tok
+
+
+def _base(cfg: dict) -> str:
+    return (cfg.get("base_url") or "https://labs.connect.dimagi.com/canopy").rstrip("/")
+
+
+def _agent_pause_file(slug: str) -> Path:
+    # Per-agent pause sentinel — a sibling of the global PAUSED, keyed by slug. The
+    # runner scans these to skip a single agent's inbox + queued turns while others run.
+    return CONFIG.with_name(f"PAUSED.{slug}")
+
+
+def _agent_paused(slug: str) -> bool:
+    return _agent_pause_file(slug).exists()
 
 
 def _launchctl(*args: str) -> subprocess.CompletedProcess:
@@ -76,12 +107,10 @@ def _domain() -> str:
 
 
 def _daemon_loaded() -> bool:
-    r = _launchctl("print", f"{_domain()}/{LABEL}")
-    return r.returncode == 0
+    return _launchctl("print", f"{_domain()}/{LABEL}").returncode == 0
 
 
 def _log_stats() -> dict:
-    """Tail-parse runner.log: freshness, today's CREATE/REUSE counts, last cycle line."""
     out = {"fresh": False, "age_s": None, "created": 0, "reused": 0, "last": ""}
     try:
         text = LOG.read_text(errors="replace")
@@ -99,121 +128,369 @@ def _log_stats() -> dict:
             continue
         if "CREATE turn=" in ln:
             out["created"] += 1
-        elif "REUSE  turn=" in ln or "REUSE turn=" in ln:
+        elif "REUSE" in ln and "turn=" in ln:
             out["reused"] += 1
     for ln in reversed(lines):
-        if "cycle:" in ln or "PAUSED" in ln or "RESUMED" in ln or "starting" in ln:
+        if any(k in ln for k in ("cycle:", "PAUSED", "RESUMED", "starting")):
             out["last"] = re.sub(r"\s+", " ", ln)[-90:]
             break
     return out
 
 
-class RunnerApp(rumps.App):
-    def __init__(self) -> None:
-        super().__init__("Canopy Runner", quit_button=None)
+def _runner_state() -> dict:
+    paused, loaded, st = PAUSE_FILE.exists(), _daemon_loaded(), _log_stats()
+    if not loaded:
+        state = "stopped"
+    elif paused:
+        state = "paused"
+    elif not st["fresh"]:
+        state = "stale"
+    else:
+        state = "running"
+    return {"state": state, "paused": paused, **st}
+
+
+# ── agent data (canopy-web API) ─────────────────────────────────────────────────
+def _api(base: str, token: str, path: str) -> object:
+    req = urllib.request.Request(f"{base}{path}", headers={"Authorization": f"Bearer {token}"})
+    with urllib.request.urlopen(req, timeout=20) as r:
+        return json.loads(r.read().decode())
+
+
+def fetch_agents(base: str, token: str) -> list[dict]:
+    """List agents, then enrich each with its detail counts (parallel). Best-effort:
+    a failed detail just leaves the base fields."""
+    if not token:
+        return []
+    try:
+        data = _api(base, token, "/api/agents/")
+    except Exception:  # noqa: BLE001
+        return []
+    items = data.get("items", data) if isinstance(data, dict) else data
+
+    def _detail(a: dict) -> dict:
+        try:
+            return {**a, **_api(base, token, f"/api/agents/{a['slug']}/")}
+        except Exception:  # noqa: BLE001
+            return a
+
+    with ThreadPoolExecutor(max_workers=6) as ex:
+        return list(ex.map(_detail, items))
+
+
+def _rel(iso: str | None) -> str:
+    if not iso:
+        return "—"
+    try:
+        t = dt.datetime.fromisoformat(iso.replace("Z", "+00:00"))
+        s = (dt.datetime.now(dt.timezone.utc) - t).total_seconds()
+    except Exception:  # noqa: BLE001
+        return "—"
+    if s < 90:
+        return "just now"
+    for unit, n in (("d", 86400), ("h", 3600), ("m", 60)):
+        if s >= n:
+            return f"{int(s // n)}{unit} ago"
+    return "just now"
+
+
+# ── HTML render (Warm Earth dark) ───────────────────────────────────────────────
+def _card(agent: dict, base: str, i: int, paused: bool) -> str:
+    slug = agent.get("slug", "")
+    name = html.escape(agent.get("name") or slug)
+    blurb = html.escape((agent.get("persona") or agent.get("description") or "").strip())
+    email = html.escape(agent.get("email") or "")
+    url = f"{base}/agents/{slug}"
+    accent = CARD_ACCENTS[i % len(CARD_ACCENTS)]
+    initial = (name[:1] or "?").upper()
+    avatar = (f'<img class="av" src="{html.escape(agent["avatar_url"])}" alt="">'
+              if agent.get("avatar_url") else
+              f'<div class="av" style="background:{accent}">{initial}</div>')
+    stats = []
+    for label, key in (("turns", "turn_count"), ("tasks", "task_count"),
+                       ("skills", "skill_count"), ("products", "work_product_count")):
+        v = agent.get(key)
+        if v is not None:
+            stats.append(f'<span class="stat"><b>{v}</b> {label}</span>')
+    last = _rel(agent.get("latest_turn_at"))
+    # Per-agent pause control. stopPropagation so toggling pause doesn't also open the
+    # agent's page. The whole card (minus this button) is the click target for open.
+    pa = "pauseAgent" if not paused else "resumeAgent"
+    plabel = "Pause" if not paused else "Resume"
+    chip = '<span class="apill">Paused</span>' if paused else ""
+    return f"""
+    <div class="card{' ispaused' if paused else ''}" onclick="open_agent('{html.escape(url)}')" title="Open {name} on canopy-web">
+      {avatar}
+      <div class="body">
+        <div class="row1"><span class="name">{name}</span>{chip}<span class="last">{last}</span></div>
+        {f'<div class="blurb">{blurb}</div>' if blurb else ''}
+        <div class="meta">{f'<span class="email">{email}</span>' if email else ''}</div>
+        <div class="cardfoot">
+          <div class="stats">{''.join(stats)}</div>
+          <button class="apause" onclick="event.stopPropagation(); act_agent('{pa}','{slug}')">{plabel}</button>
+        </div>
+      </div>
+    </div>"""
+
+
+def render(state: dict, agents: list[dict], base: str) -> str:
+    s = state["state"]
+    pill_word = {"running": "Running", "paused": "Paused",
+                 "stopped": "Stopped", "stale": "Stale"}[s]
+    age = f'{state["age_s"]}s ago' if state.get("age_s") is not None else "no log"
+    pause_label = "Resume" if state["paused"] else "Pause"
+    pause_act = "resume" if state["paused"] else "pause"
+    daemon_label, daemon_act = (("Stop daemon", "stop") if s != "stopped"
+                                else ("Start daemon", "start"))
+    cards = "".join(_card(a, base, i, _agent_paused(a.get("slug", "")))
+                    for i, a in enumerate(agents)) or \
+        '<div class="empty">No agents found (check the runner token / connection).</div>'
+    last_line = html.escape(state.get("last") or "")
+
+    return f"""<!doctype html><html><head><meta charset="utf-8">
+<style>
+  :root {{
+    --bg: oklch(0.147 0.004 49.25); --card: oklch(0.216 0.006 56.04);
+    --muted: oklch(0.268 0.007 34.3); --border: oklch(0.268 0.007 34.3);
+    --fg: oklch(0.923 0.003 48.72); --fg2: oklch(0.809 0.005 56.0);
+    --dim: oklch(0.553 0.013 58.07); --primary: oklch(0.757 0.161 53.57);
+    --ok: oklch(0.765 0.177 163.22); --warn: oklch(0.828 0.189 84.43);
+    --danger: oklch(0.63 0.2 25);
+  }}
+  * {{ box-sizing: border-box; margin: 0; }}
+  html,body {{ background: var(--bg); color: var(--fg);
+    font: 13px/1.45 -apple-system, "SF Pro Text", system-ui, sans-serif; }}
+  body {{ padding: 0; }}
+  .hdr {{ position: sticky; top: 0; background: var(--bg); padding: 12px 14px 10px;
+    border-bottom: 1px solid var(--border); z-index: 2; }}
+  .titlerow {{ display: flex; align-items: center; gap: 8px; }}
+  .brand {{ font-weight: 650; font-size: 14px; letter-spacing: .2px; }}
+  .pill {{ margin-left: auto; font-size: 11px; font-weight: 600; padding: 2px 9px;
+    border-radius: 999px; border: 1px solid transparent; }}
+  .pill.running {{ color: var(--ok); background: color-mix(in oklch, var(--ok) 12%, transparent); border-color: color-mix(in oklch, var(--ok) 30%, transparent); }}
+  .pill.paused {{ color: var(--warn); background: color-mix(in oklch, var(--warn) 12%, transparent); border-color: color-mix(in oklch, var(--warn) 30%, transparent); }}
+  .pill.stopped {{ color: var(--danger); background: color-mix(in oklch, var(--danger) 14%, transparent); border-color: color-mix(in oklch, var(--danger) 32%, transparent); }}
+  .pill.stale {{ color: var(--warn); background: color-mix(in oklch, var(--warn) 10%, transparent); }}
+  .sub {{ color: var(--dim); font-size: 11px; margin-top: 5px; }}
+  .sub b {{ color: var(--fg2); font-weight: 650; }}
+  .last {{ color: var(--dim); font-size: 10px; margin-top: 3px; font-family: ui-monospace, monospace;
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }}
+  .actions {{ display: flex; gap: 6px; margin-top: 10px; flex-wrap: wrap; }}
+  .btn {{ font: inherit; font-size: 11px; font-weight: 600; color: var(--fg2);
+    background: var(--muted); border: 1px solid var(--border); border-radius: 7px;
+    padding: 4px 10px; cursor: pointer; }}
+  .btn:hover {{ color: var(--fg); border-color: var(--dim); }}
+  .btn.primary {{ color: var(--bg); background: var(--primary); border-color: var(--primary); }}
+  .sectlabel {{ text-transform: uppercase; letter-spacing: .8px; font-size: 10px;
+    color: var(--dim); font-weight: 700; padding: 12px 14px 4px; }}
+  .list {{ padding: 2px 10px 12px; display: flex; flex-direction: column; gap: 7px; }}
+  .card {{ display: flex; gap: 10px; padding: 10px; border-radius: 10px;
+    background: var(--card); border: 1px solid var(--border); cursor: pointer; }}
+  .card:hover {{ border-color: color-mix(in oklch, var(--primary) 45%, var(--border)); }}
+  .card.ispaused {{ opacity: .58; }}
+  .card.ispaused:hover {{ opacity: .8; }}
+  .apill {{ font-size: 9.5px; font-weight: 700; text-transform: uppercase; letter-spacing: .5px;
+    color: var(--warn); background: color-mix(in oklch, var(--warn) 14%, transparent);
+    border: 1px solid color-mix(in oklch, var(--warn) 30%, transparent);
+    padding: 1px 6px; border-radius: 999px; }}
+  .cardfoot {{ display: flex; align-items: center; gap: 10px; margin-top: 7px; }}
+  .apause {{ margin-left: auto; font: inherit; font-size: 10.5px; font-weight: 600;
+    color: var(--fg2); background: var(--muted); border: 1px solid var(--border);
+    border-radius: 6px; padding: 2px 9px; cursor: pointer; }}
+  .apause:hover {{ color: var(--fg); border-color: var(--dim); }}
+  .av {{ width: 34px; height: 34px; border-radius: 9px; flex: none; object-fit: cover;
+    display: flex; align-items: center; justify-content: center; color: var(--bg);
+    font-weight: 700; font-size: 15px; }}
+  .body {{ min-width: 0; flex: 1; }}
+  .row1 {{ display: flex; align-items: baseline; gap: 8px; }}
+  .name {{ font-weight: 650; font-size: 13.5px; }}
+  .row1 .last {{ margin: 0; margin-left: auto; }}
+  .blurb {{ color: var(--fg2); font-size: 12px; margin-top: 2px;
+    overflow: hidden; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; }}
+  .email {{ color: var(--dim); font-size: 11px; font-family: ui-monospace, monospace; }}
+  .meta {{ margin-top: 4px; }}
+  .stats {{ display: flex; gap: 12px; flex-wrap: wrap; }}
+  .stat {{ color: var(--dim); font-size: 11px; }}
+  .stat b {{ color: var(--fg); font-weight: 650; }}
+  .empty {{ color: var(--dim); padding: 20px 14px; text-align: center; }}
+  .foot {{ display: flex; gap: 6px; padding: 0 14px 14px; }}
+  .foot .btn {{ flex: 1; text-align: center; }}
+</style></head><body>
+  <div class="hdr">
+    <div class="titlerow">
+      <span class="brand">🌲 Canopy Runner</span>
+      <span class="pill {s}">{pill_word}</span>
+    </div>
+    <div class="sub">Today: <b>{state.get('created', 0)}</b> created · <b>{state.get('reused', 0)}</b> reused · log {age}</div>
+    {f'<div class="last">{last_line}</div>' if last_line else ''}
+    <div class="actions">
+      <button class="btn primary" onclick="act('{pause_act}')">{pause_label}</button>
+      <button class="btn" onclick="act('{daemon_act}')">{daemon_label}</button>
+      <button class="btn" onclick="act('openLog')">Log</button>
+      <button class="btn" onclick="act('refresh')">Refresh</button>
+    </div>
+  </div>
+  <div class="sectlabel">Agents · {len(agents)}</div>
+  <div class="list">{cards}</div>
+  <div class="foot"><button class="btn" onclick="act('quit')">Quit menu-bar app</button></div>
+<script>
+  function send(m) {{ window.webkit.messageHandlers.bridge.postMessage(m); }}
+  function act(a) {{ send({{action: a}}); }}
+  function act_agent(a, slug) {{ send({{action: a, slug: slug}}); }}
+  function open_agent(url) {{ send({{action: 'open', url: url}}); }}
+</script></body></html>"""
+
+
+# ── the pyobjc app: status item → popover(WKWebView) ────────────────────────────
+class Controller(NSObject):
+    def init(self):
+        self = objc.super(Controller, self).init()
+        if self is None:
+            return None
         self.cfg = _load_cfg()
+        self.agents: list = []
+        return self
 
-        self.status_item = rumps.MenuItem("Runner: …")
-        self.stats_item = rumps.MenuItem("—")
-        self.pause_item = rumps.MenuItem("⏸  Pause runner", callback=self.toggle_pause)
+    # -- lifecycle --
+    def applicationDidFinishLaunching_(self, _notif):
+        bar = NSStatusBar.systemStatusBar()
+        self.item = bar.statusItemWithLength_(NSVariableStatusItemLength)
+        btn = self.item.button()
+        btn.setTitle_("🔴")
+        btn.setTarget_(self)
+        btn.setAction_("toggle:")
 
-        links = rumps.MenuItem("🔗  Quick links")
-        for label, url in _links(self.cfg):
-            links.add(rumps.MenuItem(label, callback=self._opener(url)))
+        cfg = WKWebViewConfiguration.alloc().init()
+        ucc = WKUserContentController.alloc().init()
+        ucc.addScriptMessageHandler_name_(self, "bridge")
+        cfg.setUserContentController_(ucc)
+        frame = NSMakeRect(0, 0, 440, 600)
+        self.web = WKWebView.alloc().initWithFrame_configuration_(frame, cfg)
 
-        self.menu = [
-            self.status_item,
-            self.stats_item,
-            None,
-            self.pause_item,
-            None,
-            links,
-            rumps.MenuItem("📄  Open runner log", callback=self.open_log),
-            None,
-            rumps.MenuItem("▶︎  Start daemon", callback=self.start_daemon),
-            rumps.MenuItem("■  Stop daemon", callback=self.stop_daemon),
-            None,
-            rumps.MenuItem("Quit menu-bar app", callback=rumps.quit_application),
-        ]
-        self.refresh(None)
+        vc = NSViewController.alloc().init()
+        vc.setView_(self.web)
+        self.pop = NSPopover.alloc().init()
+        self.pop.setContentSize_(NSMakeSize(440, 600))
+        self.pop.setBehavior_(NSPopoverBehaviorTransient)
+        self.pop.setContentViewController_(vc)
 
-    # ---- opening links ----
-    def _opener(self, url: str):
-        def _cb(_):
-            webbrowser.open(url)
-        return _cb
+        self.refresh_status()
+        NSTimer.scheduledTimerWithTimeInterval_target_selector_userInfo_repeats_(
+            5.0, self, "tick:", None, True)
 
-    def open_log(self, _):
-        subprocess.run(["open", str(LOG)]) if LOG.exists() else rumps.alert(
-            "No log yet", f"{LOG} does not exist. Start the daemon first.")
+    def applicationSupportsSecureRestorableState_(self, _app):
+        return True
 
-    # ---- pause / resume (token-safe, instant) ----
-    def toggle_pause(self, _):
-        if PAUSE_FILE.exists():
-            try:
-                PAUSE_FILE.unlink()
-            except Exception as e:  # noqa: BLE001
-                rumps.alert("Resume failed", str(e))
-        else:
-            try:
+    # -- status dot --
+    @objc.python_method
+    def refresh_status(self):
+        st = _runner_state()
+        self._state = st
+        self.item.button().setTitle_(GLYPH[st["state"]])
+
+    def tick_(self, _timer):
+        # Re-assert accessory (menu-bar-only) and refresh the dot.
+        NSApplication.sharedApplication().setActivationPolicy_(NSApplicationActivationPolicyAccessory)
+        self.refresh_status()
+
+    # -- panel open/close --
+    def toggle_(self, sender):
+        if self.pop.isShown():
+            self.pop.performClose_(sender)
+            return
+        NSApplication.sharedApplication().activateIgnoringOtherApps_(True)
+        btn = self.item.button()
+        self.pop.showRelativeToRect_ofView_preferredEdge_(btn.bounds(), btn, NSMinYEdge)
+        self._render_from_cache()      # instant paint from what we have
+        self._reload_async()           # then refresh data in the background
+
+    # Main-thread render trampoline (ObjC selector so performSelectorOnMainThread works).
+    def renderMain_(self, _obj):
+        self._render_from_cache()
+
+    @objc.python_method
+    def _render_from_cache(self):
+        html_str = render(self._state, self.agents, _base(self.cfg))
+        self.web.loadHTMLString_baseURL_(html_str, None)
+
+    @objc.python_method
+    def _reload_async(self):
+        def work():
+            agents = fetch_agents(_base(self.cfg), _token(self.cfg))
+            self.agents = agents
+            self.refresh_status()
+            self.performSelectorOnMainThread_withObject_waitUntilDone_(
+                "renderMain:", None, False)
+        threading.Thread(target=work, daemon=True).start()
+
+    # -- JS bridge --
+    def userContentController_didReceiveScriptMessage_(self, _ucc, message):
+        body = message.body()
+        action = body.get("action") if hasattr(body, "get") else None
+        if action == "open":
+            webbrowser.open(body.get("url", ""))
+            self.pop.performClose_(None)
+        elif action in ("pause", "resume"):
+            self._set_pause(action == "pause")
+            self.refresh_status()
+            self._render_from_cache()
+        elif action in ("pauseAgent", "resumeAgent"):
+            slug = body.get("slug") if hasattr(body, "get") else None
+            if slug:
+                self._set_agent_pause(slug, action == "pauseAgent")
+            self._render_from_cache()   # instant reflect (agents already cached)
+        elif action in ("start", "stop"):
+            self._daemon(action)
+            self.refresh_status()
+            self._render_from_cache()
+        elif action == "openLog":
+            if LOG.exists():
+                subprocess.run(["open", str(LOG)])
+        elif action == "refresh":
+            self._render_from_cache()
+            self._reload_async()
+        elif action == "quit":
+            NSApplication.sharedApplication().terminate_(None)
+
+    @objc.python_method
+    def _set_pause(self, paused: bool):
+        try:
+            if paused:
                 PAUSE_FILE.parent.mkdir(parents=True, exist_ok=True)
                 PAUSE_FILE.write_text(dt.datetime.now().isoformat())
-            except Exception as e:  # noqa: BLE001
-                rumps.alert("Pause failed", str(e))
-        self.refresh(None)
+            elif PAUSE_FILE.exists():
+                PAUSE_FILE.unlink()
+        except Exception:  # noqa: BLE001
+            pass
 
-    # ---- daemon start / stop (the nuclear option) ----
-    def start_daemon(self, _):
-        if not PLIST.exists():
-            rumps.alert("No plist", f"{PLIST} not found.")
-            return
-        _launchctl("bootstrap", _domain(), str(PLIST))
-        _launchctl("kickstart", f"{_domain()}/{LABEL}")
-        self.refresh(None)
+    @objc.python_method
+    def _set_agent_pause(self, slug: str, paused: bool):
+        f = _agent_pause_file(slug)
+        try:
+            if paused:
+                f.parent.mkdir(parents=True, exist_ok=True)
+                f.write_text(dt.datetime.now().isoformat())
+            elif f.exists():
+                f.unlink()
+        except Exception:  # noqa: BLE001
+            pass
 
-    def stop_daemon(self, _):
-        _launchctl("bootout", f"{_domain()}/{LABEL}")
-        self.refresh(None)
-
-    # ---- periodic status refresh ----
-    @rumps.timer(5)
-    def refresh(self, _):
-        paused = PAUSE_FILE.exists()
-        loaded = _daemon_loaded()
-        st = _log_stats()
-
-        if not loaded:
-            state = "stopped"
-        elif paused:
-            state = "paused"
-        elif not st["fresh"]:
-            state = "stale"
+    @objc.python_method
+    def _daemon(self, action: str):
+        if action == "start":
+            if PLIST.exists():
+                _launchctl("bootstrap", _domain(), str(PLIST))
+                _launchctl("kickstart", f"{_domain()}/{LABEL}")
         else:
-            state = "running"
-
-        # Belt-and-suspenders: because the .app launcher execs the venv's Python, macOS
-        # can briefly adopt Python.app's identity (dock icon + "Python" menu). Re-assert
-        # accessory (menu-bar-only) each tick so it can't win the race after launch.
-        NSApplication.sharedApplication().setActivationPolicy_(NSApplicationActivationPolicyAccessory)
-
-        # Title carries a word, not just a dot, so it's findable among the system icons.
-        self.title = f"{GLYPH[state]} Runner"
-        self.pause_item.title = "▶︎  Resume runner" if paused else "⏸  Pause runner"
-
-        pretty = {"running": "running", "paused": "PAUSED", "stopped": "stopped (daemon not loaded)",
-                  "stale": "loaded but log is stale"}[state]
-        age = f"{st['age_s']}s ago" if st["age_s"] is not None else "no log"
-        self.status_item.title = f"Runner: {pretty}  ·  last log {age}"
-        self.stats_item.title = f"Today: {st['created']} created · {st['reused']} reused"
-        if st["last"]:
-            self.stats_item.title += f"   |  {st['last']}"
+            _launchctl("bootout", f"{_domain()}/{LABEL}")
 
 
 def main() -> None:
-    # Menu-bar-only: no dock icon, no "Python" app menu. Set before the run loop starts;
-    # refresh() re-asserts it too (see note there).
-    NSApplication.sharedApplication().setActivationPolicy_(NSApplicationActivationPolicyAccessory)
-    RunnerApp().run()
+    app = NSApplication.sharedApplication()
+    app.setActivationPolicy_(NSApplicationActivationPolicyAccessory)
+    controller = Controller.alloc().init()
+    app.setDelegate_(controller)
+    app.run()
 
 
 if __name__ == "__main__":

--- a/packages/canopy_runner/menubar/build_app.sh
+++ b/packages/canopy_runner/menubar/build_app.sh
@@ -16,10 +16,11 @@ APP="${CANOPY_RUNNER_APP:-$HOME/Applications/Canopy Runner.app}"
 
 [ -d "$PKG_DIR/canopy_runner" ] || { echo "ERROR: runner package not at $PKG_DIR" >&2; exit 1; }
 
-echo "==> venv + rumps ($VENV)"
+echo "==> venv + pyobjc (Cocoa + WebKit) ($VENV)"
 [ -d "$VENV" ] || python3 -m venv "$VENV"
 "$VENV/bin/pip" install -q --upgrade pip >/dev/null
-"$VENV/bin/pip" install -q rumps >/dev/null
+# The panel is an NSPopover hosting a WKWebView, so we need Cocoa + WebKit bindings.
+"$VENV/bin/pip" install -q pyobjc-framework-Cocoa pyobjc-framework-WebKit >/dev/null
 
 echo "==> app bundle ($APP)"
 rm -rf "$APP"

--- a/tests/test_harness_services.py
+++ b/tests/test_harness_services.py
@@ -54,6 +54,20 @@ def test_claim_serializes_execution_per_agent():
     assert second is not None and second.idempotency_key == "k2"
 
 
+def test_claim_excludes_paused_agents():
+    """Per-agent pause: a paused agent's queued turn is not claimed, but stays QUEUED
+    (resumable), and other agents are unaffected."""
+    a = _agent()
+    t, _ = services.enqueue_turn(agent=a, origin="board", idempotency_key="k1")
+    r = _runner()
+    # echo paused → nothing to claim, and the turn is untouched
+    assert services.claim_next_turn(r, exclude_slugs=["echo"]) is None
+    t.refresh_from_db()
+    assert t.status == Turn.QUEUED
+    # excluding an unrelated agent doesn't block echo
+    assert services.claim_next_turn(r, exclude_slugs=["hal"]).pk == t.pk
+
+
 def test_claim_next_turn_happy_path():
     a = _agent()
     t, _ = services.enqueue_turn(agent=a, origin="board", idempotency_key="k1")


### PR DESCRIPTION
Evolves the Canopy Runner menu-bar app from a text menu into a **click-to-open panel** (like Google Drive's menu-bar UI), and adds **per-agent pause/resume**.

## Panel (`canopy_runner/menubar.py`)
- Menu-bar shows just a status **dot**; clicking opens an `NSPopover` hosting a `WKWebView`, styled to canopy-web's **Warm Earth** dark tokens.
- Lists **every agent** (fetched live from `/api/agents/` with the runner token, enriched with detail counts). Each card shows persona, email, turns/tasks/skills/products, and last-activity. **Clicking a card opens that agent's home page** on canopy-web (`/agents/<slug>`, which deep-links into the tenant).
- Header has the global runner **Pause/Resume** + **Start/Stop daemon** + Log/Refresh.

## Per-agent pause/resume
- Each card has its own **Pause/Resume**, backed by a `~/.canopy/PAUSED.<slug>` sentinel (sibling of the global `PAUSED`).
- The runner **skips inbox polling** for paused agents and passes paused slugs to `/claim`.
- `claim_next_turn(exclude_slugs=…)` **excludes their QUEUED turns server-side** — nothing is claimed-then-released; turns stay QUEUED and resume instantly when unpaused. The `paused` claim param is optional/back-compat.

Drops `rumps` for raw pyobjc (Cocoa+WebKit) — required for the popover+webview, and lets us force the accessory (menu-bar-only) activation policy directly.

Tests: harness services/api **30 passed** (incl. new `test_claim_excludes_paused_agents`); runner **57 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)