### PR TITLE
ci: fast pyflakes + migration + system-check gates (no Playwright)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,29 @@ jobs:
       - name: Sync dependencies
         run: uv sync --extra dev
 
+      # Fast, zero-DB gates before the (longer) test run — they reuse the uv env
+      # already synced above, so they add ~seconds, not a new job spin-up.
+
+      # Catch real bugs: unused imports (F401) and undefined names (F821/F811).
+      # Scoped to pyflakes (`--select F`), not the full ruff ruleset — the repo
+      # isn't style-clean yet, and this gate is about correctness, not formatting.
+      # F403/F405 are ignored: the settings modules use `from base import *` by design.
+      - name: Lint (ruff — pyflakes only)
+        run: uv run ruff check . --select F --ignore F403,F405
+
+      # A model change without its migration is a class of bug this fast-moving repo
+      # hits often; catch it before it reaches a deploy. Test settings = SQLite, no
+      # DB server needed.
+      - name: Check migrations are in sync
+        run: uv run python manage.py makemigrations --check --dry-run
+        env:
+          DJANGO_SETTINGS_MODULE: config.settings.test
+
+      - name: Django system checks
+        run: uv run python manage.py check
+        env:
+          DJANGO_SETTINGS_MODULE: config.settings.test
+
       - name: Run pytest
         run: uv run pytest
 

--- a/.github/workflows/contract-nightly.yml
+++ b/.github/workflows/contract-nightly.yml
@@ -1,9 +1,10 @@
 name: Contract tests (nightly, exhaustive)
 
-# The per-PR contract job (ci.yml) runs a fast smoke (SCHEMATHESIS_MAX_EXAMPLES
-# defaults to a few per endpoint) so it isn't a ~6-min blocker on every PR. This
-# job runs the EXHAUSTIVE property-based fuzz nightly + on demand, off the PR
-# critical path.
+# Contract tests do NOT run on PRs — ci.yml has no live backend, so the suite
+# skips there (schemathesis.from_uri can't reach a server). This job is the only
+# place they actually execute: the EXHAUSTIVE property-based fuzz against a live
+# server, nightly + on demand, off the PR critical path. (A fast in-process smoke
+# on PRs via schemathesis.from_wsgi is a possible future add.)
 
 on:
   schedule:

--- a/apps/agent_runs/tests/test_db_store.py
+++ b/apps/agent_runs/tests/test_db_store.py
@@ -1,7 +1,6 @@
 """DbRunStore read path — create ORM rows, assert the read model matches."""
 from __future__ import annotations
 
-import datetime as dt
 
 import pytest
 

--- a/apps/common/tests/test_auth_domains.py
+++ b/apps/common/tests/test_auth_domains.py
@@ -1,7 +1,6 @@
 """Tests for the multi-domain email allowlist helper."""
 from __future__ import annotations
 
-import pytest
 
 from apps.common.auth_domains import allowed_email_domains, email_in_allowlist
 

