### PR TITLE
feat(runner): ingest approved fleet reviews as harness turns

### DIFF
--- a/packages/canopy_runner/canopy_runner/client.py
+++ b/packages/canopy_runner/canopy_runner/client.py
@@ -82,6 +82,28 @@ class Client:
     def post_events(self, turn_id: str, events: list[dict]) -> None:
         self._call("POST", f"/turns/{turn_id}/events", {"events": events})
 
+    def _get_api(self, path: str) -> object:
+        """GET an arbitrary /api path (not under /api/harness) — used to read the
+        reviews surface for review-ingestion. Same auth/error handling as _call."""
+        url = f"{self.base_url}/api{path}"
+        req = urllib.request.Request(url, method="GET")
+        req.add_header("Authorization", f"Bearer {self.token}")
+        try:
+            with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:
+                raw = resp.read()
+        except urllib.error.HTTPError as exc:
+            raise ClientError(f"GET {path} -> {exc.code}") from exc
+        except urllib.error.URLError as exc:
+            raise ClientError(f"GET {path} -> {exc.reason}") from exc
+        return json.loads(raw) if raw else None
+
+    def list_reviews(self, status: str = "") -> list[dict]:
+        q = f"?status={status}" if status else ""
+        return self._get_api(f"/reviews/{q}") or []
+
+    def get_review(self, review_id: str) -> dict:
+        return self._get_api(f"/reviews/{review_id}/") or {}
+
     def enqueue_turn(self, agent_slug: str, origin: str, idempotency_key: str, *,
                      prompt: str = "", origin_ref: dict | None = None,
                      routing: str = "prefer_local") -> dict:

--- a/packages/canopy_runner/canopy_runner/config.py
+++ b/packages/canopy_runner/canopy_runner/config.py
@@ -24,6 +24,9 @@ class Config:
     executor: str = "cdp"
     cdp_port: int = 9222
     inbox_poll_seconds: int = 300
+    # How often to poll canopy-web for RESOLVED fleet reviews and enqueue the turns for
+    # each cluster the human approved (0 disables review-ingestion entirely).
+    reviews_poll_seconds: int = 300
     # {agent_slug: {"account": "<mailbox>", "client": "<gog client>", "query": "<opt>"}}
     # — the deterministic email trigger polls these and enqueues email-origin turns.
     # Per-mailbox "query" overrides the default Gmail search (e.g. restrict to certain

