### PR TITLE
fix(runner): context-aware primary button + drop header emoji

### DIFF
--- a/packages/canopy_runner/canopy_runner/menubar.py
+++ b/packages/canopy_runner/canopy_runner/menubar.py
@@ -416,10 +416,17 @@ def render(state: dict, agents: list[dict], base: str) -> str:
     pill_word = {"running": "Running", "paused": "Paused",
                  "stopped": "Stopped", "stale": "Stale"}[s]
     age = f'{state["age_s"]}s ago' if state.get("age_s") is not None else "no log"
-    pause_label = "Resume" if state["paused"] else "Pause"
-    pause_act = "resume" if state["paused"] else "pause"
-    daemon_label, daemon_act = (("Stop daemon", "stop") if s != "stopped"
-                                else ("Start daemon", "start"))
+    # Primary action is always the meaningful next step for the current state:
+    #   stopped -> Start daemon (there's nothing to pause), else Pause/Resume the runner.
+    # Pausing while stopped did nothing visible, which read as "the button is broken".
+    if s == "stopped":
+        primary_html = "<button class=\"btn primary\" onclick=\"act('start')\">Start daemon</button>"
+        daemon_html = ""
+    else:
+        plabel = "Resume" if state["paused"] else "Pause"
+        pact = "resume" if state["paused"] else "pause"
+        primary_html = f"<button class=\"btn primary\" onclick=\"act('{pact}')\">{plabel} runner</button>"
+        daemon_html = "<button class=\"btn\" onclick=\"act('stop')\">Stop daemon</button>"
     idx = {a.get("slug"): i for i, a in enumerate(agents)}
 
     # "Waiting on you" — the actionable inbox across the fleet (pending reviews + gated
@@ -535,14 +542,14 @@ def render(state: dict, agents: list[dict], base: str) -> str:
 </style></head><body>
   <div class="hdr">
     <div class="titlerow">
-      <span class="brand">🪴 Canopy Runner</span>
+      <span class="brand">Canopy Runner</span>
       <span class="pill {s}">{pill_word}</span>
     </div>
     <div class="sub">Today: <b>{state.get('created', 0)}</b> created · <b>{state.get('reused', 0)}</b> reused · log {age}</div>
     {f'<div class="last">{last_line}</div>' if last_line else ''}
     <div class="actions">
-      <button class="btn primary" onclick="act('{pause_act}')">{pause_label} runner</button>
-      <button class="btn" onclick="act('{daemon_act}')">{daemon_label}</button>
+      {primary_html}
+      {daemon_html}
       <button class="btn" onclick="act('openLog')">Log</button>
       <button class="btn" onclick="act('refresh')">Refresh</button>
     </div>


### PR DESCRIPTION
Fixes the confusing panel control. When **Stopped**, the orange top-left button was 'Pause runner' — a no-op you can't see (nothing to pause when the daemon isn't running), which read as 'the button is broken'. Now the primary button is always the meaningful next step:
- **Stopped →** 'Start daemon' (Pause/Stop hidden)
- **Running/Stale →** 'Pause runner' + 'Stop daemon'
- **Paused →** 'Resume runner' + 'Stop daemon'

Also drops the 🪴 from the panel header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)