### PR TITLE
feat(harness): cancel a queued turn + honest multi-workspace enqueue error (Phase 3 follow-ups)

### DIFF
--- a/apps/harness/api.py
+++ b/apps/harness/api.py
@@ -370,6 +370,31 @@ def finish_turn(request: HttpRequest, turn_id: uuid.UUID, payload: TurnFinishIn)
     return result
 
 
+@router.post("/turns/{turn_id}/cancel", response=TurnOut)
+def cancel_turn(request: HttpRequest, turn_id: uuid.UUID):
+    """Cancel a QUEUED turn that has not started — the misfire case the phone
+    composer needs (dispatch the wrong command, take it back before a runner
+    claims it). Records it FAILED with a cancelled note; there is no separate
+    CANCELLED status because nothing downstream distinguishes the two, and adding
+    one would touch the TERMINAL set every sweep and projection depends on.
+
+    QUEUED only. A claimed/running turn is already executing in an emdash session;
+    stopping that is a racy, different operation (the runner owns the lease) and
+    is deliberately out of scope — cancel is 'un-queue', not 'kill'.
+    """
+    turn = _turn_or_404(request, turn_id)
+    if turn.status in Turn.TERMINAL:
+        return turn  # idempotent
+    if turn.status != Turn.QUEUED:
+        raise ProblemError(
+            409, "Turn not cancelable",
+            detail=f"status={turn.status}; only a queued turn can be cancelled",
+        )
+    return services.finish_turn(
+        turn, status=Turn.FAILED, result_note="cancelled by supervisor", allow_queued=True
+    )
+
+
 # --------------------------------------------------------------------------------------
 # AgentSchedule — the runner-facing half. The supervisor's CRUD lives in api_schedules.py;
 # these two routes are what the laptop daemon actually calls: sync, then report a due slot.

--- a/apps/harness/api.py
+++ b/apps/harness/api.py
@@ -266,17 +266,34 @@ def enqueue_turn(request: HttpRequest, payload: TurnIn):
     if payload.agent_slug:
         agent = _agent_or_404(request, payload.agent_slug)
     else:
-        # A project turn carries its own tenant. current_workspace already gates
-        # membership on an explicit slug, so a non-member's enqueue cannot land in
-        # someone else's workspace. 404 rather than 403: the harness must not leak
-        # which tenants exist (same rule as _agent_or_404).
+        # A project turn carries its own tenant.
         wsvc.auto_join_workspaces(request.user)
