### PR TITLE
fix(reviews): run-child reviews attach to a narrative, never conjure one

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,6 +193,8 @@ Settings:
 
 Reviews are tokenless. `visibility=link` reviews are readable by anyone with the URL — the auth middleware lets anonymous holders through the `/review/:id` shell + the per-review read API (which self-enforce). **Submitting** a decision always requires a Dimagi login (public-readable never grants anonymous write).
 
+**Run-child gates belong to no narrative.** `RUN_CHILD_GATES` (`apps/common/ddd.py` — `product_findings` today) hang off the *run*, not the narrative timeline: `create_review` stores `narrative_slug=None` + `version=0`, the serializers never re-derive a slug from the run_id for them, and `/review/:id` renders them **standalone** (no DDD rail). In `apps/runs/aggregate.py` they may **attach** to a narrative that already exists but never **create** one — because the gate can't discriminate: a DDD findings review and Ada's fleet audit both use `product_findings`, but only the former is a child of a real run. Without that rule, parsing a slug out of any run_id conjured a phantom narrative into the DDD rail (active, empty, unnavigable). Note `_NON_NARRATIVE_GATES` (aggregate) is a *superset* — `external_release` isn't a narrative *version* but does belong to a narrative, so it may create one.
+
 ### DDD runs (`apps/runs`, mounted at `/api/ddd`)
 - `GET /api/ddd/narratives/` — List DDD narratives
 - `GET /api/ddd/narratives/{slug}/` — Get a narrative + its runs (grouped by version)

