### PR TITLE
fix(harness): guard dismiss on state; validate origin/routing at the boundary

### DIFF
--- a/apps/harness/items_api.py
+++ b/apps/harness/items_api.py
@@ -119,6 +119,12 @@ def decide_item(request: HttpRequest, item_id: uuid.UUID, payload: ItemDecideIn)
 @items_router.post("/{item_id}/dismiss", response=ItemOut, summary="Dismiss an item")
 def dismiss_item(request: HttpRequest, item_id: uuid.UUID) -> dict:
     item = _item_or_404(request, item_id)
-    return _payload(services.dismiss_item(
-        item, by=request.user.email or request.user.get_username(),
-    ))
+    try:
+        item = services.dismiss_item(
+            item, by=request.user.email or request.user.get_username(),
+        )
+    except services.AlreadyDecidedError as exc:
+        # Already decided or dismissed — mirror decide's 409 so a double-click or a
+        # dismiss-after-approve can't overwrite the decision record.
+        raise HttpError(409, str(exc)) from exc
+    return _payload(item)

--- a/apps/harness/schemas.py
+++ b/apps/harness/schemas.py
@@ -9,6 +9,15 @@ from canopy_cron import validate_cron, validate_timezone
 from ninja import Schema
 from pydantic import Field, field_validator
 
+# Kept in lockstep with Turn.ORIGIN_CHOICES / Turn.ROUTING_CHOICES (models.py).
+# These are the values the DB columns accept (origin max_length=10, routing
+# max_length=15); typing the INPUT schemas as Literals turns an out-of-set value
+# into a 422 at the API boundary instead of a Postgres "value too long" 500 that
+# SQLite CI can't reproduce. Output schemas stay `str` — they serialize values the
+# DB already validated, and a Literal there would break on any legacy row.
+Origin = Literal["board", "api", "slack", "cron", "manual", "email"]
+Routing = Literal["prefer_local", "local_only", "any"]
+
 
 class RunnerIn(Schema):
     name: str
@@ -86,11 +95,11 @@ class TurnIn(Schema):
     # by a validator so the error matches the rest of the harness's shape.
     agent_slug: str = ""
     project: str = ""
-    origin: str
+    origin: Origin
     idempotency_key: str
     prompt: str = ""
     origin_ref: dict = {}
-    routing: str = "prefer_local"
+    routing: Routing = "prefer_local"
 
 
 class TurnOut(Schema):
@@ -288,9 +297,9 @@ class TurnSpecIn(Schema):
 
     prompt: str = ""
     target_agent: str = ""
-    origin: str = "api"
+    origin: Origin = "api"
     origin_ref: dict[str, Any] = Field(default_factory=dict)
-    routing: str = "prefer_local"
+    routing: Routing = "prefer_local"
 
 
 class ItemIn(Schema):
@@ -298,7 +307,7 @@ class ItemIn(Schema):
     kind: Literal["review", "question"] = "review"
     title: str = Field(min_length=1, max_length=300)
     body: str = ""
-    origin: str = "api"
+    origin: Origin = "api"
     origin_ref: dict[str, Any] = Field(default_factory=dict)
     dispatch: list[TurnSpecIn] = Field(default_factory=list)
     batch_key: str = ""

