### PR TITLE
feat(supervisor): a phone composer that dispatches agent commands (Phase 3 composer)

### DIFF
--- a/frontend/e2e/seed.py
+++ b/frontend/e2e/seed.py
@@ -76,6 +76,12 @@ AgentWorkProduct.objects.create(
 AgentSkill.objects.create(
     agent=a, name="email-communicator", description="Send and receive email as Echo.",
     url="https://github.com/dimagi-internal/echo/blob/main/skills/email-communicator/SKILL.md")
+# A launchable skill so the phone composer has a human entry point to render; the
+# one above stays non-launchable so the composer's filter has something to drop.
+AgentSkill.objects.create(
+    agent=a, name="story-ideation", description="Generate Connect story ideas.",
+    launchable=True, args_hint="topic (optional)",
+    url="https://github.com/dimagi-internal/echo/blob/main/skills/story-ideation/SKILL.md")
 
 # A fleet-audit findings review — a run-child gate whose run_id is NOT a DDD run id
 # (nothing else in the system references it). It must render standalone: no DDD rail,

--- a/frontend/e2e/supervisor.spec.ts
+++ b/frontend/e2e/supervisor.spec.ts
@@ -30,4 +30,42 @@ test.describe('/supervisor', () => {
     // Runners still rendered despite needs-you failing.
     await expect(page.getByTestId('runner-status').or(page.getByText('No runner paired'))).toBeVisible()
   })
+
+  test('the composer dispatches a launchable command', async ({ page }) => {
+    await page.goto('/supervisor')
+    const composer = page.getByTestId('composer')
+    await expect(composer).toBeVisible()
+
+    // Pick echo — the fleet has several agents and the default is whichever sorts
+    // first; only echo carries a launchable skill in the seed.
+    await page.getByTestId('composer-agent').selectOption('echo')
+
+    // Only launchable skills appear — the seed's non-launchable email-communicator
+    // must NOT be an option; story-ideation must.
+    const skill = page.getByTestId('composer-skill')
+    await expect(skill.locator('option', { hasText: 'story-ideation' })).toHaveCount(1)
+    await expect(skill.locator('option', { hasText: 'email-communicator' })).toHaveCount(0)
+
+    await skill.selectOption('story-ideation')
+    // args_hint from the launchable skill drives the placeholder.
+    await expect(page.getByTestId('composer-args')).toHaveAttribute('placeholder', 'topic (optional)')
+    // The preview shows the exact command that will land in the session.
+    await expect(page.getByTestId('composer-preview')).toHaveText('/echo:story-ideation')
+
+    let posted: Record<string, unknown> | null = null
+    await page.route('**/api/harness/turns/', async (route) => {
+      posted = route.request().postDataJSON()
+      await route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify({ id: 't-1', agent_slug: 'echo', project: '', target: 'echo', status: 'queued' }),
+      })
+    })
+
+    await page.getByTestId('composer-args').fill('bednets')
+    await page.getByTestId('composer-send').click()
+
+    await expect(page.getByTestId('composer-sent')).toBeVisible()
+    expect(posted).toMatchObject({ agent_slug: 'echo', prompt: '/echo:story-ideation bednets' })
+  })
 })

--- a/frontend/src/api/harness.ts
+++ b/frontend/src/api/harness.ts
@@ -5,6 +5,7 @@ import { apiV2 } from './client.v2'
 import type { components } from './generated'
 
 export type RunnerOut = components['schemas']['RunnerOut']
