### PR TITLE
feat(agents): one-click decline (reason optional via '+ reason')

### DIFF
--- a/frontend/src/components/TasksBoard.tsx
+++ b/frontend/src/components/TasksBoard.tsx
@@ -302,16 +302,23 @@ function TaskActions({
           <ActionButton tone="primary" disabled={busy} onClick={() => run('accept')}>
             Accept
           </ActionButton>
-          <ActionButton
-            tone="muted"
+          {/* One-click decline: no reason required (the reason only ever feeds the
+              agent as context). Use "＋ reason" when you actually want to steer it. */}
+          <ActionButton tone="muted" disabled={busy} onClick={() => run('decline', { reason: '' })}>
+            Decline
+          </ActionButton>
+          <button
+            type="button"
             disabled={busy}
             onClick={() => {
               setError(null)
               setDeclining(true)
             }}
+            className="text-[11px] text-muted-foreground underline-offset-2 hover:text-foreground hover:underline disabled:opacity-50"
+            title="Decline with a reason for the agent"
           >
-            Decline
-          </ActionButton>
+            ＋ reason
+          </button>
         </div>
       )}
 


### PR DESCRIPTION
Declining a suggested idea/task is now **one click** — it posts immediately with an empty reason. A small **"＋ reason"** link opens the (optional) reason box for the times you want to give the agent context.

Rationale: the decline reason only ever feeds the **agent** as context (it rides the command payload the agent drains) — nothing else ingests it — so requiring/adding friction had no payoff. This keeps the signal available without making you type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)