### PR TITLE
fix(pwa): actually serve the manifest as application/manifest+json

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -3,18 +3,11 @@ Base Django settings for canopy-web.
 
 Common settings shared across all environments.
 """
-import mimetypes
 import os
 import sys
 from pathlib import Path
 
 import environ
-
-# Python's mimetypes map has no .webmanifest entry, so WhiteNoise would serve the
-# PWA manifest as application/octet-stream. Chrome tolerates that today, but it's
-# wrong per spec and Lighthouse flags it — and the manifest is the thing that
-# makes /supervisor installable.
-mimetypes.add_type("application/manifest+json", ".webmanifest")
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
@@ -157,6 +150,13 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 STATIC_URL = "static/"
 STATIC_ROOT = BASE_DIR / "staticfiles"
+
+# WhiteNoise serves the built frontend, and its MediaTypes map is its own — it
+# never consults Python's mimetypes, and it has no .webmanifest entry. Without
+# this the PWA manifest goes out as application/octet-stream. Chrome tolerates
+# that; the spec and Lighthouse don't, and the manifest is the thing that makes
+# /supervisor installable.
+WHITENOISE_MIMETYPES = {".webmanifest": "application/manifest+json"}
 
 # Frontend SPA build output (served by catch-all view; WhiteNoise handles assets)
 FRONTEND_DIST_DIR = BASE_DIR / "frontend" / "dist"

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,11 +1,17 @@
 """Module-level settings setup that has no other natural test home."""
 
 
-def test_the_webmanifest_mimetype_is_registered():
-    """WhiteNoise derives Content-Type from mimetypes, and Python's map has no
-    .webmanifest entry — so without this the PWA manifest serves as
-    application/octet-stream. Chrome tolerates it; the spec and Lighthouse don't.
-    Observed in prod before this was added."""
-    import mimetypes
+def test_whitenoise_serves_the_webmanifest_as_manifest_json():
+    """The PWA manifest must not go out as application/octet-stream.
 
-    assert mimetypes.guess_type("manifest.webmanifest")[0] == "application/manifest+json"
+    WhiteNoise's MediaTypes map is its own — it never consults Python's
+    mimetypes and has no .webmanifest entry. An earlier fix called
+    mimetypes.add_type() and shipped a test asserting mimetypes.guess_type():
+    green test, prod still served octet-stream. So assert through WhiteNoise's
+    own resolution, which is what actually decides the header.
+    """
+    from django.conf import settings
+    from whitenoise.media_types import MediaTypes
+
+    media = MediaTypes(extra_types=settings.WHITENOISE_MIMETYPES)
+    assert media.get_type("manifest.webmanifest") == "application/manifest+json"


### PR DESCRIPTION
#220 shipped a fix for this, deployed, cut over — and prod **still** serves `application/octet-stream`. Verified by curl after the new task-def (`:24`) was confirmed running.

## Why #220 couldn't have worked

It added `mimetypes.add_type("application/manifest+json", ".webmanifest")`.

WhiteNoise's `MediaTypes` (`whitenoise/media_types.py`) builds from its **own** hardcoded `default_types()` map and **never consults Python's `mimetypes`**. Verified:

```
uses mimetypes module?: False
webmanifest in default map?: False
```

So `add_type()` could never have affected the header. The real lever is the `WHITENOISE_MIMETYPES` setting, which WhiteNoise passes in as `extra_types`.

## Why the test stayed green

It asserted `mimetypes.guess_type("manifest.webmanifest")` — something that *was* true after #220, and that WhiteNoise doesn't look at. **Green test, broken prod.**

That's the same vacuous-green pattern that bit this repo twice already today (the `.env`-dependent push tests; the storm test that never called `sync_tasks`). This one was self-inflicted, and it's the reason the fix shipped without anyone noticing it did nothing.

The test now asserts through **WhiteNoise's own resolution** — the thing that actually decides the header — and fails if the setting is removed (verified by probe, both directions).

## Verified

```
MediaTypes(extra_types=settings.WHITENOISE_MIMETYPES).get_type("manifest.webmanifest")
  -> application/manifest+json
```

`sw.js` still resolves to `text/javascript` (registration requires it).

Also removes #220's dead `mimetypes.add_type` line — leaving it would tell the next reader it does something.

Tests: 613 passed, 1 skipped with `.env` moved aside.

**Severity, honestly:** Chrome tolerates a wrong manifest Content-Type, so installs were never blocked. This is spec correctness and a Lighthouse audit — not an outage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)