### PR TITLE
fix(runner): heartbeat liveness (no false Stale) + drop cryptic header line

### DIFF
--- a/packages/canopy_runner/canopy_runner/main.py
+++ b/packages/canopy_runner/canopy_runner/main.py
@@ -533,9 +533,22 @@ def main() -> None:
     logger.info("  pause: drop %s to halt work (menu-bar app toggles this); remove to resume",
                 pause_file)
 
+    # Liveness heartbeat file: touched EVERY cycle (even idle/paused). The menu-bar app
+    # reads its mtime to tell "running" from "stale" — the log alone is a bad signal
+    # because idle cycles are deliberately quiet (~15 min between lines), which would
+    # otherwise show a healthy idle runner as "stale".
+    hb_file = Path(args.config).with_name("heartbeat")
+
+    def _beat() -> None:
+        try:
+            hb_file.write_text(str(time.time()))
+        except OSError:
+            pass
+
     idle_streak = 0
     paused = False
     while True:
+        _beat()
         if pause_file.exists():
             if not paused:
                 logger.warning("PAUSED — sentinel %s present; skipping all work (no claim, no "

--- a/packages/canopy_runner/canopy_runner/menubar.py
+++ b/packages/canopy_runner/canopy_runner/menubar.py
@@ -61,6 +61,7 @@ PLIST = Path(os.environ.get(
     "~/emdash-projects/canopy-web/packages/canopy_runner/launchd/com.canopy.runner.plist",
 )).expanduser()
 PAUSE_FILE = CONFIG.with_name("PAUSED")
+HEARTBEAT = CONFIG.with_name("heartbeat")  # runner touches this every cycle (liveness)
 LABEL = "com.canopy.runner"
 
 GLYPH = {"running": "🟢", "paused": "🟡", "stopped": "🔴", "stale": "🟠"}
@@ -221,17 +222,31 @@ def _log_stats() -> dict:
     return out
 
 
+def _heartbeat_age() -> int | None:
+    """Seconds since the runner last cycled (touched the heartbeat file), or None if it
+    has never written one. This — not the log — is the liveness signal: the runner touches
+    it every cycle even when idle/paused, whereas idle log lines are ~15 min apart."""
+    try:
+        return int(dt.datetime.now().timestamp() - HEARTBEAT.stat().st_mtime)
+    except OSError:
+        return None
+
+
 def _runner_state() -> dict:
     paused, loaded, st = PAUSE_FILE.exists(), _daemon_loaded(), _log_stats()
+    hb = _heartbeat_age()
+    # Fresh = cycled recently. Prefer the heartbeat (updated every cycle); fall back to the
+    # log's mtime only for a runner too old to write a heartbeat file.
+    fresh = (hb < 75) if hb is not None else st["fresh"]
     if not loaded:
         state = "stopped"
     elif paused:
         state = "paused"
-    elif not st["fresh"]:
+    elif not fresh:
         state = "stale"
     else:
         state = "running"
-    return {"state": state, "paused": paused, **st}
+    return {"state": state, "paused": paused, "hb_age": hb, **st}
 
 
 # ── agent data (canopy-web API) ─────────────────────────────────────────────────
@@ -415,7 +430,8 @@ def render(state: dict, agents: list[dict], base: str) -> str:
     s = state["state"]
     pill_word = {"running": "Running", "paused": "Paused",
                  "stopped": "Stopped", "stale": "Stale"}[s]
-    age = f'{state["age_s"]}s ago' if state.get("age_s") is not None else "no log"
+    hb = state.get("hb_age")
+    checked = f"{hb}s ago" if hb is not None else "—"
     # Primary action is always the meaningful next step for the current state:
     #   stopped -> Start daemon (there's nothing to pause), else Pause/Resume the runner.
     # Pausing while stopped did nothing visible, which read as "the button is broken".
@@ -450,7 +466,6 @@ def render(state: dict, agents: list[dict], base: str) -> str:
     cards = "".join(_card(a, base, i, _agent_paused(a.get("slug", "")))
                     for i, a in enumerate(agents)) or \
         '<div class="empty">No agents found (check the runner token / connection).</div>'
-    last_line = html.escape(state.get("last") or "")
 
     return f"""<!doctype html><html><head><meta charset="utf-8">
 <style>
@@ -545,8 +560,7 @@ def render(state: dict, agents: list[dict], base: str) -> str:
       <span class="brand">Canopy Runner</span>
       <span class="pill {s}">{pill_word}</span>
     </div>
-    <div class="sub">Today: <b>{state.get('created', 0)}</b> created · <b>{state.get('reused', 0)}</b> reused · log {age}</div>
-    {f'<div class="last">{last_line}</div>' if last_line else ''}
+    <div class="sub">Today: <b>{state.get('created', 0)}</b> created · <b>{state.get('reused', 0)}</b> reused · checked {checked}</div>
     <div class="actions">
       {primary_html}
       {daemon_html}


### PR DESCRIPTION
Two panel fixes:
- **No more false 'Stale'.** Liveness was judged by the log's mtime, but idle cycles are deliberately quiet (~15 min apart), so a healthy idle runner flapped to Stale. The runner now touches `~/.canopy/heartbeat` **every cycle** (idle/paused included); the app uses that (fresh < 75s) as the liveness signal, header shows `checked <n>s ago`. Falls back to log mtime for a pre-heartbeat runner.
- **Removed the cryptic `e: created:<uuid>…` line** from the header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)