### PR TITLE
fix(runner): send namespaced /<agent>:turn (agents installed as CC plugins)

### DIFF
--- a/packages/canopy_runner/canopy_runner/execute.py
+++ b/packages/canopy_runner/canopy_runner/execute.py
@@ -50,9 +50,9 @@ def execute_turn(cfg, client, runner_id: str, turn: dict) -> str:
     agent = turn["agent_slug"]
     ref = turn.get("origin_ref") or {}
     thread_key = _thread_key(turn)
-    # The prompt is a clean command — the agent's own /turn command does all the work.
+    # The prompt is a clean command — the agent's namespaced /<slug>:turn does all the work.
     # Default (board turns with no prompt): a full turn. drain-turn is retired.
-    work_prompt = turn.get("prompt") or "/turn"
+    work_prompt = turn.get("prompt") or f"/{agent}:turn"
 
     plan = client.resolve_session(runner_id, agent, thread_key)
     client.start(turn_id)

--- a/packages/canopy_runner/canopy_runner/inbox.py
+++ b/packages/canopy_runner/canopy_runner/inbox.py
@@ -56,13 +56,13 @@ def check_inbox(client, agent: str, *, mailbox: str, gog_client: str,
             continue
         count = t.get("messageCount", 1)
         frm, subj = t.get("from", ""), t.get("subject", "")
-        # Clean command only — the agent's own /turn command does everything (reads the
+        # Clean command only — the agent's namespaced /<slug>:turn command does everything (reads the
         # thread, triages under guardrails, marks it read). The runner hands the exact
         # thread it already resolved so the agent doesn't re-scan the inbox.
         client.enqueue_turn(
             agent, "email", f"email-{agent}-{tid}-{count}",
             origin_ref={"thread_id": tid, "from": frm, "subject": subj},
-            prompt=f"/turn --thread {tid}",
+            prompt=f"/{agent}:turn --thread {tid}",
         )
         enqueued.append(tid)
     return enqueued

--- a/packages/canopy_runner/canopy_runner/reviews.py
+++ b/packages/canopy_runner/canopy_runner/reviews.py
@@ -16,7 +16,7 @@ never re-runs a finished turn. A local seen-set skips reviews already fully inge
 Ada's clusters look like:
     {"id": "eva-first-turn", "title": "…", "severity": "high", "fix_kind": "mechanical",
      "suggested_fix": "…",
-     "dispatch": [{"target_agent": "eva", "origin": "email", "prompt": "/turn --thread <id>",
+     "dispatch": [{"target_agent": "eva", "origin": "email", "prompt": "/eva:turn --thread <id>",
                    "origin_ref": {"thread_id": "<id>", "subject": "…"}}]}
 """
 from __future__ import annotations
@@ -74,7 +74,7 @@ def check_reviews(client, *, seen: frozenset[str] = frozenset(), max_reviews: in
                     agent,
                     spec.get("origin") or "api",
                     f"review-{rid}-{cid}-{i}",
-                    prompt=spec.get("prompt") or "/turn",
+                    prompt=spec.get("prompt") or f"/{agent}:turn",
                     origin_ref=spec.get("origin_ref") or {},
                 )
                 enqueued.append((rid, cid, agent))

--- a/packages/canopy_runner/tests/test_inbox.py
+++ b/packages/canopy_runner/tests/test_inbox.py
@@ -35,7 +35,7 @@ def test_enqueues_one_turn_per_thread():
     assert ids == ["thr-1", "thr-2"]
     assert client.enqueued[0]["origin"] == "email"
     assert client.enqueued[0]["origin_ref"]["thread_id"] == "thr-1"
-    assert client.enqueued[0]["prompt"] == "/turn --thread thr-1"
+    assert client.enqueued[0]["prompt"] == "/hal:turn --thread thr-1"
 
 
 def test_idempotency_key_includes_message_count():


### PR DESCRIPTION
Definitive fix for the 'eva session ran /ace:turn' bug. Claude's transcript proved the runner typed `/turn` but Claude resolved it to `/ace:turn` — because a bare `/turn` isn't a real command (repo-root `commands/` only loads when the repo is *installed as a plugin*), so slash-autocomplete fuzzy-matched the globally-installed `/ace:turn`.

Fix (per Jonathan): **namespace every agent like ace** — each is now installed as a CC plugin (`marketplace.json` + `claude plugin install`), so `/hal:turn` /`/eva:turn`/etc. resolve exactly (the `agent:` prefix disambiguates during typing → no collision) and agents can call each other's commands. Runner sends `/<agent>:turn`; Ada's fleet-audit + the pilot review use the namespaced form. 9 runner tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)