### PR TITLE
fix(header): hide dead nav for anonymous public-link viewers

### DIFF
--- a/frontend/src/components/AppLayout/AppLayout.tsx
+++ b/frontend/src/components/AppLayout/AppLayout.tsx
@@ -215,17 +215,26 @@ export function AppLayout() {
 
 function AppShell() {
   const location = useLocation()
+  const auth = useAuth()
   const { active } = useWorkspace()
   const [mobileOpen, setMobileOpen] = useState(false)
+
+  // Anonymous visitors only ever reach the app shell on a public link route
+  // (/walkthrough/:id, /review/:id — see AuthProvider). Every nav destination
+  // is behind the login gate, so the whole nav (inline + mobile hamburger)
+  // would be dead links that bounce to sign-in. Show just the wordmark instead.
+  const isAuthed = auth.status === 'authenticated'
 
   // Tenant nav items resolve to /w/:active/<path>; personal/global items keep
   // their absolute path. Tenant items are hidden until the active workspace is
   // known (avoids linking to a broken /w//… path on first paint).
-  const navItems = NAV_ITEMS.flatMap((item) => {
-    if (!item.tenant) return [{ path: item.path, label: item.label }]
-    if (!active) return []
-    return [{ path: `/w/${active}${item.path ? `/${item.path}` : ''}`, label: item.label }]
-  })
+  const navItems = isAuthed
+    ? NAV_ITEMS.flatMap((item) => {
+        if (!item.tenant) return [{ path: item.path, label: item.label }]
+        if (!active) return []
+        return [{ path: `/w/${active}${item.path ? `/${item.path}` : ''}`, label: item.label }]
+      })
+    : []
 
   // Collapse the mobile menu whenever the route changes (e.g. tapping a link).
   useEffect(() => {
@@ -252,7 +261,11 @@ function AppShell() {
     <div className="min-h-screen bg-background text-foreground-secondary">
       <header className="border-b border-border bg-background relative">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 py-3 flex items-center justify-between gap-3">
-          <Link to="/" className="text-lg font-semibold text-foreground shrink-0">Canopy<span className="text-primary">.</span></Link>
+          {isAuthed ? (
+            <Link to="/" className="text-lg font-semibold text-foreground shrink-0">Canopy<span className="text-primary">.</span></Link>
+          ) : (
+            <span className="text-lg font-semibold text-foreground shrink-0">Canopy<span className="text-primary">.</span></span>
+          )}
           <div className="flex items-center gap-3 xl:gap-6">
             {/* Full inline nav only once all items fit (~xl); below that it
                 overflows the viewport, so we collapse it into the menu below. */}
@@ -265,6 +278,7 @@ function AppShell() {
             </nav>
             <WorkspaceSwitcher />
             <UserMenu />
+            {isAuthed && (
             <button
               type="button"
               onClick={() => setMobileOpen((o) => !o)}
@@ -287,6 +301,7 @@ function AppShell() {
                 )}
               </svg>
             </button>
+            )}
           </div>
         </div>
         {mobileOpen && (


### PR DESCRIPTION
## Problem
On the public link viewers (`/walkthrough/:id`, `/review/:id`), an anonymous visitor renders the full app shell. The account menu already hid itself and tenant nav items were suppressed (no workspace), but the **global** nav links (Insights, Sessions, System, Supervisor), the mobile hamburger, and the "Canopy." wordmark link all remained — and every one of those destinations sits behind the login gate, so they all just bounce an anonymous viewer to sign-in. A row of dead links.

## Fix
In `AppShell` (`frontend/src/components/AppLayout/AppLayout.tsx`), gate the whole nav cluster on `auth.status === 'authenticated'`:
- **Nav items** → empty when not authed (blanks both the desktop `<nav>` and the mobile panel, which both map over `navItems`).
- **Mobile hamburger** → only rendered when authed, so it can't open an empty menu.
- **"Canopy." wordmark** → a plain `<span>` instead of `<Link to="/">` for anonymous viewers (that link also redirected to login).

Authenticated users get the full nav unchanged. `/share/:token` was already chrome-less and unaffected.

## Verification
`tsc -b` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)