### PR TITLE
feat: enable driving a repo from your phone (capabilities PATCH + persistent thread)

### DIFF
--- a/apps/harness/api.py
+++ b/apps/harness/api.py
@@ -25,6 +25,7 @@ from .schemas import (
     ResolveSessionIn,
     ResolveSessionOut,
     RunnerIn,
+    RunnerCapabilitiesIn,
     RunnerOut,
     ScheduleFireIn,
     ScheduleOut,
@@ -189,6 +190,23 @@ def list_runners(request: HttpRequest):
         .order_by(models.F("last_heartbeat_at").desc(nulls_last=True))
     )
     return list(qs[:50])
+
+
+@router.patch("/runners/{runner_id}", response=RunnerOut)
+def update_runner_capabilities(request: HttpRequest, runner_id: uuid.UUID, payload: RunnerCapabilitiesIn):
+    """Replace a runner's capabilities (owner-gated via _runner_or_404).
+
+    Capabilities are set at pairing and were otherwise immutable — the only way to
+    add `projects` to an existing runner was to re-pair, which mints a NEW runner
+    and orphans the old one's SessionLinks. This lets a paired runner opt into
+    driving repos (or new agents) in place. capabilities is a routing hint, not a
+    security boundary (the workspace gates), so replacing it changes what the
+    runner PULLS, never what it may reach.
+    """
+    runner = _runner_or_404(request, runner_id)
+    runner.capabilities = payload.capabilities
+    runner.save(update_fields=["capabilities"])
+    return runner
 
 
 @router.post("/runners/{runner_id}/retire", response={204: None})

--- a/apps/harness/schemas.py
+++ b/apps/harness/schemas.py
@@ -18,6 +18,12 @@ class RunnerIn(Schema):
     workspace: str = ""  # tenant slug; defaults to the pairer's default workspace
 
 
+class RunnerCapabilitiesIn(Schema):
+    # Wholesale replacement, like the skill catalog — the caller sends the full
+    # capabilities it wants (e.g. {"agents": [...], "projects": ["canopy-web"]}).
+    capabilities: dict
+
+
 class RunnerOut(Schema):
     id: uuid.UUID
     name: str

