### PR TITLE
feat(agents): act inline from the agent view, not just read

### DIFF
--- a/frontend/src/pages/agents/AgentOverviewSection.tsx
+++ b/frontend/src/pages/agents/AgentOverviewSection.tsx
@@ -7,9 +7,70 @@ import {
   type AgentTaskOut,
   type AgentTaskStatus,
 } from '@/api/agents'
+import { enqueueTurn } from '@/api/harness'
 import type { AgentOutletContext } from '@/pages/AgentWorkspacePage'
 import { CountStat, SyncCard } from '@/components/agents/cards'
 import { WorkbenchSubHeader, WorkbenchSkeleton } from 'canopy-ui'
+
+// Dispatch a prompt straight to THIS agent from its own page — the per-agent
+// counterpart to /supervisor's cross-fleet composer, so "act on this agent" doesn't
+// require bouncing to the supervisor. Enqueues a turn; the runner claims + runs it
+// (it waits in the queue if the runner is paused/offline).
+function QuickTurn({ slug }: { slug: string }) {
+  const [prompt, setPrompt] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [sent, setSent] = useState(false)
+
+  const send = async () => {
+    const p = prompt.trim()
+    if (!p) return
+    setBusy(true)
+    setError(null)
+    try {
+      await enqueueTurn({ agentSlug: slug, prompt: p })
+      setPrompt('')
+      setSent(true)
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Failed to dispatch')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="mb-6 rounded-lg border border-border bg-card p-3">
+      <span className="text-[11px] font-bold uppercase tracking-[0.06em] text-primary">Take a turn</span>
+      <div className="mt-2 flex gap-2">
+        <input
+          value={prompt}
+          onChange={(e) => {
+            setPrompt(e.target.value)
+            setSent(false)
+          }}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') void send()
+          }}
+          placeholder={`Dispatch a prompt to ${slug}…`}
+          data-testid="quickturn-input"
+          className="min-w-0 flex-1 rounded-md border border-input bg-input px-3 py-2 text-[13px] text-foreground"
+        />
+        <button
+          type="button"
+          disabled={busy || prompt.trim() === ''}
+          onClick={() => void send()}
+          className="shrink-0 rounded-md bg-primary px-4 py-2 text-[13px] font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
+        >
+          {busy ? 'Sending…' : 'Send'}
+        </button>
+      </div>
+      {error && <p className="mt-1 text-[11px] text-destructive">{error}</p>}
+      {sent && !error && (
+        <p className="mt-1 text-[11px] text-success">Dispatched — the runner will pick it up.</p>
+      )}
+    </div>
+  )
+}
 
 const TASK_COLUMNS: { status: AgentTaskStatus; label: string; dot: string }[] = [
   { status: 'suggested', label: 'Suggested', dot: 'bg-muted-foreground' },
@@ -77,6 +138,9 @@ export function AgentOverviewSection() {
           )}
         </div>
       )}
+
+      {/* Dispatch a turn to this agent, inline */}
+      <QuickTurn slug={agent.slug} />
 
       {/* Counts row */}
       <div className="flex flex-wrap gap-6 pb-6 mb-6 border-b border-border">

--- a/frontend/src/pages/agents/NeedsYouSection.tsx
+++ b/frontend/src/pages/agents/NeedsYouSection.tsx
@@ -8,6 +8,8 @@ import {
   type NeedsYouOut,
   type NeedsYouType,
 } from '@/api/agents'
+import { decideItem, type ItemDecision } from '@/api/items'
+import { runScheduleNow } from '@/api/schedules'
 import type { AgentOutletContext } from '@/pages/AgentWorkspacePage'
 import { TaskCard } from '@/components/TasksBoard'
 import { NEEDS_YOU_BAND, NEEDS_YOU_RANK } from '@/lib/needsYouBands'
@@ -78,6 +80,101 @@ function NotifyRow({ item }: { item: NeedsYouItem }): JSX.Element {
   )
 }
 