--- a/apps/common/ddd.py
+++ b/apps/common/ddd.py
@@ -21,3 +21,24 @@ def narrative_slug_from_run_id(run_id: str) -> str:
     """
     base = _RUN_ID_STAMP.sub("", run_id or "").strip("-")
     return base or run_id or "(untitled)"
+
+
+#: Gates whose reviews hang off the RUN, not the narrative timeline. These carry no
+#: narrative_slug and no narrative version, they never render as a version row, and
+#: they may ATTACH to a narrative but never CREATE one (``apps.runs.aggregate``).
+#:
+#: This lives here, beside the slug derivation, for the same reason that does: both
+#: ``apps.reviews`` (which assigns the slug) and ``apps.runs`` (which groups by it)
+#: must agree, and a disagreement is invisible until a phantom narrative shows up in
+#: the rail. ``apps.runs`` cannot import it from ``apps.reviews.api`` without dragging
+#: in a Ninja router.
+#:
+#: NOT the same set as ``aggregate._NON_NARRATIVE_GATES``, and the difference is load-
+#: bearing: ``external_release`` is not a *version* of a narrative but does belong to
+#: one (it approves publishing it). ``product_findings`` belongs to no narrative at all.
+RUN_CHILD_GATES = ("product_findings",)
+
+
+def is_run_child_gate(gate: str | None) -> bool:
+    """True for a review that hangs off the run rather than the narrative."""
+    return (gate or "") in RUN_CHILD_GATES

--- a/apps/reviews/api.py
+++ b/apps/reviews/api.py
@@ -28,7 +28,11 @@ from ninja import Router, Status
 from apps.api.auth import session_auth
 from apps.api.errors import TYPE_FORBIDDEN, TYPE_NOT_FOUND, ProblemError
 from apps.common.csrf import csrf_rejected
-from apps.common.ddd import narrative_slug_from_run_id
+from apps.common.ddd import (
+    RUN_CHILD_GATES,
+    is_run_child_gate,
+    narrative_slug_from_run_id,
+)
 from apps.workspaces import services as wsvc
 
 from .models import ReviewRequest
@@ -44,15 +48,22 @@ log = logging.getLogger(__name__)
 
 router = Router(auth=session_auth, tags=["reviews"])
 
-# Gates whose reviews hang off the RUN, not the narrative timeline. These never get a
-# narrative_slug or a monotonic narrative version (see create_review) — so they don't
-# pollute the version numbering or show up as narrative-version rows in the DDD shell.
-RUN_CHILD_GATES = ("product_findings",)
-
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _narrative_slug_of(review: ReviewRequest) -> str | None:
+    """The narrative this review belongs to, or None for a run-child gate.
+
+    The stored column wins. Deriving from the run_id is a fallback for legacy
+    narrative-gate rows written before the column existed — and it is NEVER applied
+    to a run-child gate, whose NULL is a deliberate assertion by create_review that
+    the review belongs to no narrative. Re-deriving there overrode that decision and
+    conjured a phantom narrative into the DDD rail."""
+    if is_run_child_gate(review.gate):
+        return None
+    return (review.narrative_slug or "").strip() or narrative_slug_from_run_id(review.run_id)
 
 
 def _get_or_404(rid: UUID) -> ReviewRequest:
@@ -91,8 +102,7 @@ def _detail_payload(review: ReviewRequest, *, is_owner: bool) -> dict:
         "gate": review.gate,
         "status": review.status,
         "visibility": review.visibility,
-        "narrative_slug": (getattr(review, "narrative_slug", None) or "").strip()
-        or narrative_slug_from_run_id(review.run_id),
+        "narrative_slug": _narrative_slug_of(review),
         "request_json": review.request_json,
         "response_json": review.response_json,
         "is_owner": is_owner,
@@ -136,7 +146,7 @@ def _list_item_payload(request: HttpRequest, review: ReviewRequest) -> dict:
         "gate": review.gate,
         "status": review.status,
         "visibility": review.visibility,
-        "narrative_slug": narrative_slug_from_run_id(review.run_id),
+        "narrative_slug": _narrative_slug_of(review),
         "title": _list_title(rj),
         "scene_count": item_count,
         "created_at": review.created_at,
@@ -195,7 +205,7 @@ def list_reviews(
         items = [
             it
             for it in items
-            if needle in it["narrative_slug"].lower()
+            if needle in (it["narrative_slug"] or "").lower()
             or needle in it["run_id"].lower()
             or needle in it["gate"].lower()
             or needle in (it["title"] or "").lower()
@@ -206,7 +216,9 @@ def list_reviews(
         "last_activity": (lambda it: it["last_activity_at"], False),
         "-created": (lambda it: it["created_at"], True),
         "created": (lambda it: it["created_at"], False),
-        "narrative_slug": (lambda it: it["narrative_slug"].lower(), False),
+        # Run-child reviews have no slug; sort them together at the end rather than
+        # crashing the whole list on a None.
+        "narrative_slug": (lambda it: ((it["narrative_slug"] or "~").lower()), False),
     }
     key_fn, reverse = sort_keys.get(order, sort_keys["-last_activity"])
     items.sort(key=key_fn, reverse=reverse)

--- a/apps/reviews/schemas.py
+++ b/apps/reviews/schemas.py
@@ -18,7 +18,9 @@ class ReviewRequestOut(StrictModel):
     run_id: str
     # Narrative slug this review belongs to (explicit narrative_slug, else derived from
     # run_id) — lets the DDD shell highlight the right narrative on the editor.
-    narrative_slug: str
+    # None for a run-child gate, which belongs to no narrative: the DDD shell is not
+    # its chrome and highlighting one would be a lie.
+    narrative_slug: str | None = None
     gate: str
     status: ReviewStatus
     visibility: ReviewVisibility
@@ -38,7 +40,8 @@ class ReviewListItemOut(StrictModel):
     status: ReviewStatus
     visibility: ReviewVisibility
     # Derived from request_json for a scannable list — never the raw payload.
-    narrative_slug: str
+    # None for a run-child gate (see ReviewRequestOut.narrative_slug).
+    narrative_slug: str | None = None
     title: str | None = None
     scene_count: int = 0
     created_at: dt.datetime

--- a/apps/reviews/tests/test_api.py
+++ b/apps/reviews/tests/test_api.py
@@ -511,3 +511,78 @@ def test_product_findings_does_not_bump_narrative_version(auth_client):
     )
     v2 = ReviewRequest.objects.get(id=second.json()["id"]).version
     assert (v1, v2) == (1, 2)
+
+
+# ---------------------------------------------------------------------------
+# Run-child gates carry no narrative_slug
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_run_child_review_reports_no_narrative_slug(auth_client, owner):
+    """create_review deliberately stores narrative_slug=NULL for a run-child gate,
+    but both serializers re-derived one from the run_id — handing the frontend a
+    slug the model had explicitly refused. That derived slug is what lit up a
+    phantom narrative in the DDD rail."""
+    review = _make_review(
+        owner,
+        run_id="ada-fleet-audit-2026-07-14",
+        gate="product_findings",
+        narrative_slug=None,
+        request_json={"run_id": "ada-fleet-audit-2026-07-14", "gate": "product_findings"},
+    )
+
+    detail = auth_client.get(f"{BASE}/{review.id}/").json()
+    assert detail["narrative_slug"] is None
+
+    listed = auth_client.get(f"{BASE}/").json()
+    row = next(r for r in listed if r["id"] == str(review.id))
+    assert row["narrative_slug"] is None
+
+
+@pytest.mark.django_db
+def test_narrative_gate_still_reports_its_slug(auth_client, owner):
+    """The counterpart: a narrative-gate review keeps its slug. Legacy rows stored
+    before the column existed have it derived from the run_id, as before."""
+    stored = _make_review(
+        owner,
+        run_id="microplans-2026-06-02-001",
+        gate="concept_change",
+        narrative_slug="microplans",
+    )
+    legacy = _make_review(
+        owner,
+        run_id="microplans-2026-06-02-002",
+        gate="concept_change",
+        narrative_slug=None,
+    )
+
+    assert auth_client.get(f"{BASE}/{stored.id}/").json()["narrative_slug"] == "microplans"
+    assert auth_client.get(f"{BASE}/{legacy.id}/").json()["narrative_slug"] == "microplans"
+
+
+@pytest.mark.django_db
+def test_list_filter_and_sort_survive_a_null_narrative_slug(auth_client, owner):
+    """?q= and ?order=narrative_slug both called .lower() on the slug bare, so a
+    NULL one 500s the whole list rather than just excluding that row."""
+    _make_review(
+        owner,
+        run_id="ada-fleet-audit-2026-07-14",
+        gate="product_findings",
+        narrative_slug=None,
+    )
+    _make_review(
+        owner,
+        run_id="microplans-2026-06-02-001",
+        gate="concept_change",
+        narrative_slug="microplans",
+    )
+
+    assert auth_client.get(f"{BASE}/?order=narrative_slug").status_code == 200
+
+    hits = auth_client.get(f"{BASE}/?q=microplans").json()
+    assert [r["narrative_slug"] for r in hits] == ["microplans"]
+
+    # A run-child review has no slug to match on, but is still findable by run_id.
+    hits = auth_client.get(f"{BASE}/?q=fleet-audit").json()
+    assert [r["run_id"] for r in hits] == ["ada-fleet-audit-2026-07-14"]

--- a/apps/runs/aggregate.py
+++ b/apps/runs/aggregate.py
@@ -13,7 +13,11 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from apps.common.ddd import narrative_slug_from_run_id
+from apps.common.ddd import (
+    RUN_CHILD_GATES,
+    is_run_child_gate,
+    narrative_slug_from_run_id,
+)
 from apps.reviews.models import ReviewRequest
 from apps.walkthroughs.models import Walkthrough
 
@@ -71,7 +75,11 @@ def narrative_of_review(r: ReviewRequest) -> str:
 #: ``product_findings`` is a run-child findings review (its narration is a degradation
 #: mirror). Including either pollutes the version list and lets it drive the narrative's
 #: title/phase (the "v0 findings review" bug).
-_NON_NARRATIVE_GATES = ("external_release", "product_findings")
+#:
+#: A superset of ``RUN_CHILD_GATES``: every run-child gate is non-narrative, but
+#: ``external_release`` is non-narrative while still *belonging* to a narrative — so it
+#: may create one, and a run-child gate may not.
+_NON_NARRATIVE_GATES = ("external_release", *RUN_CHILD_GATES)
 
 
 def _is_narrative_version(r: ReviewRequest) -> bool:
@@ -392,7 +400,20 @@ def _aggregate(
 
     for r in revs:
         slug = narrative_for_run_id(r.run_id, feature_map)
-        a = narr.setdefault(slug, _blank_narrative(slug))
+        # A run-child review ATTACHES to a narrative but never CREATES one. The
+        # gate cannot discriminate here: a DDD findings review and Ada's fleet
+        # audit both use `product_findings`, and the DDD one is a genuine child
+        # of a real run, so it must keep attaching. What separates them is
+        # whether a narrative exists at all — Ada's run_id is not a DDD run id,
+        # so nothing else references it. Without this, parsing a slug out of any
+        # run_id conjured a phantom narrative into the DDD rail (active, empty,
+        # unnavigable). Narrative-version reviews still create: a review-only
+        # narrative is legitimate (see narrative_for_run_id).
+        a = narr.get(slug)
+        if a is None:
+            if is_run_child_gate(r.gate):
+                continue
+            a = narr.setdefault(slug, _blank_narrative(slug))
         a["run_ids"].add(r.run_id)
         if r.owner_id:
             a["owner_ids"].add(r.owner_id)

--- a/apps/runs/tests/test_aggregate.py
+++ b/apps/runs/tests/test_aggregate.py
@@ -251,3 +251,47 @@ def test_product_findings_review_is_not_a_narrative_version():
     run = aggregate.build_run(rid)
     # Title/current_version come from the real narrative, not the findings cluster text.
     assert run["narrative"]["title"] == "Amani opens the weekly nutrition review."
+
+
+# ---------------------------------------------------------------------------
+# Run-child reviews attach to a narrative; they never conjure one
+# ---------------------------------------------------------------------------
+
+
+def test_run_child_review_alone_creates_no_narrative():
+    """A product_findings review whose run_id has no DDD run behind it must not
+    invent a narrative. Ada's fleet audit posts one of these with a run_id that
+    is not a DDD run id at all ("ada-fleet-audit-2026-07-14"); parsing that slug
+    out of the run_id conjured a phantom narrative into the DDD rail, active but
+    empty ("No versions yet") and impossible to navigate."""
+    u = make_user()
+    make_review(
+        u,
+        run_id="ada-fleet-audit-2026-07-14",
+        gate="product_findings",
+        request_json={
+            "run_id": "ada-fleet-audit-2026-07-14",
+            "gate": "product_findings",
+            "clusters": [{"id": "hal-inbox", "title": "discard 81 junk emails"}],
+        },
+    )
+
+    assert aggregate.list_narratives() == []
+
+
+def test_run_child_review_attaches_to_an_existing_narrative():
+    """The counterpart: a DDD findings review IS a child of a real DDD run, so it
+    must keep attaching to that run's narrative. Only *creating* is forbidden."""
+    u = make_user()
+    rid = "microplans-2026-06-02-001"
+    make_walkthrough(u, kind="video", run_id=rid, narrative_slug="microplans")
+    make_review(
+        u,
+        run_id=rid,
+        gate="product_findings",
+        request_json={"run_id": rid, "gate": "product_findings", "clusters": []},
+    )
+
+    narratives = {n["slug"]: n for n in aggregate.list_narratives()}
+    assert set(narratives) == {"microplans"}
+    assert narratives["microplans"]["run_count"] == 1