--- a/frontend/e2e/supervisor.spec.ts
+++ b/frontend/e2e/supervisor.spec.ts
@@ -101,6 +101,12 @@ test.describe('/supervisor', () => {
     await expect(page.getByTestId('composer-sent')).toBeVisible()
     expect(url).toContain('/api/w/dimagi/harness/turns/')
     expect(posted).toMatchObject({ project: 'canopy-web', prompt: 'fix the header spacing' })
+    // A stable per-(user,repo) thread_key so the NEXT dispatch continues this
+    // session rather than forking a fresh emdash task — "drive the repo" is
+    // iterative. The e2e user is e2e@dimagi.com.
+    expect((posted as { origin_ref?: { thread_key?: string } }).origin_ref?.thread_key).toBe(
+      'phone:e2e@dimagi.com:canopy-web',
+    )
     // The pin header is consumed by the rewrite and must NOT reach the wire — it
     // is a client-side routing signal, not something the server should ever see.
     expect(headers['x-canopy-workspace']).toBeUndefined()

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -1607,6 +1607,33 @@ export interface paths {
         readonly patch?: never;
         readonly trace?: never;
     };
+    readonly "/api/harness/runners/{runner_id}": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly get?: never;
+        readonly put?: never;
+        readonly post?: never;
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        /**
+         * Update Runner Capabilities
+         * @description Replace a runner's capabilities (owner-gated via _runner_or_404).
+         *
+         *     Capabilities are set at pairing and were otherwise immutable — the only way to
+         *     add `projects` to an existing runner was to re-pair, which mints a NEW runner
+         *     and orphans the old one's SessionLinks. This lets a paired runner opt into
+         *     driving repos (or new agents) in place. capabilities is a routing hint, not a
+         *     security boundary (the workspace gates), so replacing it changes what the
+         *     runner PULLS, never what it may reach.
+         */
+        readonly patch: operations["apps_harness_api_update_runner_capabilities"];
+        readonly trace?: never;
+    };
     readonly "/api/harness/runners/{runner_id}/retire": {
         readonly parameters: {
             readonly query?: never;
@@ -5334,6 +5361,13 @@ export interface components {
              */
             readonly workspace: string;
         };
+        /** RunnerCapabilitiesIn */
+        readonly RunnerCapabilitiesIn: {
+            /** Capabilities */
+            readonly capabilities: {
+                readonly [key: string]: unknown;
+            };
+        };
         /** HeartbeatIn */
         readonly HeartbeatIn: {
             /**
@@ -8482,6 +8516,32 @@ export interface operations {
         readonly responses: {
             /** @description Created */
             readonly 201: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["RunnerOut"];
+                };
+            };
+        };
+    };
+    readonly apps_harness_api_update_runner_capabilities: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path: {
+                readonly runner_id: string;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody: {
+            readonly content: {
+                readonly "application/json": components["schemas"]["RunnerCapabilitiesIn"];
+            };
+        };
+        readonly responses: {
+            /** @description OK */
+            readonly 200: {
                 headers: {
                     readonly [name: string]: unknown;
                 };

--- a/frontend/src/api/harness.ts
+++ b/frontend/src/api/harness.ts
@@ -39,8 +39,9 @@ export async function enqueueTurn(input: {
   project?: string
   workspace?: string
   prompt: string
+  threadKey?: string
 }): Promise<TurnOut> {
-  const { agentSlug = '', project = '', workspace = '', prompt } = input
+  const { agentSlug = '', project = '', workspace = '', prompt, threadKey = '' } = input
   const target = agentSlug || project
   // A stable-enough idempotency key: a double-tap of Send within the same second
   // collapses server-side rather than firing twice.
@@ -51,7 +52,10 @@ export async function enqueueTurn(input: {
     origin: 'manual',
     idempotency_key: key,
     prompt,
-    origin_ref: {},
+    // A thread_key makes the runner REUSE one session across dispatches (the
+    // phone owns a persistent thread per target) rather than forking a fresh
+    // emdash task each time. The runner reads origin_ref.thread_key.
+    origin_ref: threadKey ? { thread_key: threadKey } : {},
     routing: 'prefer_local',
   }
   // A repo turn must land in its owning workspace; pin it explicitly.

--- a/frontend/src/components/supervisor/Composer.tsx
+++ b/frontend/src/components/supervisor/Composer.tsx
@@ -2,7 +2,8 @@ import { useEffect, useState, type JSX } from 'react'
 import { listAgentSkills, type AgentOut, type AgentSkillOut } from '@/api/agents'
 import { enqueueTurn } from '@/api/harness'
 import { listWorkspaces, type WorkspaceOut } from '@/api/workspaces'
-import { buildDispatchPrompt, canDispatch } from '@/lib/dispatchPrompt'
+import { useAuth } from '@/auth/AuthProvider'
+import { buildDispatchPrompt, canDispatch, phoneThreadKey } from '@/lib/dispatchPrompt'
 
 // The phone composer: dispatch a turn without opening a laptop. Two targets.
 //
@@ -24,6 +25,7 @@ type Sent = { kind: 'ok'; label: string } | { kind: 'err'; message: string }
 type Mode = 'agent' | 'repo'
 
 export function Composer({ agents }: { agents: AgentOut[] }): JSX.Element {
+  const { user } = useAuth()
   const [mode, setMode] = useState<Mode>('agent')
 
   // Agent mode
@@ -89,7 +91,11 @@ export function Composer({ agents }: { agents: AgentOut[] }): JSX.Element {
         await enqueueTurn({ agentSlug: slug, prompt })
         setSent({ kind: 'ok', label: skillName ? `/${slug}:${skillName}` : slug })
       } else {
-        await enqueueTurn({ project: target, workspace, prompt })
+        // A stable per-(user,repo) thread so successive dispatches CONTINUE one
+        // session — the phone drives a persistent canopy-web thread rather than
+        // spawning a fresh emdash task per message.
+        const threadKey = user ? phoneThreadKey(user.email, target) : undefined
+        await enqueueTurn({ project: target, workspace, prompt, threadKey })
         setSent({ kind: 'ok', label: `${target} · ${workspace}` })
       }
       setArgs('')

--- a/frontend/src/lib/dispatchPrompt.test.ts
+++ b/frontend/src/lib/dispatchPrompt.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { buildDispatchPrompt, canDispatch } from './dispatchPrompt'
+import { buildDispatchPrompt, canDispatch, phoneThreadKey } from './dispatchPrompt'
 
 describe('buildDispatchPrompt', () => {
   it('builds a namespaced command with args', () => {
@@ -29,5 +29,23 @@ describe('canDispatch', () => {
     expect(canDispatch('', '/echo:turn')).toBe(false)
     expect(canDispatch('echo', '')).toBe(false)
     expect(canDispatch('echo', '   ')).toBe(false)
+  })
+})
+
+describe('phoneThreadKey', () => {
+  it('is stable per user+target so dispatches continue one session', () => {
+    const a = phoneThreadKey('jj@dimagi.com', 'canopy-web')
+    const b = phoneThreadKey('jj@dimagi.com', 'canopy-web')
+    expect(a).toBe(b)
+    expect(a).toBe('phone:jj@dimagi.com:canopy-web')
+  })
+
+  it('separates users and targets into distinct threads', () => {
+    expect(phoneThreadKey('jj@dimagi.com', 'canopy-web')).not.toBe(
+      phoneThreadKey('other@dimagi.com', 'canopy-web'),
+    )
+    expect(phoneThreadKey('jj@dimagi.com', 'canopy-web')).not.toBe(
+      phoneThreadKey('jj@dimagi.com', 'ace-web'),
+    )
   })
 })

--- a/frontend/src/lib/dispatchPrompt.ts
+++ b/frontend/src/lib/dispatchPrompt.ts
@@ -12,3 +12,11 @@ export function buildDispatchPrompt(slug: string, skillName: string, args: strin
 export function canDispatch(slug: string, prompt: string): boolean {
   return slug.trim() !== '' && prompt.trim() !== ''
 }
+
+// The phone owns ONE persistent thread per (user, target), so repeated dispatches
+// CONTINUE a single emdash session rather than forking a fresh one each time —
+// this is what makes "drive a repo from my phone" iterative. Stable for a given
+// user+target; the runner records/reuses a SessionLink under it.
+export function phoneThreadKey(userEmail: string, target: string): string {
+  return `phone:${userEmail}:${target}`
+}

--- a/tests/test_harness_runner_capabilities.py
+++ b/tests/test_harness_runner_capabilities.py
@@ -1,0 +1,90 @@
+"""PATCH /api/harness/runners/{id} — update a paired runner's capabilities.
+
+The only prior way to add `projects` to a runner was to re-pair, which mints a
+new runner and orphans the old one's SessionLinks. This lets a runner opt into
+driving repos in place.
+"""
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth.models import User
+from django.test import Client
+from django.utils import timezone
+
+from apps.harness.models import Runner
+from apps.workspaces.models import Workspace, WorkspaceMembership
+
+pytestmark = pytest.mark.django_db
+
+
+def _user(name):
+    return User.objects.create_user(name, f"{name}@dimagi.com", "pw")
+
+
+def _ws(slug, owner):
+    ws = Workspace.objects.create(slug=slug, display_name=slug.title(), created_by=owner)
+    WorkspaceMembership.objects.create(user=owner, workspace=ws, role=WorkspaceMembership.OWNER)
+    return ws
+
+
+def _runner(pairer, ws, **kw):
+    return Runner.objects.create(
+        name="jj-mbp", kind=Runner.EMDASH, host="jj-mac", paired_by=pairer, workspace=ws,
+        status=Runner.ONLINE, last_heartbeat_at=timezone.now(),
+        capabilities={"agents": ["echo"]}, **kw,
+    )
+
+
+def _patch(client, runner_id, caps):
+    return client.patch(
+        f"/api/harness/runners/{runner_id}",
+        {"capabilities": caps},
+        content_type="application/json",
+    )
+
+
+def test_owner_adds_projects_to_a_paired_runner():
+    jj = _user("jj")
+    ws = _ws("dimagi", jj)
+    runner = _runner(jj, ws)
+    c = Client()
+    c.force_login(jj)
+
+    resp = _patch(c, runner.id, {"agents": ["echo"], "projects": ["canopy-web"]})
+
+    assert resp.status_code == 200, resp.content
+    runner.refresh_from_db()
+    assert runner.project_names() == ["canopy-web"]
+    assert runner.agent_slugs() == ["echo"]
+
+
+def test_replacement_is_wholesale():
+    """Sending {} clears capabilities — the caller owns the full set, like the
+    skill catalog's PUT. No accidental merge that leaves stale entries."""
+    jj = _user("jj")
+    ws = _ws("dimagi", jj)
+    runner = _runner(jj, ws)
+    c = Client()
+    c.force_login(jj)
+
+    _patch(c, runner.id, {"projects": ["canopy-web"]})
+    runner.refresh_from_db()
+    assert runner.agent_slugs() == []  # the prior agents entry is gone
+    assert runner.project_names() == ["canopy-web"]
+
+
+def test_a_non_owner_cannot_touch_another_users_runner():
+    """404 not 403 — _runner_or_404 must not leak that the runner exists."""
+    jj = _user("jj")
+    ws = _ws("dimagi", jj)
+    runner = _runner(jj, ws)
+
+    mallory = _user("mallory")
+    _ws("mallory-space", mallory)
+    c = Client()
+    c.force_login(mallory)
+
+    resp = _patch(c, runner.id, {"projects": ["canopy-web"]})
+    assert resp.status_code == 404
+    runner.refresh_from_db()
+    assert runner.project_names() == []  # untouched


### PR DESCRIPTION
The last two backend/frontend pieces before the phone can actually drive a canopy-web session on the laptop.

## 1. `PATCH /api/harness/runners/{id}` — update capabilities in place

Capabilities are set at pairing and were otherwise immutable, so adding `projects` to an existing runner meant **re-pairing** — which mints a new runner and orphans the old one's `SessionLink`s. This lets a paired runner opt into driving repos (or new agents) in place, owner-gated via `_runner_or_404` (404-not-403). `capabilities` routes, never gates (the workspace gates), so replacing it changes what the runner *pulls*, not what it may reach.

This is also how the laptop runner gets `"projects": ["canopy-web"]` without losing its identity.

## 2. Persistent per-repo thread — successive dispatches continue one session

The composer now stamps `origin_ref.thread_key = phone:{email}:{project}` on repo turns. The runner reads that and **reuses** one emdash session across dispatches (the phone owns a persistent thread per target) instead of forking a fresh task per message — which is what makes "drive the repo from my phone" iterative. `phoneThreadKey` is a pure helper with vitest; the Playwright repo-dispatch test asserts the exact key rides in `origin_ref`.

## Verification

Backend 837, vitest 94, Playwright 34.

## After this merges, the remaining gaps are on the laptop (not code)

To actually test from your phone you'll need, on the machine running the daemon: pull the `canopy_runner` update, add `canopy-web` to the runner's capabilities (this PR's endpoint — I can do it for you via API once deployed), restart the daemon, and confirm emdash has a `canopy-web` project. Full checklist to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)