### PR TITLE
fix(reviews,push): bound free-string inputs that 500 on Postgres

### DIFF
--- a/apps/push/schemas.py
+++ b/apps/push/schemas.py
@@ -1,6 +1,8 @@
 """Pydantic schemas for /api/push."""
 from __future__ import annotations
 
+from pydantic import Field
+
 from apps.common.schemas import StrictModel
 
 
@@ -10,8 +12,11 @@ class VapidKeyOut(StrictModel):
 
 class PushSubscribeIn(StrictModel):
     endpoint: str
-    p256dh: str
-    auth: str
+    # p256dh/auth map to fixed-width columns (200/100) and are exact crypto values —
+    # bound them at the boundary so an over-length value is a 422, not a Postgres-only
+    # 500. (user_agent is informational and stays leniently truncated in the view.)
+    p256dh: str = Field(max_length=200)
+    auth: str = Field(max_length=100)
     user_agent: str = ""
 
 

--- a/apps/reviews/api.py
+++ b/apps/reviews/api.py
@@ -26,7 +26,7 @@ from django.utils import timezone
 from ninja import Router, Status
 
 from apps.api.auth import session_auth
-from apps.api.errors import TYPE_FORBIDDEN, TYPE_NOT_FOUND, ProblemError
+from apps.api.errors import TYPE_FORBIDDEN, TYPE_NOT_FOUND, TYPE_VALIDATION, ProblemError
 from apps.common.csrf import csrf_rejected
 from apps.runs.ddd import (
     RUN_CHILD_GATES,
@@ -266,6 +266,17 @@ def create_review(request: HttpRequest, payload: ReviewCreateIn) -> Status:
             version = ReviewRequest.next_version(narrative_slug)
         else:
             version = max(ReviewRequest.next_version(narrative_slug) - 1, 1)
+
+    # Guard the free-string request_json values against their column limits before
+    # the write. They come from an unbounded dict, so an over-length value is a
+    # Postgres-only "value too long" 500 (SQLite dev/test doesn't enforce varchar
+    # length, so it slips through CI). Bound off the model so this can't drift.
+    for field, value in (("run_id", run_id), ("gate", gate), ("narrative_slug", narrative_slug or "")):
+        limit = ReviewRequest._meta.get_field(field).max_length
+        if limit and len(value) > limit:
+            raise ProblemError(
+                422, f"{field} exceeds the {limit}-character limit", type_=TYPE_VALIDATION
+            )
 
     # Assign the owning workspace: the /w/{ws} prefix pins it (membership already
     # verified upstream); else fall back to the org default so an unchanged

--- a/apps/reviews/tests/test_api.py
+++ b/apps/reviews/tests/test_api.py
@@ -117,6 +117,21 @@ def test_create_returns_id_and_url(auth_client):
     assert body["id"] in body["url"]
 
 
+@pytest.mark.django_db
+def test_create_rejects_overlong_fields_with_422_not_500(auth_client):
+    # run_id/gate/narrative_slug come from the unbounded request_json but map to
+    # fixed-width columns; an over-length value must 422 at the boundary, not reach
+    # Postgres and 500 (SQLite CI wouldn't catch the 500).
+    over = {**SAMPLE_REQUEST_JSON, "run_id": "r" * 300}  # column is max_length=255
+    resp = auth_client.post(
+        f"{BASE}/",
+        data={"request_json": over, "visibility": "link"},
+        content_type="application/json",
+    )
+    assert resp.status_code == 422, resp.content
+    assert "run_id" in resp.content.decode()
+
+
 # ---------------------------------------------------------------------------
 # 2. GET by owner returns full record
 # ---------------------------------------------------------------------------

--- a/tests/test_push_api.py
+++ b/tests/test_push_api.py
@@ -63,6 +63,17 @@ def test_subscribe_503s_when_push_is_not_configured(client, settings):
     assert not PushSubscription.objects.filter(endpoint=SUB["endpoint"]).exists()
 
 
+def test_subscribe_rejects_overlong_crypto_keys_with_422_not_500(client):
+    # p256dh/auth map to fixed-width columns (200/100); an over-length value must be
+    # a 422 at the schema boundary, not a Postgres-only 500 on the write.
+    resp = client.post(
+        "/api/push/subscribe",
+        {**SUB, "p256dh": "B" * 300},
+        content_type="application/json",
+    )
+    assert resp.status_code == 422, resp.content
+
+
 def test_subscribe_stores_the_browser(client, user):
     resp = client.post("/api/push/subscribe", SUB, content_type="application/json")
     assert resp.status_code == 201


### PR DESCRIPTION
Two more instances of the **origin/routing bug class** (#246): unbounded input written into fixed-width `CharField`s → a Postgres-only `value too long` 500 that SQLite CI can't reproduce. Both surfaced by an idle-surface bug sweep and independently flagged by two reviewers.

- **reviews create** (`apps/reviews/api.py`) — `run_id` (255), `gate` (128), `narrative_slug` (200) are pulled from the unbounded `request_json` dict and written straight to their columns. Now guarded against the model's own `max_length` before the write → **422** via the house `ProblemError`, not a 500.
- **push subscribe** (`apps/push/schemas.py`) — `p256dh` (200) and `auth` (100) were written unbounded while `user_agent` was already truncated (an asymmetric latent 500). Bounded in the `PushSubscribeIn` schema — they're exact crypto values, so reject `> limit` rather than corrupt-by-truncation; `user_agent` stays leniently truncated.

Tests assert **422-not-500** on overflow for both. Full backend suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)