--- a/frontend/e2e/review.spec.ts
+++ b/frontend/e2e/review.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect, type Page } from '@playwright/test'
+
+// A run-child (product_findings) review belongs to no DDD narrative. It must render
+// standalone — no DDD rail — and it must not conjure a narrative out of its run_id.
+//
+// The regression: /review/<id> rendered inside DddShell unconditionally, and the
+// aggregate parsed a narrative slug out of ANY review's run_id. Ada's fleet audit
+// therefore appeared in the DDD rail as a narrative that existed only because
+// someone parsed its id — active, empty ("No versions yet"), and unnavigable.
+
+const FLEET_AUDIT_RUN_ID = 'ada-fleet-audit-2026-07-14'
+
+/** The seeded fleet-audit review's id (generated, so discover it via the API). */
+async function fleetAuditReviewId(page: Page): Promise<string> {
+  const rows = await (await page.request.get('/api/reviews/')).json()
+  const row = rows.find((r: { run_id: string }) => r.run_id === FLEET_AUDIT_RUN_ID)
+  expect(row, 'seed should provide a fleet-audit review').toBeTruthy()
+  return row.id
+}
+
+test('a fleet-audit findings review renders without the DDD rail', async ({ page }) => {
+  await page.goto(`/review/${await fleetAuditReviewId(page)}`)
+
+  // The findings surface itself is present...
+  await expect(page.getByText('hal: discard 81 junk/stale unread emails (of 82 total)')).toBeVisible()
+
+  // ...and the page still names its own run, which is its only honest identity.
+  await expect(page.getByText(FLEET_AUDIT_RUN_ID, { exact: true })).toBeVisible()
+
+  // ...but none of the DDD narratives rail is.
+  await expect(page.getByRole('link', { name: 'Narratives', exact: true })).toHaveCount(0)
+  await expect(page.getByText('DDD runs, grouped by narrative')).toHaveCount(0)
+  await expect(page.getByText('No versions yet')).toHaveCount(0)
+})
+
+test('a fleet-audit run_id conjures no narrative into the DDD rail', async ({ page }) => {
+  const narratives = await (await page.request.get('/api/ddd/narratives/')).json()
+  const slugs = narratives.map((n: { slug: string }) => n.slug)
+
+  expect(slugs).not.toContain(FLEET_AUDIT_RUN_ID)
+  expect(slugs).not.toContain('ada-fleet-audit')
+})
+
+test('a run-child review reports no narrative_slug', async ({ page }) => {
+  const id = await fleetAuditReviewId(page)
+  const detail = await (await page.request.get(`/api/reviews/${id}/`)).json()
+
+  expect(detail.narrative_slug).toBeNull()
+})

