### PR TITLE
fix(pwa): stop the service worker swallowing the OAuth login redirect (prod outage)

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -54,9 +54,23 @@ export default defineConfig({
         // no notification). importScripts (not injectManifest) keeps the
         // plugin's own precaching intact while adding push handling.
         importScripts: ['sw-push.js'],
-        // Stop the SW serving cached index.html for /api/ paths; they should 404/500 honestly.
-        // (Not the API-cache guard — see runtimeCaching below.)
-        navigateFallbackDenylist: [/^\/api\//, /^\/canopy\/api\//],
+        // navigateFallback defaults to index.html, so the SW answers EVERY
+        // navigation with the cached SPA shell unless the path is denylisted
+        // here. That must exclude Django-owned routes — above all /accounts/
+        // (OAuth): without it the SW swallows the `me → 401 → redirect to
+        // /accounts/google/login/` navigation and re-serves the shell, so a
+        // lapsed session can never re-login and the app spins forever (the
+        // server sees the me-401 churn with zero /accounts/ hits). /api/, /admin/,
+        // /static/, /auth/ (CLI authorize) and /health/ are backend too. The
+        // optional (canopy/) prefix covers both the labs tenant mount and root.
+        navigateFallbackDenylist: [
+          /^\/(canopy\/)?api\//,
+          /^\/(canopy\/)?accounts\//,
+          /^\/(canopy\/)?admin\//,
+          /^\/(canopy\/)?static\//,
+          /^\/(canopy\/)?auth\//,
+          /^\/(canopy\/)?health\/?$/,
+        ],
         // No runtimeCaching routes registered: all non-precached fetches bypass the SW and hit
         // the network. This keeps the API uncached (stale "0 waiting" is worse than a spinner).
         // When adding entries here, take care not to match /api/ — nothing else guards against that.


### PR DESCRIPTION
## The outage

`labs.connect.dimagi.com/canopy` was an **infinite loop** for anyone whose session had lapsed.

The new PWA's service worker uses vite-plugin-pwa's default `navigateFallback: index.html`, so it answers **every navigation** with the cached SPA shell unless the path is in `navigateFallbackDenylist` — which only listed `/api/`.

The cycle:
1. Session lapses (normal expiry, or the #235 `SECRET_KEY` rotation) → `GET /api/me/` **401**.
2. `client.v2.ts` `onResponse` → `window.location.href = /canopy/accounts/google/login/`.
3. **The service worker intercepts that navigation** (not `/api/`, so not denylisted) and serves the cached `index.html` instead of letting it reach Django's allauth.
4. SPA re-boots → `/api/me/` → 401 → redirect → SW serves the shell again → **forever**.

OAuth can never complete because its route never leaves the browser. AWS ECS logs confirm it: **37 `me`-401s in one hour, zero `/accounts/` requests.**

## The fix

Add the Django-owned routes to the SW navigation denylist so those navigations bypass the service worker and reach the server:

- `/accounts/` — OAuth login (**the fix**)
- `/admin/`, `/static/`, `/auth/` (CLI authorize), `/health/` — also backend-owned

The optional `(canopy/)` prefix covers both the labs tenant mount and a root deployment. SPA routes (`/w`, `/supervisor`, `/walkthrough`, `/review`, `/share`, …) keep the fallback.

## Verification

Built with `VITE_BASE_PATH=/canopy/` and inspected the emitted `dist/sw.js`:

```
NavigationRoute(createHandlerBoundToURL("index.html"), { denylist: [
  /^\/(canopy\/)?api\//, /^\/(canopy\/)?accounts\//, /^\/(canopy\/)?admin\//,
  /^\/(canopy\/)?static\//, /^\/(canopy\/)?auth\//, /^\/(canopy\/)?health\/?$/
]})
```

The `createHandlerBoundToURL("index.html")` is the proof the SW was answering all navigations with the shell.

## Recovery

`registerType: 'autoUpdate'` (skipWaiting + clientsClaim) means stuck browsers pick up the new SW on their next update check and self-heal; a hard refresh / closing all app tabs once guarantees it. No migration in this change (`run_migrations=false`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)