+export type TurnOut = components['schemas']['TurnOut']
 
 function unwrap<T>(res: { data?: T; error?: unknown }, what: string): T {
   if (res.error !== undefined || res.data === undefined) {
@@ -20,4 +21,44 @@ export async function listRunners(): Promise<RunnerOut[]> {
   // ./agents.ts's toPage comment for the full explanation. Array.from rebuilds
   // a real array rather than casting.
   return Array.from(unwrap(res, 'listRunners'))
+}
+
+// Dispatch a command to an AGENT from the phone composer. Agent turns route
+// through the flat mount cleanly — the server resolves the agent's single
+// workspace, so there is no tenant ambiguity to disambiguate.
+//
+// Repo (project) dispatch is deliberately NOT here yet: a project turn carries
+// its OWN workspace, and a repo like canopy-web is not owned by one workspace,
+// so the composer must first answer "which tenant does this repo turn belong to"
+// AND route to /api/w/{ws}/... (the flat route 422s a multi-workspace user).
+// That is a real design decision, tracked in the Phase 3 plan — not a rushed
+// raw-fetch here.
+export async function enqueueTurn(input: {
+  agentSlug: string
+  prompt: string
+}): Promise<TurnOut> {
+  const { agentSlug, prompt } = input
+  // A stable-enough idempotency key: a double-tap of Send within the same second
+  // collapses server-side rather than firing twice.
+  const key = `cmd-${agentSlug}-${Date.now()}`
+  const res = await apiV2.POST('/api/harness/turns/', {
+    body: {
+      agent_slug: agentSlug,
+      project: '',
+      origin: 'manual',
+      idempotency_key: key,
+      prompt,
+      origin_ref: {},
+      routing: 'prefer_local',
+    },
+  })
+  return unwrap(res, 'enqueueTurn')
+}
+
+// Un-queue a misfired turn (queued only; the server 409s a running turn).
+export async function cancelTurn(turnId: string): Promise<TurnOut> {
+  const res = await apiV2.POST('/api/harness/turns/{turn_id}/cancel', {
+    params: { path: { turn_id: turnId } },
+  })
+  return unwrap(res, 'cancelTurn')
 }

--- a/frontend/src/components/supervisor/Composer.tsx
+++ b/frontend/src/components/supervisor/Composer.tsx
@@ -1,0 +1,146 @@
+import { useEffect, useState, type JSX } from 'react'
+import { listAgentSkills, type AgentOut, type AgentSkillOut } from '@/api/agents'
+import { enqueueTurn } from '@/api/harness'
+import { buildDispatchPrompt, canDispatch } from '@/lib/dispatchPrompt'
+
+// The phone composer: dispatch a command to an agent without opening a laptop.
+// Pick an agent → pick one of its LAUNCHABLE skills (the agent declares which of
+// its catalog are human entry points; see AgentSkill.launchable) or type a free
+// prompt → send. The dispatch enqueues a manual turn the runner claims within a
+// poll tick; the prompt is exactly the namespaced command, which the agent's
+// /<slug>:<skill> does all the work from.
+//
+// Repo (project) dispatch is intentionally absent — see enqueueTurn's note.
+
+type Sent = { kind: 'ok'; label: string } | { kind: 'err'; message: string }
+
+export function Composer({ agents }: { agents: AgentOut[] }): JSX.Element {
+  const [slug, setSlug] = useState<string>(agents[0]?.slug ?? '')
+  const [skills, setSkills] = useState<AgentSkillOut[] | null>(null)
+  const [skillName, setSkillName] = useState<string>('') // '' = free prompt
+  const [args, setArgs] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [sent, setSent] = useState<Sent | null>(null)
+
+  // Load the selected agent's launchable skills. A non-launchable skill is a
+  // footgun on a phone (/echo:setup one thumb away), so the catalog is filtered
+  // to launchable here — the server marks them, we never render the rest.
+  useEffect(() => {
+    if (!slug) return
+    let cancelled = false
+    setSkills(null)
+    setSkillName('')
+    setArgs('')
+    listAgentSkills(slug)
+      .then((all) => {
+        if (!cancelled) setSkills(all.filter((s) => s.launchable))
+      })
+      .catch(() => {
+        if (!cancelled) setSkills([])
+      })
+  }, [slug])
+
+  const selected = skills?.find((s) => s.name === skillName)
+  const prompt = buildDispatchPrompt(slug, skillName, args)
+  const canSend = !busy && canDispatch(slug, prompt)
+
+  async function send(): Promise<void> {
+    if (!canSend) return
+    setBusy(true)
+    setSent(null)
+    try {
+      await enqueueTurn({ agentSlug: slug, prompt: prompt.trim() })
+      setSent({ kind: 'ok', label: skillName ? `/${slug}:${skillName}` : slug })
+      setArgs('')
+      setSkillName('')
+    } catch (e) {
+      setSent({ kind: 'err', message: e instanceof Error ? e.message : 'Failed to send' })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  if (agents.length === 0) return <></>
+
+  return (
+    <div className="flex flex-col gap-2 rounded-lg border border-border bg-card p-3" data-testid="composer">
+      <div className="flex flex-wrap gap-2">
+        <label className="sr-only" htmlFor="composer-agent">
+          Agent
+        </label>
+        <select
+          id="composer-agent"
+          data-testid="composer-agent"
+          value={slug}
+          onChange={(e) => setSlug(e.target.value)}
+          className="rounded border border-input bg-input px-2 py-1.5 text-[13px] text-foreground"
+        >
+          {agents.map((a) => (
+            <option key={a.slug} value={a.slug}>
+              {a.name}
+            </option>
+          ))}
+        </select>
+
+        <label className="sr-only" htmlFor="composer-skill">
+          Command
+        </label>
+        <select
+          id="composer-skill"
+          data-testid="composer-skill"
+          value={skillName}
+          onChange={(e) => setSkillName(e.target.value)}
+          disabled={skills === null}
+          className="min-w-0 flex-1 rounded border border-input bg-input px-2 py-1.5 text-[13px] text-foreground disabled:opacity-50"
+        >
+          <option value="">Free prompt…</option>
+          {(skills ?? []).map((s) => (
+            <option key={s.name} value={s.name}>
+              /{slug}:{s.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="flex gap-2">
+        <input
+          data-testid="composer-args"
+          value={args}
+          onChange={(e) => setArgs(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') void send()
+          }}
+          placeholder={selected?.args_hint || (skillName ? 'arguments (optional)' : 'Type a prompt…')}
+          className="min-w-0 flex-1 rounded border border-input bg-input px-2 py-1.5 text-[13px] text-foreground placeholder:text-muted-foreground"
+        />
+        <button
+          type="button"
+          data-testid="composer-send"
+          onClick={() => void send()}
+          disabled={!canSend}
+          className="rounded bg-primary px-3 py-1.5 text-[13px] font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+        >
+          {busy ? 'Sending…' : 'Send'}
+        </button>
+      </div>
+
+      {/* The exact command about to fire — no surprise about what lands in the session. */}
+      {prompt.trim() !== '' && (
+        <p className="truncate font-mono text-[11px] text-muted-foreground" data-testid="composer-preview">
+          {prompt}
+        </p>
+      )}
+
+      {sent?.kind === 'ok' && (
+        <p className="text-[12px] text-success" data-testid="composer-sent">
+          Queued {sent.label} — the runner picks it up on its next tick.
+        </p>
+      )}
+      {sent?.kind === 'err' && (
+        <p className="text-[12px] text-destructive" data-testid="composer-error">
+          {sent.message}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/lib/dispatchPrompt.test.ts
+++ b/frontend/src/lib/dispatchPrompt.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { buildDispatchPrompt, canDispatch } from './dispatchPrompt'
+
+describe('buildDispatchPrompt', () => {
+  it('builds a namespaced command with args', () => {
+    expect(buildDispatchPrompt('echo', 'story-ideation', 'bednets')).toBe(
+      '/echo:story-ideation bednets',
+    )
+  })
+
+  it('drops the trailing space when a skill takes no args', () => {
+    expect(buildDispatchPrompt('echo', 'story-ideation', '')).toBe('/echo:story-ideation')
+    expect(buildDispatchPrompt('echo', 'story-ideation', '   ')).toBe('/echo:story-ideation')
+  })
+
+  it('sends a free prompt verbatim when no skill is picked', () => {
+    expect(buildDispatchPrompt('echo', '', 'summarize the week')).toBe('summarize the week')
+  })
+
+  it('trims args so a stray space never reaches the session', () => {
+    expect(buildDispatchPrompt('echo', 'x', '  y  ')).toBe('/echo:x y')
+    expect(buildDispatchPrompt('echo', '', '  hello  ')).toBe('hello')
+  })
+})
+
+describe('canDispatch', () => {
+  it('requires both an agent and a non-empty prompt', () => {
+    expect(canDispatch('echo', '/echo:turn')).toBe(true)
+    expect(canDispatch('', '/echo:turn')).toBe(false)
+    expect(canDispatch('echo', '')).toBe(false)
+    expect(canDispatch('echo', '   ')).toBe(false)
+  })
+})

--- a/frontend/src/lib/dispatchPrompt.ts
+++ b/frontend/src/lib/dispatchPrompt.ts
@@ -1,0 +1,14 @@
+// The command a composer dispatch actually sends. A launchable skill fires the
+// agent's namespaced `/{slug}:{name} {args}`; an empty skill name is a free
+// prompt sent verbatim. Kept pure (no React) so the exact string — which is what
+// lands in the agent's session — is unit-testable; the component only wires it.
+
+export function buildDispatchPrompt(slug: string, skillName: string, args: string): string {
+  const trimmed = args.trim()
+  if (!skillName) return trimmed // free prompt
+  return trimmed ? `/${slug}:${skillName} ${trimmed}` : `/${slug}:${skillName}`
+}
+
+export function canDispatch(slug: string, prompt: string): boolean {
+  return slug.trim() !== '' && prompt.trim() !== ''
+}

--- a/frontend/src/pages/SupervisorPage.tsx
+++ b/frontend/src/pages/SupervisorPage.tsx
@@ -4,6 +4,7 @@ import { listRunners, type RunnerOut } from '@/api/harness'
 import { RunnerStatus } from '@/components/supervisor/RunnerStatus'
 import { AgentKpiCard } from '@/components/supervisor/AgentKpiCard'
 import { WaitingOnYou } from '@/components/supervisor/WaitingOnYou'
+import { Composer } from '@/components/supervisor/Composer'
 import { InstallPrompt } from '@/pwa/InstallPrompt'
 import { PushToggle } from '@/pwa/PushToggle'
 import { setBadge } from '@/pwa/usePush'
@@ -63,6 +64,15 @@ export default function SupervisorPage(): JSX.Element {
 
       <InstallPrompt />
       <PushToggle />
+
+      {agents && agents.length > 0 && (
+        <section>
+          <h2 className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+            Dispatch
+          </h2>
+          <Composer agents={agents} />
+        </section>
+      )}
 
       <section>
         <h2 className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">


### PR DESCRIPTION
The near half of the dogfooding loop: dispatch a command to an agent from `/supervisor` without opening a laptop. Frontend-only — rides the `enqueue` + `launchable` backend shipped in #232/#236.

## What

Pick an agent → pick one of its **launchable** skills (or type a free prompt) → Send. The dispatch enqueues a manual turn the runner claims on its next tick; the prompt is exactly the namespaced `/<slug>:<skill>`, which the agent does the work from. `args_hint` drives the placeholder; a monospace preview shows the exact command before it fires.

Only launchable skills render — a non-launchable one (`echo:setup`, a pre-send discipline another skill invokes) is a footgun one thumb away, so the catalog is filtered to what the agent declared launchable in #232.

## Testing split (this repo's convention)

No `@testing-library/react` here — vitest tests pure logic, Playwright tests rendered behaviour. So the prompt-building (`/{slug}:{skill} {args}` vs a verbatim free prompt, trimmed so no stray space reaches the session) is a pure helper `lib/dispatchPrompt` with its own vitest. The Playwright test proves the launchable filter (`email-communicator` absent, `story-ideation` present), the `args_hint` placeholder, the preview, and that Send posts `prompt="/echo:story-ideation bednets"`.

## Deliberately NOT here: repo dispatch

A project turn carries its **own** workspace, and a repo like `canopy-web` isn't owned by one workspace — so the composer must first answer *"which tenant does this repo turn belong to"* AND route to `/api/w/{ws}/…` (the flat route 422s a multi-workspace user, which the real user is). That's a genuine design decision, tracked in the plan, not something to paper over with a rushed raw-fetch under the flat route. `cancelTurn` is added to the client for the take-it-back path; wiring it to a UI control ships with repo dispatch.

## Verification

Backend 811, vitest 91, Playwright 32 (both desktop + Pixel 7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)