### PR TITLE
fix(auth): break the login-redirect loop at the source — bounce once, never spin

### DIFF
--- a/frontend/src/api/client.v2.test.ts
+++ b/frontend/src/api/client.v2.test.ts
@@ -1,5 +1,35 @@
 import { describe, it, expect } from 'vitest'
-import { rewriteForWorkspace } from './client.v2'
+import { rewriteForWorkspace, shouldBounceToLogin } from './client.v2'
+
+// The login-loop breaker. A lapsed session should bounce through OAuth exactly
+// once; a second 401 landing back inside the window means the round-trip isn't
+// sticking (rejected cookie, IdP hiccup, a service worker shadowing /accounts/ —
+// the #244 outage), so we must HOLD and surface the login screen instead of
+// navigating again. This is the pure decision behind that guard; the DOM/
+// sessionStorage plumbing around it is not exercised here (this file's "no live
+// DOM" convention), but the branch that actually prevents the infinite loop is.
+describe('shouldBounceToLogin', () => {
+  const WINDOW = 10_000
+
+  it('bounces when the session lapses and we have never redirected', () => {
+    expect(shouldBounceToLogin(0, 1_000_000)).toBe(true)
+  })
+
+  it('holds — breaks the loop — on a second 401 within the window', () => {
+    const now = 1_000_000
+    expect(shouldBounceToLogin(now - 500, now)).toBe(false)
+  })
+
+  it('bounces again once the window has elapsed (a genuine later expiry)', () => {
+    const now = 1_000_000
+    expect(shouldBounceToLogin(now - (WINDOW + 1), now)).toBe(true)
+  })
+
+  it('treats the exact window boundary as elapsed, so it bounces', () => {
+    const now = 1_000_000
+    expect(shouldBounceToLogin(now - WINDOW, now)).toBe(true)
+  })
+})
 
 // Regression test for the workspace-rewrite middleware eating request bodies.
 //

--- a/frontend/src/api/client.v2.ts
+++ b/frontend/src/api/client.v2.ts
@@ -2,12 +2,63 @@ import createClient from "openapi-fetch";
 import type { paths } from "./generated";
 import { API_BASE, getCsrfToken } from "./base";
 
-function redirectToLogin(): never {
+// A lapsed session should bounce the user through OAuth exactly ONCE. The guard
+// below is what makes that a bounce and not a loop: if we land back here still
+// 401 within this window of the last bounce, the round-trip isn't sticking (a
+// rejected cookie, an IdP hiccup, a service worker shadowing /accounts/ — the
+// #244 outage), so we STOP navigating and let the 401 fall through to the
+// in-app login screen, which the user drives by hand. Defense in depth: an
+// infinite redirect loop is now structurally impossible regardless of *why* the
+// session won't take. sessionStorage (not a module-scope var) because the
+// timestamp must survive the full-page OAuth navigation to Google and back.
+const LOGIN_REDIRECT_AT_KEY = "canopy:auth:lastLoginRedirectAt";
+const LOGIN_LOOP_WINDOW_MS = 10_000;
+
+/**
+ * Pure loop-breaker decision, split out so it's unit-testable without a DOM
+ * (this file's convention — see rewriteForWorkspace). Bounce to OAuth only if we
+ * have NOT already bounced within the window; a second 401 inside it means the
+ * round-trip isn't sticking, so hold and let the login screen render instead.
+ */
+export function shouldBounceToLogin(lastRedirectAt: number, now: number): boolean {
+  return !(lastRedirectAt > 0 && now - lastRedirectAt < LOGIN_LOOP_WINDOW_MS);
+}
+
+/**
+ * Clear the loop guard once a request has authenticated, so a genuine later
+ * expiry still gets its own clean single bounce. Called by AuthProvider on a
+ * successful /api/me. Best-effort — sessionStorage can throw in private mode.
+ */
+export function noteAuthSucceeded(): void {
+  try {
+    sessionStorage.removeItem(LOGIN_REDIRECT_AT_KEY);
+  } catch {
+    /* sessionStorage unavailable (private mode / sandboxed frame) — guard is best-effort */
+  }
+}
+
+function redirectToLogin(): void {
+  let lastRedirectAt = 0;
+  try {
+    lastRedirectAt = Number(sessionStorage.getItem(LOGIN_REDIRECT_AT_KEY)) || 0;
+  } catch {
+    /* unavailable — treat as "never redirected" and allow the one bounce */
+  }
+  if (!shouldBounceToLogin(lastRedirectAt, Date.now())) {
+    // We bounced moments ago and we're back with another 401 — we're looping.
+    // Do NOT navigate; let the caller surface the login screen (getMe → null →
+    // <LoginPrompt/>, whose Sign-in button is a user-driven single attempt).
+    return;
+  }
+  try {
+    sessionStorage.setItem(LOGIN_REDIRECT_AT_KEY, String(Date.now()));
+  } catch {
+    /* unavailable — a best-effort guard is better than blocking the redirect */
+  }
   const next = encodeURIComponent(window.location.pathname + window.location.search);
   // Prefix-aware: BASE_URL is "/" at root and "/canopy/" as a labs tenant, so
   // this stays under the deployment instead of bouncing to a sibling tenant.
   window.location.href = `${import.meta.env.BASE_URL.replace(/\/$/, '')}/accounts/google/login/?next=${next}`;
-  throw new Error("Redirecting to login");
 }
 
 // Per-token public-link routes (e.g. /review/<id>?t=…) self-gate on their share

--- a/frontend/src/auth/AuthProvider.tsx
+++ b/frontend/src/auth/AuthProvider.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useEffect, useState, type ReactNode } from 'react'
 import { bootstrapCsrf } from '@/api/csrf'
