### PR TITLE
fix(runner): honest inbox logging + stop resolved-review warning spam

### DIFF
--- a/packages/canopy_runner/canopy_runner/client.py
+++ b/packages/canopy_runner/canopy_runner/client.py
@@ -109,11 +109,13 @@ class Client:
                      routing: str = "prefer_local") -> dict:
         """Enqueue a turn (idempotent on idempotency_key — safe to re-enqueue the same
         email). Used by the deterministic inbox/slack triggers."""
-        _, payload = self._call("POST", "/turns/", {
+        status, payload = self._call("POST", "/turns/", {
             "agent_slug": agent_slug, "origin": origin, "idempotency_key": idempotency_key,
             "prompt": prompt, "origin_ref": origin_ref or {}, "routing": routing,
         })
-        return payload or {}
+        # 201 = a NEW turn; 200 = idempotent hit on one we already enqueued. Callers log
+        # the difference so a re-poll of the same unread mail reads as "nothing new".
+        return {**(payload or {}), "_created": status == 201}
 
     def start(self, turn_id: str, session_id: str = "") -> None:
         self._call("POST", f"/turns/{turn_id}/start", {"session_id": session_id})

--- a/packages/canopy_runner/canopy_runner/inbox.py
+++ b/packages/canopy_runner/canopy_runner/inbox.py
@@ -45,11 +45,14 @@ def search_threads(mailbox: str, gog_client: str, query: str = DEFAULT_QUERY,
 
 
 def check_inbox(client, agent: str, *, mailbox: str, gog_client: str,
-                query: str = DEFAULT_QUERY, max_threads: int = 15, runner=subprocess.run) -> list[str]:
-    """Enqueue an email-origin turn for each new thread state. Returns the thread ids
-    enqueued. Idempotent on (thread, messageCount): re-polling is a no-op server-side."""
+                query: str = DEFAULT_QUERY, max_threads: int = 15, runner=subprocess.run) -> dict:
+    """Enqueue an email-origin turn for each new thread state. Returns
+    {"new": [thread_ids that became a NEW turn], "seen": [ids already tracked]} — the split
+    matters for logging: re-polling the same unread mail is idempotent server-side, so it
+    must read as "nothing new", not as fresh work."""
     threads = search_threads(mailbox, gog_client, query, max_threads, runner=runner)
-    enqueued: list[str] = []
+    new: list[str] = []
+    seen: list[str] = []
     for t in threads:
         tid = t.get("id")
         if not tid:
@@ -59,10 +62,10 @@ def check_inbox(client, agent: str, *, mailbox: str, gog_client: str,
         # Clean command only — the agent's namespaced /<slug>:turn command does everything (reads the
         # thread, triages under guardrails, marks it read). The runner hands the exact
         # thread it already resolved so the agent doesn't re-scan the inbox.
-        client.enqueue_turn(
+        res = client.enqueue_turn(
             agent, "email", f"email-{agent}-{tid}-{count}",
             origin_ref={"thread_id": tid, "from": frm, "subject": subj},
             prompt=f"/{agent}:turn --thread {tid}",
         )
-        enqueued.append(tid)
-    return enqueued
+        (new if (res or {}).get("_created") else seen).append(tid)
+    return {"new": new, "seen": seen}

--- a/packages/canopy_runner/canopy_runner/main.py
+++ b/packages/canopy_runner/canopy_runner/main.py
@@ -133,13 +133,15 @@ def _maybe_check_inboxes(cfg: Config, client: Client, now_fn=time.time,
         if paused and agent in paused:
             continue
         try:
-            ids = inbox_mod.check_inbox(
+            res = inbox_mod.check_inbox(
                 client, agent, mailbox=box["account"], gog_client=box["client"],
                 query=box.get("query", inbox_mod.DEFAULT_QUERY), max_threads=cap,
             )
-            if ids:
-                logger.info("inbox[%s]: enqueued %d thread turn(s) (cap %d) — each becomes a session",
-                            agent, len(ids), cap)
+            n_new, n_seen = len(res["new"]), len(res["seen"])
+            # Log EVERY poll, not just ones that enqueue — otherwise a healthy poll that
+            # finds nothing new is silent and you can't tell polling is happening at all.
+            logger.info("inbox[%s]: polled — %d unread (%d NEW -> session, %d already tracked)",
+                        agent, n_new + n_seen, n_new, n_seen)
         except Exception as exc:  # noqa: BLE001 — one bad inbox never kills the loop
             logger.warning("inbox check for %s failed: %s", agent, exc)
     try:

--- a/packages/canopy_runner/canopy_runner/reviews.py
+++ b/packages/canopy_runner/canopy_runner/reviews.py
@@ -35,9 +35,8 @@ def check_reviews(client, *, seen: frozenset[str] = frozenset(), max_reviews: in
     """Dispatch the work for every `implement`-decided cluster in resolved, not-yet-seen
     reviews. Returns {"enqueued": [(review_id, cluster_id, agent), …],
                       "processed": {review_id, …}}  — review ids that were fully ingested
-    (every implemented cluster had a dispatch block) and can be skipped next poll. A review
-    with an implemented-but-undispatched cluster is left UNprocessed so a later Ada fix + a
-    re-poll picks it up."""
+    — handled once and skipped on later polls. An approved cluster with no dispatch block is
+    logged once and skipped (a resolved review is immutable; Ada re-emits as a NEW review)."""
     enqueued: list[tuple[str, str, str]] = []
     processed: set[str] = set()
 
@@ -51,14 +50,12 @@ def check_reviews(client, *, seen: frozenset[str] = frozenset(), max_reviews: in
         resp = detail.get("response_json") or {}
         decisions = resp.get("decisions") or {}
 
-        complete = True  # every implemented cluster had a dispatch block
         for cluster in req.get("clusters") or []:
             cid = cluster.get("id") or ""
             if (decisions.get(cid) or {}).get("decision") != IMPLEMENT:
                 continue
             specs = cluster.get("dispatch") or []
             if not specs:
-                complete = False
                 logger.warning("review %s cluster '%s' was approved but has no dispatch[] "
                                "block — Ada must emit {target_agent, prompt, origin, "
                                "origin_ref}; skipping (will retry once fixed)", rid, cid)
@@ -66,7 +63,6 @@ def check_reviews(client, *, seen: frozenset[str] = frozenset(), max_reviews: in
             for i, spec in enumerate(specs):
                 agent = (spec.get("target_agent") or "").strip()
                 if not agent:
-                    complete = False
                     logger.warning("review %s cluster '%s' turn #%d missing target_agent; "
                                    "skipping", rid, cid, i)
                     continue
@@ -79,8 +75,10 @@ def check_reviews(client, *, seen: frozenset[str] = frozenset(), max_reviews: in
                 )
                 enqueued.append((rid, cid, agent))
 
-        if complete:
-            processed.add(rid)
+        # A resolved review's decisions are immutable, and Ada re-emits fixes as a NEW
+        # review id — so retrying this one forever can never succeed. Mark it processed
+        # regardless; the seen-set then skips it (no re-fetch, no repeated warning).
+        processed.add(rid)
 
     if enqueued:
         logger.info("reviews: enqueued %d turn(s) from %d review(s) — %s",

--- a/packages/canopy_runner/tests/test_inbox.py
+++ b/packages/canopy_runner/tests/test_inbox.py
@@ -8,13 +8,14 @@ from canopy_runner import inbox
 
 
 class FakeClient:
-    def __init__(self):
+    def __init__(self, created=True):
         self.enqueued = []
+        self._created = created
 
     def enqueue_turn(self, agent, origin, idem, *, prompt="", origin_ref=None, routing="prefer_local"):
         self.enqueued.append({"agent": agent, "origin": origin, "idem": idem,
                               "origin_ref": origin_ref, "prompt": prompt})
-        return {"id": "t-x"}
+        return {"id": "t-x", "_created": self._created}
 
 
 def _runner(threads):
@@ -31,8 +32,8 @@ def test_enqueues_one_turn_per_thread():
         {"id": "thr-1", "from": "Hal <hal@dimagi-ai.com>", "subject": "re: bednet", "messageCount": 3},
         {"id": "thr-2", "from": "x@y.com", "subject": "hi", "messageCount": 1},
     ])
-    ids = inbox.check_inbox(client, "hal", mailbox="hal@dimagi-ai.com", gog_client="canopy", runner=r)
-    assert ids == ["thr-1", "thr-2"]
+    res = inbox.check_inbox(client, "hal", mailbox="hal@dimagi-ai.com", gog_client="canopy", runner=r)
+    assert res["new"] == ["thr-1", "thr-2"]
     assert client.enqueued[0]["origin"] == "email"
     assert client.enqueued[0]["origin_ref"]["thread_id"] == "thr-1"
     assert client.enqueued[0]["prompt"] == "/hal:turn --thread thr-1"
@@ -47,7 +48,7 @@ def test_idempotency_key_includes_message_count():
 
 def test_empty_inbox_enqueues_nothing():
     client = FakeClient()
-    assert inbox.check_inbox(client, "hal", mailbox="m", gog_client="c", runner=_runner([])) == []
+    assert inbox.check_inbox(client, "hal", mailbox="m", gog_client="c", runner=_runner([])) == {"new": [], "seen": []}
     assert client.enqueued == []
 
 

--- a/packages/canopy_runner/tests/test_reviews.py
+++ b/packages/canopy_runner/tests/test_reviews.py
@@ -67,11 +67,13 @@ def test_non_findings_gate_ignored():
     assert c.enqueued == []
 
 
-def test_implemented_without_routing_block_is_not_marked_processed():
-    """An approved cluster with no dispatch[] can't be dispatched — leave the review
-    unprocessed so a later Ada fix + re-poll picks it up."""
+def test_implemented_without_routing_block_is_logged_and_review_still_handled_once():
+    """An approved cluster with no dispatch[] can't be dispatched. The review is still
+    marked processed — its decisions are immutable and Ada re-emits as a NEW review, so
+    retrying forever would only spam the log every poll."""
     clusters = [{"id": "eva-first-turn"}]  # no dispatch[]
     c = FakeClient([{"id": "r3", "gate": "product_findings"}],
                    {"r3": _detail(clusters, {"eva-first-turn": {"decision": "implement"}})})
     res = reviews.check_reviews(c)
-    assert c.enqueued == [] and res["processed"] == set()
+    assert c.enqueued == []            # nothing dispatchable
+    assert res["processed"] == {"r3"}  # but handled once — no perpetual re-warning


### PR DESCRIPTION
Two logging defects that actively hid real problems (ace's turns sat **queued for 2.75h** while the log cheerfully said `idle`):

- **Inbox polls were silent unless they enqueued**, and logged `enqueued N` even when every N was an *idempotent re-hit* on turns already tracked — so re-polling the same unread mail read as fresh work. Now `enqueue_turn` reports `_created` (201 vs 200), `check_inbox` returns `{new, seen}`, and **every** poll logs `inbox[x]: polled — N unread (M NEW -> session, K already tracked)`.
- **A resolved review with an unroutable approved cluster re-warned every 5 minutes forever.** A resolved review's decisions are immutable and Ada re-emits fixes as a *new* review id, so retrying can never succeed — log once, mark processed, move on.

62 runner tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)