--- a/apps/harness/services.py
+++ b/apps/harness/services.py
@@ -17,7 +17,6 @@ from django.utils import timezone
 from apps.workspaces import services as wsvc
 
 from .models import (
-    HEARTBEAT_ONLINE_WINDOW,
     AgentSchedule,
     Item,
     Runner,
@@ -26,13 +25,15 @@ from .models import (
     TurnEvent,
 )
 
+# HEARTBEAT_ONLINE_WINDOW lives on models.py (Runner.live_status uses it too;
+# models.py cannot import services.py, which already imports models.py) and is
+# re-exported here so existing importers of services.HEARTBEAT_ONLINE_WINDOW keep
+# working. Intentional re-export — noqa keeps the F401 gate from deleting it.
+from .models import HEARTBEAT_ONLINE_WINDOW  # noqa: F401
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_LEASE_SECONDS = 900
-# HEARTBEAT_ONLINE_WINDOW lives on models.py (Runner.live_status uses it too;
-# models.py cannot import services.py, which already imports models.py) and is
-# re-exported here so existing importers of services.HEARTBEAT_ONLINE_WINDOW
-# keep working.
 
 
 def enqueue_turn(

--- a/apps/reviews/tests/test_api.py
+++ b/apps/reviews/tests/test_api.py
@@ -390,7 +390,7 @@ def test_list_status_filter(auth_client, owner):
 @pytest.mark.django_db
 def test_list_orders_by_last_activity_desc_by_default(auth_client, owner):
     older = _make_review(owner, run_id="older-2026-05-01-001")
-    newer = _make_review(owner, run_id="newer-2026-05-01-001")
+    _make_review(owner, run_id="newer-2026-05-01-001")  # the row matters, not the binding
     # Resolve the older one *now* so its last_activity jumps ahead of newer's.
     older.status = ReviewRequest.STATUS_RESOLVED
     older.resolved_at = timezone.now()

--- a/apps/session_sharing/api.py
+++ b/apps/session_sharing/api.py
@@ -36,7 +36,6 @@ from .schemas import (
     ArcCreateIn,
     ArcCreateOut,
     ArcDetailOut,
-    ArcItemOut,
     ArcListItemOut,
     ArcPatchIn,
     SessionDetailOut,

--- a/apps/timeline/tests/test_workspace_scoping.py
+++ b/apps/timeline/tests/test_workspace_scoping.py
@@ -90,7 +90,6 @@ def _sub_ids(user, subsystem):
 def test_all_tenant_sources_scoped_to_members_workspace(db):
     """walkthroughs, shareouts, agents, projects each only show the caller's
     workspace's rows — the DDD source proves reviews/runs; this proves the rest."""
-    import datetime as dt
 
     from django.utils import timezone
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -3,7 +3,6 @@ Base Django settings for canopy-web.
 
 Common settings shared across all environments.
 """
-import os
 import sys
 from pathlib import Path
 

--- a/packages/canopy_agent_runs/tests/test_drive_fork.py
+++ b/packages/canopy_agent_runs/tests/test_drive_fork.py
@@ -14,7 +14,6 @@ The fork point is a phase BOUNDARY (the first step of the middle phase) so the
 Drive store's phase-granular folder copy and step-granular statuses agree —
 see the module docstring's interior-fork caveat.
 """
-import datetime as dt
 
 import pytest
 import yaml

--- a/packages/canopy_runner/canopy_runner/emdash.py
+++ b/packages/canopy_runner/canopy_runner/emdash.py
@@ -18,7 +18,6 @@ because the DOM cannot answer it (see `task_state`).
 from __future__ import annotations
 
 import hashlib
-import json
 import sqlite3
 import time
 from contextlib import contextmanager

--- a/packages/canopy_runner/tests/test_main.py
+++ b/packages/canopy_runner/tests/test_main.py
@@ -2,7 +2,6 @@ import json
 import sqlite3
 import sys
 import time
-import uuid
 from pathlib import Path
 
 import pytest
@@ -345,7 +344,7 @@ def test_completed_run_within_grace_is_left_alone(db, tmp_path):
     assert "completed_seen_at" in state["active"]["t-1"]
 
     result = run_once(cfg, client)  # still well within GRACE_SECONDS
-    assert result != f"failed:t-1"
+    assert result != "failed:t-1"
     assert not client.failed
     state = json.loads(Path(cfg.state_path).read_text())
     assert "t-1" in state["active"]

--- a/tests/contract/test_schemathesis.py
+++ b/tests/contract/test_schemathesis.py
@@ -26,12 +26,11 @@ import schemathesis
 from hypothesis import HealthCheck, settings
 
 # Per-endpoint example count. Schemathesis is property-based: each (path × method)
-# runs `max_examples` generated requests. The default (100) × canopy-web's many
-# endpoints made this a ~6-min blocker on every PR. So PRs run a fast smoke (a few
-# examples each — still hits every endpoint and catches the contract breaks that
-# matter: wrong status codes / schema mismatches), and the nightly job
-# (.github/workflows/contract-nightly.yml) sets SCHEMATHESIS_MAX_EXAMPLES high for
-# exhaustive fuzzing off the PR critical path.
+# runs `max_examples` generated requests. These tests need a live server (from_uri
+# below), which PR CI does not stand up — so on PRs the suite SKIPS. It runs in the
+# nightly job (.github/workflows/contract-nightly.yml), which sets
+# SCHEMATHESIS_MAX_EXAMPLES high for exhaustive fuzzing, and locally against a
+# running server. The low default here keeps an ad-hoc local run fast.
 _MAX_EXAMPLES = int(os.environ.get("SCHEMATHESIS_MAX_EXAMPLES", "6"))
 
 SCHEMA_URL = os.environ.get(

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -5,7 +5,6 @@ import pytest
 from allauth.core.exceptions import ImmediateHttpResponse
 from django.contrib.auth import get_user_model
 from django.test import Client, override_settings
-from django.urls import reverse
 
 from apps.common.auth_adapter import CustomSocialAccountAdapter
 

--- a/tests/test_harness_api.py
+++ b/tests/test_harness_api.py
@@ -9,7 +9,7 @@ from django.test import Client
 from django.utils import timezone
 
 from apps.agents.models import Agent
-from apps.harness.models import HEARTBEAT_ONLINE_WINDOW, Runner, Turn
+from apps.harness.models import HEARTBEAT_ONLINE_WINDOW, Runner
 
 pytestmark = pytest.mark.django_db
 

--- a/tests/test_harness_project_turns.py
+++ b/tests/test_harness_project_turns.py
@@ -7,7 +7,7 @@ always project-generic; only the data model insisted on an agent.
 from __future__ import annotations
 
 import pytest
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError
 
 from apps.agents.models import Agent
 from apps.harness.models import Turn

--- a/tests/test_harness_services.py
+++ b/tests/test_harness_services.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 
 from apps.agents.models import Agent
 from apps.harness import services
-from apps.harness.models import Runner, Turn, TurnEvent
+from apps.harness.models import Runner, Turn
 
 pytestmark = pytest.mark.django_db
 


### PR DESCRIPTION
Three fast, zero-DB gates in the existing backend job — CI that catches more real bugs **without** slowing the pipeline. Each reuses the already-synced uv env, so it adds ~seconds, not a new job spin-up.

## What's gated now (before pytest, for fast-fail)
- **`ruff --select F`** (pyflakes only) — unused imports (F401), undefined names (F821/F811). Scoped to *correctness*, not style: the repo isn't ruff-formatted (259 files would change), so a full ruff/format gate is a separate cleanup that would collide with in-flight work. `F403/F405` ignored — the settings modules use `from base import *` by design.
- **`makemigrations --check`** — a model change without its migration is a recurring class of bug in this fast-moving repo; catch it before a deploy. Runs under test settings (SQLite, no DB server).
- **`manage.py check`** — Django system checks.

## Cleanup to make the F gate green
Cleared the 16 existing F violations (14 auto-fixed unused imports + 1 empty f-string + 1 unused var). **Restored the deliberate `HEARTBEAT_ONLINE_WINDOW` re-export** with a `# noqa: F401` — `ruff --fix` had silently deleted it, exactly the trap flagged in the prior review.

## Honesty fix
The contract-test docs claimed "PRs run a fast smoke." They don't — `ci.yml` stands up no server, so the schemathesis suite **skips** on PRs and runs only in the nightly. Comments now say so (and note `from_wsgi` as a future in-process-smoke option).

## Deliberately not added
- **Playwright** — per direction, to keep CI fast.
- **Full eslint gate** — 66 pre-existing errors, mostly one HMR rule (`react-refresh/only-export-components`); a separate cleanup/config decision.

Local: all three gates pass, backend 838 passed / 1 skipped, canopy_runner 86 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)