+import { noteAuthSucceeded } from '@/api/client.v2'
 import { getMe, type MeOut as MeResponse } from '@/api/me'
 
 type AuthState =
@@ -41,8 +42,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         await bootstrapCsrf()
         const me = await getMe()
         if (cancelled) return
-        if (me) setState({ status: 'authenticated', user: me })
-        else setState({ status: 'anonymous', user: null })
+        if (me) {
+          // Reset the login-loop guard: this session took, so a genuine later
+          // expiry gets its own clean single bounce (see client.v2 redirectToLogin).
+          noteAuthSucceeded()
+          setState({ status: 'authenticated', user: me })
+        } else setState({ status: 'anonymous', user: null })
       } catch {
         if (!cancelled) setState({ status: 'anonymous', user: null })
       }


### PR DESCRIPTION
Follow-up hardening to #244 (the PWA service-worker outage). #244 stopped the service worker from swallowing the `/accounts/` OAuth navigation. **This makes the redirect itself loop-proof** so no *future* cause — a rejected session cookie, an IdP hiccup, another SW regression — can turn a dead session into an infinite tab spin.

## Why

`client.v2.ts` `onResponse` hard-navigates to `/accounts/google/login/` on **any** 401. That's the right "session expired → re-login" UX, but it silently assumed the OAuth round-trip always sticks. When it didn't (the #244 SW bug), the tab spun: `me` 401 → redirect → land back → `me` 401 → redirect → forever. The redirect was the *amplifier* that turned a dead session into an outage.

## The guard

`redirectToLogin` now stamps a timestamp in `sessionStorage` (which survives the full-page nav to Google and back) and bounces **only if we haven't already bounced within `LOGIN_LOOP_WINDOW_MS` (10s)**. A second 401 landing back inside that window means the round-trip isn't taking, so we **hold** — let the 401 fall through to `AuthProvider`'s `<LoginPrompt/>`, whose Sign-in button is a user-driven single attempt. No automatic navigation, so no loop is possible.

The guard clears on a successful `/api/me` (`noteAuthSucceeded()`), so a genuine later expiry still gets its own clean single bounce.

Net behavior:
- **Normal expiry** → one automatic bounce through OAuth → back, authenticated. (unchanged)
- **Round-trip won't stick** → one bounce, then the in-app login screen with a working Sign-in button. (was: infinite loop)

## Tests

The decision is a pure exported `shouldBounceToLogin(lastRedirectAt, now)` — DOM-free and unit-testable per this file's "no live DOM" convention — so the branch that actually prevents the loop is covered without jsdom. 4 boundary cases added.

Verified locally: `tsc -b` clean, `vite build` clean, `vitest` 9/9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)