--- a/frontend/e2e/seed.py
+++ b/frontend/e2e/seed.py
@@ -11,7 +11,10 @@ from django.contrib.sessions.backends.db import SessionStore
 from apps.agents.models import (
     Agent, AgentSkill, AgentSync, AgentTask, AgentTaskCommand, AgentWorkProduct,
 )
+from apps.reviews.models import ReviewRequest
 from apps.workspaces import services as wsvc
+
+FLEET_AUDIT_RUN_ID = "ada-fleet-audit-2026-07-14"
 
 User = get_user_model()
 user, _ = User.objects.get_or_create(username="e2e", defaults={"email": "e2e@dimagi.com"})
@@ -72,6 +75,34 @@ AgentSkill.objects.create(
     agent=a, name="email-communicator", description="Send and receive email as Echo.",
     url="https://github.com/dimagi-internal/echo/blob/main/skills/email-communicator/SKILL.md")
 
+# A fleet-audit findings review — a run-child gate whose run_id is NOT a DDD run id
+# (nothing else in the system references it). It must render standalone: no DDD rail,
+# and no narrative conjured out of its run_id. Mirrors what Ada posts.
+ReviewRequest.objects.filter(run_id=FLEET_AUDIT_RUN_ID).delete()
+fleet_audit = ReviewRequest.objects.create(
+    owner=user,
+    workspace=ws,
+    run_id=FLEET_AUDIT_RUN_ID,
+    narrative_slug=None,  # create_review stores NULL for a run-child gate
+    version=0,
+    gate="product_findings",
+    visibility="link",
+    request_json={
+        "run_id": FLEET_AUDIT_RUN_ID,
+        "gate": "product_findings",
+        "iteration": 1,
+        "clusters": [
+            {
+                "id": "hal-inbox",
+                "title": "hal: discard 81 junk/stale unread emails (of 82 total)",
+                "severity": "high",
+                "fix_kind": "mechanical",
+                "suggested_fix": "All 81 are automated or older than 1 week.",
+            }
+        ],
+    },
+)
+
 session = SessionStore()
 session["_auth_user_id"] = str(user.pk)
 session["_auth_user_backend"] = settings.AUTHENTICATION_BACKENDS[0]
