### PR TITLE
fix(harness): runner status is derived, not a one-way door

### DIFF
--- a/apps/harness/api.py
+++ b/apps/harness/api.py
@@ -173,6 +173,18 @@ def list_runners(request: HttpRequest):
     return list(qs[:50])
 
 
+@router.post("/runners/{runner_id}/retire", response={204: None})
+def retire_runner(request: HttpRequest, runner_id: uuid.UUID):
+    """Retire a runner — permanent, not a liveness state (see Runner.live_status).
+    Idempotent by construction: _runner_or_404 already excludes retired runners,
+    so retiring an already-retired runner 404s at lookup rather than no-opping
+    here."""
+    runner = _runner_or_404(request, runner_id)
+    runner.status = Runner.RETIRED
+    runner.save(update_fields=["status"])
+    return Status(204, None)
+
+
 @router.post("/runners/{runner_id}/heartbeat", response=RunnerOut)
 def runner_heartbeat(request: HttpRequest, runner_id: uuid.UUID, payload: HeartbeatIn):
     runner = _runner_or_404(request, runner_id)

--- a/apps/harness/models.py
+++ b/apps/harness/models.py
@@ -7,9 +7,16 @@ control-plane-design.md.
 """
 from __future__ import annotations
 
+import datetime as dt
 import uuid
 
 from django.db import models
+from django.utils import timezone
+
+# Owned here (not services.py) so Runner.live_status can use it without a
+# models -> services import cycle (services already imports models). services.py
+# imports this constant from here rather than declaring a second one.
+HEARTBEAT_ONLINE_WINDOW = dt.timedelta(seconds=90)
 
 
 class Runner(models.Model):
@@ -82,6 +89,24 @@ class Runner(models.Model):
 
     def agent_slugs(self) -> list[str]:
         return list(self.capabilities.get("agents", []))
+
+    @property
+    def live_status(self) -> str:
+        """What we can OBSERVE, not what the runner last claimed.
+
+        `heartbeat()` writes ONLINE and nothing demotes it — a runner that dies
+        never gets to tell us. So liveness is derived from heartbeat age here,
+        and RunnerOut serves this rather than the raw column. `degraded` is
+        different: the runner self-reports it, so it survives as long as the
+        runner is still fresh enough to be reporting anything at all.
+        """
+        if self.status == self.RETIRED:
+            return self.RETIRED
+        if self.last_heartbeat_at is None:
+            return self.DISCONNECTED
+        if timezone.now() - self.last_heartbeat_at > HEARTBEAT_ONLINE_WINDOW:
+            return self.STALE
+        return self.status
 
 
 class Turn(models.Model):

--- a/apps/harness/schemas.py
+++ b/apps/harness/schemas.py
@@ -33,6 +33,13 @@ class RunnerOut(Schema):
     def resolve_workspace(obj) -> str | None:
         return obj.workspace_id
 
+    @staticmethod
+    def resolve_status(obj) -> str:
+        # Serve the derived value, not the stored column: heartbeat() writes
+        # ONLINE and nothing ever demotes it, so the raw status lies once a
+        # runner goes quiet. See Runner.live_status.
+        return obj.live_status
+
 
 class HeartbeatIn(Schema):
     active_turn_ids: list[str] = []

--- a/apps/harness/services.py
+++ b/apps/harness/services.py
@@ -14,12 +14,15 @@ from django.db import IntegrityError, transaction
 from django.db.models import Max, Q
 from django.utils import timezone
 
-from .models import AgentSchedule, Runner, SessionLink, Turn, TurnEvent
+from .models import HEARTBEAT_ONLINE_WINDOW, AgentSchedule, Runner, SessionLink, Turn, TurnEvent
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_LEASE_SECONDS = 900
-HEARTBEAT_ONLINE_WINDOW = dt.timedelta(seconds=90)
+# HEARTBEAT_ONLINE_WINDOW lives on models.py (Runner.live_status uses it too;
+# models.py cannot import services.py, which already imports models.py) and is
+# re-exported here so existing importers of services.HEARTBEAT_ONLINE_WINDOW
+# keep working.
 
 
 def enqueue_turn(
@@ -102,7 +105,7 @@ EXECUTING = [Turn.CLAIMED, Turn.RUNNING, Turn.NEEDS_HUMAN]
 
 def claim_next_turn(runner: Runner, *, lease_seconds: int = DEFAULT_LEASE_SECONDS,
                     exclude_slugs: list[str] | None = None) -> Turn | None:
-    if runner.status != Runner.ONLINE:
+    if runner.live_status != Runner.ONLINE:
         return None
     sweep_expired_leases()
     # Lazy sweeps, both BEFORE the busy_agents read: a turn released here frees

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -1551,6 +1551,29 @@ export interface paths {
         readonly patch?: never;
         readonly trace?: never;
     };
+    readonly "/api/harness/runners/{runner_id}/retire": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly get?: never;
+        readonly put?: never;
+        /**
+         * Retire Runner
+         * @description Retire a runner — permanent, not a liveness state (see Runner.live_status).
+         *     Idempotent by construction: _runner_or_404 already excludes retired runners,
+         *     so retiring an already-retired runner 404s at lookup rather than no-opping
+         *     here.
+         */
+        readonly post: operations["apps_harness_api_retire_runner"];
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
     readonly "/api/harness/runners/{runner_id}/heartbeat": {
         readonly parameters: {
             readonly query?: never;
@@ -8059,6 +8082,26 @@ export interface operations {
                 content: {
                     readonly "application/json": components["schemas"]["RunnerOut"];
                 };
+            };
+        };
+    };
+    readonly apps_harness_api_retire_runner: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path: {
+                readonly runner_id: string;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description No Content */
+            readonly 204: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };

--- a/tests/test_harness_api.py
+++ b/tests/test_harness_api.py
@@ -1,12 +1,15 @@
 """API-level tests for /api/harness (runner pairing, claim loop, turn lifecycle)."""
 from __future__ import annotations
 
+from datetime import timedelta
+
 import pytest
 from django.contrib.auth.models import User
 from django.test import Client
+from django.utils import timezone
 
 from apps.agents.models import Agent
-from apps.harness.models import Runner, Turn
+from apps.harness.models import HEARTBEAT_ONLINE_WINDOW, Runner, Turn
 
 pytestmark = pytest.mark.django_db
 
@@ -259,3 +262,82 @@ def test_list_runners_excludes_retired(client, agent):
     rid = _pair(client)
     Runner.objects.filter(pk=rid).update(status=Runner.RETIRED)
     assert client.get("/api/harness/runners/").json() == []
+
+
+# --------------------------------------------------------------------------------------
+# Runner.live_status — the column says what the runner last claimed; the API must serve
+# what we can actually OBSERVE (heartbeat age), not the raw column. See models.py.
+# --------------------------------------------------------------------------------------
+
+def test_stale_heartbeat_reports_stale_even_though_column_says_online(client, agent):
+    rid = _pair(client)
+    assert _hb(client, rid).status_code == 200
+    # Push the last heartbeat outside the window without going through heartbeat()
+    # again — the stored column is untouched and still says "online".
+    old = timezone.now() - HEARTBEAT_ONLINE_WINDOW - timedelta(seconds=1)
+    Runner.objects.filter(pk=rid).update(last_heartbeat_at=old)
+
+    stored = Runner.objects.get(pk=rid)
+    assert stored.status == Runner.ONLINE  # the lie: nothing ever demoted the column
+
+    body = client.get("/api/harness/runners/").json()
+    assert len(body) == 1 and body[0]["status"] == "stale"  # the API tells the truth
+
+
+def test_never_heartbeated_reports_disconnected_regardless_of_stored_status(client, agent):
+    rid = _pair(client)
+    # Force the column to ONLINE directly (never call heartbeat()) so this test
+    # exercises the "no heartbeat at all" branch distinctly from the column value —
+    # last_heartbeat_at stays None throughout.
+    Runner.objects.filter(pk=rid).update(status=Runner.ONLINE)
+    assert Runner.objects.get(pk=rid).last_heartbeat_at is None
+
+    body = client.get("/api/harness/runners/").json()
+    assert len(body) == 1 and body[0]["status"] == "disconnected"
+
+
+def test_fresh_heartbeat_reports_online(client, agent):
+    rid = _pair(client)
+    assert _hb(client, rid).status_code == 200
+    body = client.get("/api/harness/runners/").json()
+    assert len(body) == 1 and body[0]["status"] == "online"
+
+
+def test_degraded_and_fresh_stays_degraded(client, agent):
+    rid = _pair(client)
+    resp = _hb(client, rid, degraded=True)
+    assert resp.status_code == 200 and resp.json()["status"] == "degraded"
+    body = client.get("/api/harness/runners/").json()
+    assert len(body) == 1 and body[0]["status"] == "degraded"  # not clobbered to online
+
+
+def test_retired_runner_404s_on_gated_routes(client, agent):
+    rid = _pair(client)
+    Runner.objects.filter(pk=rid).update(status=Runner.RETIRED)
+    resp = client.post(
+        f"/api/harness/runners/{rid}/heartbeat",
+        {"active_turn_ids": [], "degraded": False, "note": ""},
+        content_type="application/json",
+    )
+    assert resp.status_code == 404
+
+
+# --------------------------------------------------------------------------------------
+# POST /runners/{id}/retire
+# --------------------------------------------------------------------------------------
+
+def test_retire_runner_removes_it_from_the_list(client, agent):
+    rid = _pair(client)
+    resp = client.post(f"/api/harness/runners/{rid}/retire")
+    assert resp.status_code == 204
+    assert Runner.objects.get(pk=rid).status == Runner.RETIRED
+    assert client.get("/api/harness/runners/").json() == []
+
+
+def test_retiring_an_already_retired_runner_404s(client, agent):
+    """Idempotent by construction: _runner_or_404 excludes retired runners at
+    lookup, so a second retire is a 404, not a no-op 204 — the existing
+    lookup behaviour, not a special case added for this route."""
+    rid = _pair(client)
+    assert client.post(f"/api/harness/runners/{rid}/retire").status_code == 204
+    assert client.post(f"/api/harness/runners/{rid}/retire").status_code == 404

--- a/tests/test_harness_authz.py
+++ b/tests/test_harness_authz.py
@@ -294,3 +294,14 @@ def test_pinned_matching_workspace_runner_is_listed_and_actionable(owner_client,
     )
     assert hb.status_code == 200
     assert Runner.objects.get(pk=runner.id).last_heartbeat_at is not None
+
+
+def test_stranger_cannot_retire_someone_elses_runner(owner_client, stranger_client, workspace):
+    rid = owner_client.post(
+        "/api/harness/runners/",
+        {"name": "jj-mbp", "kind": "emdash", "capabilities": {"agents": ["echo"]}},
+        content_type="application/json",
+    ).json()["id"]
+    resp = stranger_client.post(f"/api/harness/runners/{rid}/retire")
+    assert resp.status_code == 404
+    assert Runner.objects.get(pk=rid).status != Runner.RETIRED  # untouched


### PR DESCRIPTION
Found while looking at why `/supervisor` listed six runners when one is real.

## The bug

`heartbeat()` writes `ONLINE`. **Nothing ever demotes it.** `HEARTBEAT_ONLINE_WINDOW = 90s` had been sitting at `services.py:21` referenced by nothing since it was written.

Live prod, right now:

```
jj-mbp-cdp   online        18s ago     <- real
e2e-final    online        1d ago      <- lie
hal-demo     online        1d ago      <- lie
dup-test     disconnected  never
```

A runner that dies never gets to tell us it died. So "online" means "once said hello."

**It's load-bearing, not cosmetic.** `/supervisor` renders its status dot straight off this field, so the phone reports three live runners when one is alive. And `claim_next_turn` gates on `status == ONLINE`. Phase 4 lets you bind an agent to a chosen runner — bind to one that merely *claims* to be online and that agent's turns queue forever, with no error anywhere.

The macOS menubar already gets this right by computing liveness locally from its own heartbeat file. The server should be honest at the source instead of every client re-deriving it.

## The fix

`Runner.live_status` derives liveness from heartbeat age on read; `RunnerOut` serves it and `claim_next_turn` gates on it. No cron, no sweep.

`status` was quietly doing two jobs, and the split matters: **`degraded` is self-reported** (the runner tells us about schema drift), while **`stale`/`disconnected` are only ever observed by us**. So `degraded` passes through as long as the runner is fresh enough to still be reporting anything.

Uses the dead constant rather than inventing a second number. It had to move to `models.py` (circular import — `services` imports `models`); `services` re-exports it so existing importers keep working.

`RunnerStatus.tsx` is untouched and becomes honest for free — its dot map already had `stale`/`disconnected`/`degraded`.

## Also: nothing could retire a runner

`RETIRED` exists in the model and `_runner_visibility_q` already excludes it — but **nothing could set it**, so test debris (`e2e-final`, `hal-demo`, `dup-test`, `dup-test2`) accumulated in prod with no way to clear it.

Adds `POST /api/harness/runners/{id}/retire` → 204, gated by the existing `_runner_or_404` (workspace membership + `paired_by`, 404-not-403). Retiring an already-retired runner 404s at lookup — the helper excludes them — which is the correct existing behaviour.

## Verified

- **Mutation probe:** clobbering `live_status` to `return self.status` fails the stale/disconnected tests (`'online' == 'disconnected'`); restored, all 38 harness tests pass. The tests assert the stored column and the served value **diverge** — that divergence is the whole point.
- 731 passed, 1 skipped with `.env` moved aside (the CI-equivalent state).
- `resolve_status` works because `RunnerOut` is a `ninja.Schema` — verified, not assumed. (`StrictModel` elsewhere in this repo is plain pydantic and would have silently ignored it; a sibling app was bitten by exactly that.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)