### PR TITLE
feat(supervisor): repo dispatch with first-class workspace ownership

### DIFF
--- a/frontend/e2e/supervisor.spec.ts
+++ b/frontend/e2e/supervisor.spec.ts
@@ -68,4 +68,41 @@ test.describe('/supervisor', () => {
     await expect(page.getByTestId('composer-sent')).toBeVisible()
     expect(posted).toMatchObject({ agent_slug: 'echo', prompt: '/echo:story-ideation bednets' })
   })
+
+  test('a repo dispatch pins its workspace and routes to the tenant endpoint', async ({ page }) => {
+    await page.goto('/supervisor')
+    await page.getByTestId('composer-mode-repo').click()
+
+    // A repo turn's tenant is first-class and defaults to dimagi (the e2e
+    // workspace), shown in the selector — not hidden server magic.
+    await expect(page.getByTestId('composer-workspace')).toHaveValue('dimagi')
+    await page.getByTestId('composer-project').fill('canopy-web')
+
+    let url: string | null = null
+    let posted: Record<string, unknown> | null = null
+    let headers: Record<string, string> = {}
+    // The proof the workspace is pinned: the request lands on the TENANT-scoped
+    // path /api/w/dimagi/…, not the flat mount (which would 422 a multi-workspace
+    // user). WORKSPACE_HEADER drove the client-side rewrite.
+    await page.route('**/api/w/*/harness/turns/', async (route) => {
+      url = route.request().url()
+      posted = route.request().postDataJSON()
+      headers = route.request().headers()
+      await route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify({ id: 't-2', agent_slug: null, project: 'canopy-web', target: 'canopy-web', status: 'queued' }),
+      })
+    })
+
+    await page.getByTestId('composer-args').fill('fix the header spacing')
+    await page.getByTestId('composer-send').click()
+
+    await expect(page.getByTestId('composer-sent')).toBeVisible()
+    expect(url).toContain('/api/w/dimagi/harness/turns/')
+    expect(posted).toMatchObject({ project: 'canopy-web', prompt: 'fix the header spacing' })
+    // The pin header is consumed by the rewrite and must NOT reach the wire — it
+    // is a client-side routing signal, not something the server should ever see.
+    expect(headers['x-canopy-workspace']).toBeUndefined()
+  })
 })

--- a/frontend/src/api/client.v2.test.ts
+++ b/frontend/src/api/client.v2.test.ts
@@ -33,6 +33,23 @@ describe('rewriteForWorkspace', () => {
     await expect(rewritten.json()).resolves.toEqual(payload)
   })
 