@@ -84,4 +115,4 @@ with open("frontend/e2e/.auth/session.txt", "w") as f:
     f.write(session.session_key)
 
 print(f"seeded: {a.tasks.count()} tasks, {a.commands.filter(status='pending').count()} pending; "
-      f"session {session.session_key[:8]}")
+      f"fleet-audit review {str(fleet_audit.id)[:8]}; session {session.session_key[:8]}")

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -2565,7 +2565,7 @@ export interface components {
              */
             readonly visibility: "private" | "link";
             /** Narrative Slug */
-            readonly narrative_slug: string;
+            readonly narrative_slug?: string | null;
             /** Title */
             readonly title?: string | null;
             /**
@@ -2630,7 +2630,7 @@ export interface components {
             /** Run Id */
             readonly run_id: string;
             /** Narrative Slug */
-            readonly narrative_slug: string;
+            readonly narrative_slug?: string | null;
             /** Gate */
             readonly gate: string;
             /**

--- a/frontend/src/api/reviews.ts
+++ b/frontend/src/api/reviews.ts
@@ -240,8 +240,9 @@ export interface ReviewSubmitPayload {
 export interface ReviewDetail {
   id: string
   run_id: string
-  /** Narrative slug this review belongs to (for highlighting in the DDD shell). */
-  narrative_slug: string
+  /** Narrative slug this review belongs to (for highlighting in the DDD shell).
+   *  null for a run-child gate, which belongs to no narrative — it gets no DDD chrome. */
+  narrative_slug: string | null
   gate: string
   status: ReviewStatus
   visibility: ReviewVisibility
@@ -351,7 +352,8 @@ export interface ReviewListItem {
   gate: string
   status: ReviewStatus
   visibility: ReviewVisibility
-  narrative_slug: string
+  /** null for a run-child gate (see ReviewDetail.narrative_slug). */
+  narrative_slug: string | null
   title: string | null
   scene_count: number
   created_at: string

--- a/frontend/src/components/ddd/DddLeftNav.tsx
+++ b/frontend/src/components/ddd/DddLeftNav.tsx
@@ -108,9 +108,15 @@ function NarrativeRuns({
   activeRunId?: string
 }) {
   const [detail, setDetail] = useState<DddNarrativeDetail | null>(null)
-  // Run-child product-findings reviews for this narrative, grouped by run_id.
-  // Sourced from the reviews list (the narrative API doesn't carry run-children),
-  // filtered to gate === 'product_findings' so they never show as version rows.
+  // Run-child product-findings reviews, grouped by run_id. Sourced from the reviews
+  // list (the narrative API doesn't carry run-children), filtered to
+  // gate === 'product_findings' so they never show as version rows.
+  //
+  // Scoping to THIS narrative is structural, not a filter: the render only ever looks
+  // up findingsByRun.get(run_id) for runs already in this narrative's version tree, so
+  // a review belonging to another narrative is simply never consulted. A run-child
+  // review carries no narrative_slug to compare against anyway — it attaches by the
+  // run it names, which is the only honest link it has.
   const [findingsByRun, setFindingsByRun] = useState<Map<string, ReviewListItem[]>>(new Map())
 
   useEffect(() => {
@@ -132,7 +138,6 @@ function NarrativeRuns({
         const byRun = new Map<string, ReviewListItem[]>()
         for (const r of reviews) {
           if (r.gate !== 'product_findings') continue
-          if (r.narrative_slug !== slug) continue
           const list = byRun.get(r.run_id) ?? []
           list.push(r)
           byRun.set(r.run_id, list)

--- a/frontend/src/pages/ReviewPage.tsx
+++ b/frontend/src/pages/ReviewPage.tsx
@@ -1705,14 +1705,22 @@ export function ReviewPage() {
     return () => { cancelled = true }
   }, [id]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  // The DDD rail belongs to internal, signed-in browsing. Public share links
-  // (?t=token) stay standalone — the rail's APIs need a session and would just
-  // 403 for token holders. Either way we keep our own scroll container so the
-  // full-bleed AppLayout main doesn't clip the editor.
-  const showShell = !shareToken && auth.status === 'authenticated'
+  // The DDD rail belongs to internal, signed-in browsing of a review that is
+  // actually part of a narrative. Three cases get no rail:
+  //   - anonymous (the rail's APIs need a session and would just 403)
+  //   - a run-child gate (narrative_slug === null) — it belongs to no narrative,
+  //     so the DDD rail is not its chrome. Rendering it anyway is what put Ada's
+  //     fleet audit in a rail it could not navigate, under a narrative that only
+  //     existed because someone parsed its run_id.
+  //   - still loading — we don't know yet, and flashing a rail in then out is
+  //     worse than showing it a beat late.
+  // Either way we keep our own scroll container so the full-bleed AppLayout main
+  // doesn't clip the editor.
+  const showShell =
+    !shareToken && auth.status === 'authenticated' && review?.narrative_slug != null
   const withChrome = (node: ReactNode) =>
     showShell ? (
-      <DddShell activeSlug={review?.narrative_slug} activeRunId={review?.run_id}>
+      <DddShell activeSlug={review?.narrative_slug ?? undefined} activeRunId={review?.run_id}>
         {node}
       </DddShell>
     ) : (


### PR DESCRIPTION
## The bug

Ada's fleet audit — `gate=product_findings`, `run_id` `ada-fleet-audit-2026-07-14` — rendered inside the **DDD narratives rail**, under a narrative that existed only because someone parsed its run_id: active, empty ("No versions yet"), and impossible to navigate (findings reviews only render nested under a version → run, which this narrative never had).


## Two causes, both re-deriving what the model refused

`create_review` **already** stores `narrative_slug=None` + `version=0` for a run-child gate. Downstream ignored it:

- **the serializers** re-derived a slug from the run_id anyway, handing the frontend the phantom → `activeSlug` → rail lights up;
- **`_aggregate`** grouped *every* review by a run_id-parsed slug, `setdefault`-ing a narrative into existence.

## The discriminator is not the gate

A **DDD findings review** and **Ada's fleet audit** both use `product_findings` — and the DDD one is a genuine child of a real run that *must* keep nesting under it. What separates them is whether a narrative exists at all.

> **A run-child review may ATTACH to a narrative, but never CREATE one.**

## Changes

| Where | What |
|---|---|
| `apps/common/ddd.py` | `RUN_CHILD_GATES` + `is_run_child_gate()` move here, beside the slug derivation, for the reason that module already documents: `reviews` (assigns the slug) and `runs` (groups by it) must agree, and `apps.runs` can't import from `apps.reviews.api` without dragging in a Ninja router. `_NON_NARRATIVE_GATES` is now derived from it as the superset it is — `external_release` isn't a *version* but does belong to a narrative, so it may still create one. |
| `apps/reviews` | One `_narrative_slug_of()` replaces two divergent derivations (detail preferred the stored column; **list ignored it entirely**). `narrative_slug` → `str \| None`. |
| `apps/reviews` | None-guard `?q=` and `order=narrative_slug` — both called `.lower()` bare and would have **500'd the whole list** once the slug could be null. |
| `ReviewPage.tsx` | No `narrative_slug` → standalone, not `DddShell`. |
| `DddLeftNav.tsx` | Drop the `narrative_slug !== slug` filter. Scoping was always **structural** (the render only consults `findingsByRun` for runs already in this narrative's tree); that filter only looked load-bearing because it read the derived slug. |

## Verification

**The tests fail without the fix** — verified by stashing the implementation, keeping the tests, and re-running: all 3 e2e and both key unit tests fail, reproducing the screenshot.

- 2 unit tests: a run-child review with no run behind it creates **no** narrative; a DDD findings review **still attaches** to its real one.
- 3 e2e (new `frontend/e2e/review.spec.ts`, seeded fleet-audit review): the page renders **without the rail**, no narrative is conjured, `narrative_slug` is null.
- `591 passed` backend · `25 passed` e2e (incl. #212's agents + supervisor specs) · `npm run build` clean.

## Scope

Deliberately **not** here: any new home for Ada's review. Post-fix it renders standalone at `/review/:id` — link-delivered, exactly how Ada delivers it today. Giving it a real home belongs with the unified dispatch-item work, where a framework-owned item has an `agent` FK natively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
