### PR TITLE
fix(security): prod signs cookies with the real SECRET_KEY, and refuses the dev default

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -29,7 +29,14 @@ if env_file.exists():
     env.read_env(str(env_file))
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = env("SECRET_KEY", default="django-insecure-change-me-in-production")
+# This is a shared, deliberately-insecure default so a fresh checkout can run
+# `manage.py runserver` with zero setup — localhost signs nothing worth stealing,
+# so devs do NOT each need their own key. It is NOT a real secret: the `django-
+# insecure-` prefix is Django's own marker for exactly this. Production reads
+# SECRET_KEY from the environment and production.py hard-fails if it ever sees
+# this default (see the assertion there), so prod can never fall back to it.
+INSECURE_DEV_SECRET_KEY = "django-insecure-change-me-in-production"
+SECRET_KEY = env("SECRET_KEY", default=INSECURE_DEV_SECRET_KEY)
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = env("DEBUG")

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -1,9 +1,26 @@
 """
-Production Django settings for Cloud Run + Cloud SQL deployment.
+Production Django settings for the AWS ECS Fargate deployment
+(https://labs.connect.dimagi.com/canopy/; provisioned by deploy/aws/canopy-web.cfn.yaml).
 """
+from django.core.exceptions import ImproperlyConfigured
+
 from .base import *  # noqa: F401, F403
+from .base import INSECURE_DEV_SECRET_KEY, SECRET_KEY
 
 DEBUG = False
+
+# Refuse to boot on the insecure dev default. base.py keeps that default so local
+# `runserver` works with no setup, but in production it must come from the
+# environment (the SECRET_KEY secret in the ECS task def). This assertion is the
+# durable fix for the DJANGO_SECRET_KEY/SECRET_KEY name mismatch that let prod
+# silently sign cookies with the public placeholder — a misconfigured deploy now
+# crashes loudly instead of running compromised.
+if SECRET_KEY == INSECURE_DEV_SECRET_KEY:
+    raise ImproperlyConfigured(
+        "SECRET_KEY is the insecure dev default in a production settings module. "
+        "Set the SECRET_KEY environment variable to a strong secret "
+        "(ECS task def maps it from the canopy-web/django-secret-key Secrets Manager entry)."
+    )
 
 # Cloud Run sets PORT; uvicorn binds to it.
 # ALLOWED_HOSTS was declared as a list type in base.py, so env() returns a list.

--- a/deploy/aws/canopy-web.cfn.yaml
+++ b/deploy/aws/canopy-web.cfn.yaml
@@ -163,7 +163,10 @@ Resources:
             - { Name: VAPID_PUBLIC_KEY, Value: "BI34-mR1N-xMAhF3tQ1ajAe7g9KaK1nlrhX49pRQmBgo5s-KgoTtgcfOz9ejYeeAJR-tQh9JZ1cRJUCb8td-W58" }
             - { Name: VAPID_SUBJECT, Value: mailto:jjackson@dimagi.com }
           Secrets:
-            - { Name: DJANGO_SECRET_KEY, ValueFrom: !Ref DjangoSecretKey }
+            # Name MUST be SECRET_KEY — that's what config/settings/base.py reads.
+            # (It was DJANGO_SECRET_KEY, which nothing read, so prod silently fell
+            # back to the insecure dev default; production.py now hard-fails on that.)
+            - { Name: SECRET_KEY, ValueFrom: !Ref DjangoSecretKey }
             - { Name: DATABASE_URL, ValueFrom: !Ref DatabaseUrl }
             - { Name: REDIS_URL, ValueFrom: !Ref RedisUrl }
             - { Name: GOOGLE_OAUTH_CLIENT_ID, ValueFrom: !Ref GoogleOauthClientId }