+  it('rewrites a harness path — the explicit-workspace (header) case is not limited to the implicit prefix list', async () => {
+    // A repo turn is dispatched from /supervisor (not a tenant surface) and pins
+    // its workspace via WORKSPACE_HEADER; the middleware then rewrites via this
+    // function regardless of whether /api/harness is in WS_SCOPED_API_PREFIXES
+    // (it is not — that list is only for the implicit URL-driven case).
+    const original = new Request('http://localhost/api/harness/turns/', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ project: 'canopy-web', prompt: 'fix the header' }),
+    })
+
+    const rewritten = await rewriteForWorkspace(original, 'dimagi')
+
+    expect(new URL(rewritten.url).pathname).toBe('/api/w/dimagi/harness/turns/')
+    await expect(rewritten.json()).resolves.toEqual({ project: 'canopy-web', prompt: 'fix the header' })
+  })
+
   it('rewrites a bodyless GET without attaching a body', async () => {
     const original = new Request('http://localhost/api/projects/', { method: 'GET' })
 

--- a/frontend/src/api/client.v2.ts
+++ b/frontend/src/api/client.v2.ts
@@ -52,6 +52,12 @@ const WS_SCOPED_API_PREFIXES = [
   "/api/items",
 ];
 
+// A request header a caller sets to pin the tenant explicitly when the page it
+// dispatches from is not itself workspace-scoped. Never leaves the browser — the
+// onRequest middleware consumes it and rewrites the path to /api/w/:ws/…. Exported
+// so callers reference the constant rather than re-typing the string.
+export const WORKSPACE_HEADER = "X-Canopy-Workspace";
+
 function activeWorkspaceFromUrl(): string | null {
   // Strip the deployment prefix (/canopy) before reading the app route.
   const p = window.location.pathname.slice(API_BASE.length);
@@ -98,6 +104,17 @@ export async function rewriteForWorkspace(request: Request, ws: string): Promise
 
 apiV2.use({
   async onRequest({ request }) {
+    // Explicit workspace override. A caller on a NON-tenant surface (/supervisor,
+    // whose URL carries no /w/:ws/) can still pin a workspace by setting this
+    // header — used when a resource is workspace-owned but the page it is dispatched
+    // from is not (a repo turn's tenant, chosen in the composer). Takes precedence
+    // over the URL, applies to ANY path (not just the WS_SCOPED_API_PREFIXES list,
+    // which is for the implicit URL-driven case), and is stripped before the send.
+    const pinned = request.headers.get(WORKSPACE_HEADER);
+    if (pinned) {
+      request.headers.delete(WORKSPACE_HEADER);
+      return rewriteForWorkspace(request, pinned);
+    }
     const ws = activeWorkspaceFromUrl();
     if (!ws) return request;
     const url = new URL(request.url);

--- a/frontend/src/api/harness.ts
+++ b/frontend/src/api/harness.ts
@@ -1,7 +1,7 @@
 // Harness API client — the runner registry and turn lifecycle. Separate from
 // ./agents because a Runner is not an agent: the harness is framework tier and
 // the agent surface is product tier (see ARCHITECTURE.md).
-import { apiV2 } from './client.v2'
+import { apiV2, WORKSPACE_HEADER } from './client.v2'
 import type { components } from './generated'
 
 export type RunnerOut = components['schemas']['RunnerOut']
@@ -23,35 +23,42 @@ export async function listRunners(): Promise<RunnerOut[]> {
   return Array.from(unwrap(res, 'listRunners'))
 }
 
-// Dispatch a command to an AGENT from the phone composer. Agent turns route
-// through the flat mount cleanly — the server resolves the agent's single
-// workspace, so there is no tenant ambiguity to disambiguate.
+// Dispatch a turn from the phone composer — to an agent OR a repo.
 //
-// Repo (project) dispatch is deliberately NOT here yet: a project turn carries
-// its OWN workspace, and a repo like canopy-web is not owned by one workspace,
-// so the composer must first answer "which tenant does this repo turn belong to"
-// AND route to /api/w/{ws}/... (the flat route 422s a multi-workspace user).
-// That is a real design decision, tracked in the Phase 3 plan — not a rushed
-// raw-fetch here.
+// An AGENT turn routes through the flat mount: the server derives the agent's
+// single workspace, so there is nothing to disambiguate.
+//
+// A REPO turn's tenant is FIRST-CLASS — the turn is owned by a workspace, and the
+// caller says which. `/supervisor` is not a tenant surface, so we pin the
+// workspace explicitly via WORKSPACE_HEADER, which the v2 client rewrites onto
+// /api/w/{ws}/harness/turns/ (the server gates membership there). No hidden
+// default: the composer chooses the workspace (defaulting its VALUE to dimagi),
+// so repo→workspace ownership stays explicit and survives into cloud/multiplayer.
 export async function enqueueTurn(input: {
-  agentSlug: string
+  agentSlug?: string
+  project?: string
+  workspace?: string
   prompt: string
 }): Promise<TurnOut> {
-  const { agentSlug, prompt } = input
+  const { agentSlug = '', project = '', workspace = '', prompt } = input
+  const target = agentSlug || project
   // A stable-enough idempotency key: a double-tap of Send within the same second
   // collapses server-side rather than firing twice.
-  const key = `cmd-${agentSlug}-${Date.now()}`
-  const res = await apiV2.POST('/api/harness/turns/', {
-    body: {
-      agent_slug: agentSlug,
-      project: '',
-      origin: 'manual',
-      idempotency_key: key,
-      prompt,
-      origin_ref: {},
-      routing: 'prefer_local',
-    },
-  })
+  const key = `cmd-${target}-${Date.now()}`
+  const body = {
+    agent_slug: agentSlug,
+    project,
+    origin: 'manual',
+    idempotency_key: key,
+    prompt,
+    origin_ref: {},
+    routing: 'prefer_local',
+  }
+  // A repo turn must land in its owning workspace; pin it explicitly.
+  const init = project
+    ? { body, headers: { [WORKSPACE_HEADER]: workspace } }
+    : { body }
+  const res = await apiV2.POST('/api/harness/turns/', init)
   return unwrap(res, 'enqueueTurn')
 }
 

--- a/frontend/src/components/supervisor/Composer.tsx
+++ b/frontend/src/components/supervisor/Composer.tsx
@@ -1,23 +1,41 @@
 import { useEffect, useState, type JSX } from 'react'
 import { listAgentSkills, type AgentOut, type AgentSkillOut } from '@/api/agents'
 import { enqueueTurn } from '@/api/harness'
+import { listWorkspaces, type WorkspaceOut } from '@/api/workspaces'
 import { buildDispatchPrompt, canDispatch } from '@/lib/dispatchPrompt'
 
-// The phone composer: dispatch a command to an agent without opening a laptop.
-// Pick an agent → pick one of its LAUNCHABLE skills (the agent declares which of
-// its catalog are human entry points; see AgentSkill.launchable) or type a free
-// prompt → send. The dispatch enqueues a manual turn the runner claims within a
-// poll tick; the prompt is exactly the namespaced command, which the agent's
-// /<slug>:<skill> does all the work from.
+// The phone composer: dispatch a turn without opening a laptop. Two targets.
 //
-// Repo (project) dispatch is intentionally absent — see enqueueTurn's note.
+// AGENT — pick an agent → a LAUNCHABLE skill (the agent declares which of its
+// catalog are human entry points; #232) or a free prompt. Routes through the
+// flat mount; the server derives the agent's workspace.
+//
+// REPO — pick a repo (e.g. canopy-web) → a free prompt (repos have no skill
+// catalog). A repo turn is OWNED BY A WORKSPACE, first-class: the composer picks
+// it (defaulting to dimagi) and pins it explicitly, so the turn lands in the
+// right tenant even though /supervisor is not itself a tenant surface.
+
+// dimagi is the default repo tenant for now (Jonathan, 2026-07-16) — a value the
+// composer defaults to, NOT a server fallback, so repo→workspace ownership stays
+// explicit and survives into cloud/multiplayer mode.
+const DEFAULT_REPO_WORKSPACE = 'dimagi'
 
 type Sent = { kind: 'ok'; label: string } | { kind: 'err'; message: string }
+type Mode = 'agent' | 'repo'
 
 export function Composer({ agents }: { agents: AgentOut[] }): JSX.Element {
+  const [mode, setMode] = useState<Mode>('agent')
+
+  // Agent mode
   const [slug, setSlug] = useState<string>(agents[0]?.slug ?? '')
   const [skills, setSkills] = useState<AgentSkillOut[] | null>(null)
   const [skillName, setSkillName] = useState<string>('') // '' = free prompt
+
+  // Repo mode
+  const [project, setProject] = useState('')
+  const [workspaces, setWorkspaces] = useState<WorkspaceOut[]>([])
+  const [workspace, setWorkspace] = useState<string>(DEFAULT_REPO_WORKSPACE)
+
   const [args, setArgs] = useState('')
   const [busy, setBusy] = useState(false)
   const [sent, setSent] = useState<Sent | null>(null)
@@ -26,11 +44,10 @@ export function Composer({ agents }: { agents: AgentOut[] }): JSX.Element {
   // footgun on a phone (/echo:setup one thumb away), so the catalog is filtered
   // to launchable here — the server marks them, we never render the rest.
   useEffect(() => {
-    if (!slug) return
+    if (mode !== 'agent' || !slug) return
     let cancelled = false
     setSkills(null)
     setSkillName('')
-    setArgs('')
     listAgentSkills(slug)
       .then((all) => {
         if (!cancelled) setSkills(all.filter((s) => s.launchable))
@@ -38,19 +55,43 @@ export function Composer({ agents }: { agents: AgentOut[] }): JSX.Element {
       .catch(() => {
         if (!cancelled) setSkills([])
       })
-  }, [slug])
+  }, [slug, mode])
+
+  // The user's workspaces populate the repo tenant selector — first-class
+  // ownership, defaulting to dimagi when present.
+  useEffect(() => {
+    let cancelled = false
+    listWorkspaces()
+      .then((ws) => {
+        if (cancelled) return
+        setWorkspaces(ws)
+        if (!ws.some((w) => w.slug === DEFAULT_REPO_WORKSPACE) && ws[0]) {
+          setWorkspace(ws[0].slug)
+        }
+      })
+      .catch(() => {
+        /* leave the default; a repo dispatch will surface any error inline */
+      })
+  }, [])
 
   const selected = skills?.find((s) => s.name === skillName)
-  const prompt = buildDispatchPrompt(slug, skillName, args)
-  const canSend = !busy && canDispatch(slug, prompt)
+  const prompt =
+    mode === 'agent' ? buildDispatchPrompt(slug, skillName, args) : args.trim()
+  const target = mode === 'agent' ? slug : project.trim()
+  const canSend = !busy && canDispatch(target, prompt) && (mode === 'agent' || workspace !== '')
 
   async function send(): Promise<void> {
     if (!canSend) return
     setBusy(true)
     setSent(null)
     try {
-      await enqueueTurn({ agentSlug: slug, prompt: prompt.trim() })
-      setSent({ kind: 'ok', label: skillName ? `/${slug}:${skillName}` : slug })
+      if (mode === 'agent') {
+        await enqueueTurn({ agentSlug: slug, prompt })
+        setSent({ kind: 'ok', label: skillName ? `/${slug}:${skillName}` : slug })
+      } else {
+        await enqueueTurn({ project: target, workspace, prompt })
+        setSent({ kind: 'ok', label: `${target} · ${workspace}` })
+      }
       setArgs('')
       setSkillName('')
     } catch (e) {
@@ -64,43 +105,104 @@ export function Composer({ agents }: { agents: AgentOut[] }): JSX.Element {
 
   return (
     <div className="flex flex-col gap-2 rounded-lg border border-border bg-card p-3" data-testid="composer">
-      <div className="flex flex-wrap gap-2">
-        <label className="sr-only" htmlFor="composer-agent">
-          Agent
-        </label>
-        <select
-          id="composer-agent"
-          data-testid="composer-agent"
-          value={slug}
-          onChange={(e) => setSlug(e.target.value)}
-          className="rounded border border-input bg-input px-2 py-1.5 text-[13px] text-foreground"
-        >
-          {agents.map((a) => (
-            <option key={a.slug} value={a.slug}>
-              {a.name}
-            </option>
-          ))}
-        </select>
-
-        <label className="sr-only" htmlFor="composer-skill">
-          Command
-        </label>
-        <select
-          id="composer-skill"
-          data-testid="composer-skill"
-          value={skillName}
-          onChange={(e) => setSkillName(e.target.value)}
-          disabled={skills === null}
-          className="min-w-0 flex-1 rounded border border-input bg-input px-2 py-1.5 text-[13px] text-foreground disabled:opacity-50"
-        >
-          <option value="">Free prompt…</option>
-          {(skills ?? []).map((s) => (
-            <option key={s.name} value={s.name}>
-              /{slug}:{s.name}
-            </option>
-          ))}
-        </select>
+      {/* Target-type toggle */}
+      <div className="flex gap-1 self-start rounded-md border border-input p-0.5 text-[12px]">
+        {(['agent', 'repo'] as Mode[]).map((m) => (
+          <button
+            key={m}
+            type="button"
+            data-testid={`composer-mode-${m}`}
+            onClick={() => {
+              setMode(m)
+              setSent(null)
+              setArgs('')
+            }}
+            className={
+              mode === m
+                ? 'rounded bg-primary px-2.5 py-1 font-medium text-primary-foreground'
+                : 'rounded px-2.5 py-1 text-muted-foreground hover:text-foreground'
+            }
+          >
+            {m === 'agent' ? 'Agent' : 'Repo'}
+          </button>
+        ))}
       </div>
+
+      {mode === 'agent' ? (
+        <div className="flex flex-wrap gap-2">
+          <label className="sr-only" htmlFor="composer-agent">
+            Agent
+          </label>
+          <select
+            id="composer-agent"
+            data-testid="composer-agent"
+            value={slug}
+            onChange={(e) => setSlug(e.target.value)}
+            className="rounded border border-input bg-input px-2 py-1.5 text-[13px] text-foreground"
+          >
+            {agents.map((a) => (
+              <option key={a.slug} value={a.slug}>
+                {a.name}
+              </option>
+            ))}
+          </select>
+
+          <label className="sr-only" htmlFor="composer-skill">
+            Command
+          </label>
+          <select
+            id="composer-skill"
+            data-testid="composer-skill"
+            value={skillName}
+            onChange={(e) => setSkillName(e.target.value)}
+            disabled={skills === null}
+            className="min-w-0 flex-1 rounded border border-input bg-input px-2 py-1.5 text-[13px] text-foreground disabled:opacity-50"
+          >
+            <option value="">Free prompt…</option>
+            {(skills ?? []).map((s) => (
+              <option key={s.name} value={s.name}>
+                /{slug}:{s.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      ) : (
+        <div className="flex flex-wrap gap-2">
+          <label className="sr-only" htmlFor="composer-project">
+            Repo
+          </label>
+          <input
+            id="composer-project"
+            data-testid="composer-project"
+            value={project}
+            onChange={(e) => setProject(e.target.value)}
+            placeholder="repo (e.g. canopy-web)"
+            className="min-w-0 flex-1 rounded border border-input bg-input px-2 py-1.5 text-[13px] text-foreground placeholder:text-muted-foreground"
+          />
+          <label className="sr-only" htmlFor="composer-workspace">
+            Workspace
+          </label>
+          <select
+            id="composer-workspace"
+            data-testid="composer-workspace"
+            value={workspace}
+            onChange={(e) => setWorkspace(e.target.value)}
+            title="Which workspace owns this repo turn"
+            className="rounded border border-input bg-input px-2 py-1.5 text-[13px] text-foreground"
+          >
+            {/* Keep the default selectable even before the list loads. */}
+            {workspaces.length === 0 ? (
+              <option value={DEFAULT_REPO_WORKSPACE}>{DEFAULT_REPO_WORKSPACE}</option>
+            ) : (
+              workspaces.map((w) => (
+                <option key={w.slug} value={w.slug}>
+                  {w.slug}
+                </option>
+              ))
+            )}
+          </select>
+        </div>
+      )}
 
       <div className="flex gap-2">
         <input
@@ -110,7 +212,11 @@ export function Composer({ agents }: { agents: AgentOut[] }): JSX.Element {
           onKeyDown={(e) => {
             if (e.key === 'Enter') void send()
           }}
-          placeholder={selected?.args_hint || (skillName ? 'arguments (optional)' : 'Type a prompt…')}
+          placeholder={
+            mode === 'repo'
+              ? 'What should the agent do in this repo?'
+              : selected?.args_hint || (skillName ? 'arguments (optional)' : 'Type a prompt…')
+          }
           className="min-w-0 flex-1 rounded border border-input bg-input px-2 py-1.5 text-[13px] text-foreground placeholder:text-muted-foreground"
         />
         <button
@@ -124,8 +230,8 @@ export function Composer({ agents }: { agents: AgentOut[] }): JSX.Element {
         </button>
       </div>
 
-      {/* The exact command about to fire — no surprise about what lands in the session. */}
-      {prompt.trim() !== '' && (
+      {/* The exact command about to fire (agent mode) — no surprise about what lands. */}
+      {mode === 'agent' && prompt.trim() !== '' && (
         <p className="truncate font-mono text-[11px] text-muted-foreground" data-testid="composer-preview">
           {prompt}
         </p>


### PR DESCRIPTION
Completes the composer: dispatch a turn to a **repo**, not just an agent. Builds on #237.

## The design decision (Jonathan, 2026-07-16)

Repo turns default to the `dimagi` workspace **for now** — but workspace ownership is modeled as **first-class**, not a hidden server fallback. A repo like `canopy-web` isn't owned by one workspace, so rather than bury a magic "default to dimagi" in the enqueue handler (where it would rot the moment cloud/multiplayer runners arrive), the composer picks the owning workspace explicitly — a real dropdown of the user's workspaces, defaulting its *value* to dimagi. The turn genuinely belongs to that tenant.

## What

- **Composer** gains an Agent | Repo toggle. Repo mode: name the repo + pick the workspace + free prompt (repos have no skill catalog).
- **Routing** — `/supervisor` isn't under `/w/:ws/`, so the URL-driven tenant rewrite in `client.v2` doesn't fire. A new `WORKSPACE_HEADER` lets a caller pin the tenant explicitly; the `onRequest` middleware rewrites the path onto `/api/w/{ws}/harness/turns/` and strips the header so it never reaches the wire. **No backend change** — the server already gates that path via `WorkspaceResolveMiddleware`.

The flat route would 422 a multi-workspace user (which the real user is); the tenant route is correct and now the one taken.

## Tests

- vitest: `rewriteForWorkspace` handles a `/api/harness` path — the explicit-header case isn't limited to the implicit prefix list.
- Playwright: the repo dispatch shows dimagi as the owning workspace, lands on `/api/w/dimagi/harness/turns/` with `project` + `prompt`, and the pin header is **consumed** (asserted absent from the request).

vitest 92, Playwright 34, backend 811.

## Note

Still deferred: Task 8 (a stable `phone:{user}:{target}` thread_key so a second message *continues* a session rather than launching fresh) and wiring `cancelTurn` to a UI control. Both tracked in the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)