### PR TITLE
Document canopy_cron, correct stale scheduled-turns firing claims, run canopy_agent_runs tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,15 @@ jobs:
         working-directory: packages/canopy_runner
         run: uv run --with pytest pytest
 
+      # canopy_agent_runs is the Django-free run-lifecycle core that apps/agent_runs
+      # imports directly (schemas, stores, the Drive client) — not dead code — yet its
+      # suite had never run in CI. `--extra drive` is required, not optional polish:
+      # the Drive google_client tests import googleapiclient, which lives in the
+      # package's optional `drive` group. Without it 10 tests fail on ImportError.
+      - name: Run canopy_agent_runs tests
+        working-directory: packages/canopy_agent_runs
+        run: uv run --extra drive --with pytest pytest
+
   test-frontend:
     name: Frontend build
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,7 +235,7 @@ An `Agent` (e.g. "Echo") is a first-class entity — distinct from a code Projec
 - `POST /api/agents/{slug}/schedules/preview` — preview the next 3 fire times for a cron+tz pair, computed with the same `next_slots()` the firing path uses (so the client never re-implements cron)
 
 ### Agent runs (`apps/agent_runs`, mounted under `/api/agents`)
-The unified agent **run lifecycle** (run → step → artifact → verdict/QA → decision → gate → fork) as a storage-agnostic read model behind a `RunStore` Protocol (DB adapter persists rows; Drive adapter reads ACE's YAML). The keystone of the framework harvest — see `docs/superpowers/specs/2026-06-29-unified-agent-run-lifecycle-design.md`. Backed by the installable Django-free `canopy_runs` library.
+The unified agent **run lifecycle** (run → step → artifact → verdict/QA → decision → gate → fork) as a storage-agnostic read model behind a `RunStore` Protocol (DB adapter persists rows; Drive adapter reads ACE's YAML). The keystone of the framework harvest — see `docs/superpowers/specs/2026-06-29-unified-agent-run-lifecycle-design.md`. Backed by the installable Django-free `canopy_agent_runs` library (`packages/canopy_agent_runs`).
 - `GET /api/agents/{slug}/runs/` — List an agent's runs (paginated)
 - `POST /api/agents/{slug}/runs/` — Create a run
 - `GET /api/agents/{slug}/runs/{run_id}/` — Full run read model
@@ -262,6 +262,8 @@ The agent-execution control plane: paired `Runner`s (laptop emdash daemons, clou
 **Recurring turns** — the runner-facing half of scheduling; the supervisor's CRUD is the `/api/agents/{slug}/schedules/` surface above. `runner_id` is a query param on both routes; the tenant is derived from `runner.paired_by` (the human who paired the runner) rather than the `Runner.workspace` FK — see the Design Decisions entry below.
 - `GET /api/harness/schedules/?runner_id=…` — runner syncs the schedules it may fire. **Tenant-scoped, never scoped by `capabilities`** (a caller-supplied hint, not a boundary — see b4f5ead).
 - `POST /api/harness/schedules/{id}/fire?runner_id=…` — the runner reports a due slot; the server materializes the turn.
+
+Firing is automatic: on each poll tick the runner syncs its schedules, evaluates every cron with `canopy_cron.due_slot(cron, tz, after=fire_after)`, and POSTs any due slot to `fire`. The anchor is the server-computed `ScheduleOut.fire_after` (`= last_slot or created_at`), never `last_slot` — see the Design Decisions entry below. Both halves of the slot math are backed by the installable Django-free `canopy_cron` library (`packages/canopy_cron`): the server's `preview` endpoint and the runner's firing call the **same** `next_slots()` / `due_slot()`, so the UI cannot promise "Fridays" while the runner fires Thursdays. It also owns the `croniter>=6.0,<7.0` bound, once, where the DST/slot semantics live.
 
 > **Operational note — deleting a user bricks their runners' schedules.** `Runner.paired_by` is `on_delete=SET_NULL`, and `_runner_schedule_qs` derives the schedule tenant from it, failing closed when it is NULL: deleting a pairing user's Django `User` orphans their runners, and every schedule route then returns nothing for that runner, forever. The runner must be re-paired (a new row); the orphan can only be retired. This is correct — a runner with no owner has no tenant to derive, and inferring one would be privilege escalation — so prefer deactivating a departing user (`is_active=False`) over deleting them if their runners should keep running.
 
@@ -352,7 +354,7 @@ Design **specs** (the "why" record) live in `docs/superpowers/specs/`. The execu
 - `docs/superpowers/specs/2026-06-19-team-activity-timeline-design.md` — `/timeline` team activity feed design (shipped, PR #138)
 - `docs/superpowers/specs/2026-06-24-canopy-framework-harvest-design.md` — Canopy-as-the-framework harvest strategy (umbrella for Waves 0–4: the framework/product boundary + what moves out of ACE)
 - `docs/superpowers/specs/2026-06-28-shared-agent-client-design.md` — Shared agent-client, the framework's first harvested piece
-- `docs/superpowers/specs/2026-06-29-unified-agent-run-lifecycle-design.md` — Unified agent⊕run lifecycle (Wave 1 keystone; the `apps/agent_runs` + `canopy_runs` library, shipped PR #154)
+- `docs/superpowers/specs/2026-06-29-unified-agent-run-lifecycle-design.md` — Unified agent⊕run lifecycle (Wave 1 keystone; the `apps/agent_runs` + `canopy_agent_runs` library, shipped PR #154)
 - `docs/superpowers/specs/2026-06-29-wave2-3-harvest-execution.md` — Wave 2/3 execution spec (run-step verdicts + multi-tenant workspaces; shipped PRs #158–#162)
 - `docs/superpowers/specs/2026-06-30-workspace-multi-tenancy-design.md` — Workspace-as-tenant full multi-tenancy design (anchor-roots-inherit-children, `/w/` reclaim, path-prefix API; shipped PR #183)
 - `docs/superpowers/specs/2026-07-05-agent-execution-control-plane-design.md` — Agent-execution control plane: paired `Runner`s heartbeat and claim queued `Turn`s, with an append-only `TurnEvent` ledger

--- a/docs/superpowers/specs/2026-07-15-agent-scheduled-turns-design.md
+++ b/docs/superpowers/specs/2026-07-15-agent-scheduled-turns-design.md
@@ -1,8 +1,10 @@
 # Agent scheduled turns — design
 
 **Date:** 2026-07-15
-**Status:** Shipped (server + UI). Automatic firing awaits the runner-side
-work — see *Runner-side work* in the plan; **Run now** is the only trigger today.
+**Status:** Shipped (server + UI + runner). Schedules fire automatically: the
+runner syncs them each poll tick, evaluates each cron with `canopy_cron.due_slot`
+(anchored on the server-computed `fire_after`), and POSTs the due slot to
+`/api/harness/schedules/{id}/fire`. **Run now** remains the off-cycle trigger.
 **Tier:** Framework (`apps/harness`)
 
 ## Problem


### PR DESCRIPTION
Docs + CI only. No application code, no migrations.

## What was stale

**CLAUDE.md**
- **`canopy_cron` was undocumented** (zero mentions) despite being the shared cron/DST slot math. Now documented in the harness *Recurring turns* section, matching the `canopy_agent_runs` precedent: what it is, and why it exists — the server's `preview` and the runner's firing call the same `next_slots()`/`due_slot()`, so the UI can't promise "Fridays" while the runner fires Thursdays. It also owns the `croniter>=6.0,<7.0` bound once, where the DST semantics live.
- **The run-lifecycle library was named wrong.** CLAUDE.md called it `canopy_runs` in two places. The real package is `canopy_agent_runs` (`packages/canopy_agent_runs`, dist `canopy-agent-runs`) — that's what `apps/agent_runs` imports. No `canopy_runs` exists. Corrected both. *(Not in the original brief; found while verifying.)*

**Spec — `2026-07-15-agent-scheduled-turns-design.md`**
- The **Status** line claimed automatic firing awaited runner-side work and that **Run now** was the only trigger. Now false: `packages/canopy_runner/canopy_runner/schedules.py` imports `canopy_cron.due_slot`, evaluates each cron anchored on the server-computed `fire_after` (`= last_slot or created_at`, never `last_slot` — NULL until first fire, and an unbounded backward lookup would fire a slot predating the schedule), and POSTs the due slot to `/api/harness/schedules/{id}/fire`. Status corrected; design rationale untouched.

### Checked but NOT stale
The CLAUDE.md **Design Decisions** entry and the `/api/harness/schedules/` endpoint docs already described runner-evaluated cron and the `fire_after` anchor correctly on `main` — no "Run now is the only trigger" claim there. Left as-is. The spec's *Open for iteration* section is design rationale (grace-period/nag guesses), not a false claim.

## What now runs in CI

`packages/canopy_agent_runs` — **142 tests that had never run on a PR.** The root suite sets `addopts = "--ignore=packages"`, so in-repo packages need their own step; `canopy_cron` and `canopy_runner` each got one, `canopy_agent_runs` was missed. It's the Django-free run-lifecycle core `apps/agent_runs` imports directly, so it is not dead code.

**One deliberate deviation from the two existing steps:** the command is `uv run --extra drive --with pytest pytest`. The `--extra drive` is required, not polish — `tests/test_drive_google_client.py` imports `googleapiclient`, which lives in the package's optional `drive` dependency group. Without it, 10 of 142 tests fail on `ModuleNotFoundError`. Verified both ways locally.

## Verification

- `uv run pytest -q` (root) — 765 passed, 1 skipped
- `packages/canopy_agent_runs`: `uv run --extra drive --with pytest pytest` — **142 passed** (the exact command now in CI)
- `packages/canopy_cron` — 11 passed; `packages/canopy_runner` — 90 passed
- `uv run ruff check apps/ packages/` — 160 errors, **identical to the `origin/main` baseline** (diff touches no Python). Note: the brief said ~64 pre-existing; the real current baseline is 160.
- No `continue-on-error` — a failing test fails the job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)