--- a/packages/canopy_runner/canopy_runner/main.py
+++ b/packages/canopy_runner/canopy_runner/main.py
@@ -148,6 +148,44 @@ def _maybe_check_inboxes(cfg: Config, client: Client, now_fn=time.time,
         pass
 
 
+def _maybe_check_reviews(cfg: Config, client: Client, now_fn=time.time) -> None:
+    """At most every reviews_poll_seconds, ingest RESOLVED fleet reviews: enqueue the
+    turns for each cluster the human approved. Best-effort — a failing poll logs and is
+    skipped, never crashes the loop. A local seen-set (reviews-seen.json) skips reviews
+    already fully ingested so we don't re-fetch/re-enqueue them every poll."""
+    if not getattr(cfg, "reviews_poll_seconds", 0):
+        return
+    base = Path(cfg.state_path) if cfg.state_path else Path("runner-state.json")
+    stamp = base.with_name("reviews-last.txt")
+    seen_path = base.with_name("reviews-seen.json")
+    try:
+        last = float(stamp.read_text())
+    except (OSError, ValueError):
+        last = 0.0
+    if now_fn() - last < cfg.reviews_poll_seconds:
+        return
+    try:
+        seen = set(json.loads(seen_path.read_text()))
+    except (OSError, ValueError):
+        seen = set()
+    from . import reviews as reviews_mod
+    try:
+        res = reviews_mod.check_reviews(client, seen=frozenset(seen))
+    except Exception as exc:  # noqa: BLE001 — review-ingestion never kills the loop
+        logger.warning("review ingestion failed: %s", exc)
+        return
+    newly = res.get("processed") or set()
+    if newly:
+        try:
+            seen_path.write_text(json.dumps(sorted(seen | newly)))
+        except OSError:
+            pass
+    try:
+        stamp.write_text(str(now_fn()))
+    except OSError:
+        pass
+
+
 def _run_once_cdp(cfg: Config, client: Client) -> str:
     """CDP executor: heartbeat (with macOS host, for reuse ownership) → claim one
     turn → route it to an emdash session (reuse or create). Turns finish synchronously
@@ -159,6 +197,7 @@ def _run_once_cdp(cfg: Config, client: Client) -> str:
     client.heartbeat(cfg.runner_id, [], host=host_id())
     paused = _paused_agents(cfg)
     _maybe_check_inboxes(cfg, client, paused=paused)
+    _maybe_check_reviews(cfg, client)
     try:
         turn = client.claim(cfg.runner_id, paused_agents=sorted(paused))
     except ClientError as exc:

--- a/packages/canopy_runner/canopy_runner/reviews.py
+++ b/packages/canopy_runner/canopy_runner/reviews.py
@@ -1,0 +1,87 @@
+"""Deterministic review-ingestion: turn a human-approved fleet review into harness turns.
+
+Ada (the fleet conductor) posts a canopy-web review (`gate=product_findings`) whose
+clusters each carry a `turns[]` routing block — the exact fields the harness needs:
+`{target_agent, prompt, origin, origin_ref}`. Jonathan goes through the review in the
+web UI and submits `implement | skip | defer` per cluster. This module is the runner's
+side: it polls RESOLVED reviews and, for every cluster he decided `implement`, enqueues
+the turn(s) Ada attached — routed to the right agent, with session-continuity context.
+
+No LLM in the hot path — "approved cluster → its turns[]" is a fixed rule. Idempotency
+is keyed `review-<review_id>-<cluster_id>-<i>`, so re-polling never double-enqueues and
+never re-runs a finished turn. A local seen-set skips reviews already fully ingested.
+
+Ada's clusters look like:
+    {"id": "eva-first-turn", "title": "…", "severity": "high", "fix_kind": "mechanical",
+     "suggested_fix": "…",
+     "turns": [{"target_agent": "eva", "origin": "email", "prompt": "/eva:turn --thread <id>",
+                "origin_ref": {"thread_id": "<id>", "subject": "…"}}]}
+"""
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger("canopy_runner.reviews")
+
+# The only review gate we ingest — the fleet-conductor findings surface. Other gates
+# (DDD narrative review, etc.) are for humans only and never become fleet turns.
+INGESTIBLE_GATE = "product_findings"
+IMPLEMENT = "implement"
+
+
+def check_reviews(client, *, seen: frozenset[str] = frozenset(), max_reviews: int = 25) -> dict:
+    """Enqueue the turns for every `implement`-decided cluster in resolved, not-yet-seen
+    reviews. Returns {"enqueued": [(review_id, cluster_id, agent), …],
+                      "processed": {review_id, …}}  — review ids that were fully ingested
+    (every implemented cluster had a routing block) and can be skipped next poll. A review
+    with an implemented-but-unrouted cluster is left UNprocessed so a later Ada fix + a
+    re-poll picks it up."""
+    enqueued: list[tuple[str, str, str]] = []
+    processed: set[str] = set()
+
+    for row in (client.list_reviews(status="resolved") or [])[:max_reviews]:
+        rid = str(row.get("id") or "")
+        if not rid or rid in seen or row.get("gate") != INGESTIBLE_GATE:
+            continue
+
+        detail = client.get_review(rid) or {}
+        req = detail.get("request_json") or {}
+        resp = detail.get("response_json") or {}
+        decisions = resp.get("decisions") or {}
+
+        complete = True  # every implemented cluster had a routing block
+        for cluster in req.get("clusters") or []:
+            cid = cluster.get("id") or ""
+            if (decisions.get(cid) or {}).get("decision") != IMPLEMENT:
+                continue
+            specs = cluster.get("turns") or []
+            if not specs:
+                complete = False
+                logger.warning("review %s cluster '%s' was approved but has no turns[] "
+                               "routing block — Ada must emit {target_agent, prompt, origin, "
+                               "origin_ref}; skipping (will retry once fixed)", rid, cid)
+                continue
+            for i, spec in enumerate(specs):
+                agent = (spec.get("target_agent") or "").strip()
+                if not agent:
+                    complete = False
+                    logger.warning("review %s cluster '%s' turn #%d missing target_agent; "
+                                   "skipping", rid, cid, i)
+                    continue
+                client.enqueue_turn(
+                    agent,
+                    spec.get("origin") or "api",
+                    f"review-{rid}-{cid}-{i}",
+                    prompt=spec.get("prompt") or f"/{agent}:turn",
+                    origin_ref=spec.get("origin_ref") or {},
+                )
+                enqueued.append((rid, cid, agent))
+
+        if complete:
+            processed.add(rid)
+
+    if enqueued:
+        logger.info("reviews: enqueued %d turn(s) from %d review(s) — %s",
+                    len(enqueued), len({e[0] for e in enqueued}),
+                    ", ".join(f"{cid}->{agent}" for _, cid, agent in enqueued))
+    return {"enqueued": enqueued, "processed": processed}

--- a/packages/canopy_runner/tests/test_reviews.py
+++ b/packages/canopy_runner/tests/test_reviews.py
@@ -1,0 +1,77 @@
+"""Deterministic review-ingestion — approved clusters -> harness turns."""
+from canopy_runner import reviews
+
+
+class FakeClient:
+    def __init__(self, listing, details):
+        self._listing = listing        # list of review rows (as /api/reviews/ returns)
+        self._details = details         # {review_id: detail dict}
+        self.enqueued = []
+
+    def list_reviews(self, status=""):
+        assert status == "resolved"
+        return self._listing
+
+    def get_review(self, review_id):
+        return self._details[review_id]
+
+    def enqueue_turn(self, agent, origin, idem, *, prompt="", origin_ref=None, routing="prefer_local"):
+        self.enqueued.append({"agent": agent, "origin": origin, "idem": idem,
+                              "prompt": prompt, "origin_ref": origin_ref})
+        return {"id": "t-x"}
+
+
+def _detail(clusters, decisions, gate="product_findings"):
+    return {"gate": gate, "request_json": {"clusters": clusters},
+            "response_json": {"decisions": decisions}}
+
+
+def test_enqueues_implemented_cluster_turns():
+    clusters = [
+        {"id": "eva-first-turn", "turns": [
+            {"target_agent": "eva", "origin": "email", "prompt": "/eva:turn --thread T",
+             "origin_ref": {"thread_id": "T"}}]},
+        {"id": "hal-skip-me", "turns": [{"target_agent": "hal", "prompt": "/hal:turn"}]},
+    ]
+    decisions = {"eva-first-turn": {"decision": "implement"},
+                 "hal-skip-me": {"decision": "skip"}}
+    c = FakeClient([{"id": "r1", "gate": "product_findings"}],
+                   {"r1": _detail(clusters, decisions)})
+    res = reviews.check_reviews(c)
+    assert [e["agent"] for e in c.enqueued] == ["eva"]                 # only implemented
+    assert c.enqueued[0]["idem"] == "review-r1-eva-first-turn-0"
+    assert c.enqueued[0]["origin_ref"] == {"thread_id": "T"}
+    assert res["processed"] == {"r1"}                                  # fully ingested
+
+
+def test_fanout_cluster_enqueues_one_turn_each():
+    clusters = [{"id": "echo-stale-board", "turns": [
+        {"target_agent": "echo", "prompt": "/echo:turn nudge Sarvesh"},
+        {"target_agent": "echo", "prompt": "/echo:turn nudge Amie"}]}]
+    c = FakeClient([{"id": "r2", "gate": "product_findings"}],
+                   {"r2": _detail(clusters, {"echo-stale-board": {"decision": "implement"}})})
+    reviews.check_reviews(c)
+    assert [e["idem"] for e in c.enqueued] == \
+        ["review-r2-echo-stale-board-0", "review-r2-echo-stale-board-1"]
+
+
+def test_seen_reviews_are_skipped():
+    c = FakeClient([{"id": "r1", "gate": "product_findings"}], {})  # get_review never called
+    res = reviews.check_reviews(c, seen=frozenset({"r1"}))
+    assert c.enqueued == [] and res["processed"] == set()
+
+
+def test_non_findings_gate_ignored():
+    c = FakeClient([{"id": "r9", "gate": "ddd_narrative"}], {})
+    reviews.check_reviews(c)
+    assert c.enqueued == []
+
+
+def test_implemented_without_routing_block_is_not_marked_processed():
+    """An approved cluster with no turns[] can't be dispatched — leave the review
+    unprocessed so a later Ada fix + re-poll picks it up."""
+    clusters = [{"id": "eva-first-turn"}]  # no turns[]
+    c = FakeClient([{"id": "r3", "gate": "product_findings"}],
+                   {"r3": _detail(clusters, {"eva-first-turn": {"decision": "implement"}})})
+    res = reviews.check_reviews(c)
+    assert c.enqueued == [] and res["processed"] == set()


### PR DESCRIPTION
Runner-side (Option 1) ingestion of Ada's fleet reviews. After Jonathan goes through a review and submits decisions, the runner turns each **approved** cluster into harness turns routed to the right agent.

## Flow
1. Ada posts a review (`gate=product_findings`) where each cluster carries a **`turns[]` routing block** (`{target_agent, prompt, origin, origin_ref}`) — updated in Ada's `conduct` skill (separate repo).
2. Jonathan reviews at `/review/<id>` and submits `implement | skip | defer` per cluster.
3. The runner polls **resolved** reviews and enqueues the `turns[]` of every `implement` cluster via `POST /api/harness/turns/`, idempotency-keyed `review-<id>-<cluster>-<i>`.

## Details
- `reviews.py` — pure/testable `check_reviews()`. Fan-out clusters → one turn each. Approved-but-unrouted clusters are logged + skipped, and the review is left unprocessed so a later Ada fix + re-poll picks it up.
- `client.py` — `list_reviews()` / `get_review()` (reads the `/api/reviews` surface; team-internal PAT read).
- `main.py` — `_maybe_check_reviews()` gated by `reviews_poll_seconds`, with a persisted seen-set so fully-ingested reviews aren't re-scanned.
- `config.py` — `reviews_poll_seconds` (default 300; 0 disables).

No canopy-web/harness change — the harness already accepts these exact turn fields. Runner tests: **62 passed** (5 new in `test_reviews.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)