-        try:
-            workspace = wsvc.current_workspace(
-                request.user, getattr(request, "workspace_slug", None)
-            )
-        except ValueError:
-            raise HttpError(404, "workspace not found")
+        ws_slug = getattr(request, "workspace_slug", None)
+        if ws_slug:
+            # current_workspace gates membership on an explicit slug, so a
+            # non-member's enqueue cannot land in someone else's workspace. 404
+            # rather than 403: the harness must not leak which tenants exist
+            # (same rule as _agent_or_404).
+            try:
+                workspace = wsvc.current_workspace(request.user, ws_slug)
+            except ValueError:
+                raise HttpError(404, "workspace not found")
+        else:
+            workspace = wsvc.user_default_workspace(request.user)
+            if workspace is None:
+                # None means 0 memberships OR 2+ (ambiguous), and the two deserve
+                # different answers. A 404 for the ambiguous case is a lie that
+                # cost real debugging time: the flat shim 404'd every project
+                # enqueue for a 2-workspace user (which the actual prod user is)
+                # while reporting "not found". There is nothing to leak here —
+                # they are the caller's OWN workspaces — so name the fix.
+                if wsvc.user_workspace_slugs(request.user):
+                    raise HttpError(
+                        422,
+                        "you belong to multiple workspaces; enqueue via "
+                        "/api/w/{workspace}/harness/turns/",
+                    )
+                raise HttpError(404, "workspace not found")
 
     turn, created = services.enqueue_turn(
         agent=agent,

--- a/docs/superpowers/plans/2026-07-15-canopy-mobile-phase-3-dispatch.md
+++ b/docs/superpowers/plans/2026-07-15-canopy-mobile-phase-3-dispatch.md
@@ -127,3 +127,23 @@ capability; the backend landing first changes no existing behaviour.
 - [ ] `uv run pytest` with `.env` moved aside
 - [ ] `npm run build`, `npm run test`, `npx playwright test`
 - [ ] PR, CI green, merge, deploy, **verify the live ECS image tag == the merge SHA** (not that the workflow says success)
+
+## Blockers found by probing prod (must clear before Task 6 ships)
+
+1. **A probe turn is stuck QUEUED in prod** (`project=canopy-web`, `idempotency_key=probe-p3-4`,
+   id `1dfc5754-…`). Enqueued while verifying #232 on Postgres. It is inert *only* because no
+   runner declares `canopy-web` — the moment Task 6 adds `"projects": ["canopy-web"]` to the
+   runner's capabilities it gets claimed and types "probe" into a real emdash session. **Delete it
+   before the runner learns projects.** The token user is not staff, so admin delete 403s; needs
+   staff access or a management command.
+
+2. **No way to cancel a QUEUED turn.** `finish` 409s on a queued turn (only claimed/running are
+   finishable). The phone composer makes this urgent — a misfired dispatch must be cancellable.
+   Add `POST /turns/{id}/cancel` (queued → a terminal state) before or with the composer (Task 7).
+
+3. **`SessionLink` project rows have no tenant.** `resolve_session` returns a thread's rolling
+   `summary` + live task id; for agent links `_agent_or_404` gates it, but a project `SessionLink`
+   has no workspace FK, so any runner paired by any user could read another user's session context
+   by guessing `thread_key`. The spec (§3) never addressed project-link tenancy. Options: add a
+   `workspace` FK to `SessionLink` (mirrors Turn), or gate the resolve/record endpoints on the
+   runner's own tenant. Decide before the runner drives project sessions (Task 6/8).

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -1813,6 +1813,34 @@ export interface paths {
         readonly patch?: never;
         readonly trace?: never;
     };
+    readonly "/api/harness/turns/{turn_id}/cancel": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly get?: never;
+        readonly put?: never;
+        /**
+         * Cancel Turn
+         * @description Cancel a QUEUED turn that has not started — the misfire case the phone
+         *     composer needs (dispatch the wrong command, take it back before a runner
+         *     claims it). Records it FAILED with a cancelled note; there is no separate
+         *     CANCELLED status because nothing downstream distinguishes the two, and adding
+         *     one would touch the TERMINAL set every sweep and projection depends on.
+         *
+         *     QUEUED only. A claimed/running turn is already executing in an emdash session;
+         *     stopping that is a racy, different operation (the runner owns the lease) and
+         *     is deliberately out of scope — cancel is 'un-queue', not 'kill'.
+         */
+        readonly post: operations["apps_harness_api_cancel_turn"];
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
     readonly "/api/harness/schedules/": {
         readonly parameters: {
             readonly query?: never;
@@ -8727,6 +8755,28 @@ export interface operations {
                 readonly "application/json": components["schemas"]["TurnFinishIn"];
             };
         };
+        readonly responses: {
+            /** @description OK */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["TurnOut"];
+                };
+            };
+        };
+    };
+    readonly apps_harness_api_cancel_turn: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path: {
+                readonly turn_id: string;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
         readonly responses: {
             /** @description OK */
             readonly 200: {

--- a/tests/test_harness_cancel_turn.py
+++ b/tests/test_harness_cancel_turn.py
@@ -1,0 +1,114 @@
+"""Cancelling a queued turn — the composer's take-it-back, and the only API
+path to retire a misfired turn before a runner claims it."""
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth import get_user_model
+
+from apps.agents.models import Agent
+from apps.harness.models import Runner, Turn
+from apps.workspaces.models import Workspace, WorkspaceMembership
+
+pytestmark = pytest.mark.django_db
+
+
+def _user(name):
+    return get_user_model().objects.create_user(username=name, email=f"{name}@dimagi.com")
+
+
+def _ws(slug, owner):
+    ws = Workspace.objects.create(slug=slug, display_name=slug.title(), created_by=owner)
+    WorkspaceMembership.objects.create(workspace=ws, user=owner, role=WorkspaceMembership.OWNER)
+    return ws
+
+
+@pytest.fixture
+def jj(db):
+    return _user("jj")
+
+
+@pytest.fixture
+def canopy(db, jj):
+    return _ws("canopy", jj)
+
+
+@pytest.fixture
+def cli(client, jj, canopy):
+    client.force_login(jj)
+    return client
+
+
+def test_cancel_a_queued_project_turn(cli, canopy):
+    turn = Turn.objects.create(
+        project="canopy-web", workspace=canopy, origin=Turn.ORIGIN_MANUAL, idempotency_key="k1"
+    )
+    resp = cli.post(f"/api/harness/turns/{turn.id}/cancel")
+
+    assert resp.status_code == 200, resp.content
+    turn.refresh_from_db()
+    assert turn.status == Turn.FAILED
+    assert "cancelled" in turn.result_note
+
+
+def test_cancel_a_queued_agent_turn(cli, canopy):
+    agent = Agent.objects.create(slug="echo", name="Echo", workspace=canopy)
+    turn = Turn.objects.create(agent=agent, origin=Turn.ORIGIN_MANUAL, idempotency_key="k1")
+
+    assert cli.post(f"/api/harness/turns/{turn.id}/cancel").status_code == 200
+    turn.refresh_from_db()
+    assert turn.status == Turn.FAILED
+
+
+def test_cannot_cancel_a_running_turn(cli, canopy):
+    """A running turn is live in an emdash session — the runner owns its lease.
+    Cancel is un-queue, not kill."""
+    agent = Agent.objects.create(slug="echo", name="Echo", workspace=canopy)
+    turn = Turn.objects.create(
+        agent=agent, origin=Turn.ORIGIN_MANUAL, idempotency_key="k1", status=Turn.RUNNING
+    )
+    resp = cli.post(f"/api/harness/turns/{turn.id}/cancel")
+
+    assert resp.status_code == 409
+    turn.refresh_from_db()
+    assert turn.status == Turn.RUNNING  # untouched
+
+
+def test_cancel_is_idempotent(cli, canopy):
+    turn = Turn.objects.create(
+        project="canopy-web", workspace=canopy, origin=Turn.ORIGIN_MANUAL, idempotency_key="k1"
+    )
+    assert cli.post(f"/api/harness/turns/{turn.id}/cancel").status_code == 200
+    # second cancel: already FAILED (terminal) -> still 200, no error
+    assert cli.post(f"/api/harness/turns/{turn.id}/cancel").status_code == 200
+
+
+def test_a_cancelled_turn_is_not_claimable(cli, canopy, jj):
+    """The point of cancel: the turn must never be picked up after."""
+    from apps.harness import services
+    from django.utils import timezone
+
+    turn = Turn.objects.create(
+        project="canopy-web", workspace=canopy, origin=Turn.ORIGIN_MANUAL, idempotency_key="k1"
+    )
+    cli.post(f"/api/harness/turns/{turn.id}/cancel")
+
+    runner = Runner.objects.create(
+        name="jj-mbp", kind=Runner.EMDASH, paired_by=jj, status=Runner.ONLINE,
+        last_heartbeat_at=timezone.now(), capabilities={"projects": ["canopy-web"]},
+    )
+    assert services.claim_next_turn(runner) is None
+
+
+def test_cannot_cancel_another_tenants_turn(client, canopy, jj):
+    """_turn_or_404 gates the cancel: a non-member gets 404, not a cancel."""
+    turn = Turn.objects.create(
+        project="canopy-web", workspace=canopy, origin=Turn.ORIGIN_MANUAL, idempotency_key="k1"
+    )
+    mallory = _user("mallory")
+    _ws("mallory-space", mallory)
+    client.force_login(mallory)
+
+    resp = client.post(f"/api/harness/turns/{turn.id}/cancel")
+    assert resp.status_code == 404
+    turn.refresh_from_db()
+    assert turn.status == Turn.QUEUED  # untouched

--- a/tests/test_harness_enqueue_projects.py
+++ b/tests/test_harness_enqueue_projects.py
@@ -95,3 +95,41 @@ def test_agent_turns_still_enqueue(cli, canopy):
     # Agent turns DERIVE tenancy via agent.workspace — they must not denormalize
     # a second copy that can drift out of step with the agent's own workspace.
     assert turn.workspace_id is None
+
+
+def test_a_multi_workspace_user_is_told_to_name_one_not_404d(client, db, jj, canopy):
+    """The gap my suite had, found only by probing prod.
+
+    Every test user here had exactly ONE workspace, so current_workspace always
+    resolved. The real prod user belongs to two ('connect' and 'dimagi'), which
+    makes the default ambiguous — and the flat route 404'd every project enqueue
+    while reporting "workspace not found". The turn was fine; the error was a lie.
+
+    Nothing to protect here: they are the caller's own workspaces, so name the fix
+    rather than hide behind the 404-not-403 rule (which exists to avoid leaking
+    OTHER tenants' existence).
+    """
+    _ws("dimagi", jj)  # jj is now in two
+    client.force_login(jj)
+
+    resp = _post(client, project="canopy-web")
+
+    assert resp.status_code == 422, resp.content
+    assert "multiple workspaces" in resp.json()["detail"]
+    assert not Turn.objects.exists()
+
+
+def test_a_multi_workspace_user_can_enqueue_via_the_tenant_scoped_route(client, db, jj, canopy):
+    """The other half: naming the workspace works. Verified against prod too —
+    POST /api/w/connect/harness/turns/ queued a canopy-web turn."""
+    _ws("dimagi", jj)
+    client.force_login(jj)
+
+    resp = client.post(
+        "/api/w/canopy/harness/turns/",
+        data={"project": "canopy-web", "origin": "manual", "idempotency_key": "k1"},
+        content_type="application/json",
+    )
+
+    assert resp.status_code == 201, resp.content
+    assert Turn.objects.get(idempotency_key="k1").workspace_id == "canopy"


### PR DESCRIPTION
Two backend follow-ups to #232, both found by probing prod after it deployed. No client/runner changes — safe to ship independently.

## 1. Cancel a queued turn

`POST /api/harness/turns/{id}/cancel` retires a QUEUED turn as FAILED. Two reasons it's needed now:
- The phone composer (Task 7) needs a take-it-back — dispatch the wrong command, undo it before a runner claims it.
- It's the only API path to retire a misfired turn: `finish` 409s on a queued turn. (This PR's first user is me — there's a stuck probe turn in prod from #232 verification that I'll cancel once this deploys.)

QUEUED only — a claimed/running turn is executing in an emdash session with a runner-held lease; killing that is a racy, separate operation. No new `CANCELLED` status: nothing downstream distinguishes it from FAILED, and a new terminal state would touch every sweep/projection that reads `Turn.TERMINAL`. Gated by `_turn_or_404` (non-member → 404). Tested that a cancelled turn is never subsequently claimable.

## 2. An honest error for a multi-workspace user

The flat `POST /api/harness/turns/` 404'd **every** project enqueue for the real prod user, who belongs to two workspaces (`connect`, `dimagi`). `current_workspace` returns None on both zero and ambiguous membership, and the view mapped None → "workspace not found" — a lie; the turn was enqueuable all along via `/api/w/{ws}/harness/turns/`.

Now: 0 memberships → 404 (nothing to name); 2+ → **422** "you belong to multiple workspaces; enqueue via `/api/w/{workspace}/…`". Nothing to leak — they're the caller's own workspaces — so the 404-not-403 rule (which hides *other* tenants) doesn't apply. My suite missed this because every test user had exactly one workspace; added a two-workspace test and its positive twin, both verified against prod.

## Still open (recorded in the plan, not in this PR)

`SessionLink` project rows have no tenant, so once the runner drives project sessions (Task 6/8) a runner paired by any user could read another user's session summary by guessing `thread_key`. Not live yet (no project SessionLinks exist), must fix before Task 8.

## Verification

805 backend (`.env` aside, matching CI), types regenerated. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)