--- a/apps/harness/services.py
+++ b/apps/harness/services.py
@@ -630,8 +630,17 @@ def decide_item(item: Item, *, decision: str, comment: str, by: str) -> tuple[It
 
 
 def dismiss_item(item: Item, *, by: str) -> Item:
-    """Retire an item without acting. Never dispatches, whatever `decision` holds —
-    a producer that raised it in error, or a subject that changed under it."""
+    """Retire an OPEN item without acting — a producer that raised it in error, or
+    a subject that changed under it.
+
+    Only an OPEN item may be dismissed. Dismissing an already-DECIDED item would
+    overwrite `decided_by`/`decided_at` — erasing who approved it — while the turns
+    that decision already dispatched keep running: the queue would read "dismissed"
+    for work that is executing, with the approver's identity gone. So dismiss guards
+    on state exactly like decide does; a re-dismiss is likewise a 409, not a
+    silent second write."""
+    if item.state != Item.OPEN:
+        raise AlreadyDecidedError(f"item {item.id} is already {item.state}")
     item.state = Item.DISMISSED
     item.decided_by = by
     item.decided_at = timezone.now()

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -5001,8 +5001,9 @@ export interface components {
             /**
              * Origin
              * @default api
+             * @enum {string}
              */
-            readonly origin: string;
+            readonly origin: "board" | "api" | "slack" | "cron" | "manual" | "email";
             /** Origin Ref */
             readonly origin_ref?: {
                 readonly [key: string]: unknown;
@@ -5038,8 +5039,9 @@ export interface components {
             /**
              * Origin
              * @default api
+             * @enum {string}
              */
-            readonly origin: string;
+            readonly origin: "board" | "api" | "slack" | "cron" | "manual" | "email";
             /** Origin Ref */
             readonly origin_ref?: {
                 readonly [key: string]: unknown;
@@ -5047,8 +5049,9 @@ export interface components {
             /**
              * Routing
              * @default prefer_local
+             * @enum {string}
              */
-            readonly routing: string;
+            readonly routing: "prefer_local" | "local_only" | "any";
         };
         /** ItemDecideIn */
         readonly ItemDecideIn: {
@@ -5519,8 +5522,11 @@ export interface components {
              * @default
              */
             readonly project: string;
-            /** Origin */
-            readonly origin: string;
+            /**
+             * Origin
+             * @enum {string}
+             */
+            readonly origin: "board" | "api" | "slack" | "cron" | "manual" | "email";
             /** Idempotency Key */
             readonly idempotency_key: string;
             /**
@@ -5538,8 +5544,9 @@ export interface components {
             /**
              * Routing
              * @default prefer_local
+             * @enum {string}
              */
-            readonly routing: string;
+            readonly routing: "prefer_local" | "local_only" | "any";
         };
         /** TurnEventCountOut */
         readonly TurnEventCountOut: {

--- a/frontend/src/api/harness.ts
+++ b/frontend/src/api/harness.ts
@@ -57,7 +57,10 @@ export async function enqueueTurn(input: {
     // emdash task each time. The runner reads origin_ref.thread_key.
     origin_ref: threadKey ? { thread_key: threadKey } : {},
     routing: 'prefer_local',
-  }
+    // `satisfies` keeps the origin/routing string literals narrow so they match the
+    // generated enum unions (origin: board|api|…; routing: prefer_local|…) instead
+    // of widening to `string`, and flags any future TurnIn schema drift here.
+  } satisfies components['schemas']['TurnIn']
   // A repo turn must land in its owning workspace; pin it explicitly.
   const init = project
     ? { body, headers: { [WORKSPACE_HEADER]: workspace } }

--- a/tests/test_item_schemas.py
+++ b/tests/test_item_schemas.py
@@ -14,7 +14,22 @@ def test_turnspec_target_agent_defaults_to_self():
 
 def test_item_requires_a_title_and_key():
     with pytest.raises(ValidationError):
-        ItemIn(kind="review", origin="audit")
+        ItemIn(kind="review", origin="api")
+
+
+def test_item_rejects_an_origin_outside_the_choices():
+    # `origin` maps to a max_length=10 column with a fixed choice set; an out-of-set
+    # value must 422 at the boundary, not reach the DB and 500 (Postgres-only, so
+    # SQLite CI can't catch it).
+    with pytest.raises(ValidationError):
+        ItemIn(title="t", idempotency_key="k", origin="audit")
+
+
+def test_turnspec_rejects_bad_origin_and_routing():
+    with pytest.raises(ValidationError):
+        TurnSpecIn(prompt="/ada:conduct", origin="not-an-origin")
+    with pytest.raises(ValidationError):
+        TurnSpecIn(prompt="/ada:conduct", routing="teleport")
 
 
 def test_item_rejects_a_notify_kind():

--- a/tests/test_item_services.py
+++ b/tests/test_item_services.py
@@ -125,6 +125,35 @@ def test_dismiss_never_dispatches_even_with_a_decision_set(ada):
     assert Turn.objects.count() == 0
 
 
+def test_dismiss_refuses_an_already_decided_item(ada):
+    # Dismissing a decided-and-dispatched item would erase who approved it while its
+    # turns keep running. Dismiss guards on state exactly like decide does.
+    item = _item(ada, dispatch=[{"prompt": "/ada:conduct"}])
+    item, _turns = services.decide_item(
+        item, decision=Item.IMPLEMENT, comment="", by="approver@dimagi.com"
+    )
+    assert item.state == Item.DECIDED
+
+    with pytest.raises(services.AlreadyDecidedError):
+        services.dismiss_item(item, by="dismisser@dimagi.com")
+
+    item.refresh_from_db()
+    assert item.state == Item.DECIDED  # unchanged
+    assert item.decided_by == "approver@dimagi.com"  # approval record intact
+    assert item.dispatched_at is not None  # the dispatched turn still stands
+
+
+def test_dismiss_twice_is_a_conflict_not_a_silent_rewrite(ada):
+    item = _item(ada)
+    services.dismiss_item(item, by="first@dimagi.com")
+
+    with pytest.raises(services.AlreadyDecidedError):
+        services.dismiss_item(item, by="second@dimagi.com")
+
+    item.refresh_from_db()
+    assert item.decided_by == "first@dimagi.com"
+
+
 def test_create_items_is_idempotent_per_key(ada):
     payload = [{"kind": "review", "title": "a", "origin": "audit", "idempotency_key": "dupe"}]
 


### PR DESCRIPTION
Two correctness gaps from the Item ⊕ Turn review, both verified still-open on main.

## dismiss_item had no state guard
Dismissing an already-DECIDED (dispatched) item returned 200, flipped state to `dismissed`, and **overwrote `decided_by`/`decided_at`** — erasing who approved it — while the dispatched turns kept running. The queue would read "dismissed" for work that's executing, with the approver's identity gone. `decide` guards on `OPEN`; `dismiss` didn't.

Now `dismiss_item` guards on `OPEN` (409 on a decided/dismissed item), and `items_api.dismiss_item` maps `AlreadyDecidedError` → 409 — the endpoint previously had **no** error handling, so the raise would have surfaced as a 500.

## origin/routing were unvalidated free strings
`TurnIn`/`TurnSpecIn`/`ItemIn` typed `origin`/`routing` as `str`, but they map to `max_length=10`/`15` choice columns. An out-of-set value was a **Postgres-only** `value too long` 500 that SQLite CI can't reproduce. Now typed as `Literal`s kept in lockstep with `Turn.ORIGIN_CHOICES`/`ROUTING_CHOICES`, so it's a 422 at the boundary. Output schemas stay `str` (they serialize DB-validated values; a Literal there would break on legacy rows).

## Tests
- dismiss refuses a decided item (approval record + dispatched turn intact) and a re-dismiss (409, not a silent second write)
- origin/routing Literals reject out-of-set values

Full backend suite: **842 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)