+// A real harness Item that needs a decision — decide it inline (implement / skip /
+// defer) instead of bouncing to the Items rail. Closed decision set, same as
+// ItemsSection; only `implement` dispatches. A bad dispatch spec 422s and the item
+// stays open — we surface that rather than leave the tap looking like it worked.
+const ITEM_DECISIONS: ItemDecision[] = ['implement', 'skip', 'defer']
+
+function ItemActionRow({ item, onActed }: { item: NeedsYouItem; onActed: () => void }): JSX.Element {
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  return (
+    <article
+      data-testid={`needsyou-item-${item.ref_id}`}
+      className="rounded-lg border border-border bg-card p-3"
+    >
+      <p className="text-[13px] font-semibold leading-snug text-foreground">{item.title}</p>
+      {item.subtitle && <p className="mt-1 text-[11px] leading-snug text-muted-foreground">{item.subtitle}</p>}
+      {error && <p className="mt-1 text-[11px] text-destructive">{error}</p>}
+      <div className="mt-2 flex flex-wrap gap-2">
+        {ITEM_DECISIONS.map((d) => (
+          <button
+            key={d}
+            type="button"
+            disabled={busy}
+            onClick={async () => {
+              setBusy(true)
+              setError(null)
+              try {
+                await decideItem(String(item.ref_id), d)
+                onActed()
+              } catch (e: unknown) {
+                setError(e instanceof Error ? e.message : 'Failed to decide')
+              } finally {
+                setBusy(false)
+              }
+            }}
+            className="rounded-md border border-border px-3 py-1 text-[12px] capitalize text-foreground transition-colors hover:bg-muted disabled:opacity-50"
+          >
+            {d}
+          </button>
+        ))}
+      </div>
+    </article>
+  )
+}
+
+// The unattended-schedule nag — fire the occurrence off-cycle right here (Run now),
+// instead of deep-linking out to the Schedules rail to find the same button.
+function ScheduleNagRow({
+  slug,
+  item,
+  onActed,
+}: {
+  slug: string
+  item: NeedsYouItem
+  onActed: () => void
+}): JSX.Element {
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  return (
+    <article
+      data-testid={`needsyou-schedule-${item.ref_id}`}
+      className="rounded-lg border border-border bg-card p-3"
+    >
+      <div className="flex items-start gap-2">
+        <div className="min-w-0 flex-1">
+          <p className="text-[13px] font-semibold leading-snug text-foreground">{item.title}</p>
+          {item.subtitle && (
+            <p className="mt-1 text-[11px] leading-snug text-muted-foreground">{item.subtitle}</p>
+          )}
+        </div>
+        <button
+          type="button"
+          disabled={busy}
+          onClick={async () => {
+            setBusy(true)
+            setError(null)
+            try {
+              await runScheduleNow(slug, Number(item.ref_id))
+              onActed()
+            } catch (e: unknown) {
+              setError(e instanceof Error ? e.message : 'Failed to run')
+            } finally {
+              setBusy(false)
+            }
+          }}
+          className="shrink-0 rounded-md border border-border px-3 py-1 text-[12px] text-foreground transition-colors hover:bg-muted disabled:opacity-50"
+        >
+          {busy ? 'Starting…' : 'Run now'}
+        </button>
+      </div>
+      {error && <p className="mt-1 text-[11px] text-destructive">{error}</p>}
+    </article>
+  )
+}
+
 function Band({
   type,
   label,
@@ -85,6 +182,7 @@ function Band({
   dot,
   items,
   tasksById,
+  slug,
   reload,
 }: {
   type: NeedsYouType
@@ -93,6 +191,7 @@ function Band({
   dot: string
   items: NeedsYouItem[]
   tasksById: Map<number, AgentTaskOut>
+  slug: string
   reload: () => void
 }): JSX.Element | null {
   const mine = items.filter((i) => i.type === type)
@@ -121,6 +220,15 @@ function Band({
                 <TaskCard task={task} onChanged={reload} />
               </div>
             )
+          }
+          // Real Items decide inline; schedule nags fire inline — the two review/
+          // question kinds that were dead links before. Everything else (sync,
+          // work product, run gate) still links out to its artifact/review surface.
+          if (i.ref_kind === 'item') {
+            return <ItemActionRow key={`item-${i.ref_id}`} item={i} onActed={reload} />
+          }
+          if (i.ref_kind === 'schedule') {
+            return <ScheduleNagRow key={`schedule-${i.ref_id}`} slug={slug} item={i} onActed={reload} />
           }
           return <NotifyRow key={`${i.ref_kind}-${i.ref_id}`} item={i} />
         })}
@@ -176,7 +284,14 @@ export function NeedsYouSection() {
       ) : (
         <div className="space-y-7">
           {BANDS.map((b) => (
-            <Band key={b.type} {...b} items={[...(data.items ?? [])]} tasksById={tasksById} reload={reload} />
+            <Band
+              key={b.type}
+              {...b}
+              items={[...(data.items ?? [])]}
+              tasksById={tasksById}
+              slug={agent.slug}
+              reload={reload}
+            />
           ))}
         </div>
       )}


### PR DESCRIPTION
The agents side of your agents-vs-sessions split (sessions = the other agent's emdash session controller). The per-agent surface was mostly *read* where it mattered; two dead-ends fixed so you can trigger things on mobile without bouncing rails or going to `/supervisor`.

## Needs-you (the default landing) is now fully actionable
It already rendered the live board card for **task** items (accept/decline/dispatch inline). But:
- **Real Items** rendered as dead link rows → now **decide inline** (implement / skip / defer — same closed set and 422-surfacing as the Items rail).
- **Schedule nags** deep-linked *out* to the Schedules rail → now a **Run now** button right on the row.

Every review/question row is now actionable where you land.

## Overview gains "Take a turn"
A compact composer that dispatches a prompt **straight to this agent** — the per-agent counterpart to `/supervisor`'s cross-fleet composer, so acting on an agent doesn't require leaving its page. Enqueues a turn; the runner claims it (waits in queue if paused/offline).

## Notes
- All wiring reuses already-tested API clients (`decideItem`, `runScheduleNow`, `enqueueTurn`) in the exact pattern of the working Items / Schedules / Composer surfaces.
- Touches only `frontend/src/pages/agents/*` — no overlap with the emdash-session-controller branch (`apps/harness` + `/supervisor`).
- `npm run build` typechecks clean; 98 vitest pass. This repo tests logic in `lib/`, not components (no `@testing-library`), so no component render test — consistent with the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)