### PR TITLE
ci(deploy): migrate automatically on every deploy, not by a manual flag

### DIFF
--- a/.github/workflows/deploy-labs.yml
+++ b/.github/workflows/deploy-labs.yml
@@ -12,7 +12,7 @@ name: Deploy to Labs (AWS)
 # provisioner (ECR repo, secrets, target group, listener rule, task def, service,
 # using the SHARED task/exec roles). This workflow handles every ongoing deploy:
 # it sources the live task def, swaps ONLY the image (so env/secrets/resources
-# never drift from the stack), optionally migrates, then rolls the service.
+# never drift from the stack), migrates automatically, then rolls the service.
 #
 # Required GitHub secrets (see deploy/aws + Phase 2 of the labs migration):
 #   AWS_ROLE_ARN         — the shared github-actions-labs-deploy OIDC role
@@ -25,10 +25,10 @@ name: Deploy to Labs (AWS)
 on:
   workflow_dispatch:
     inputs:
-      run_migrations:
-        description: 'Run database migrations before cutover'
+      skip_migrations:
+        description: 'EMERGENCY ONLY: skip migrations. They run automatically by default.'
         type: boolean
-        required: true
+        required: false
         default: false
 
 concurrency:
@@ -150,11 +150,18 @@ jobs:
           echo "::notice::Registered $NEW_ARN"
 
       - name: Run database migrations
-        if: ${{ inputs.run_migrations == true }}
+        if: ${{ inputs.skip_migrations != true }}
         run: |