--- a/tests/test_production_secret_key.py
+++ b/tests/test_production_secret_key.py
@@ -1,0 +1,58 @@
+"""Production must never boot on the insecure dev SECRET_KEY default.
+
+Regression guard for the DJANGO_SECRET_KEY/SECRET_KEY env-name mismatch that let
+production silently sign session/CSRF/reset tokens with the public placeholder in
+config/settings/base.py. config.settings.production now refuses to import unless
+SECRET_KEY is supplied from the environment.
+
+Settings modules import-and-cache once per process, so we load the settings in a
+fresh interpreter per case. Accessing any setting forces Django to import the
+settings module, which runs production.py's top-level guard — the real startup
+failure mode — without populating the app registry.
+"""
+import os
+import subprocess
+import sys
+
+from config.settings.base import INSECURE_DEV_SECRET_KEY
+
+_BOOT = "from django.conf import settings; settings.DEBUG"
+
+
+def _boot_production(secret_key: str | None) -> subprocess.CompletedProcess:
+    # Inherit the real environment (keeps the venv/interpreter resolvable), then
+    # override only what this test controls.
+    env = {
+        **os.environ,
+        "DJANGO_SETTINGS_MODULE": "config.settings.production",
+        "ALLOWED_HOSTS": "example.com",
+    }
+    if secret_key is None:
+        env.pop("SECRET_KEY", None)
+    else:
+        env["SECRET_KEY"] = secret_key
+    return subprocess.run(
+        [sys.executable, "-c", _BOOT],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_production_refuses_the_insecure_default():
+    # No SECRET_KEY in the env → base.py falls back to the insecure default →
+    # production.py must raise ImproperlyConfigured and the process must die.
+    result = _boot_production(None)
+    assert result.returncode != 0
+    assert "ImproperlyConfigured" in result.stderr
+    assert "SECRET_KEY" in result.stderr
+
+
+def test_production_boots_with_a_real_secret_key():
+    result = _boot_production("a-real-strong-secret-value-not-the-default")
+    assert result.returncode == 0, result.stderr
+
+
+def test_the_default_is_recognisably_insecure():
+    # The marker prefix Django uses is load-bearing for the assertion's intent.
+    assert INSECURE_DEV_SECRET_KEY.startswith("django-insecure-")


### PR DESCRIPTION
## The bug (live on prod right now)

The ECS task def injects the generated secret as **\`DJANGO_SECRET_KEY\`**, but \`config/settings/base.py:32\` reads **\`SECRET_KEY\`**. Nothing reads \`DJANGO_SECRET_KEY\`, so production silently fell back to the committed placeholder \`django-insecure-change-me-in-production\` and signed **every session / CSRF / password-reset token** with a value published in this repo.

Verified against the live deployment: task def \`labs-jj-canopy-web:26\` has \`DJANGO_SECRET_KEY\` in its secrets and no \`SECRET_KEY\`; \`https://labs.connect.dimagi.com/canopy/\` returns 200. That's a forgeable-session auth bypass on an internet-facing host, amplified by \`/api/debug/mint-session/\` and PAT bearer auth.

## The fix

1. **`deploy/aws/canopy-web.cfn.yaml`** — map the Secrets Manager value to \`SECRET_KEY\`, the name settings actually reads. Matches the unprefixed convention of every other secret (\`DATABASE_URL\`, \`REDIS_URL\`, \`GOOGLE_OAUTH_*\`).
2. **`config/settings/production.py`** — hard-fail on boot if \`SECRET_KEY\` is still the dev default. This is the durable fix: a misconfigured deploy now crashes loudly instead of running compromised, so this whole class of mistake can't recur silently.
3. **`base.py`** — name the default \`INSECURE_DEV_SECRET_KEY\` and document *why* a shared insecure dev default is fine (localhost has nothing to protect) while prod never uses it. Devs do **not** each need their own key.
4. **`tests/test_production_secret_key.py`** — regression guard: prod refuses the default, boots with a real key.

## Rotation is automatic

The exposed key is the placeholder. The generated Secrets Manager value has **never been used** (nothing read \`DJANGO_SECRET_KEY\`) and was never in git. Deploying this switches prod onto that never-exposed value — so the deploy *is* the rotation. Existing cookies invalidate; users re-login (expected).

## Deploy note (required to actually remediate)

The \`deploy-labs\` workflow sources the live task def and swaps only the image, so it will **not** pick up this env-name change on its own. The CloudFormation stack must be updated (the one-time provisioner path) so the task def re-renders with \`SECRET_KEY\`, then the service rolled. Happy to run that once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)