-          # One-off Fargate task on the NEW task def (new code), command
-          # overridden to `migrate`. Runs BEFORE the service cutover so new code
-          # never serves against an un-migrated schema.
+          # Runs on EVERY deploy by default — `migrate --noinput` is idempotent, a
+          # near-instant no-op when nothing is pending, so there is no cost to always
+          # running it and no way to forget. (A deploy of new code that SELECTs a
+          # not-yet-added column is exactly how /api/agents/tasks 500'd in prod when a
+          # migration shipped un-run; automatic migration removes that whole failure
+          # class.) Escape hatch: skip_migrations=true for the rare emergency.
+          #
+          # One-off Fargate task on the NEW task def (new code), command overridden to
+          # `migrate`. Runs BEFORE the service cutover so new code never serves against
+          # an un-migrated schema.
           TASK_ARN=$(aws ecs run-task \
             --cluster "${{ env.ECS_CLUSTER }}" \
             --task-definition "${{ steps.register-task.outputs.task-def-arn }}" \
@@ -198,7 +205,7 @@ jobs:
             echo "| Ref | \`${{ github.ref_name }}\` @ \`${{ github.sha }}\` |"
             echo "| Image | \`${{ env.ECR_REPO }}:${{ github.sha }}\` |"
             echo "| Task definition | \`${{ steps.register-task.outputs.task-def-arn }}\` |"
-            echo "| Migrations run | \`${{ inputs.run_migrations }}\` |"
+            echo "| Migrations | \`${{ inputs.skip_migrations == true && 'SKIPPED (emergency)' || 'ran automatically' }}\` |"
             echo "| Service | \`${{ env.ECS_SERVICE }}\` |"
             echo "| URL | https://labs.connect.dimagi.com/canopy/ |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ first-class AI agents, demo-driven development (DDD), walkthroughs, and shareout
 - **Frontend:** React 19 + Vite + Tailwind CSS 4 + shadcn/ui
 - **AI:** Anthropic Claude API via SSE streaming. Dual backend — direct API key (`AI_BACKEND=api`) or Claude Code CLI subscription (`AI_BACKEND=cli`), switchable at runtime via `/api/ai/switch/`.
 - **MCP server:** `apps/mcp/` is a FastMCP 3.x Streamable-HTTP server mounted into the ASGI app at `/api/mcp/` (wired in `config/asgi.py`). Tools run **as the authenticated user** via per-user PAT (`CanopyPATVerifier`) and reuse the same service functions as the REST views, so the two surfaces can't drift. See `docs/architecture/mcp-surface.md`.
-- **Deployment:** AWS ECS Fargate on the shared labs platform (account `858923557655`, `us-east-1`), served at `https://labs.connect.dimagi.com/canopy/` behind the shared ALB. One container (Django serves the built SPA + API + MCP). Deploys run from GitHub via the **Deploy to Labs (AWS)** workflow (`.github/workflows/deploy-labs.yml`): build → push to ECR (`labs-jj-canopy-web`) → register task-def revision → optional migrate → roll the ECS service. Infra is provisioned by `deploy/aws/canopy-web.cfn.yaml` (CloudFormation). Runtime settings in `config/settings/connectlabs.py` (extends `production.py`; `FORCE_SCRIPT_NAME=/canopy`, shared RDS `canopy_web` DB).
+- **Deployment:** AWS ECS Fargate on the shared labs platform (account `858923557655`, `us-east-1`), served at `https://labs.connect.dimagi.com/canopy/` behind the shared ALB. One container (Django serves the built SPA + API + MCP). Deploys run from GitHub via the **Deploy to Labs (AWS)** workflow (`.github/workflows/deploy-labs.yml`): build → push to ECR (`labs-jj-canopy-web`) → register task-def revision → auto-migrate (idempotent; skippable only via `skip_migrations`) → roll the ECS service. Infra is provisioned by `deploy/aws/canopy-web.cfn.yaml` (CloudFormation). Runtime settings in `config/settings/connectlabs.py` (extends `production.py`; `FORCE_SCRIPT_NAME=/canopy`, shared RDS `canopy_web` DB).
 - **Framework/product boundary (the one invariant):** apps split into **framework** (generic, agent-agnostic substrate — `agents`, `agent_runs`, `workspaces`, `api`, `common`, `timeline`, `tokens`, `session_sharing`, `issues`, `mcp`, `system`) and **product** (canopy's own features — `projects`, `walkthroughs`, `reviews`, `shareouts`, `runs`). **Framework code must never import product code; product freely imports framework.** This keeps the blend cuttable (the framework apps could lift onto a standalone host without dragging canopy's product). It's a *direction, not a wall* — we don't move apps into `framework/`/`product/` folders. Enforced by `tests/test_architecture_boundary.py` (fails CI on a framework→product import, or on a new app left untiered). Full rationale, the per-app tier table, and the accepted carve-outs (the `api` composition root, the `mcp` insights tool): **`ARCHITECTURE.md`**. The framework apps are being harvested as the generic layer out of ACE — see `docs/superpowers/specs/2026-06-24-canopy-framework-harvest-design.md`.
 
 ## Development
@@ -40,12 +40,13 @@ docker compose up
 # Deploy to AWS labs (https://labs.connect.dimagi.com/canopy/). Deploys run from
 # GitHub only — trigger the "Deploy to Labs (AWS)" workflow from the Actions tab
 # (workflow_dispatch), or:
-gh workflow run "Deploy to Labs (AWS)" --ref main -f run_migrations=false
-gh workflow run "Deploy to Labs (AWS)" --ref main -f run_migrations=true   # when the change has a migration
+gh workflow run "Deploy to Labs (AWS)" --ref main                          # migrations run automatically
+gh workflow run "Deploy to Labs (AWS)" --ref main -f skip_migrations=true  # EMERGENCY ONLY: skip migrations
 # Production ships from `main` ONLY — the workflow hard-fails on any other ref.
 # It builds+pushes the image to ECR, registers a task-def revision (image swap
-# only), optionally migrates on a one-off Fargate task, then rolls the ECS
-# service. See .github/workflows/deploy-labs.yml + deploy/aws/canopy-web.cfn.yaml.
+# only), ALWAYS migrates on a one-off Fargate task before cutover (migrate --noinput
+# is idempotent — a no-op when nothing is pending, so it can't be forgotten), then
+# rolls the ECS service. See .github/workflows/deploy-labs.yml + deploy/aws/canopy-web.cfn.yaml.
 ```
 
 When `AI_BACKEND=cli`, the `claude` binary must be on PATH and authenticated. In Docker, use the headless auth flow at `/settings` (drives `claude setup-token` via PTY; token persists in `CLAUDE_CODE_OAUTH_TOKEN`).


### PR DESCRIPTION
## Why

The migration step was gated on a manual `run_migrations` boolean **defaulting to `false`**. Deploy #242 shipped code that `SELECT`s the new `agenttask.score`/`review` columns but left the box unchecked — so the migration never ran, and every endpoint that reads a task row (`/api/agents/*/tasks`, `/api/agents/*/needs-you`) **500'd in production**. The supervisor showed `getFleetNeedsYou failed: … Internal server error`.

(Found because the new native menu-bar app loads the real `/supervisor` surface, which exercised the API and surfaced the drift immediately.)

A box you can forget is a footgun.

## Change

Migrations now run on **every deploy**, automatically:

```diff
-      run_migrations:            # manual, default false
-        if: ${{ inputs.run_migrations == true }}
+      skip_migrations:           # emergency escape hatch, default false
+        if: ${{ inputs.skip_migrations != true }}
```

`migrate --noinput` is idempotent — a near-instant no-op when nothing is pending — so there's no cost to always running it and no way to forget. It's still a one-off Fargate task on the new task def, **before** the service cutover, so new code never serves an un-migrated schema (unchanged ordering).

`skip_migrations=true` remains for the rare emergency.

## Note

connect-labs (the referenced prior art) uses the **same** manual-flag pattern (`if: github.event.inputs.run_migrations == 'true'`), so there was nothing better to copy — this is strictly an improvement over both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)