### PR TITLE
feat(realtime): SP1 — realtime substrate (Wave 4)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -40,6 +40,7 @@ the arrow's direction and enforce it in CI.
 | `mcp` | **framework** | MCP server infra + audit + rate-limit. (Individual *tools* may be product — see carve-outs.) |
 | `system` | **framework** | System metadata / AI-backend status. |
 | `push` | **framework** | Web Push subscription registry (VAPID keypair + `PushSubscription` rows). Agent-agnostic — any agent's board could trigger a send; observes `agents` (never the reverse), same direction `harness` takes. |
+| `realtime` | **framework** | WebSocket transport (Django Channels + Redis): live-tails the `harness` `TurnEvent` ledger (`turn.{id}`) and pushes `/supervisor` runner-status + waiting-count deltas. Fan-out mirrors `push` (signal/`post_save` → `on_commit` → `group_send`); observes `harness`/`push`/`agents`, never the reverse. Wave 4 (`docs/superpowers/specs/2026-07-16-realtime-chat-cloud-runner-program-design.md`). |
 | `projects` | **product** | Canopy's portfolio/insights feature: repos + which canopy skills ran (`skills[]`, `skill_name`, hygiene-skill frontend). Not a generic registry today — promote to framework only when a real second consumer needs one. |
 | `walkthroughs` | **product** | DDD walkthrough artifacts (HTML/video demos). |
 | `reviews` | **product** | DDD narrative review surface. |

--- a/apps/harness/services.py
+++ b/apps/harness/services.py
@@ -248,6 +248,17 @@ def append_events(turn: Turn, events: list[dict]) -> int:
             for i, e in enumerate(events)
         ]
         TurnEvent.objects.bulk_create(rows)
+
+    # Fire AFTER commit so subscribers (apps/realtime) fan out durable rows and
+    # never race the DB. Local import + on_commit avoids an import-time cycle and
+    # a fan-out on a transaction that ultimately rolls back. bulk_create emits no
+    # post_save, so this signal is the only hook a live tail can ride.
+    def _fire_appended():
+        from apps.harness.signals import turn_events_appended
+
+        turn_events_appended.send(sender=Turn, turn=turn, rows=rows)
+
+    transaction.on_commit(_fire_appended)
     return len(rows)
 
 

--- a/apps/harness/signals.py
+++ b/apps/harness/signals.py
@@ -1,0 +1,16 @@
+"""Domain signals emitted by the harness write path.
+
+`turn_events_appended` fires AFTER an append commits (via transaction.on_commit)
+so a subscriber (apps/realtime) can fan out durable events without racing the DB.
+
+It exists because `services.append_events` uses bulk_create, which does NOT emit
+post_save — a post_save receiver on TurnEvent would silently never fire. Framework
+consumers connect to this instead.
+"""
+from __future__ import annotations
+
+from django.dispatch import Signal
+
+# Sent with: sender=Turn, turn=<Turn>, rows=<list[TurnEvent]> (the newly appended
+# rows, in seq order). Fired post-commit.
+turn_events_appended = Signal()

--- a/apps/realtime/apps.py
+++ b/apps/realtime/apps.py
@@ -1,0 +1,12 @@
+from django.apps import AppConfig
+
+
+class RealtimeConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.realtime"
+    label = "realtime"
+
+    def ready(self) -> None:
+        # Connect fan-out receivers (import for side effect). In ready() so wiring
+        # happens once, after the app registry is populated.
+        from . import signals  # noqa: F401

--- a/apps/realtime/channels_auth.py
+++ b/apps/realtime/channels_auth.py
@@ -1,0 +1,70 @@
+"""WebSocket handshake auth: session cookie first, then Bearer PAT.
+
+Ports ace-web's AceSessionAuthMiddleware. Reads settings.SESSION_COOKIE_NAME
+(sessionid_canopy on connectlabs, sessionid elsewhere) — never hardcoded. Bearer
+resolution reuses apps/tokens (PersonalToken.lookup) so scripted clients — and
+SP4's ace-web — authenticate over WS exactly as they do over REST.
+
+The middleware always sets scope["user"] to a real User or AnonymousUser; the
+per-surface authorization (can this user read this turn?) happens in the consumer.
+"""
+from __future__ import annotations
+
+from http.cookies import SimpleCookie
+from importlib import import_module
+
+from channels.db import database_sync_to_async
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
+
+
+def _header(scope, name: bytes) -> bytes | None:
+    for key, value in scope.get("headers", []):
+        if key == name:
+            return value
+    return None
+
+
+@database_sync_to_async
+def _user_from_session(scope):
+    raw = _header(scope, b"cookie")
+    if not raw:
+        return None
+    jar = SimpleCookie()
+    jar.load(raw.decode("latin1"))
+    morsel = jar.get(settings.SESSION_COOKIE_NAME)
+    if not morsel:
+        return None
+    engine = import_module(settings.SESSION_ENGINE)
+    session = engine.SessionStore(morsel.value)
+    uid = session.get("_auth_user_id")
+    if not uid:
+        return None
+    User = get_user_model()
+    return User.objects.filter(pk=uid, is_active=True).first()
+
+
+@database_sync_to_async
+def _user_from_bearer(scope):
+    raw = _header(scope, b"authorization")
+    if not raw or not raw.lower().startswith(b"bearer "):
+        return None
+    token_value = raw[7:].decode("latin1").strip()
+    if not token_value:
+        return None
+    from apps.tokens.models import PersonalToken
+
+    token = PersonalToken.lookup(token_value)
+    return token.user if token is not None else None
+
+
+class RealtimeAuthMiddleware:
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        user = await _user_from_session(scope) or await _user_from_bearer(scope)
+        scope = dict(scope)
+        scope["user"] = user or AnonymousUser()
+        return await self.app(scope, receive, send)

--- a/apps/realtime/channels_auth.py
+++ b/apps/realtime/channels_auth.py
@@ -15,8 +15,9 @@ from importlib import import_module
 
 from channels.db import database_sync_to_async
 from django.conf import settings
-from django.contrib.auth import get_user_model
+from django.contrib.auth import HASH_SESSION_KEY, SESSION_KEY, get_user_model
 from django.contrib.auth.models import AnonymousUser
+from django.utils.crypto import constant_time_compare
 
 
 def _header(scope, name: bytes) -> bytes | None:
@@ -38,11 +39,20 @@ def _user_from_session(scope):
         return None
     engine = import_module(settings.SESSION_ENGINE)
     session = engine.SessionStore(morsel.value)
-    uid = session.get("_auth_user_id")
+    uid = session.get(SESSION_KEY)
     if not uid:
         return None
     User = get_user_model()
-    return User.objects.filter(pk=uid, is_active=True).first()
+    user = User.objects.filter(pk=uid, is_active=True).first()
+    if user is None:
+        return None
+    # Verify the session auth hash, exactly as django.contrib.auth.get_user does,
+    # so a session a password change SHOULD have invalidated cannot authenticate
+    # over WS until it happens to expire.
+    session_hash = session.get(HASH_SESSION_KEY)
+    if not (session_hash and constant_time_compare(session_hash, user.get_session_auth_hash())):
+        return None
+    return user
 
 
 @database_sync_to_async

--- a/apps/realtime/consumers.py
+++ b/apps/realtime/consumers.py
@@ -19,6 +19,8 @@ from . import groups
 
 
 class TurnConsumer(AsyncJsonWebsocketConsumer):
+    REPLAY_PAGE = 500
+
     async def connect(self):
         user = self.scope.get("user")
         if not getattr(user, "is_authenticated", False):
@@ -36,10 +38,21 @@ class TurnConsumer(AsyncJsonWebsocketConsumer):
         await self.channel_layer.group_add(self.group, self.channel_name)
         await self.accept()
         # Cursor replay: send everything after the client's last-seen seq, then
-        # live-tail via turn_event group messages.
+        # live-tail via turn_event group messages. Paged to exhaustion — a turn
+        # with more than REPLAY_PAGE unseen events (routine on the SP2 chat path,
+        # where a turn streams token-level events) must not be silently truncated:
+        # those rows predate the group join, so the live tail would never re-emit
+        # them, leaving a hole between the replayed page and new appends.
         after = self._after_from_query()
-        for event in await self._replay(turn, after):
-            await self.send_json({"event": event})
+        while True:
+            batch = await self._replay_batch(turn, after)
+            if not batch:
+                break
+            for event in batch:
+                await self.send_json({"event": event})
+            after = batch[-1]["seq"]
+            if len(batch) < self.REPLAY_PAGE:
+                break
 
     async def disconnect(self, code):
         group = getattr(self, "group", None)
@@ -64,8 +77,8 @@ class TurnConsumer(AsyncJsonWebsocketConsumer):
         )
 
     @database_sync_to_async
-    def _replay(self, turn, after: int):
-        rows = turn.events.filter(seq__gt=after).order_by("seq")[:500]
+    def _replay_batch(self, turn, after: int):
+        rows = turn.events.filter(seq__gt=after).order_by("seq")[: self.REPLAY_PAGE]
         return [groups.serialize_turn_event(row) for row in rows]
 
     def _after_from_query(self) -> int:

--- a/apps/realtime/consumers.py
+++ b/apps/realtime/consumers.py
@@ -1,0 +1,79 @@
+"""WebSocket consumers over the realtime transport.
+
+TurnConsumer live-tails one turn's append-only TurnEvent ledger. Replay is
+cursor-based (?after=seq) reusing the same read the REST endpoint uses, then live
+frames arrive via the turn.{id} group. Frames are idempotent on the client by seq.
+
+SupervisorConsumer (Task 7) pushes runner-status + waiting-count deltas.
+"""
+from __future__ import annotations
+
+import uuid
+
+from channels.db import database_sync_to_async
+from channels.generic.websocket import AsyncJsonWebsocketConsumer
+
+from apps.harness.models import Turn
+
+from . import groups
+
+
+class TurnConsumer(AsyncJsonWebsocketConsumer):
+    async def connect(self):
+        user = self.scope.get("user")
+        if not getattr(user, "is_authenticated", False):
+            await self.close(code=4001)
+            return
+        raw_id = self.scope["url_route"]["kwargs"]["turn_id"]
+        turn = await self._get_turn(raw_id)
+        if turn is None:
+            await self.close(code=4004)
+            return
+        if not await database_sync_to_async(groups.user_can_read_turn)(user, turn):
+            await self.close(code=4003)
+            return
+        self.group = groups.turn_group(turn.id)
+        await self.channel_layer.group_add(self.group, self.channel_name)
+        await self.accept()
+        # Cursor replay: send everything after the client's last-seen seq, then
+        # live-tail via turn_event group messages.
+        after = self._after_from_query()
+        for event in await self._replay(turn, after):
+            await self.send_json({"event": event})
+
+    async def disconnect(self, code):
+        group = getattr(self, "group", None)
+        if group:
+            await self.channel_layer.group_discard(group, self.channel_name)
+
+    async def turn_event(self, message):
+        # group_send type="turn.event" dispatches here (dots -> underscores).
+        await self.send_json({"event": message["event"]})
+
+    # -- helpers --
+    @database_sync_to_async
+    def _get_turn(self, raw_id):
+        try:
+            turn_id = uuid.UUID(str(raw_id))
+        except (ValueError, TypeError):
+            return None
+        return (
+            Turn.objects.select_related("agent")
+            .filter(pk=turn_id)
+            .first()
+        )
+
+    @database_sync_to_async
+    def _replay(self, turn, after: int):
+        rows = turn.events.filter(seq__gt=after).order_by("seq")[:500]
+        return [groups.serialize_turn_event(row) for row in rows]
+
+    def _after_from_query(self) -> int:
+        raw = (self.scope.get("query_string") or b"").decode()
+        for part in raw.split("&"):
+            if part.startswith("after="):
+                try:
+                    return int(part[len("after="):])
+                except ValueError:
+                    return 0
+        return 0

--- a/apps/realtime/consumers.py
+++ b/apps/realtime/consumers.py
@@ -77,3 +77,36 @@ class TurnConsumer(AsyncJsonWebsocketConsumer):
                 except ValueError:
                     return 0
         return 0
+
+
+class SupervisorConsumer(AsyncJsonWebsocketConsumer):
+    """Live /supervisor: a per-user group receives runner-status and
+    waiting-count deltas; a snapshot is sent on connect. The socket spans all the
+    user's workspaces (the fleet is cross-tenant, like /insights)."""
+
+    async def connect(self):
+        user = self.scope.get("user")
+        if not getattr(user, "is_authenticated", False):
+            await self.close(code=4001)
+            return
+        self.group = groups.supervisor_user_group(user.id)
+        await self.channel_layer.group_add(self.group, self.channel_name)
+        await self.accept()
+        await self.send_json(await self._snapshot(user))
+
+    async def disconnect(self, code):
+        group = getattr(self, "group", None)
+        if group:
+            await self.channel_layer.group_discard(group, self.channel_name)
+
+    async def supervisor_runner(self, message):
+        await self.send_json(message)
+
+    async def supervisor_waiting(self, message):
+        await self.send_json(message)
+
+    @database_sync_to_async
+    def _snapshot(self, user):
+        from .snapshot import supervisor_snapshot
+
+        return supervisor_snapshot(user)

--- a/apps/realtime/groups.py
+++ b/apps/realtime/groups.py
@@ -1,0 +1,66 @@
+"""Group names, the turn membership gate, event serialization, and a null-safe
+publish helper.
+
+Pure functions (no socket, no async) so they unit-test without Channels. The one
+impure helper, publish(), degrades to a no-op when no channel layer is configured
+or a send fails — realtime is an enhancement, never a hard dependency of a write.
+
+Note: the Workspace PK *is* the slug (workspaces.services.user_workspace_slugs
+compares `workspace_id`), so a turn's tenant is read straight off `workspace_id`
+without dereferencing the Workspace row.
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+
+from asgiref.sync import async_to_sync
+from channels.layers import get_channel_layer
+
+from apps.harness.models import Turn, TurnEvent
+from apps.workspaces.services import user_workspace_slugs
+
+log = logging.getLogger(__name__)
+
+
+def turn_group(turn_id: uuid.UUID | str) -> str:
+    hexid = turn_id.hex if isinstance(turn_id, uuid.UUID) else uuid.UUID(str(turn_id)).hex
+    return f"turn.{hexid}"
+
+
+def supervisor_user_group(user_id: int) -> str:
+    return f"supervisor.user.{user_id}"
+
+
+def turn_workspace_slug(turn: Turn) -> str | None:
+    """The turn's tenant slug: derived from the agent for agent turns, or the
+    turn's own workspace FK for project turns. None when neither is set."""
+    if turn.agent_id:
+        return turn.agent.workspace_id  # workspace PK == slug
+    return turn.workspace_id
+
+
+def user_can_read_turn(user, turn: Turn) -> bool:
+    if not getattr(user, "is_authenticated", False):
+        return False
+    if user.is_superuser:
+        return True
+    slug = turn_workspace_slug(turn)
+    return bool(slug) and slug in user_workspace_slugs(user)
+
+
+def serialize_turn_event(te: TurnEvent) -> dict:
+    return {"seq": te.seq, "kind": te.kind, "payload": te.payload, "ts": te.ts.isoformat()}
+
+
+def publish(group: str, message: dict) -> None:
+    """Fan a message out to a channel-layer group. Never raises: a missing layer
+    or a send failure is logged and swallowed so a realtime hiccup can't break
+    the write that triggered it."""
+    try:
+        layer = get_channel_layer()
+        if layer is None:
+            return
+        async_to_sync(layer.group_send)(group, message)
+    except Exception:  # pragma: no cover - realtime must never break a write
+        log.exception("realtime publish to %s failed", group)

--- a/apps/realtime/routing.py
+++ b/apps/realtime/routing.py
@@ -1,0 +1,13 @@
+"""WebSocket URL routes for the realtime app.
+
+turn_id is matched loosely (hex + dashes) and parsed/validated in the consumer,
+which 4004s an unparsable id rather than 404ing at the router.
+"""
+from django.urls import path, re_path
+
+from . import consumers
+
+websocket_urlpatterns = [
+    re_path(r"^ws/turns/(?P<turn_id>[0-9a-fA-F-]+)/$", consumers.TurnConsumer.as_asgi()),
+    path("ws/supervisor/", consumers.SupervisorConsumer.as_asgi()),
+]

--- a/apps/realtime/signals.py
+++ b/apps/realtime/signals.py
@@ -1,0 +1,74 @@
+"""Fan-out receivers: turn the harness write path into live WS frames.
+
+Mirrors apps/push/signals.py — a signal / post_save receiver schedules a
+group_send on transaction.on_commit. Every publish is null-safe (see
+groups.publish), so a realtime failure never breaks the write that triggered it.
+
+Three sources, three frame types:
+  - turn_events_appended (harness)       -> turn.{id}            "turn.event"
+  - post_save Runner (harness)           -> supervisor.user.{id} "supervisor.runner"
+  - post_save AgentWaitingSnapshot(push) -> supervisor.user.{id} "supervisor.waiting"
+
+turn_events_appended is already sent post-commit (append_events fires it inside
+its own on_commit), so its receiver publishes directly. The two post_save
+receivers fire mid-transaction, so they defer their publish to on_commit.
+"""
+from __future__ import annotations
+
+from django.db import transaction
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from apps.harness.models import Runner
+from apps.harness.signals import turn_events_appended
+from apps.push.models import AgentWaitingSnapshot
+from apps.workspaces.services import workspace_member_ids
+
+from . import groups
+
+
+@receiver(turn_events_appended, dispatch_uid="realtime_turn_events")
+def _on_turn_events(sender, turn, rows, **kwargs):
+    group = groups.turn_group(turn.id)
+    for row in rows:
+        groups.publish(group, {"type": "turn.event", "event": groups.serialize_turn_event(row)})
+
+
+@receiver(post_save, sender=Runner, dispatch_uid="realtime_runner")
+def _on_runner_saved(sender, instance: Runner, **kwargs):
+    # A runner with no pairer has no user to notify (and no derivable tenant).
+    if not instance.paired_by_id:
+        return
+    frame = {
+        "type": "supervisor.runner",
+        "runner": {
+            "id": str(instance.id),
+            "name": instance.name,
+            "kind": instance.kind,
+            "status": instance.live_status,
+            "last_heartbeat_at": (
+                instance.last_heartbeat_at.isoformat() if instance.last_heartbeat_at else None
+            ),
+        },
+    }
+    group = groups.supervisor_user_group(instance.paired_by_id)
+    transaction.on_commit(lambda: groups.publish(group, frame))
+
+
+@receiver(post_save, sender=AgentWaitingSnapshot, dispatch_uid="realtime_waiting")
+def _on_waiting_saved(sender, instance: AgentWaitingSnapshot, **kwargs):
+    agent = instance.agent
+    if not agent.workspace_id:
+        return
+    frame = {
+        "type": "supervisor.waiting",
+        "agent": agent.slug,
+        "waiting_count": instance.waiting_count,
+    }
+    member_ids = workspace_member_ids(agent.workspace)
+
+    def _fire():
+        for uid in member_ids:
+            groups.publish(groups.supervisor_user_group(uid), frame)
+
+    transaction.on_commit(_fire)

--- a/apps/realtime/snapshot.py
+++ b/apps/realtime/snapshot.py
@@ -1,0 +1,47 @@
+"""The /supervisor connect snapshot — current runner status + per-agent waiting
+counts for a user, built request-free (a socket has no HttpRequest and is not
+tenant-pinned, so it uses the same 'unpinned' visibility branch the REST
+_visible_agent_workspace_ids / _runner_visibility_q use)."""
+from __future__ import annotations
+
+from django.db.models import Q
+
+from apps.agents import services as agent_services
+from apps.harness.models import Runner
+from apps.workspaces import services as wsvc
+
+
+def _runner_frame(runner: Runner) -> dict:
+    return {
+        "id": str(runner.id),
+        "name": runner.name,
+        "kind": runner.kind,
+        "status": runner.live_status,
+        "last_heartbeat_at": (
+            runner.last_heartbeat_at.isoformat() if runner.last_heartbeat_at else None
+        ),
+    }
+
+
+def supervisor_snapshot(user) -> dict:
+    wsvc.auto_join_workspaces(user)
+    slugs = set(wsvc.user_workspace_slugs(user))
+
+    agents = [
+        a
+        for a in agent_services.list_agents()
+        if a.workspace_id in slugs or a.workspace_id is None
+    ]
+    waiting = {a.slug: int(agent_services.needs_you(a).get("waiting_count") or 0) for a in agents}
+
+    runners = Runner.objects.exclude(status=Runner.RETIRED).filter(
+        (Q(workspace_id__in=slugs) | Q(workspace_id__isnull=True))
+        & (Q(paired_by=user) | Q(paired_by__isnull=True))
+    )
+
+    return {
+        "type": "supervisor.snapshot",
+        "runners": [_runner_frame(r) for r in runners],
+        "waiting": waiting,
+        "total_waiting": sum(waiting.values()),
+    }

--- a/apps/workspaces/services.py
+++ b/apps/workspaces/services.py
@@ -119,6 +119,12 @@ def workspace_slugs_for_user_id(user_id) -> set[str]:
     return user_workspace_slugs(user)
 
 
+def workspace_member_ids(ws) -> list[int]:
+    """User ids of every member of a workspace. Used to fan a supervisor update
+    out to each member's live socket."""
+    return list(ws.memberships.values_list("user_id", flat=True))
+
+
 def user_default_workspace(user) -> Workspace | None:
     """The user's workspace when unambiguous — their sole membership, else None
     (0 or 2+ memberships). Used to resolve a default for headless PAT callers."""

--- a/config/asgi.py
+++ b/config/asgi.py
@@ -26,10 +26,14 @@ from django.core.asgi import get_asgi_application  # noqa: E402
 # import services/models).
 _django_asgi_app = get_asgi_application()
 
+from channels.routing import ProtocolTypeRouter, URLRouter  # noqa: E402
+from channels.security.websocket import AllowedHostsOriginValidator  # noqa: E402
 from starlette.applications import Starlette  # noqa: E402
 from starlette.routing import Mount  # noqa: E402
 
 from apps.mcp.server import build_http_app  # noqa: E402
+from apps.realtime.channels_auth import RealtimeAuthMiddleware  # noqa: E402
+from apps.realtime.routing import websocket_urlpatterns  # noqa: E402
 
 _MCP_PREFIX = "/api/mcp"
 
@@ -37,11 +41,22 @@ _MCP_PREFIX = "/api/mcp"
 # root, i.e. /api/mcp/.
 _mcp_app = build_http_app()
 
+# The catch-all: HTTP goes to Django as before; WebSocket goes through the
+# realtime handshake auth + URL router (apps/realtime). Same shape ace-web uses.
+_django_with_ws = ProtocolTypeRouter(
+    {
+        "http": _django_asgi_app,
+        "websocket": AllowedHostsOriginValidator(
+            RealtimeAuthMiddleware(URLRouter(websocket_urlpatterns))
+        ),
+    }
+)
+
 application = Starlette(
     routes=[
         Mount(_MCP_PREFIX, app=_mcp_app),
-        # Django handles everything else (mounted last as the catch-all).
-        Mount("/", app=_django_asgi_app),
+        # Django + realtime WS handle everything else (mounted last as catch-all).
+        Mount("/", app=_django_with_ws),
     ],
     # Run the MCP session-manager lifespan for the whole process.
     lifespan=_mcp_app.lifespan,

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -145,6 +145,9 @@ if _CHANNELS_REDIS_URL:
     CHANNEL_LAYERS = {
         "default": {
             "BACKEND": "channels_redis.core.RedisChannelLayer",
+            # prefix namespaces channel keys away from the Django cache on the
+            # same Redis DB (it does not survive a FLUSHDB, but cache.clear() is
+            # not on a prod path).
             "CONFIG": {"hosts": [_CHANNELS_REDIS_URL], "prefix": "canopy:realtime:"},
         }
     }

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -73,6 +73,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     # Third-party
+    "channels",
     "corsheaders",
     "allauth",
     "allauth.account",
@@ -96,6 +97,7 @@ INSTALLED_APPS = [
     "apps.timeline",
     "apps.system",
     "apps.harness",
+    "apps.realtime",
 ]
 
 MIDDLEWARE = [
@@ -133,6 +135,21 @@ TEMPLATES = [
 ]
 
 ASGI_APPLICATION = "config.asgi.application"
+
+# --- Channels realtime layer (apps/realtime) -------------------------
+# In-memory by default so a fresh checkout / single-process runserver works with
+# zero infra. When REDIS_URL is set (docker-compose, prod) use the Redis layer so
+# fan-out crosses processes/containers. Tests keep the in-memory layer.
+_CHANNELS_REDIS_URL = env("REDIS_URL", default="")
+if _CHANNELS_REDIS_URL:
+    CHANNEL_LAYERS = {
+        "default": {
+            "BACKEND": "channels_redis.core.RedisChannelLayer",
+            "CONFIG": {"hosts": [_CHANNELS_REDIS_URL], "prefix": "canopy:realtime:"},
+        }
+    }
+else:
+    CHANNEL_LAYERS = {"default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}}
 
 # Database
 DATABASES = {

--- a/config/settings/connectlabs.py
+++ b/config/settings/connectlabs.py
@@ -65,3 +65,12 @@ if _REDIS_URL:
             "LOCATION": _REDIS_URL,
         }
     }
+    # W4: the Channels layer lands here now that `channels` is a dependency. A
+    # dedicated prefix keeps channel-layer pub/sub from colliding with the Django
+    # cache on the same shared ElastiCache instance.
+    CHANNEL_LAYERS = {
+        "default": {
+            "BACKEND": "channels_redis.core.RedisChannelLayer",
+            "CONFIG": {"hosts": [_REDIS_URL], "prefix": "canopy:realtime:"},
+        }
+    }

--- a/config/settings/connectlabs.py
+++ b/config/settings/connectlabs.py
@@ -65,9 +65,11 @@ if _REDIS_URL:
             "LOCATION": _REDIS_URL,
         }
     }
-    # W4: the Channels layer lands here now that `channels` is a dependency. A
-    # dedicated prefix keeps channel-layer pub/sub from colliding with the Django
-    # cache on the same shared ElastiCache instance.
+    # W4: the Channels layer lands here now that `channels` is a dependency. The
+    # prefix namespaces channel-layer keys so they don't COLLIDE with the Django
+    # cache on the same shared ElastiCache DB index. (It does not protect against
+    # a cache FLUSHDB, which ignores prefixes — but cache.clear() is never on a
+    # prod path here, and clients rebuild from durable DB state on reconnect.)
     CHANNEL_LAYERS = {
         "default": {
             "BACKEND": "channels_redis.core.RedisChannelLayer",

--- a/docs/superpowers/plans/2026-07-16-sp1-realtime-substrate.md
+++ b/docs/superpowers/plans/2026-07-16-sp1-realtime-substrate.md
@@ -1,0 +1,734 @@
+# SP1 — Realtime Substrate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give canopy-web its first realtime transport (Django Channels + Redis) and put two surfaces live over it — the per-turn `TurnEvent` ledger tail and `/supervisor` — with no new domain model.
+
+**Architecture:** A new framework app `apps/realtime` holds two `AsyncJsonWebsocketConsumer`s. The write path stays untouched except for one harness-owned signal (needed because `append_events` uses `bulk_create`, which skips `post_save`). Fanout mirrors `apps/push`: signal/`post_save` → `transaction.on_commit` → `channel_layer.group_send`. The turn tail replays via the existing `?after=seq` cursor then live-tails; `/supervisor` sends a snapshot then deltas. `config/asgi.py`'s Starlette router gains a Channels `ProtocolTypeRouter` for the `websocket` scope.
+
+**Tech Stack:** Django 5 ASGI, `channels`, `channels_redis`, uvicorn, Redis (ElastiCache in prod, in-memory layer in dev/tests), React 19 + Vite (vitest), plain browser `WebSocket`.
+
+## Global Constraints
+
+- Framework/product boundary: `apps/realtime` is **framework**; may import only framework apps (`harness`, `agents`, `workspaces`, `tokens`, `push`, `common`); never a product app. Add it to `FRAMEWORK` in `tests/test_architecture_boundary.py` and the `ARCHITECTURE.md` tier table.
+- Realtime is an enhancement, never a hard dependency: a missing/misconfigured channel layer must degrade to a no-op, never raise in a write path.
+- WS auth reads `settings.SESSION_COOKIE_NAME` (it is `sessionid_canopy` on connectlabs, `sessionid` elsewhere) — never hardcode the cookie name.
+- Respect the `/canopy` `FORCE_SCRIPT_NAME` prefix; `config/asgi_prefix.py::StripScriptName` already strips it for `websocket` scopes.
+- Dependency floors: `channels>=4.1,<5.0`, `channels-redis>=4.2,<5.0`.
+- Python deps via `uv` (uv.lock committed); backend tests `uv run pytest`; frontend `cd frontend && npm run build` / `npx vitest`.
+
+---
+
+### Task 1: Scaffold the `realtime` app + Channels deps + settings
+
+**Files:**
+- Modify: `pyproject.toml` (add `channels`, `channels-redis`)
+- Create: `apps/realtime/__init__.py`, `apps/realtime/apps.py`
+- Modify: `config/settings/base.py` (INSTALLED_APPS + `CHANNEL_LAYERS`)
+- Modify: `config/settings/connectlabs.py` (Redis channel layer)
+- Modify: `tests/test_architecture_boundary.py` (add `realtime` to FRAMEWORK)
+- Modify: `ARCHITECTURE.md` (tier table)
+- Test: `tests/test_architecture_boundary.py` (existing), `apps/realtime/tests/test_app.py`
+
+**Interfaces:**
+- Produces: the `apps.realtime` app label; `CHANNEL_LAYERS["default"]` configured (InMemory when no `REDIS_URL`, `RedisChannelLayer` when set).
+
+- [ ] **Step 1:** Add deps to `pyproject.toml` `dependencies` list:
+```toml
+    "channels>=4.1,<5.0",
+    "channels-redis>=4.2,<5.0",
+```
+- [ ] **Step 2:** `uv sync --extra dev` (updates uv.lock). Expected: resolves channels + channels-redis.
+- [ ] **Step 3:** Create `apps/realtime/__init__.py` (empty) and `apps/realtime/apps.py`:
+```python
+from django.apps import AppConfig
+
+
+class RealtimeConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.realtime"
+    label = "realtime"
+
+    def ready(self) -> None:
+        # Connect fanout receivers (import for side effect). Kept in ready() so
+        # signal wiring happens exactly once, after the app registry is populated.
+        from . import signals  # noqa: F401
+```
+(Task 4 creates `signals.py`; until then, add a temporary empty `apps/realtime/signals.py` so `ready()` imports cleanly.)
+- [ ] **Step 4:** Add `"apps.realtime",` to `INSTALLED_APPS` in `config/settings/base.py` (after `"apps.harness",`). **Channels ordering note:** `channels` must be listed too — add `"channels",` to INSTALLED_APPS *above* the Local apps block (Channels needs to be installed for `ASGI_APPLICATION`/runworker, though we drive ASGI via Starlette).
+- [ ] **Step 5:** Add to `config/settings/base.py` after `ASGI_APPLICATION`:
+```python
+# --- Channels realtime layer (apps/realtime) -------------------------
+# In-memory by default so a fresh checkout / single-process runserver works with
+# zero infra. When REDIS_URL is set (docker-compose, prod) use the Redis layer so
+# fan-out crosses processes/containers. Tests force InMemory (see test settings).
+_CHANNELS_REDIS_URL = env("REDIS_URL", default="")
+if _CHANNELS_REDIS_URL:
+    CHANNEL_LAYERS = {
+        "default": {
+            "BACKEND": "channels_redis.core.RedisChannelLayer",
+            "CONFIG": {"hosts": [_CHANNELS_REDIS_URL], "prefix": "canopy:realtime:"},
+        }
+    }
+else:
+    CHANNEL_LAYERS = {"default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}}
+```
+- [ ] **Step 6:** In `config/settings/connectlabs.py`, replace the "Channels layer lands with W4" comment block's tail by adding, inside the `if _REDIS_URL:` block after `CACHES = {...}`:
+```python
+    CHANNEL_LAYERS = {
+        "default": {
+            "BACKEND": "channels_redis.core.RedisChannelLayer",
+            # Dedicated prefix so channel-layer pub/sub never collides with the
+            # Django cache on the same shared ElastiCache instance.
+            "CONFIG": {"hosts": [_REDIS_URL], "prefix": "canopy:realtime:"},
+        }
+    }
+```
+- [ ] **Step 7:** In `tests/test_architecture_boundary.py`, add `"realtime"` to the `FRAMEWORK` set.
+- [ ] **Step 8:** In `ARCHITECTURE.md`, add a `realtime` row to the framework tier table (one line: "realtime — Channels WS transport; pushes the harness ledger + supervisor live").
+- [ ] **Step 9:** Create `apps/realtime/tests/__init__.py` and `apps/realtime/tests/test_app.py`:
+```python
+from django.apps import apps
+
+
+def test_realtime_app_is_installed():
+    assert apps.is_installed("apps.realtime")
+
+
+def test_channel_layers_configured(settings):
+    assert "default" in settings.CHANNEL_LAYERS
+```
+- [ ] **Step 10:** Run `uv run pytest tests/test_architecture_boundary.py apps/realtime/tests/test_app.py -q`. Expected: PASS.
+- [ ] **Step 11:** Commit: `feat(realtime): scaffold framework app + channels deps + channel layer`
+
+---
+
+### Task 2: `groups.py` — group names, membership gates, null-safe publish, serialization
+
+**Files:**
+- Create: `apps/realtime/groups.py`
+- Test: `apps/realtime/tests/test_groups.py`
+
+**Interfaces:**
+- Produces:
+  - `turn_group(turn_id: uuid.UUID | str) -> str`
+  - `supervisor_user_group(user_id: int) -> str`
+  - `user_can_read_turn(user, turn: Turn) -> bool`
+  - `serialize_turn_event(te: TurnEvent) -> dict` → `{"seq", "kind", "payload", "ts"}`
+  - `publish(group: str, message: dict) -> None` (null-safe; no-op if no channel layer)
+
+- [ ] **Step 1:** Write `apps/realtime/tests/test_groups.py`:
+```python
+import uuid
+import pytest
+from apps.realtime import groups
+
+
+def test_turn_group_is_stable():
+    tid = uuid.uuid4()
+    assert groups.turn_group(tid) == f"turn.{tid.hex}"
+    assert groups.turn_group(str(tid)) == groups.turn_group(tid)
+
+
+def test_supervisor_user_group():
+    assert groups.supervisor_user_group(7) == "supervisor.user.7"
+
+
+@pytest.mark.django_db
+def test_user_can_read_turn_by_workspace(agent_factory, user_factory, turn_factory, membership_factory):
+    ws_user = user_factory()
+    agent = agent_factory()  # belongs to a workspace
+    membership_factory(user=ws_user, workspace=agent.workspace)
+    turn = turn_factory(agent=agent)
+    assert groups.user_can_read_turn(ws_user, turn) is True
+    assert groups.user_can_read_turn(user_factory(), turn) is False
+
+
+def test_publish_is_noop_without_layer(settings):
+    settings.CHANNEL_LAYERS = {}
+    # must not raise
+    groups.publish("turn.x", {"type": "turn.event", "seq": 1})
+```
+(If those factories don't exist, use inline ORM creation in the test — see existing `apps/harness/tests` conftest for fixtures; reuse them.)
+- [ ] **Step 2:** Run the test → FAIL (module missing).
+- [ ] **Step 3:** Write `apps/realtime/groups.py`:
+```python
+"""Group names, membership gates, and a null-safe publish helper.
+
+Pure functions (no socket, no async) so they unit-test without Channels. The
+one impure helper, publish(), degrades to a no-op when no channel layer is
+configured — realtime is an enhancement, never a hard dependency of a write.
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+
+from asgiref.sync import async_to_sync
+from channels.layers import get_channel_layer
+
+from apps.harness.models import Turn, TurnEvent
+from apps.workspaces.services import user_workspace_slugs
+
+log = logging.getLogger(__name__)
+
+
+def turn_group(turn_id: uuid.UUID | str) -> str:
+    hexid = turn_id.hex if isinstance(turn_id, uuid.UUID) else uuid.UUID(str(turn_id)).hex
+    return f"turn.{hexid}"
+
+
+def supervisor_user_group(user_id: int) -> str:
+    return f"supervisor.user.{user_id}"
+
+
+def turn_workspace_slug(turn: Turn) -> str | None:
+    if turn.agent_id:
+        return turn.agent.workspace.slug if turn.agent.workspace_id else None
+    return turn.workspace.slug if turn.workspace_id else None
+
+
+def user_can_read_turn(user, turn: Turn) -> bool:
+    if not getattr(user, "is_authenticated", False):
+        return False
+    if user.is_superuser:
+        return True
+    slug = turn_workspace_slug(turn)
+    return bool(slug) and slug in user_workspace_slugs(user)
+
+
+def serialize_turn_event(te: TurnEvent) -> dict:
+    return {"seq": te.seq, "kind": te.kind, "payload": te.payload, "ts": te.ts.isoformat()}
+
+
+def publish(group: str, message: dict) -> None:
+    layer = get_channel_layer()
+    if layer is None:
+        return
+    try:
+        async_to_sync(layer.group_send)(group, message)
+    except Exception:  # pragma: no cover - realtime must never break a write
+        log.exception("realtime publish to %s failed", group)
+```
+- [ ] **Step 4:** Run `uv run pytest apps/realtime/tests/test_groups.py -q`. Expected: PASS.
+- [ ] **Step 5:** Commit: `feat(realtime): group names, membership gate, null-safe publish`
+
+---
+
+### Task 3: harness `turn_events_appended` signal fired from `append_events`
+
+**Files:**
+- Create: `apps/harness/signals.py`
+- Modify: `apps/harness/services.py` (`append_events`)
+- Test: `apps/harness/tests/test_events_signal.py`
+
+**Interfaces:**
+- Produces: `apps.harness.signals.turn_events_appended` — a `django.dispatch.Signal` sent with `sender=Turn, turn=<Turn>, rows=<list[TurnEvent]>` **after commit**.
+
+- [ ] **Step 1:** Write `apps/harness/tests/test_events_signal.py`:
+```python
+import pytest
+from django.db import transaction
+from apps.harness import services
+from apps.harness.signals import turn_events_appended
+
+
+@pytest.mark.django_db
+def test_append_events_fires_signal_after_commit(turn_factory):
+    turn = turn_factory()
+    received = []
+    turn_events_appended.connect(lambda **kw: received.append(kw), weak=False)
+    services.append_events(turn, [{"kind": "assistant", "payload": {"text": "hi"}}])
+    assert len(received) == 1
+    assert received[0]["turn"].pk == turn.pk
+    assert [r.seq for r in received[0]["rows"]] == [1]
+```
+- [ ] **Step 2:** Run → FAIL (no `signals` module).
+- [ ] **Step 3:** Create `apps/harness/signals.py`:
+```python
+"""Domain signals emitted by the harness write path.
+
+`turn_events_appended` fires AFTER the append commits (via transaction.on_commit)
+so a subscriber (apps/realtime) can fan out durable events without racing the DB.
+It exists because append_events uses bulk_create, which does NOT emit post_save —
+a post_save receiver on TurnEvent would silently never fire.
+"""
+from django.dispatch import Signal
+
+# providing_args (informational): turn: Turn, rows: list[TurnEvent]
+turn_events_appended = Signal()
+```
+- [ ] **Step 4:** In `apps/harness/services.py`, modify `append_events` to fire the signal on commit. Replace the function body's tail:
+```python
+def append_events(turn: Turn, events: list[dict]) -> int:
+    with transaction.atomic():
+        Turn.objects.select_for_update().get(pk=turn.pk)
+        current = (
+            TurnEvent.objects.filter(turn=turn).aggregate(m=Max("seq"))["m"] or 0
+        )
+        rows = [
+            TurnEvent(turn=turn, seq=current + i + 1, kind=e["kind"], payload=e.get("payload", {}))
+            for i, e in enumerate(events)
+        ]
+        TurnEvent.objects.bulk_create(rows)
+
+    def _fire():
+        from apps.harness.signals import turn_events_appended
+        turn_events_appended.send(sender=Turn, turn=turn, rows=rows)
+
+    transaction.on_commit(_fire)
+    return len(rows)
+```
+(Import stays local to avoid import-time cycles.)
+- [ ] **Step 5:** Run `uv run pytest apps/harness/tests/test_events_signal.py -q`. Expected: PASS. Then run the full harness suite `uv run pytest apps/harness -q` to confirm no regression (append_events is on a hot path).
+- [ ] **Step 6:** Commit: `feat(harness): emit turn_events_appended signal on commit`
+
+---
+
+### Task 4: `realtime/signals.py` — the three fanout receivers
+
+**Files:**
+- Modify: `apps/realtime/signals.py` (replace the temporary empty file)
+- Test: `apps/realtime/tests/test_fanout.py`
+
+**Interfaces:**
+- Consumes: `apps.harness.signals.turn_events_appended`, `post_save` on `apps.harness.models.Runner`, `post_save` on `apps.push.models.AgentWaitingSnapshot`; `groups.publish`, `groups.turn_group`, `groups.supervisor_user_group`, `groups.serialize_turn_event`.
+- Produces: live frames `{"type": "turn.event", ...}`, `{"type": "supervisor.runner", ...}`, `{"type": "supervisor.waiting", ...}` on the right groups.
+
+- [ ] **Step 1:** Write `apps/realtime/tests/test_fanout.py` (uses InMemory layer + `capture_on_commit_callbacks`):
+```python
+import pytest
+from django.test import TestCase
+from channels.layers import get_channel_layer
+from asgiref.sync import async_to_sync
+from apps.harness import services
+from apps.realtime import groups
+
+
+@pytest.mark.django_db(transaction=True)
+def test_turn_event_fanout(turn_factory, django_capture_on_commit_callbacks):
+    turn = turn_factory()
+    layer = get_channel_layer()
+    async_to_sync(layer.group_add)(groups.turn_group(turn.id), "test-chan")
+    with django_capture_on_commit_callbacks(execute=True):
+        services.append_events(turn, [{"kind": "assistant", "payload": {"text": "hi"}}])
+    msg = async_to_sync(layer.receive)("test-chan")
+    assert msg["type"] == "turn.event"
+    assert msg["event"]["seq"] == 1
+```
+(Add analogous `test_runner_fanout` saving a Runner and asserting a `supervisor.runner` frame on `supervisor_user_group(runner.paired_by_id)`, and `test_waiting_fanout` by calling `apps.push.services.refresh_agent_waiting`.)
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3:** Write `apps/realtime/signals.py`:
+```python
+"""Fan-out receivers: turn the harness write path into live WS frames.
+
+Mirrors apps/push/signals.py — post_save/custom-signal → transaction.on_commit →
+group_send. Every publish is wrapped so a realtime failure never breaks a write.
+"""
+from __future__ import annotations
+
+from django.db import transaction
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from apps.harness.models import Runner
+from apps.harness.signals import turn_events_appended
+from apps.push.models import AgentWaitingSnapshot
+from apps.workspaces.services import workspace_member_ids
+from . import groups
+
+
+@receiver(turn_events_appended, dispatch_uid="realtime_turn_events")
+def _on_turn_events(sender, turn, rows, **kwargs):
+    payload_group = groups.turn_group(turn.id)
+    events = [groups.serialize_turn_event(r) for r in rows]
+    # already inside on_commit (append_events fires post-commit); publish directly.
+    for ev in events:
+        groups.publish(payload_group, {"type": "turn.event", "event": ev})
+
+
+@receiver(post_save, sender=Runner, dispatch_uid="realtime_runner")
+def _on_runner_saved(sender, instance: Runner, **kwargs):
+    if not instance.paired_by_id:
+        return
+    frame = {
+        "type": "supervisor.runner",
+        "runner": {
+            "id": str(instance.id),
+            "name": instance.name,
+            "kind": instance.kind,
+            "status": instance.live_status,
+            "last_heartbeat_at": instance.last_heartbeat_at.isoformat() if instance.last_heartbeat_at else None,
+        },
+    }
+    grp = groups.supervisor_user_group(instance.paired_by_id)
+    transaction.on_commit(lambda: groups.publish(grp, frame))
+
+
+@receiver(post_save, sender=AgentWaitingSnapshot, dispatch_uid="realtime_waiting")
+def _on_waiting_saved(sender, instance: AgentWaitingSnapshot, **kwargs):
+    agent = instance.agent
+    if not agent.workspace_id:
+        return
+    frame = {
+        "type": "supervisor.waiting",
+        "agent": agent.slug,
+        "waiting_count": instance.waiting_count,
+    }
+    user_ids = list(workspace_member_ids(agent.workspace))
+    def _fire():
+        for uid in user_ids:
+            groups.publish(groups.supervisor_user_group(uid), frame)
+    transaction.on_commit(_fire)
+```
+- [ ] **Step 4:** Add `workspace_member_ids(ws) -> list[int]` to `apps/workspaces/services.py` if it doesn't exist:
+```python
+def workspace_member_ids(ws) -> list[int]:
+    return list(ws.memberships.values_list("user_id", flat=True))
+```
+(Check the membership related_name first; adjust `.memberships` to the actual accessor.)
+- [ ] **Step 5:** Run `uv run pytest apps/realtime/tests/test_fanout.py -q`. Expected: PASS.
+- [ ] **Step 6:** Commit: `feat(realtime): fan-out receivers for turn events + supervisor`
+
+---
+
+### Task 5: `channels_auth.py` — cookie-then-Bearer handshake middleware
+
+**Files:**
+- Create: `apps/realtime/channels_auth.py`
+- Test: `apps/realtime/tests/test_channels_auth.py`
+
+**Interfaces:**
+- Produces: `RealtimeAuthMiddleware(app)` — an ASGI middleware that sets `scope["user"]` (a real `User` or `AnonymousUser`) from the session cookie first, then `Authorization: Bearer <PAT>`.
+
+- [ ] **Step 1:** Write `apps/realtime/tests/test_channels_auth.py` — connect a `WebsocketCommunicator` through the middleware wrapping a probe consumer that echoes `scope["user"].is_authenticated`; assert anon by default, authed with a valid session cookie, authed with a valid Bearer PAT. (See existing token tests in `apps/tokens/tests` for how to mint a PAT.)
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3:** Write `apps/realtime/channels_auth.py`:
+```python
+"""WebSocket handshake auth: session cookie first, then Bearer PAT.
+
+Ports ace-web's AceSessionAuthMiddleware. Reads settings.SESSION_COOKIE_NAME
+(sessionid_canopy on connectlabs) — never hardcoded. Bearer resolution reuses
+apps/tokens so scripted clients (and SP4's ace-web) authenticate the same way
+they do over REST.
+"""
+from __future__ import annotations
+
+from http.cookies import SimpleCookie
+
+from asgiref.sync import sync_to_async
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
+from importlib import import_module
+
+
+def _header(scope, name: bytes) -> bytes | None:
+    for k, v in scope.get("headers", []):
+        if k == name:
+            return v
+    return None
+
+
+@sync_to_async
+def _user_from_session(scope):
+    raw = _header(scope, b"cookie")
+    if not raw:
+        return None
+    cookies = SimpleCookie()
+    cookies.load(raw.decode("latin1"))
+    morsel = cookies.get(settings.SESSION_COOKIE_NAME)
+    if not morsel:
+        return None
+    engine = import_module(settings.SESSION_ENGINE)
+    session = engine.SessionStore(morsel.value)
+    uid = session.get("_auth_user_id")
+    if not uid:
+        return None
+    User = get_user_model()
+    return User.objects.filter(pk=uid, is_active=True).first()
+
+
+@sync_to_async
+def _user_from_bearer(scope):
+    raw = _header(scope, b"authorization")
+    if not raw or not raw.lower().startswith(b"bearer "):
+        return None
+    token = raw[7:].decode("latin1").strip()
+    from apps.tokens.services import resolve_token  # returns User | None
+    return resolve_token(token)
+
+
+class RealtimeAuthMiddleware:
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        user = await _user_from_session(scope) or await _user_from_bearer(scope)
+        scope = dict(scope)
+        scope["user"] = user or AnonymousUser()
+        return await self.app(scope, receive, send)
+```
+(Verify the token resolver: it's whatever `apps/tokens/middleware.py::BearerTokenAuthMiddleware` calls — reuse that exact function; adjust the import to match.)
+- [ ] **Step 4:** Run `uv run pytest apps/realtime/tests/test_channels_auth.py -q`. Expected: PASS.
+- [ ] **Step 5:** Commit: `feat(realtime): cookie-then-Bearer WS handshake auth`
+
+---
+
+### Task 6: `TurnConsumer` — per-turn ledger tail
+
+**Files:**
+- Create: `apps/realtime/consumers.py` (TurnConsumer)
+- Test: `apps/realtime/tests/test_turn_consumer.py`
+
+**Interfaces:**
+- Consumes: `groups.turn_group`, `groups.user_can_read_turn`, `groups.serialize_turn_event`, the harness `Turn` model + `?after=seq` read.
+- Produces: WS frames — on connect, replayed `{"event": {seq,kind,payload,ts}}` then live `turn.event` frames. Close codes: `4001` anon, `4003` forbidden, `4004` turn not found.
+
+- [ ] **Step 1:** Write `apps/realtime/tests/test_turn_consumer.py`:
+```python
+import uuid
+import pytest
+from channels.testing import WebsocketCommunicator
+from apps.realtime.consumers import TurnConsumer
+from apps.harness import services
+
+
+def _app():
+    return TurnConsumer.as_asgi()
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_anon_rejected(user_factory, turn_factory):
+    turn = await sync_turn(turn_factory)
+    comm = WebsocketCommunicator(_app(), f"/ws/turns/{turn.id}/")
+    comm.scope["user"] = AnonymousUser()
+    comm.scope["url_route"] = {"kwargs": {"turn_id": str(turn.id)}}
+    connected, code = await comm.connect()
+    assert not connected
+```
+(Fill in helpers; assert: non-member → 4003; member → receives replay of a pre-existing event then a live event appended via `services.append_events` after connect. Set `comm.scope["user"]` and `comm.scope["url_route"]` manually since we bypass the router in unit tests.)
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3:** Write `TurnConsumer` in `apps/realtime/consumers.py`:
+```python
+"""WebSocket consumers over the realtime transport.
+
+TurnConsumer: live-tail one turn's append-only TurnEvent ledger. Replay is
+cursor-based (?after=seq) reusing the same read the REST endpoint uses, then
+live frames arrive via the turn.{id} group. Idempotent on the client by seq.
+"""
+from __future__ import annotations
+
+import uuid
+
+from asgiref.sync import sync_to_async
+from channels.generic.websocket import AsyncJsonWebsocketConsumer
+
+from apps.harness.models import Turn
+from . import groups
+
+
+class TurnConsumer(AsyncJsonWebsocketConsumer):
+    async def connect(self):
+        user = self.scope.get("user")
+        if not getattr(user, "is_authenticated", False):
+            await self.close(code=4001)
+            return
+        raw_id = self.scope["url_route"]["kwargs"]["turn_id"]
+        turn = await self._get_turn(raw_id)
+        if turn is None:
+            await self.close(code=4004)
+            return
+        if not await sync_to_async(groups.user_can_read_turn)(user, turn):
+            await self.close(code=4003)
+            return
+        self.turn = turn
+        self.group = groups.turn_group(turn.id)
+        await self.channel_layer.group_add(self.group, self.channel_name)
+        await self.accept()
+        # Cursor replay: ?after=<seq> (default 0), then live-tail.
+        after = self._after_from_query()
+        for ev in await self._replay(turn, after):
+            await self.send_json({"event": ev})
+
+    async def disconnect(self, code):
+        grp = getattr(self, "group", None)
+        if grp:
+            await self.channel_layer.group_discard(grp, self.channel_name)
+
+    async def turn_event(self, message):
+        # group_send type="turn.event" -> this handler. Forward the event frame.
+        await self.send_json({"event": message["event"]})
+
+    # -- helpers --
+    @sync_to_async
+    def _get_turn(self, raw_id):
+        try:
+            return Turn.objects.select_related("agent", "agent__workspace", "workspace").get(pk=uuid.UUID(str(raw_id)))
+        except (Turn.DoesNotExist, ValueError):
+            return None
+
+    @sync_to_async
+    def _replay(self, turn, after):
+        qs = turn.events.filter(seq__gt=after).order_by("seq")[:500]
+        return [groups.serialize_turn_event(e) for e in qs]
+
+    def _after_from_query(self):
+        qs = (self.scope.get("query_string") or b"").decode()
+        for part in qs.split("&"):
+            if part.startswith("after="):
+                try:
+                    return int(part[6:])
+                except ValueError:
+                    return 0
+        return 0
+```
+- [ ] **Step 4:** Run `uv run pytest apps/realtime/tests/test_turn_consumer.py -q`. Expected: PASS.
+- [ ] **Step 5:** Commit: `feat(realtime): TurnConsumer live-tails the turn ledger`
+
+---
+
+### Task 7: `SupervisorConsumer` — live runner status + waiting counts
+
+**Files:**
+- Modify: `apps/realtime/consumers.py` (add SupervisorConsumer)
+- Test: `apps/realtime/tests/test_supervisor_consumer.py`
+
+**Interfaces:**
+- Consumes: `groups.supervisor_user_group`; a snapshot builder that reuses the same services `/supervisor` REST reads (runners visible to the user + per-agent waiting counts).
+- Produces: on connect, one `{"type":"supervisor.snapshot","runners":[...],"waiting":{slug:count}}`; then `supervisor.runner` / `supervisor.waiting` deltas.
+
+- [ ] **Step 1:** Write `apps/realtime/tests/test_supervisor_consumer.py`: anon → 4001; authed → receives a snapshot frame; after a `Runner.save()` (heartbeat) the socket receives a `supervisor.runner` delta.
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3:** Add `SupervisorConsumer` to `apps/realtime/consumers.py`:
+```python
+class SupervisorConsumer(AsyncJsonWebsocketConsumer):
+    async def connect(self):
+        user = self.scope.get("user")
+        if not getattr(user, "is_authenticated", False):
+            await self.close(code=4001)
+            return
+        self.group = groups.supervisor_user_group(user.id)
+        await self.channel_layer.group_add(self.group, self.channel_name)
+        await self.accept()
+        await self.send_json(await self._snapshot(user))
+
+    async def disconnect(self, code):
+        grp = getattr(self, "group", None)
+        if grp:
+            await self.channel_layer.group_discard(grp, self.channel_name)
+
+    async def supervisor_runner(self, message):
+        await self.send_json(message)
+
+    async def supervisor_waiting(self, message):
+        await self.send_json(message)
+
+    @sync_to_async
+    def _snapshot(self, user):
+        from apps.realtime.snapshot import supervisor_snapshot
+        return supervisor_snapshot(user)
+```
+- [ ] **Step 4:** Create `apps/realtime/snapshot.py::supervisor_snapshot(user) -> dict` that reuses the existing supervisor read services (the same ones `SupervisorPage` fetches — the fleet needs-you + runner list visible to `user`). Return `{"type": "supervisor.snapshot", "runners": [...], "waiting": {slug: count}}`. Match the field shapes the REST endpoints already return so the frontend view-model is unchanged.
+- [ ] **Step 5:** Run `uv run pytest apps/realtime/tests/test_supervisor_consumer.py -q`. Expected: PASS.
+- [ ] **Step 6:** Commit: `feat(realtime): SupervisorConsumer snapshot + live deltas`
+
+---
+
+### Task 8: `routing.py` + ASGI websocket wiring
+
+**Files:**
+- Create: `apps/realtime/routing.py`
+- Modify: `config/asgi.py`
+- Test: `apps/realtime/tests/test_routing.py`
+
+**Interfaces:**
+- Produces: `websocket_urlpatterns` — `ws/turns/<uuid:turn_id>/` → TurnConsumer, `ws/supervisor/` → SupervisorConsumer. `config.asgi.application` routes `websocket` scope through `RealtimeAuthMiddleware`.
+
+- [ ] **Step 1:** Write `apps/realtime/routing.py`:
+```python
+from django.urls import path, re_path
+from . import consumers
+
+websocket_urlpatterns = [
+    re_path(r"^ws/turns/(?P<turn_id>[0-9a-f-]+)/$", consumers.TurnConsumer.as_asgi()),
+    path("ws/supervisor/", consumers.SupervisorConsumer.as_asgi()),
+]
+```
+- [ ] **Step 2:** Modify `config/asgi.py`: after `_django_asgi_app = get_asgi_application()` and before the Starlette app, build a Channels `ProtocolTypeRouter`:
+```python
+from channels.routing import ProtocolTypeRouter, URLRouter  # noqa: E402
+from channels.security.websocket import AllowedHostsOriginValidator  # noqa: E402
+from apps.realtime.channels_auth import RealtimeAuthMiddleware  # noqa: E402
+from apps.realtime.routing import websocket_urlpatterns  # noqa: E402
+
+_django_with_ws = ProtocolTypeRouter({
+    "http": _django_asgi_app,
+    "websocket": AllowedHostsOriginValidator(
+        RealtimeAuthMiddleware(URLRouter(websocket_urlpatterns))
+    ),
+})
+```
+Then change the catch-all mount from `Mount("/", app=_django_asgi_app)` to `Mount("/", app=_django_with_ws)`.
+- [ ] **Step 3:** Write `apps/realtime/tests/test_routing.py`: assert `websocket_urlpatterns` resolves a turn UUID path to `TurnConsumer` and `ws/supervisor/` to `SupervisorConsumer` (inspect the patterns), and that importing `config.asgi` builds `application` without error.
+- [ ] **Step 4:** Run `uv run pytest apps/realtime/tests/test_routing.py -q`. Expected: PASS. Then `uv run pytest -q` (full backend suite) to confirm the ASGI change didn't break MCP/lifespan wiring.
+- [ ] **Step 5:** Commit: `feat(realtime): websocket routing + ASGI ProtocolTypeRouter`
+
+---
+
+### Task 9: Frontend — `wsUrl`, `useLiveTurn`, turn-view integration
+
+**Files:**
+- Create: `frontend/src/lib/wsUrl.ts`, `frontend/src/hooks/useLiveTurn.ts`, `frontend/src/api/types.ws.ts`
+- Create: `frontend/src/hooks/useLiveTurn.test.ts`
+- Modify: the turn detail component that currently polls `GET /turns/{id}/events` (locate via `grep -rn "turns/.*events\|read_turn_events\|harness" frontend/src`)
+
+**Interfaces:**
+- Produces: `useLiveTurn(turnId: string): { events: TurnEventFrame[]; connected: boolean; lastError: string | null }`. `wsUrl(path: string): string` respecting `import.meta.env.BASE_URL`.
+
+- [ ] **Step 1:** Write `frontend/src/lib/wsUrl.ts`:
+```ts
+// Build a ws(s):// URL for a path under the SPA base (honors the /canopy prefix).
+export function wsUrl(path: string): string {
+  const base = import.meta.env.BASE_URL.replace(/\/$/, "");
+  const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
+  const clean = path.replace(/^\//, "");
+  return `${proto}//${window.location.host}${base}/${clean}`;
+}
+```
+- [ ] **Step 2:** Write `frontend/src/api/types.ws.ts` (`TurnEventFrame = { seq: number; kind: string; payload: unknown; ts: string }`, plus supervisor frame types used in Task 10).
+- [ ] **Step 3:** Write `frontend/src/hooks/useLiveTurn.test.ts` (vitest) driving a mock `WebSocket`: assert events merge de-duped by `seq`, reconnect uses the highest seen `seq` in the `?after=` query, and out-of-order/duplicate frames don't double-insert. Factor the merge into a pure `mergeEvents(prev, incoming)` so it unit-tests without a socket.
+- [ ] **Step 4:** Run vitest → FAIL.
+- [ ] **Step 5:** Write `frontend/src/hooks/useLiveTurn.ts`: a `WebSocket` to `wsUrl(\`ws/turns/${turnId}/?after=${cursor}\`)`, exponential-backoff reconnect (`[1,2,5,10]s`), `mergeEvents` on each `{event}` frame, tracks max seq as the reconnect cursor, exposes `{events, connected, lastError}`.
+- [ ] **Step 6:** Run vitest → PASS.
+- [ ] **Step 7:** Swap the turn detail component's polling for `useLiveTurn(turnId)`; keep the REST `GET …/events` as the initial/fallback fetch. Run `cd frontend && npm run build`. Expected: type-check + build PASS.
+- [ ] **Step 8:** Commit: `feat(realtime): useLiveTurn hook + live turn view`
+
+---
+
+### Task 10: Frontend — `useLiveSupervisor` + SupervisorPage integration
+
+**Files:**
+- Create: `frontend/src/hooks/useLiveSupervisor.ts`, `frontend/src/hooks/useLiveSupervisor.test.ts`
+- Modify: `frontend/src/pages/SupervisorPage.tsx` (+ `components/supervisor/*` as needed)
+
+**Interfaces:**
+- Produces: `useLiveSupervisor(): { runners; waiting; connected }` — applies a `supervisor.snapshot` then `supervisor.runner` / `supervisor.waiting` deltas into a view-model matching what `SupervisorPage` renders today.
+
+- [ ] **Step 1:** Write `useLiveSupervisor.test.ts` — a pure `applyFrame(state, frame)` reducer: snapshot seeds runners+waiting; a `supervisor.runner` frame upserts by runner id; a `supervisor.waiting` frame updates `waiting[slug]`. Unit-test all three.
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3:** Write `useLiveSupervisor.ts` (WS to `wsUrl("ws/supervisor/")`, backoff reconnect, `applyFrame`).
+- [ ] **Step 4:** Run → PASS.
+- [ ] **Step 5:** Wire `SupervisorPage` to prefer the live view-model, falling back to its current mount-fetch when the socket is not connected. `cd frontend && npm run build` → PASS.
+- [ ] **Step 6:** Commit: `feat(realtime): useLiveSupervisor hook + live /supervisor`
+
+---
+
+## Self-Review
+
+**Spec coverage:** SP1 spec §2 app layout → Task 1; §3 transport → Tasks 1,8; §4 groups/routing → Tasks 2,8; §5 fanout (3 paths, bulk_create caveat) → Tasks 3,4; §6 WS auth → Task 5; §7 replay/snapshot → Tasks 6,7; §8 frontend hooks → Tasks 9,10; §9 boundary → Task 1; §10 testing → every task's TDD steps. All covered.
+
+**Placeholder scan:** The two soft spots are deliberately marked "verify the exact accessor/resolver": `workspace_member_ids` related_name (Task 4 Step 4), the token resolver import (Task 5 Step 3), and the snapshot service reuse (Task 7 Step 4). These are lookups against existing code to confirm during execution, not unspecified logic — each has a concrete fallback described.
+
+**Type consistency:** `turn_group`/`supervisor_user_group`/`serialize_turn_event`/`publish` signatures are identical across Tasks 2, 4, 6, 7. Frame `type` strings (`turn.event`, `supervisor.runner`, `supervisor.waiting`, `supervisor.snapshot`) match between the fanout receivers (Task 4/7) and the consumer group-handler method names (Channels maps `type="turn.event"` → `turn_event`). Consumer close codes (4001/4003/4004) consistent.

--- a/docs/superpowers/specs/2026-07-16-realtime-chat-cloud-runner-program-design.md
+++ b/docs/superpowers/specs/2026-07-16-realtime-chat-cloud-runner-program-design.md
@@ -1,0 +1,219 @@
+# Wave 4 — Realtime, Chat & the Canopy Cloud Runner
+
+**Status:** Draft for review · **Date:** 2026-07-16 · **Author:** Jonathan + Claude
+
+> Program / strategy design doc, not an implementation plan. It settles the
+> architecture for bringing ACE-web's chat + multiplayer approach into canopy-web
+> as generic framework substrate, and for making canopy-web execute agent runs in
+> the cloud — with **ace-web as the first consumer** of that cloud runner.
+> Each sub-project (SP1–SP4) gets its own spec → plan → implementation cycle.
+>
+> This is **Wave 4** under the framework-harvest strategy
+> (`2026-06-24-canopy-framework-harvest-design.md`). The dependency arrow is
+> unchanged: **ACE → Canopy.** Canopy is the home; ace-web depends on it.
+
+---
+
+## 1. The settled stance
+
+One sentence: **canopy-web becomes the hosted hub for live agent execution —
+generic chat, multiplayer, and a real cloud runner — and ace-web becomes its
+first consumer, retiring its in-container `claude -p` subprocess model.**
+
+Four load-bearing decisions, settled in brainstorming:
+
+1. **Hosted hub, not a shared library.** canopy-web *runs* the shared control
+   plane + realtime + cloud-runner fleet as a live service. ace-web calls its API
+   as tenant #1. (Consistent with the harvest invariant: no neutral third package;
+   Canopy is the home.)
+2. **Generic chat moves to canopy; ace-web keeps its product layer.** canopy owns
+   the agent-agnostic `Session` / `Message` / `Draft` / presence / execution
+   substrate. ace-web keeps only its opp-specific product concerns (workbench UI,
+   Drive tools, decision buffer, opp linkage) and talks to canopy's chat API.
+   This is the framework/product split, honored across a repo boundary.
+3. **Unify on the harness ledger.** A chat "send" enqueues a harness `Turn` (the
+   durable execution envelope); the assistant's streamed output is appended to the
+   existing `TurnEvent` ledger by the cloud runner; `Message` rows are a
+   **projection** over the ledger. Chat is the interactive front-door to a durable
+   cloud run — **one** execution substrate, not two.
+4. **Warm runner service.** The canopy cloud runner is a `kind=cloud` daemon on
+   its **own** ECS service (separate from the web tier), porting ace-web's proven
+   `claude -p` stream-json subprocess pool. Session affinity rides the existing
+   harness `SessionLink` / `resolve-session` mechanism. Start warm; add
+   task-per-run isolation later only if a workload demands it.
+
+### 1.1 Why this is the natural shape
+
+The two halves already exist, split across the two repos:
+
+- **canopy-web already owns the control plane** — `apps/harness/` has the `Runner`
+  registry, the `Turn` queue with atomic claim + leases, the append-only
+  `TurnEvent` ledger, cron `AgentSchedule`, and `SessionLink` cross-account session
+  reuse. It has **no realtime** — everything is HTTP polling today.
+- **ace-web already owns the chat/multiplayer pattern** — Django Channels + Redis
+  WebSockets, co-edited `Draft`, Redis-HASH presence, and a `turn_driver` that
+  streams a turn and survives the initiating client's disconnect. But its cloud
+  **execution** is the pain: the Django ASGI container spawns `claude -p`
+  **in-process**, one subprocess per session, pooled in memory per ECS task —
+  so it needs ALB stickiness and **every deploy/OOM SIGKILLs all live runs**
+  (patched today with post-deploy auto-resume).
+
+Wave 4 unifies them in canopy: canopy contributes the durable queue/claim/lease it
+already has; ace-web contributes the realtime chat pattern it already proved. The
+result fixes ace-web's deploy-kill pain for free — because execution moves off the
+web tier onto a durable, reclaimable runner tier.
+
+canopy-web was pre-wired for exactly this: `config/settings/connectlabs.py`
+reserves the Channels layer for "W4," and `session_sharing` was **renamed from
+`sessions`** specifically "to free that name for the live-session harness."
+
+---
+
+## 2. Target architecture
+
+```
+Browser (canopy-web SPA — or ace-web SPA as a client)
+        │  WebSocket (live) + REST (commands)
+        ▼
+┌──────────────────────────────────────────────────────┐
+│ canopy-web  (ASGI: uvicorn + Django Channels)          │
+│                                                        │
+│   realtime  ──pushes──►  TurnEvent ledger appends      │  new · framework
+│   sessions  ──"send"──►  enqueues harness Turn         │  new · framework
+│   harness   (queue · claim · lease · ledger · links)   │  exists · framework
+│   Redis     (channel layer · presence · cache)         │
+└──────────────────────────────────────────────────────┘
+        ▲  claim Turn · append TurnEvent  (REST, + WS for cancel)
+        │
+┌───────┴────────────────────────┐
+│  canopy cloud runner            │  new · its OWN ECS service
+│   kind=cloud daemon             │
+│   ports ace-web CLIBackend pool │
+│   spawns `claude -p` stream-json│
+│   SessionLink affinity          │
+└─────────────────────────────────┘
+```
+
+### 2.1 The unified data model (the crux of "unify on the ledger")
+
+- **`Session`** — a durable conversation thread. Framework, **agent-agnostic**: it
+  carries opaque product metadata (ace-web's `opp_slug` / `opp_run_id` /
+  `opp_step_skill` become generic string labels the framework never interprets).
+- **`Draft`** — the shared, co-edited outgoing message (multiplayer input model).
+  A "send" commits the active Draft.
+- Committing a Draft **enqueues a harness `Turn`** — the durable execution
+  envelope: `queued → claimed → leased → executing → done/failed`, reclaimable if
+  a runner dies.
+- The cloud runner executes `claude -p` and **appends the assistant + tool stream
+  to the existing `TurnEvent` ledger** — no second streaming engine is introduced.
+- The **`realtime`** layer fans ledger appends (+ presence + draft events) to the
+  session's WebSocket group.
+- **`Message`** rows are a **projection** over the session's ordered Turns +
+  TurnEvents — the durable transcript, *derived* from the ledger, not primary.
+
+Consequence: "chat" and "cloud agent execution" become the same thing. You get
+durable execution (lease/reclaim survives any deploy), the append-only ledger the
+control plane already trusts, and the cloud-runner path — all without a parallel
+system.
+
+### 2.2 What ace-web keeps vs. sheds
+
+- **Keeps (product):** opp workbench UI, Drive tool integration, the decision-edit
+  buffer, opp↔session linkage, and any opp-specific chrome. These ride as opaque
+  session/Turn metadata into canopy.
+- **Sheds (now canopy's job):** its Django Channels stack, `Session`/`Message`/
+  `Draft` models, `turn_driver`, and the `CLIBackend` in-process subprocess pool.
+  ace-web stops running `claude -p` in its own container entirely.
+
+---
+
+## 3. The program — four sub-projects
+
+This is a program, not one spec. Each SP is its own spec → plan → build. The risky
+architecture (unify-on-ledger + warm cloud runner + live stream) is **proven by the
+end of SP2**, not deferred to the finish.
+
+### SP1 — Realtime substrate  *(build first)*
+Stand up the reserved Channels + Redis channel layer, a generic WebSocket consumer,
+the ASGI + ALB websocket wiring, and push the **existing** `TurnEvent` ledger live
+to a per-turn / per-session group.
+**Deliverable:** `/supervisor` and the turn views go live (no more polling).
+**Why first:** standalone value, needs no ace-web, lowest risk, and it is a hard
+prerequisite for every later slice.
+
+### SP2 — Cloud runner + unified execution  *(vertical slice)*
+The `kind=cloud` warm runner service (ported subprocess pool) claims a Turn, runs
+`claude -p`, and appends TurnEvents; plus the minimal chat front-door — a `Session`,
+a "send" that enqueues a Turn, and a single-user live view over SP1's transport.
+**Deliverable:** chat with a *canopy* agent whose execution runs on the cloud
+runner, streamed live end-to-end.
+**Why here:** proves the whole architecture — unify-on-ledger, the warm cloud
+runner, and realtime — together, early.
+
+### SP3 — Multiplayer
+Co-edited `Draft` (version guard + derived idle soft-lock), Redis-HASH presence
+with debounced DB writes, participants/roles, full-state snapshot on (re)connect,
+stream-survives-disconnect, and cross-process stop.
+**Deliverable:** teammates co-drive a session (full ace-web parity).
+
+### SP4 — ace-web as first consumer
+ace-web's opp workbench points at canopy's chat/realtime API and enqueues Turns to
+canopy's cloud runner; it retires its own Channels / Session / `CLIBackend` stack.
+Opp-specific concerns stay in ace-web and travel as session/Turn metadata.
+**Deliverable:** ace-web cloud runs go through canopy — no in-container `claude -p`,
+no deploy-kills, independent scaling.
+
+---
+
+## 4. Framework/product boundary
+
+Enforced by `tests/test_architecture_boundary.py` (pure `ast`, in CI) against
+`ARCHITECTURE.md`. The two new apps are **generic substrate → framework tier**:
+
+- `realtime` (SP1) and `sessions` (SP2/SP3) are classified **framework**, added to
+  both the boundary test's framework set and the `ARCHITECTURE.md` tier table.
+  (`test_every_app_is_classified` fails CI on any untiered new app.)
+- They may import only framework apps (`harness`, `agents`, `common`, `workspaces`,
+  `tokens`, …) — never product apps.
+- ace-web's opp coupling never enters canopy: it arrives as opaque session/Turn
+  metadata, so the framework stays agent-agnostic and liftable.
+
+The name `sessions` is the one reserved by the `session_sharing` rename — use it for
+the live-session app.
+
+---
+
+## 5. Decisions deferred to each sub-project's spec
+
+Recorded here so they are not lost; each is resolved when its SP is brainstormed:
+
+- **Cross-app auth / tenancy / CORS** — ace-web → canopy over PATs (both apps
+  already have a PAT model). Which token, which workspace, CORS/WS-origin policy.
+- **Turn targeting for chat** — a new `session` target on `Turn`, vs. reuse
+  agent/project targeting plus a `session_id`. (`Turn` currently enforces agent XOR
+  project.)
+- **Per-session execution lock** — interactive chat wants one executing turn *per
+  session*, not the harness's per-agent `one_executing_turn_per_agent`. New partial
+  index vs. reuse.
+- **Message projection mechanics** — materialized rows kept in sync from the ledger
+  vs. derived-on-read; how tool_use/tool_result pairing and cost land.
+- **Cloud runner internals** — credential staging in the container (ace-web's
+  staged-`$HOME` + symlinked `~/.claude`), warm-pool sizing / idle reaper /
+  autoscaling, and whether/when to add optional Fargate task-per-run isolation.
+- **ALB / infra** — websocket target-group config, sticky-vs-stateless now that the
+  pool lives on the runner tier, ECS service definition for the runner.
+
+---
+
+## 6. Relationship to existing canopy work
+
+- **`apps/harness/`** — reused as-is for the queue/claim/lease/ledger. Extended
+  (not replaced) for session-scoped execution and the realtime push.
+- **`apps/agent_runs/` + `packages/canopy_agent_runs`** — the run→step→verdict read
+  model is orthogonal; a cloud run can still surface as an `AgentRun`. No change
+  required for SP1–SP3; revisited in SP4 if ACE run structure should project here.
+- **`packages/canopy_runner`** — the existing polling daemon is the seed of the
+  cloud runner; SP2 grows it a cloud execution path (ported subprocess pool)
+  alongside its current emdash/CDP path.
+- **`apps/agents/`** — unchanged; `AgentTurn` (packaged report) stays distinct from
+  the harness `Turn` (execution envelope), as today.

--- a/docs/superpowers/specs/2026-07-16-sp1-realtime-substrate-design.md
+++ b/docs/superpowers/specs/2026-07-16-sp1-realtime-substrate-design.md
@@ -1,0 +1,223 @@
+# SP1 — Realtime Substrate
+
+**Status:** Draft for review · **Date:** 2026-07-16 · **Author:** Jonathan + Claude
+
+> Sub-project 1 of the Wave 4 program
+> (`2026-07-16-realtime-chat-cloud-runner-program-design.md`). Stands up canopy-web's
+> first realtime transport (Django Channels + Redis) and puts two surfaces live over
+> it: the per-turn `TurnEvent` ledger tail, and `/supervisor`. No chat, no cloud
+> runner, no ace-web yet — this is the foundation every later slice rides on.
+
+---
+
+## 1. Goal & deliverable
+
+Today canopy-web has **no realtime** — the SPA polls. SP1 adds the transport that
+the Channels layer in `config/settings/connectlabs.py` was already reserved for
+("lands with W4"), and proves it against the two surfaces that most want to be live:
+
+- **Turn tail** — the turn detail view live-tails a turn's append-only `TurnEvent`
+  ledger. This is the exact primitive SP2's chat streaming builds on.
+- **Supervisor** — `/supervisor` shows runner status + per-agent waiting counts live
+  (no more mount-time-only fetch).
+
+Both are consumers of **one** transport, exercising both fanout shapes:
+point-to-point (`turn.{id}`) and per-workspace broadcast (`w.{slug}.supervisor`).
+
+**Explicitly out of scope for SP1** (later SPs): any chat/Session/Draft model,
+presence, co-editing, the cloud runner, and cross-app (ace-web) access. SP1 pushes
+data that *already exists* over a new transport; it introduces no new domain model.
+
+---
+
+## 2. New framework app: `realtime`
+
+A new Django app `apps/realtime/`, **framework tier**. Layout:
+
+- `consumers.py` — `TurnConsumer`, `SupervisorConsumer` (both `AsyncJsonWebsocketConsumer`).
+- `routing.py` — websocket URL patterns.
+- `channels_auth.py` — the handshake auth middleware (cookie → Bearer PAT).
+- `groups.py` — group-name helpers + membership gates (pure, unit-testable).
+- `signals.py` — the `post_save` → `on_commit` → `group_send` fanout receivers.
+- `apps.py` — wires signals in `ready()`.
+
+It imports only framework apps (`harness`, `agents`, `workspaces`, `tokens`,
+`common`). It is added to the framework set in both `ARCHITECTURE.md` and
+`tests/test_architecture_boundary.py` (§9).
+
+---
+
+## 3. Transport wiring
+
+- **Deps:** add `channels` and `channels_redis` to `pyproject.toml` (uv.lock committed).
+- **Channel layer:** `CHANNEL_LAYERS = {"default": {"BACKEND": "channels_redis.core.RedisChannelLayer", "CONFIG": {"hosts": [REDIS_URL]}}}`. Reuse the ElastiCache Redis already configured as the cache in `connectlabs.py`; namespace the channel-layer prefix so a cache flush can't disturb pub/sub. Local/dev uses the same Redis from `docker-compose`. **Tests** override to `InMemoryChannelLayer` (§10).
+- **ASGI:** extend `config/asgi.py`. Today a Starlette `Router` owns lifespan and
+  mounts FastMCP at `/api/mcp` + Django ASGI elsewhere (http only). Add a Channels
+  `ProtocolTypeRouter` so the `websocket` scope routes into
+  `AllowedHostsOriginValidator(RealtimeAuthMiddleware(URLRouter(realtime.routing.websocket_urlpatterns)))`,
+  while `http` continues to Django and Starlette keeps `lifespan` + the MCP mount.
+  Respect the `/canopy` `FORCE_SCRIPT_NAME` / `StripScriptName` prefix
+  (`config/asgi_prefix.py`) for WS paths too.
+- **Server:** unchanged — `uvicorn config.asgi:application` already speaks websockets;
+  no daphne needed.
+
+---
+
+## 4. Groups & routing
+
+| Surface | WS route | Channels group | Membership gate |
+|---|---|---|---|
+| Turn tail | `ws/turns/{turn_id}/` | `turn.{turn_id}` | turn → agent/project → workspace → caller is a member |
+| Supervisor | `ws/supervisor/` | `w.{slug}.supervisor` (one per workspace the caller belongs to) | caller's workspace memberships |
+
+`/supervisor` is deliberately cross-workspace (like `/insights`), so a single
+`ws/supervisor/` socket joins the caller to **each** `w.{slug}.supervisor` group for
+the workspaces they belong to; the client sends nothing to choose scope. Group-name
+construction and the membership checks live in `groups.py` as pure functions
+(`turn_group(turn_id)`, `supervisor_group(slug)`, `user_can_read_turn(user, turn)`,
+`user_workspace_slugs(user)` — the last already exists in `workspaces` services).
+
+---
+
+## 5. Fanout — how a write reaches the socket
+
+Mirror the established `apps/push/signals.py` pattern (post_save + `on_commit`), so
+the write path (`harness.services.append_events`, `heartbeat`, etc.) is **not**
+coupled to Channels and stays synchronous/testable.
+
+- **Turn tail** — `post_save` on `TurnEvent` → `transaction.on_commit` →
+  `group_send(turn_group(te.turn_id), {"type": "turn.event", "seq": te.seq, "event": <serialized>})`.
+  Because `append_events` assigns `seq` under a `select_for_update` row lock and can
+  write a batch, the receiver coalesces a batch into one `group_send` carrying the
+  contiguous new events (ordered by `seq`).
+- **Supervisor** — two triggers:
+  1. **Runner status** — `post_save` on `Runner` (heartbeat renews `last_heartbeat_at`; pair/retire change `status`) → `group_send(supervisor_group(runner.workspace.slug), {"type": "supervisor.runner", ...})`.
+  2. **Waiting counts** — hook the point where `apps/push` already recomputes an
+     agent's `waiting_count` (`services.refresh_agent_waiting` / `AgentWaitingSnapshot`):
+     when the snapshot changes, also `group_send(supervisor_group(agent.workspace.slug), {"type": "supervisor.waiting", "agent": slug, "waiting_count": n})`. This reuses the existing coalesced recompute — no new counting logic.
+
+All `group_send` calls go through a tiny `groups.publish(...)` helper wrapping
+`get_channel_layer()` + `async_to_sync`, so a null/misconfigured layer degrades to a
+no-op (the REST surfaces still work) rather than raising in a request.
+
+---
+
+## 6. WS handshake auth
+
+Port ace-web's `AceSessionAuthMiddleware` as `realtime/channels_auth.py::RealtimeAuthMiddleware`:
+
+1. Resolve `scope["user"]` from the **session cookie** first (canopy's session cookie
+   name; honors the `/canopy` deploy), then fall back to `Authorization: Bearer <PAT>`
+   (reusing `apps/tokens` resolution) for scripted clients.
+2. Anonymous → the consumer rejects with close code `4001` on `connect()`.
+3. Per-surface authorization happens in the consumer's `connect()`, not the
+   middleware: `TurnConsumer` rejects `4003` if `user_can_read_turn` is false;
+   `SupervisorConsumer` joins only the caller's workspace groups (empty set → still
+   connect, just silent).
+
+Bearer WS auth is included now because it's cheap alongside the cookie path and SP4
+will need it; SP1's primary consumer is the browser SPA on the cookie path.
+
+---
+
+## 7. Replay & connect semantics
+
+- **Turn tail (cursor replay).** Client connects with its last-seen `seq` as a query
+  param (`?after=<seq>`, default 0). On `connect()`, after joining the group, the
+  consumer reads `harness` ledger `after=seq` (the existing
+  `GET /turns/{id}/events` read path, called in-process) and sends those events, then
+  live-tails. A monotonic `seq` makes replay-then-tail idempotent: any event delivered
+  both in the replay and via a race is de-duped by `seq` on the client. Strictly better
+  than a full-snapshot re-fetch for an append-only ledger.
+- **Supervisor (snapshot on connect).** On `connect()`, send one
+  `supervisor.snapshot` frame = current runners (with derived `live_status`) + current
+  per-agent `waiting_count` for the caller's workspaces (reads the same services the
+  REST `/supervisor` endpoints use), then stream `supervisor.runner` /
+  `supervisor.waiting` deltas. Runner/waiting state is small and mutable (not an
+  append log), so a snapshot is the right primitive here — the opposite choice from the
+  turn tail, on purpose.
+
+---
+
+## 8. Frontend
+
+- **`useLiveTurn(turnId)`** — owns a `WebSocket` to `ws/turns/{id}/?after=<seq>`,
+  exponential-backoff reconnect (`[1,2,5,10]s`, ported from ace-web's
+  `useSessionSocket`), tracks the highest `seq` seen so a reconnect resumes from the
+  cursor (no full re-fetch), and merges events de-duped by `seq`. Returns
+  `{events, connected, lastError}`. The turn detail view swaps its REST poll for this
+  hook; the REST `GET …/events` stays as the manual/fallback fetch.
+- **`useLiveSupervisor()`** — one `WebSocket` to `ws/supervisor/`, applies the snapshot
+  then runner/waiting deltas into the existing supervisor view-model. `SupervisorPage`,
+  `RunnerStatus`, `WaitingOnYou`, `AgentKpiCard` read from it instead of a mount-time
+  fetch.
+- **`lib/wsUrl.ts`** — a ws/wss URL builder that respects `import.meta.env.BASE_URL`
+  (the `/canopy` prefix), ported from ace-web.
+- **Types** — hand-written WS frame types in `frontend/src/api/types.ws.ts`
+  (`TurnEventFrame`, `SupervisorSnapshot`, `SupervisorRunner`, `SupervisorWaiting`);
+  the OpenAPI generator does not cover the WS protocol.
+
+---
+
+## 9. Framework boundary
+
+`apps/realtime` is **framework**. Add it to the framework set in
+`tests/test_architecture_boundary.py` and the `ARCHITECTURE.md` tier table
+(`test_every_app_is_classified` fails CI otherwise). It imports `harness`, `agents`,
+`workspaces`, `tokens`, `common` — all framework — and no product app. It touches no
+product concept; a turn's opaque metadata is never interpreted here.
+
+---
+
+## 10. Testing
+
+- **Consumer tests** (`channels.testing.WebsocketCommunicator`, `InMemoryChannelLayer`
+  via the test settings already used by ace-web's e2e/test configs): connect →
+  auth reject paths (`4001` anon, `4003` non-member) → cursor replay delivers prior
+  events → a fresh `append_events` is received live → supervisor snapshot + a runner
+  heartbeat delta is received.
+- **Group/gate unit tests** — `groups.py` pure functions (name construction,
+  `user_can_read_turn`, workspace-set membership) tested without a socket.
+- **Signal tests** — saving a `TurnEvent` inside a transaction fans out exactly once
+  on commit (and coalesces a batch); a rollback fans out nothing; a null channel layer
+  is a no-op, not an error.
+- **Frontend** — `useLiveTurn` reducer/merge logic unit-tested (seq de-dupe, reconnect
+  resumes from cursor), mirroring ace-web's `sessionReducer` tests.
+
+---
+
+## 11. Deployment / infra
+
+- **ALB** — the shared labs ALB already carries HTTP/1.1; enable websocket upgrade on
+  the canopy target group and raise the target-group idle timeout above the WS
+  heartbeat interval so idle sockets aren't culled. (ace-web already runs Channels
+  behind this same ALB — a proven path.)
+- **Redis** — reuse the existing shared ElastiCache instance; the channel layer is
+  additive to the current cache use. No new infra to provision.
+- **ECS** — single web container is unchanged (uvicorn already serves WS). No new
+  service in SP1 (the cloud-runner service arrives in SP2).
+- **Settings** — `CHANNEL_LAYERS` added to `base.py` (dev/docker Redis) and confirmed
+  in `connectlabs.py` (the reserved seam).
+
+---
+
+## 12. Error handling & degradation
+
+- A missing/misconfigured channel layer → `groups.publish` no-ops; REST surfaces
+  keep working. Realtime is an enhancement, never a hard dependency of a write.
+- A dropped socket → client backoff-reconnects and resumes turn tail from its `seq`
+  cursor / re-requests a supervisor snapshot. No server-side per-socket durable queue
+  in SP1 (the ledger + snapshot are the durable state).
+- Fanout is best-effort: the durable record is always the DB (ledger row / runner row
+  / waiting snapshot); the socket is a live view over it.
+
+---
+
+## 13. Deferred to later SPs
+
+- Chat `Session`/`Message`/`Draft`, presence, co-editing, stream-survives-disconnect,
+  cross-process stop → **SP2/SP3** (they reuse this transport + `useLiveTurn`).
+- The cloud runner appending events (SP1 pushes whatever *any* writer appends today) →
+  **SP2**.
+- Cross-app (ace-web) WS access + CORS/origin policy for a second frontend → **SP4**
+  (the Bearer handshake is in place; the origin allowlist widens then).

--- a/docs/superpowers/specs/2026-07-16-sp1-realtime-substrate-design.md
+++ b/docs/superpowers/specs/2026-07-16-sp1-realtime-substrate-design.md
@@ -68,14 +68,18 @@ It imports only framework apps (`harness`, `agents`, `workspaces`, `tokens`,
 | Surface | WS route | Channels group | Membership gate |
 |---|---|---|---|
 | Turn tail | `ws/turns/{turn_id}/` | `turn.{turn_id}` | turn → agent/project → workspace → caller is a member |
-| Supervisor | `ws/supervisor/` | `w.{slug}.supervisor` (one per workspace the caller belongs to) | caller's workspace memberships |
+| Supervisor | `ws/supervisor/` | `supervisor.user.{user_id}` | the caller's own group; snapshot + deltas scoped to their visible agents/runners |
 
-`/supervisor` is deliberately cross-workspace (like `/insights`), so a single
-`ws/supervisor/` socket joins the caller to **each** `w.{slug}.supervisor` group for
-the workspaces they belong to; the client sends nothing to choose scope. Group-name
-construction and the membership checks live in `groups.py` as pure functions
-(`turn_group(turn_id)`, `supervisor_group(slug)`, `user_can_read_turn(user, turn)`,
-`user_workspace_slugs(user)` — the last already exists in `workspaces` services).
+**As built:** the supervisor socket joins **one per-user group** (`supervisor.user.{id}`),
+not a per-workspace group. `/supervisor` is cross-workspace (like `/insights`), and its
+visibility is *not* pure workspace membership — runners are `paired_by`-scoped and
+agents span the caller's workspaces (+ unhomed). A single per-user group with fan-out
+that resolves recipients (a runner delta → its `paired_by` user; a waiting delta → the
+agent's workspace members) is simpler and a tighter isolation boundary than N
+per-workspace subscriptions. Group-name construction + the turn gate live in `groups.py`
+as pure functions (`turn_group`, `supervisor_user_group`, `user_can_read_turn`); the
+snapshot's visibility mirrors the REST `_visible_agent_workspace_ids` /
+`_runner_visibility_q` unpinned branch (`apps/realtime/snapshot.py`).
 
 ---
 
@@ -90,11 +94,11 @@ coupled to Channels and stays synchronous/testable.
   Because `append_events` assigns `seq` under a `select_for_update` row lock and can
   write a batch, the receiver coalesces a batch into one `group_send` carrying the
   contiguous new events (ordered by `seq`).
-- **Supervisor** — two triggers:
-  1. **Runner status** — `post_save` on `Runner` (heartbeat renews `last_heartbeat_at`; pair/retire change `status`) → `group_send(supervisor_group(runner.workspace.slug), {"type": "supervisor.runner", ...})`.
+- **Supervisor** — two triggers (each resolves recipients to **per-user** groups):
+  1. **Runner status** — `post_save` on `Runner` (heartbeat renews `last_heartbeat_at`; pair/retire change `status`) → `group_send(supervisor_user_group(runner.paired_by_id), {"type": "supervisor.runner", ...})`.
   2. **Waiting counts** — hook the point where `apps/push` already recomputes an
      agent's `waiting_count` (`services.refresh_agent_waiting` / `AgentWaitingSnapshot`):
-     when the snapshot changes, also `group_send(supervisor_group(agent.workspace.slug), {"type": "supervisor.waiting", "agent": slug, "waiting_count": n})`. This reuses the existing coalesced recompute — no new counting logic.
+     when the snapshot changes, fan out to each member of the agent's workspace — `group_send(supervisor_user_group(uid), {"type": "supervisor.waiting", "agent": slug, "waiting_count": n})` for `uid in workspace_member_ids(agent.workspace)`. Reuses the existing coalesced recompute — no new counting logic.
 
 All `group_send` calls go through a tiny `groups.publish(...)` helper wrapping
 `get_channel_layer()` + `async_to_sync`, so a null/misconfigured layer degrades to a
@@ -148,9 +152,12 @@ will need it; SP1's primary consumer is the browser SPA on the cookie path.
   `{events, connected, lastError}`. The turn detail view swaps its REST poll for this
   hook; the REST `GET …/events` stays as the manual/fallback fetch.
 - **`useLiveSupervisor()`** — one `WebSocket` to `ws/supervisor/`, applies the snapshot
-  then runner/waiting deltas into the existing supervisor view-model. `SupervisorPage`,
-  `RunnerStatus`, `WaitingOnYou`, `AgentKpiCard` read from it instead of a mount-time
-  fetch.
+  then runner/waiting deltas (pure `applyFrame` reducer). `SupervisorPage` overlays the
+  live view-model on its mount fetch: the "Waiting on you" **header total**, the runner
+  band status, the `AgentKpiCard` counts, and the app badge go live. **As built (SP1
+  scope):** the `WaitingOnYou` *item list* stays on the mount fetch — the snapshot/deltas
+  carry waiting *counts*, not the itemized needs-you rows; making that list live means
+  streaming the items themselves, deferred to a later slice.
 - **`lib/wsUrl.ts`** — a ws/wss URL builder that respects `import.meta.env.BASE_URL`
   (the `/canopy` prefix), ported from ace-web.
 - **Types** — hand-written WS frame types in `frontend/src/api/types.ws.ts`

--- a/frontend/src/api/types.ws.ts
+++ b/frontend/src/api/types.ws.ts
@@ -1,0 +1,40 @@
+// WebSocket protocol frames for the realtime transport (apps/realtime).
+// Hand-written — the OpenAPI generator covers REST, not the WS protocol.
+
+export interface TurnEventFrame {
+  seq: number
+  kind: string
+  payload: unknown
+  ts: string
+}
+
+export interface SupervisorRunnerLive {
+  id: string
+  name: string
+  kind: string
+  status: string
+  last_heartbeat_at: string | null
+}
+
+export interface SupervisorSnapshotFrame {
+  type: 'supervisor.snapshot'
+  runners: SupervisorRunnerLive[]
+  waiting: Record<string, number>
+  total_waiting: number
+}
+
+export interface SupervisorRunnerFrame {
+  type: 'supervisor.runner'
+  runner: SupervisorRunnerLive
+}
+
+export interface SupervisorWaitingFrame {
+  type: 'supervisor.waiting'
+  agent: string
+  waiting_count: number
+}
+
+export type SupervisorFrame =
+  | SupervisorSnapshotFrame
+  | SupervisorRunnerFrame
+  | SupervisorWaitingFrame

--- a/frontend/src/hooks/useLiveSupervisor.test.ts
+++ b/frontend/src/hooks/useLiveSupervisor.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import { applyFrame, EMPTY_SUPERVISOR_STATE } from './useLiveSupervisor'
+import type { SupervisorRunnerLive } from '@/api/types.ws'
+
+const runner = (id: string, status = 'online'): SupervisorRunnerLive => ({
+  id,
+  name: `r-${id}`,
+  kind: 'cloud',
+  status,
+  last_heartbeat_at: null,
+})
+
+describe('applyFrame', () => {
+  it('seeds state from a snapshot', () => {
+    const s = applyFrame(EMPTY_SUPERVISOR_STATE, {
+      type: 'supervisor.snapshot',
+      runners: [runner('a')],
+      waiting: { echo: 2 },
+      total_waiting: 2,
+    })
+    expect(Object.keys(s.runners)).toEqual(['a'])
+    expect(s.waiting).toEqual({ echo: 2 })
+    expect(s.totalWaiting).toBe(2)
+  })
+
+  it('upserts a runner by id on a runner delta', () => {
+    const seeded = applyFrame(EMPTY_SUPERVISOR_STATE, {
+      type: 'supervisor.snapshot',
+      runners: [runner('a', 'online')],
+      waiting: {},
+      total_waiting: 0,
+    })
+    const next = applyFrame(seeded, { type: 'supervisor.runner', runner: runner('a', 'stale') })
+    expect(next.runners['a'].status).toBe('stale')
+  })
+
+  it('updates a waiting count and recomputes the total', () => {
+    const seeded = applyFrame(EMPTY_SUPERVISOR_STATE, {
+      type: 'supervisor.snapshot',
+      runners: [],
+      waiting: { echo: 1, ada: 1 },
+      total_waiting: 2,
+    })
+    const next = applyFrame(seeded, { type: 'supervisor.waiting', agent: 'echo', waiting_count: 4 })
+    expect(next.waiting).toEqual({ echo: 4, ada: 1 })
+    expect(next.totalWaiting).toBe(5)
+  })
+})

--- a/frontend/src/hooks/useLiveSupervisor.ts
+++ b/frontend/src/hooks/useLiveSupervisor.ts
@@ -1,0 +1,100 @@
+import { useEffect, useRef, useState } from 'react'
+
+import type { SupervisorFrame, SupervisorRunnerLive } from '@/api/types.ws'
+import { wsUrl } from '@/lib/wsUrl'
+
+export interface SupervisorState {
+  runners: Record<string, SupervisorRunnerLive>
+  waiting: Record<string, number>
+  totalWaiting: number
+}
+
+export const EMPTY_SUPERVISOR_STATE: SupervisorState = {
+  runners: {},
+  waiting: {},
+  totalWaiting: 0,
+}
+
+// Pure reducer: a snapshot seeds state; runner/waiting deltas patch it. Exported
+// so it unit-tests without a socket.
+export function applyFrame(state: SupervisorState, frame: SupervisorFrame): SupervisorState {
+  switch (frame.type) {
+    case 'supervisor.snapshot': {
+      const runners: Record<string, SupervisorRunnerLive> = {}
+      for (const r of frame.runners) runners[r.id] = r
+      return { runners, waiting: { ...frame.waiting }, totalWaiting: frame.total_waiting }
+    }
+    case 'supervisor.runner':
+      return { ...state, runners: { ...state.runners, [frame.runner.id]: frame.runner } }
+    case 'supervisor.waiting': {
+      const waiting = { ...state.waiting, [frame.agent]: frame.waiting_count }
+      const totalWaiting = Object.values(waiting).reduce((a, b) => a + b, 0)
+      return { ...state, waiting, totalWaiting }
+    }
+    default:
+      return state
+  }
+}
+
+const BACKOFFS_MS = [1000, 2000, 5000, 10000]
+
+export interface LiveSupervisor {
+  runners: SupervisorRunnerLive[]
+  waiting: Record<string, number>
+  connected: boolean
+  hasSnapshot: boolean
+}
+
+// Live /supervisor: snapshot on connect, then runner/waiting deltas, over one WS
+// with backoff reconnect. SupervisorPage layers this over its mount fetch.
+export function useLiveSupervisor(): LiveSupervisor {
+  const [state, setState] = useState<SupervisorState>(EMPTY_SUPERVISOR_STATE)
+  const [connected, setConnected] = useState(false)
+  const [hasSnapshot, setHasSnapshot] = useState(false)
+  const attemptRef = useRef(0)
+
+  useEffect(() => {
+    let ws: WebSocket | null = null
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+    let closed = false
+
+    const connect = () => {
+      if (closed) return
+      ws = new WebSocket(wsUrl('ws/supervisor/'))
+      ws.onopen = () => {
+        attemptRef.current = 0
+        setConnected(true)
+      }
+      ws.onmessage = (msg) => {
+        try {
+          const frame = JSON.parse(msg.data) as SupervisorFrame
+          if (frame.type === 'supervisor.snapshot') setHasSnapshot(true)
+          setState((prev) => applyFrame(prev, frame))
+        } catch {
+          /* ignore malformed frame */
+        }
+      }
+      ws.onclose = () => {
+        setConnected(false)
+        if (closed) return
+        const delay = BACKOFFS_MS[Math.min(attemptRef.current, BACKOFFS_MS.length - 1)]
+        attemptRef.current += 1
+        reconnectTimer = setTimeout(connect, delay)
+      }
+    }
+
+    connect()
+    return () => {
+      closed = true
+      if (reconnectTimer) clearTimeout(reconnectTimer)
+      if (ws) ws.close()
+    }
+  }, [])
+
+  return {
+    runners: Object.values(state.runners),
+    waiting: state.waiting,
+    connected,
+    hasSnapshot,
+  }
+}

--- a/frontend/src/hooks/useLiveTurn.test.ts
+++ b/frontend/src/hooks/useLiveTurn.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+
+import { mergeEvents } from './useLiveTurn'
+import type { TurnEventFrame } from '@/api/types.ws'
+
+const ev = (seq: number, text = ''): TurnEventFrame => ({
+  seq,
+  kind: 'assistant',
+  payload: { text },
+  ts: '2026-07-16T00:00:00Z',
+})
+
+describe('mergeEvents', () => {
+  it('appends new events in seq order', () => {
+    const out = mergeEvents([ev(1)], [ev(2), ev(3)])
+    expect(out.map((e) => e.seq)).toEqual([1, 2, 3])
+  })
+
+  it('de-dupes by seq (replay + live overlap is idempotent)', () => {
+    const out = mergeEvents([ev(1), ev(2)], [ev(2), ev(3)])
+    expect(out.map((e) => e.seq)).toEqual([1, 2, 3])
+  })
+
+  it('sorts out-of-order arrivals', () => {
+    const out = mergeEvents([], [ev(3), ev(1), ev(2)])
+    expect(out.map((e) => e.seq)).toEqual([1, 2, 3])
+  })
+
+  it('does not mutate the previous array', () => {
+    const prev = [ev(1)]
+    mergeEvents(prev, [ev(2)])
+    expect(prev.map((e) => e.seq)).toEqual([1])
+  })
+})

--- a/frontend/src/hooks/useLiveTurn.ts
+++ b/frontend/src/hooks/useLiveTurn.ts
@@ -1,0 +1,92 @@
+import { useEffect, useRef, useState } from 'react'
+
+import type { TurnEventFrame } from '@/api/types.ws'
+import { wsUrl } from '@/lib/wsUrl'
+
+// Pure merge: append only unseen seqs, keep the list ordered by seq. Idempotent,
+// so replay-then-live-tail and reconnect races never double-insert. Exported so
+// it unit-tests without a socket (this repo's "no live DOM" test convention).
+export function mergeEvents(prev: TurnEventFrame[], incoming: TurnEventFrame[]): TurnEventFrame[] {
+  const seen = new Set(prev.map((e) => e.seq))
+  const merged = prev.slice()
+  for (const ev of incoming) {
+    if (!seen.has(ev.seq)) {
+      seen.add(ev.seq)
+      merged.push(ev)
+    }
+  }
+  merged.sort((a, b) => a.seq - b.seq)
+  return merged
+}
+
+const BACKOFFS_MS = [1000, 2000, 5000, 10000]
+
+export interface LiveTurn {
+  events: TurnEventFrame[]
+  connected: boolean
+  lastError: string | null
+}
+
+// Live-tail one turn's TurnEvent ledger over the realtime WS. Reconnects with
+// backoff and resumes from the highest seq seen (?after=cursor), so a drop never
+// re-fetches the whole ledger. The turn view / SP2 chat consume this.
+export function useLiveTurn(turnId: string | null): LiveTurn {
+  const [events, setEvents] = useState<TurnEventFrame[]>([])
+  const [connected, setConnected] = useState(false)
+  const [lastError, setLastError] = useState<string | null>(null)
+  const cursorRef = useRef(0)
+  const attemptRef = useRef(0)
+
+  useEffect(() => {
+    if (!turnId) return
+    // Reset per-turn state.
+    setEvents([])
+    cursorRef.current = 0
+    attemptRef.current = 0
+
+    let ws: WebSocket | null = null
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+    let closed = false
+
+    const connect = () => {
+      if (closed) return
+      ws = new WebSocket(wsUrl(`ws/turns/${turnId}/?after=${cursorRef.current}`))
+
+      ws.onopen = () => {
+        attemptRef.current = 0
+        setConnected(true)
+        setLastError(null)
+      }
+      ws.onmessage = (msg) => {
+        try {
+          const frame = JSON.parse(msg.data) as { event?: TurnEventFrame }
+          if (frame.event) {
+            const ev = frame.event
+            cursorRef.current = Math.max(cursorRef.current, ev.seq)
+            setEvents((prev) => mergeEvents(prev, [ev]))
+          }
+        } catch {
+          setLastError('bad frame')
+        }
+      }
+      ws.onerror = () => setLastError('connection error')
+      ws.onclose = () => {
+        setConnected(false)
+        if (closed) return
+        const delay = BACKOFFS_MS[Math.min(attemptRef.current, BACKOFFS_MS.length - 1)]
+        attemptRef.current += 1
+        reconnectTimer = setTimeout(connect, delay)
+      }
+    }
+
+    connect()
+
+    return () => {
+      closed = true
+      if (reconnectTimer) clearTimeout(reconnectTimer)
+      if (ws) ws.close()
+    }
+  }, [turnId])
+
+  return { events, connected, lastError }
+}

--- a/frontend/src/lib/wsUrl.ts
+++ b/frontend/src/lib/wsUrl.ts
@@ -1,0 +1,13 @@
+// Build a ws(s):// URL under the SPA base path (honors the /canopy prefix).
+// buildWsUrl is the pure core so it unit-tests without a DOM; wsUrl reads window.
+
+export function buildWsUrl(base: string, protocol: string, host: string, path: string): string {
+  const b = base.replace(/\/$/, '')
+  const proto = protocol === 'https:' ? 'wss:' : 'ws:'
+  const clean = path.replace(/^\//, '')
+  return `${proto}//${host}${b}/${clean}`
+}
+
+export function wsUrl(path: string): string {
+  return buildWsUrl(import.meta.env.BASE_URL, window.location.protocol, window.location.host, path)
+}

--- a/frontend/src/pages/SupervisorPage.tsx
+++ b/frontend/src/pages/SupervisorPage.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState, type JSX } from 'react'
+import { useEffect, useMemo, useState, type JSX } from 'react'
 import { listAgents, getFleetNeedsYou, type AgentOut, type FleetNeedsYouOut } from '@/api/agents'
 import { listRunners, type RunnerOut } from '@/api/harness'
+import { useLiveSupervisor } from '@/hooks/useLiveSupervisor'
 import { RunnerStatus } from '@/components/supervisor/RunnerStatus'
 import { AgentKpiCard } from '@/components/supervisor/AgentKpiCard'
 import { WaitingOnYou } from '@/components/supervisor/WaitingOnYou'
@@ -51,10 +52,33 @@ export default function SupervisorPage(): JSX.Element {
     }
   }, [])
 
+  // Live overlay: snapshot + runner/waiting deltas over WS. Falls back silently
+  // to the mount fetch above until the socket delivers a snapshot.
+  const live = useLiveSupervisor()
+  const liveById = useMemo(
+    () => Object.fromEntries(live.runners.map((r) => [r.id, r] as const)),
+    [live.runners],
+  )
+  // Runner rows with live status/heartbeat patched in when the socket knows them.
+  const renderRunners: RunnerOut[] | null =
+    runners?.map((r) => {
+      const lr = liveById[r.id]
+      return lr ? { ...r, status: lr.status, last_heartbeat_at: lr.last_heartbeat_at } : r
+    }) ?? null
+  // Waiting count per agent + total: prefer the live value once a snapshot lands.
+  const waitingFor = (slug: string): number =>
+    live.hasSnapshot && slug in live.waiting
+      ? live.waiting[slug]
+      : fleet
+        ? ((fleet.agents ?? []).find((b) => b.agent_slug === slug)?.waiting_count ?? 0)
+        : 0
+  const liveTotalWaiting = Object.values(live.waiting).reduce((a, b) => a + b, 0)
+  const totalWaiting = live.hasSnapshot ? liveTotalWaiting : (fleet?.total_waiting ?? 0)
+
   // The app-icon count. Android honours this; elsewhere it no-ops.
   useEffect(() => {
-    if (fleet) setBadge(fleet.total_waiting)
-  }, [fleet])
+    if (live.hasSnapshot || fleet) setBadge(totalWaiting)
+  }, [live.hasSnapshot, fleet, totalWaiting])
 
   return (
     <div className="mx-auto flex max-w-2xl flex-col gap-5 p-4" data-testid="supervisor-page">
@@ -84,7 +108,7 @@ export default function SupervisorPage(): JSX.Element {
 
       <section>
         <h2 className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-          Waiting on you {fleet && fleet.total_waiting > 0 ? `· ${fleet.total_waiting}` : ''}
+          Waiting on you {totalWaiting > 0 ? `· ${totalWaiting}` : ''}
         </h2>
         {errs.fleet ? (
           <BandError message={errs.fleet} />
@@ -99,10 +123,10 @@ export default function SupervisorPage(): JSX.Element {
         <h2 className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">Runners</h2>
         {errs.runners ? (
           <BandError message={errs.runners} />
-        ) : runners === null ? (
+        ) : renderRunners === null ? (
           <Skeleton className="h-12 w-full" />
         ) : (
-          <RunnerStatus runners={runners} />
+          <RunnerStatus runners={renderRunners} />
         )}
       </section>
 
@@ -118,11 +142,7 @@ export default function SupervisorPage(): JSX.Element {
         ) : (
           <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
             {agents.map((a) => (
-              <AgentKpiCard
-                key={a.slug}
-                agent={a}
-                waiting={fleet ? ((fleet.agents ?? []).find((b) => b.agent_slug === a.slug)?.waiting_count ?? 0) : 0}
-              />
+              <AgentKpiCard key={a.slug} agent={a} waiting={waitingFor(a.slug)} />
             ))}
           </div>
         )}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ dev = [
     "pytest-asyncio>=0.23,<1.0",
     "ruff>=0.4,<1.0",
     "schemathesis>=3.30,<4.0",
+    # dev-only: channels.testing.WebsocketCommunicator imports daphne's live
+    # test harness at package import time. Prod serves WS via uvicorn, not daphne.
+    "daphne>=4.1,<5.0",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ dependencies = [
     "google-api-python-client>=2.120,<3.0",
     "google-auth>=2.29,<3.0",
     "fastmcp>=3.3,<4.0",
+    "channels>=4.1,<5.0",
+    "channels-redis>=4.2,<5.0",
     # The Django-free run-lifecycle core (read model + RunStore Protocol + Drive
     # adapter). Lives in-repo at packages/canopy_agent_runs; resolved as an editable
     # path dep via [tool.uv.sources] below. Django's DbRunStore (apps/agent_runs)

--- a/tests/test_architecture_boundary.py
+++ b/tests/test_architecture_boundary.py
@@ -24,7 +24,7 @@ ROOT = pathlib.Path(__file__).resolve().parent.parent
 APPS = ROOT / "apps"
 
 # ── The tiers (canonical copy lives in ARCHITECTURE.md; keep them in sync) ──────
-FRAMEWORK = {"agents", "agent_runs", "workspaces", "api", "common", "timeline", "tokens", "session_sharing", "issues", "mcp", "system", "harness", "push"}
+FRAMEWORK = {"agents", "agent_runs", "workspaces", "api", "common", "timeline", "tokens", "session_sharing", "issues", "mcp", "system", "harness", "push", "realtime"}
 PRODUCT = {"projects",
            "walkthroughs", "reviews", "shareouts", "runs"}
 

--- a/tests/test_harness_events_signal.py
+++ b/tests/test_harness_events_signal.py
@@ -1,0 +1,58 @@
+"""SP1 Task 3 — append_events emits turn_events_appended after commit.
+
+The signal exists because append_events uses bulk_create, which does NOT emit
+post_save; a post_save receiver on TurnEvent would silently never fire.
+"""
+from __future__ import annotations
+
+import pytest
+
+from apps.agents.models import Agent
+from apps.harness import services
+from apps.harness.models import Turn
+from apps.harness.signals import turn_events_appended
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+
+def _turn():
+    agent = Agent.objects.create(slug="echo", name="Echo")
+    return Turn.objects.create(agent=agent, origin=Turn.ORIGIN_BOARD, idempotency_key="k1")
+
+
+def test_append_events_fires_signal_after_commit():
+    turn = _turn()
+    received: list[dict] = []
+    turn_events_appended.connect(
+        lambda **kw: received.append(kw), weak=False, dispatch_uid="test-recv"
+    )
+    try:
+        services.append_events(turn, [{"kind": "assistant", "payload": {"text": "hi"}}])
+    finally:
+        turn_events_appended.disconnect(dispatch_uid="test-recv")
+
+    assert len(received) == 1
+    assert received[0]["turn"].pk == turn.pk
+    assert [r.seq for r in received[0]["rows"]] == [1]
+    assert received[0]["rows"][0].kind == "assistant"
+
+
+def test_append_events_batch_fires_once_with_all_rows():
+    turn = _turn()
+    received: list[dict] = []
+    turn_events_appended.connect(
+        lambda **kw: received.append(kw), weak=False, dispatch_uid="test-recv"
+    )
+    try:
+        services.append_events(
+            turn,
+            [
+                {"kind": "tool_start", "payload": {}},
+                {"kind": "tool_end", "payload": {}},
+            ],
+        )
+    finally:
+        turn_events_appended.disconnect(dispatch_uid="test-recv")
+
+    assert len(received) == 1
+    assert [r.seq for r in received[0]["rows"]] == [1, 2]

--- a/tests/test_realtime_app.py
+++ b/tests/test_realtime_app.py
@@ -1,0 +1,17 @@
+"""SP1 Task 1 — the realtime app is installed and a channel layer is configured."""
+from __future__ import annotations
+
+from django.apps import apps
+
+
+def test_realtime_app_is_installed():
+    assert apps.is_installed("apps.realtime")
+
+
+def test_channel_layers_configured(settings):
+    assert "default" in settings.CHANNEL_LAYERS
+
+
+def test_channel_layer_is_in_memory_under_tests(settings):
+    # No REDIS_URL in the test env, so the in-memory layer is selected.
+    assert settings.CHANNEL_LAYERS["default"]["BACKEND"].endswith("InMemoryChannelLayer")

--- a/tests/test_realtime_channels_auth.py
+++ b/tests/test_realtime_channels_auth.py
@@ -31,9 +31,13 @@ async def _run_mw(scope):
 
 
 def _make_session(user) -> str:
+    from django.contrib.auth import BACKEND_SESSION_KEY, HASH_SESSION_KEY, SESSION_KEY
+
     engine = import_module(settings.SESSION_ENGINE)
     session = engine.SessionStore()
-    session["_auth_user_id"] = str(user.pk)
+    session[SESSION_KEY] = str(user.pk)
+    session[HASH_SESSION_KEY] = user.get_session_auth_hash()
+    session[BACKEND_SESSION_KEY] = "django.contrib.auth.backends.ModelBackend"
     session.save()
     return session.session_key
 
@@ -59,6 +63,26 @@ async def test_resolves_from_session_cookie():
     user = await _run_mw({"type": "websocket", "headers": [(b"cookie", cookie)]})
     assert user.is_authenticated
     assert user.pk == u.pk
+
+
+async def test_session_without_auth_hash_is_anonymous():
+    # A session missing the auth hash (e.g. one a password change invalidated)
+    # must not authenticate over WS, matching django.contrib.auth.get_user.
+    u = await database_sync_to_async(User.objects.create_user)("jj", "jj@dimagi.com", "pw")
+
+    def mk():
+        from django.contrib.auth import SESSION_KEY
+
+        engine = import_module(settings.SESSION_ENGINE)
+        session = engine.SessionStore()
+        session[SESSION_KEY] = str(u.pk)  # deliberately no HASH_SESSION_KEY
+        session.save()
+        return session.session_key
+
+    key = await database_sync_to_async(mk)()
+    cookie = f"{settings.SESSION_COOKIE_NAME}={key}".encode()
+    user = await _run_mw({"type": "websocket", "headers": [(b"cookie", cookie)]})
+    assert user.is_authenticated is False
 
 
 async def test_bad_bearer_is_anonymous():

--- a/tests/test_realtime_channels_auth.py
+++ b/tests/test_realtime_channels_auth.py
@@ -1,0 +1,67 @@
+"""SP1 Task 5 — RealtimeAuthMiddleware resolves scope['user'].
+
+Anonymous by default; from a session cookie; from a Bearer PAT. DB reads inside
+the middleware go through database_sync_to_async — if sqlite :memory: rows aren't
+visible from that executor, the bearer/session tests fail (and we switch those
+tests to a shared-cache DB).
+"""
+from __future__ import annotations
+
+from importlib import import_module
+
+import pytest
+from channels.db import database_sync_to_async
+from django.conf import settings
+from django.contrib.auth.models import User
+
+from apps.realtime.channels_auth import RealtimeAuthMiddleware
+from apps.tokens.models import PersonalToken
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+
+async def _run_mw(scope):
+    holder: dict = {}
+
+    async def app(s, receive, send):
+        holder["user"] = s["user"]
+
+    await RealtimeAuthMiddleware(app)(scope, None, None)
+    return holder["user"]
+
+
+def _make_session(user) -> str:
+    engine = import_module(settings.SESSION_ENGINE)
+    session = engine.SessionStore()
+    session["_auth_user_id"] = str(user.pk)
+    session.save()
+    return session.session_key
+
+
+async def test_anonymous_when_no_creds():
+    user = await _run_mw({"type": "websocket", "headers": []})
+    assert user.is_authenticated is False
+
+
+async def test_resolves_from_bearer():
+    u = await database_sync_to_async(User.objects.create_user)("jj", "jj@dimagi.com", "pw")
+    raw, _tok = await database_sync_to_async(PersonalToken.create_for_user)(user=u, label="t")
+    scope = {"type": "websocket", "headers": [(b"authorization", f"Bearer {raw}".encode())]}
+    user = await _run_mw(scope)
+    assert user.is_authenticated
+    assert user.pk == u.pk
+
+
+async def test_resolves_from_session_cookie():
+    u = await database_sync_to_async(User.objects.create_user)("jj", "jj@dimagi.com", "pw")
+    key = await database_sync_to_async(_make_session)(u)
+    cookie = f"{settings.SESSION_COOKIE_NAME}={key}".encode()
+    user = await _run_mw({"type": "websocket", "headers": [(b"cookie", cookie)]})
+    assert user.is_authenticated
+    assert user.pk == u.pk
+
+
+async def test_bad_bearer_is_anonymous():
+    scope = {"type": "websocket", "headers": [(b"authorization", b"Bearer not-a-real-token")]}
+    user = await _run_mw(scope)
+    assert user.is_authenticated is False

--- a/tests/test_realtime_fanout.py
+++ b/tests/test_realtime_fanout.py
@@ -1,0 +1,100 @@
+"""SP1 Task 4 — the three fan-out receivers put frames on the right groups.
+
+transaction=True so on_commit callbacks actually fire (pytest-django's default
+marker rolls the wrapping atomic back, discarding on_commit). All channel-layer
+ops go through async_to_sync in the test's own thread, which asgiref pins to a
+single cached event loop — so the InMemoryChannelLayer queues stay consistent
+across group_add / group_send / receive.
+"""
+from __future__ import annotations
+
+import pytest
+from asgiref.sync import async_to_sync
+from channels.layers import get_channel_layer
+from django.contrib.auth.models import User
+
+from apps.agents.models import Agent
+from apps.harness import services
+from apps.harness.models import Runner, Turn
+from apps.push.models import AgentWaitingSnapshot
+from apps.realtime import groups
+from apps.workspaces.models import Workspace, WorkspaceMembership
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+
+def _fixtures():
+    user = User.objects.create_user("jj", "jj@dimagi.com", "pw")
+    ws = Workspace.objects.create(slug="canopy", display_name="Canopy", created_by=user)
+    WorkspaceMembership.objects.create(user=user, workspace=ws, role=WorkspaceMembership.OWNER)
+    agent = Agent.objects.create(slug="echo", name="Echo", workspace=ws, owner=user)
+    return user, ws, agent
+
+
+def test_turn_event_fanout():
+    _user, _ws, agent = _fixtures()
+    turn = Turn.objects.create(agent=agent, origin=Turn.ORIGIN_BOARD, idempotency_key="k1")
+    layer = get_channel_layer()
+    async_to_sync(layer.group_add)(groups.turn_group(turn.id), "turn-chan")
+
+    services.append_events(turn, [{"kind": "assistant", "payload": {"text": "hi"}}])
+
+    msg = async_to_sync(layer.receive)("turn-chan")
+    assert msg["type"] == "turn.event"
+    assert msg["event"]["seq"] == 1
+    assert msg["event"]["kind"] == "assistant"
+
+
+def test_runner_fanout_to_pairer():
+    user, _ws, _agent = _fixtures()
+    runner = Runner.objects.create(name="cloud-1", kind=Runner.CLOUD, paired_by=user)
+    layer = get_channel_layer()
+    async_to_sync(layer.group_add)(groups.supervisor_user_group(user.id), "sup-chan")
+
+    # A heartbeat-style save re-fires post_save -> on_commit publish.
+    runner.status = Runner.ONLINE
+    runner.save(update_fields=["status"])
+
+    msg = async_to_sync(layer.receive)("sup-chan")
+    assert msg["type"] == "supervisor.runner"
+    assert msg["runner"]["id"] == str(runner.id)
+    assert msg["runner"]["name"] == "cloud-1"
+
+
+def test_runner_with_no_pairer_does_not_fan_out():
+    # No subscriber assertion is fragile; instead assert the guard directly by
+    # saving a pairer-less runner and confirming nothing lands for a bystander.
+    _user, _ws, _agent = _fixtures()
+    runner = Runner.objects.create(name="orphan", kind=Runner.CLOUD)
+    layer = get_channel_layer()
+    async_to_sync(layer.group_add)(groups.supervisor_user_group(999999), "nobody-chan")
+    runner.status = Runner.ONLINE
+    runner.save(update_fields=["status"])
+    # Nothing should be queued for an unrelated group; receive would block, so
+    # assert emptiness via the layer's per-channel queue.
+    import asyncio
+
+    async def _empty():
+        try:
+            await asyncio.wait_for(layer.receive("nobody-chan"), timeout=0.2)
+            return False
+        except (asyncio.TimeoutError, TimeoutError):
+            return True
+
+    assert async_to_sync(_empty)() is True
+
+
+def test_waiting_fanout_to_members():
+    user, _ws, agent = _fixtures()
+    # Create the snapshot BEFORE subscribing so its create-post_save goes nowhere.
+    snap, _ = AgentWaitingSnapshot.objects.get_or_create(agent=agent)
+    layer = get_channel_layer()
+    async_to_sync(layer.group_add)(groups.supervisor_user_group(user.id), "sup-chan")
+
+    snap.waiting_count = 3
+    snap.save(update_fields=["waiting_count", "updated_at"])
+
+    msg = async_to_sync(layer.receive)("sup-chan")
+    assert msg["type"] == "supervisor.waiting"
+    assert msg["agent"] == agent.slug
+    assert msg["waiting_count"] == 3

--- a/tests/test_realtime_groups.py
+++ b/tests/test_realtime_groups.py
@@ -1,0 +1,67 @@
+"""SP1 Task 2 — group names, the turn membership gate, and null-safe publish."""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from django.contrib.auth.models import AnonymousUser, User
+
+from apps.agents.models import Agent
+from apps.harness.models import Turn
+from apps.realtime import groups
+from apps.workspaces.models import Workspace, WorkspaceMembership
+
+
+def test_turn_group_is_stable():
+    tid = uuid.uuid4()
+    assert groups.turn_group(tid) == f"turn.{tid.hex}"
+    # accepts a str too, and normalizes to the same group
+    assert groups.turn_group(str(tid)) == groups.turn_group(tid)
+
+
+def test_supervisor_user_group():
+    assert groups.supervisor_user_group(7) == "supervisor.user.7"
+
+
+@pytest.mark.django_db
+def test_user_can_read_turn_by_workspace_membership():
+    owner = User.objects.create_user("jj", "jj@dimagi.com", "pw")
+    ws = Workspace.objects.create(slug="canopy", display_name="Canopy", created_by=owner)
+    WorkspaceMembership.objects.create(user=owner, workspace=ws, role=WorkspaceMembership.OWNER)
+    agent = Agent.objects.create(slug="echo", name="Echo", workspace=ws, owner=owner)
+    turn = Turn.objects.create(agent=agent, origin=Turn.ORIGIN_BOARD, idempotency_key="k1")
+
+    assert groups.user_can_read_turn(owner, turn) is True
+    outsider = User.objects.create_user("no", "no@dimagi.com", "pw")
+    assert groups.user_can_read_turn(outsider, turn) is False
+    assert groups.user_can_read_turn(AnonymousUser(), turn) is False
+
+
+@pytest.mark.django_db
+def test_user_cannot_read_workspaceless_turn():
+    # An agent with no workspace has no tenant to gate on -> not readable.
+    user = User.objects.create_user("jj", "jj@dimagi.com", "pw")
+    agent = Agent.objects.create(slug="loner", name="Loner")
+    turn = Turn.objects.create(agent=agent, origin=Turn.ORIGIN_BOARD, idempotency_key="k1")
+    assert groups.user_can_read_turn(user, turn) is False
+
+
+@pytest.mark.django_db
+def test_superuser_can_read_any_turn():
+    su = User.objects.create_superuser("admin", "admin@dimagi.com", "pw")
+    agent = Agent.objects.create(slug="loner", name="Loner")
+    turn = Turn.objects.create(agent=agent, origin=Turn.ORIGIN_BOARD, idempotency_key="k1")
+    assert groups.user_can_read_turn(su, turn) is True
+
+
+def test_publish_is_noop_when_no_layer(monkeypatch):
+    monkeypatch.setattr(groups, "get_channel_layer", lambda: None)
+    groups.publish("turn.x", {"type": "turn.event"})  # must not raise
+
+
+def test_publish_swallows_layer_errors(monkeypatch):
+    def boom():
+        raise RuntimeError("redis down")
+
+    monkeypatch.setattr(groups, "get_channel_layer", boom)
+    groups.publish("turn.x", {"type": "turn.event"})  # must not raise

--- a/tests/test_realtime_integration.py
+++ b/tests/test_realtime_integration.py
@@ -34,9 +34,13 @@ def _ws_app():
 
 
 def _make_session(user) -> str:
+    from django.contrib.auth import BACKEND_SESSION_KEY, HASH_SESSION_KEY, SESSION_KEY
+
     engine = import_module(settings.SESSION_ENGINE)
     session = engine.SessionStore()
-    session["_auth_user_id"] = str(user.pk)
+    session[SESSION_KEY] = str(user.pk)
+    session[HASH_SESSION_KEY] = user.get_session_auth_hash()
+    session[BACKEND_SESSION_KEY] = "django.contrib.auth.backends.ModelBackend"
     session.save()
     return session.session_key
 

--- a/tests/test_realtime_integration.py
+++ b/tests/test_realtime_integration.py
@@ -1,0 +1,100 @@
+"""SP1 polish — authenticated end-to-end through the ASSEMBLED websocket stack.
+
+The consumer unit tests inject scope['user'] directly; the uvicorn smoke test
+proves anon rejection over the wire. This closes the gap: it drives the real
+RealtimeAuthMiddleware -> URLRouter -> consumer composition (the websocket branch
+of config.asgi) with a genuine session cookie, exercising cookie->user auth +
+routing + consumer accept + snapshot/replay/live-tail together, in-process.
+"""
+from __future__ import annotations
+
+from importlib import import_module
+
+import pytest
+from channels.db import database_sync_to_async
+from channels.routing import URLRouter
+from channels.testing import WebsocketCommunicator
+from django.conf import settings
+from django.contrib.auth.models import User
+
+from apps.agents.models import Agent
+from apps.harness import services
+from apps.harness.models import Turn
+from apps.realtime.channels_auth import RealtimeAuthMiddleware
+from apps.realtime.routing import websocket_urlpatterns
+from apps.workspaces.models import Workspace, WorkspaceMembership
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+
+def _ws_app():
+    # The exact websocket composition config.asgi mounts, minus the origin
+    # validator (Channels' own code; the uvicorn smoke test covers it live).
+    return RealtimeAuthMiddleware(URLRouter(websocket_urlpatterns))
+
+
+def _make_session(user) -> str:
+    engine = import_module(settings.SESSION_ENGINE)
+    session = engine.SessionStore()
+    session["_auth_user_id"] = str(user.pk)
+    session.save()
+    return session.session_key
+
+
+def _seed():
+    user = User.objects.create_user("jj", "jj@dimagi.com", "pw")
+    ws = Workspace.objects.create(slug="canopy", display_name="Canopy", created_by=user)
+    WorkspaceMembership.objects.create(user=user, workspace=ws, role=WorkspaceMembership.OWNER)
+    agent = Agent.objects.create(slug="echo", name="Echo", workspace=ws, owner=user)
+    return user, agent
+
+
+def _cookie_header(session_key: str):
+    return [(b"cookie", f"{settings.SESSION_COOKIE_NAME}={session_key}".encode())]
+
+
+async def test_authenticated_supervisor_connect_and_snapshot():
+    def setup():
+        user, _agent = _seed()
+        return _make_session(user)
+
+    key = await database_sync_to_async(setup)()
+    comm = WebsocketCommunicator(_ws_app(), "/ws/supervisor/", headers=_cookie_header(key))
+    connected, _ = await comm.connect()
+    assert connected is True
+    snap = await comm.receive_json_from(timeout=2)
+    assert snap["type"] == "supervisor.snapshot"
+    assert "echo" in snap["waiting"]
+    await comm.disconnect()
+
+
+async def test_authenticated_turn_tail_replay_then_live():
+    def setup():
+        user, agent = _seed()
+        turn = Turn.objects.create(agent=agent, origin=Turn.ORIGIN_BOARD, idempotency_key="k1")
+        services.append_events(turn, [{"kind": "assistant", "payload": {"text": "old"}}])
+        return turn, _make_session(user)
+
+    turn, key = await database_sync_to_async(setup)()
+    comm = WebsocketCommunicator(_ws_app(), f"/ws/turns/{turn.id}/", headers=_cookie_header(key))
+    connected, _ = await comm.connect()
+    assert connected is True
+
+    replayed = await comm.receive_json_from(timeout=2)
+    assert replayed["event"]["seq"] == 1
+    assert replayed["event"]["payload"]["text"] == "old"
+
+    await database_sync_to_async(services.append_events)(
+        turn, [{"kind": "assistant", "payload": {"text": "new"}}]
+    )
+    live = await comm.receive_json_from(timeout=2)
+    assert live["event"]["seq"] == 2
+    assert live["event"]["payload"]["text"] == "new"
+    await comm.disconnect()
+
+
+async def test_anonymous_rejected_through_full_stack():
+    comm = WebsocketCommunicator(_ws_app(), "/ws/supervisor/")
+    connected, code = await comm.connect()
+    assert connected is False
+    assert code == 4001

--- a/tests/test_realtime_routing.py
+++ b/tests/test_realtime_routing.py
@@ -1,0 +1,38 @@
+"""SP1 Task 8 — websocket routing resolves to the right consumers, and the
+combined ASGI application builds with the Channels websocket wiring in place."""
+from __future__ import annotations
+
+import uuid
+
+from apps.realtime.consumers import SupervisorConsumer, TurnConsumer
+from apps.realtime.routing import websocket_urlpatterns
+
+
+def _match(path: str):
+    for pat in websocket_urlpatterns:
+        if pat.pattern.regex.match(path):
+            # channels' as_asgi() stamps .consumer_class on the returned app.
+            return pat.callback.consumer_class
+    return None
+
+
+def test_two_routes_registered():
+    assert len(websocket_urlpatterns) == 2
+
+
+def test_turn_route_resolves():
+    assert _match(f"ws/turns/{uuid.uuid4().hex}/") is TurnConsumer
+
+
+def test_supervisor_route_resolves():
+    assert _match("ws/supervisor/") is SupervisorConsumer
+
+
+def test_unknown_route_unmatched():
+    assert _match("ws/nope/") is None
+
+
+def test_asgi_application_builds():
+    import config.asgi as asgi
+
+    assert asgi.application is not None

--- a/tests/test_realtime_supervisor_consumer.py
+++ b/tests/test_realtime_supervisor_consumer.py
@@ -1,0 +1,66 @@
+"""SP1 Task 7 — SupervisorConsumer: auth gate, snapshot on connect, live deltas."""
+from __future__ import annotations
+
+import pytest
+from channels.db import database_sync_to_async
+from channels.testing import WebsocketCommunicator
+from django.contrib.auth.models import AnonymousUser, User
+
+from apps.agents.models import Agent
+from apps.harness.models import Runner
+from apps.realtime.consumers import SupervisorConsumer
+from apps.workspaces.models import Workspace, WorkspaceMembership
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+
+def _user_ws_agent():
+    user = User.objects.create_user("jj", "jj@dimagi.com", "pw")
+    ws = Workspace.objects.create(slug="canopy", display_name="Canopy", created_by=user)
+    WorkspaceMembership.objects.create(user=user, workspace=ws, role=WorkspaceMembership.OWNER)
+    agent = Agent.objects.create(slug="echo", name="Echo", workspace=ws, owner=user)
+    return user, ws, agent
+
+
+async def _connect(user):
+    comm = WebsocketCommunicator(SupervisorConsumer.as_asgi(), "/ws/supervisor/")
+    comm.scope["user"] = user
+    return comm
+
+
+async def test_anonymous_rejected():
+    comm = await _connect(AnonymousUser())
+    connected, code = await comm.connect()
+    assert connected is False
+    assert code == 4001
+
+
+async def test_snapshot_on_connect():
+    user, _ws, agent = await database_sync_to_async(_user_ws_agent)()
+    comm = await _connect(user)
+    connected, _ = await comm.connect()
+    assert connected is True
+    snap = await comm.receive_json_from(timeout=2)
+    assert snap["type"] == "supervisor.snapshot"
+    assert agent.slug in snap["waiting"]
+    assert isinstance(snap["runners"], list)
+    await comm.disconnect()
+
+
+async def test_live_runner_delta():
+    user, _ws, _agent = await database_sync_to_async(_user_ws_agent)()
+    comm = await _connect(user)
+    await comm.connect()
+    await comm.receive_json_from(timeout=2)  # drain the snapshot
+
+    def _make_runner():
+        runner = Runner.objects.create(name="cloud-1", kind=Runner.CLOUD, paired_by=user)
+        runner.status = Runner.ONLINE
+        runner.save(update_fields=["status"])
+        return runner
+
+    await database_sync_to_async(_make_runner)()
+    frame = await comm.receive_json_from(timeout=2)
+    assert frame["type"] == "supervisor.runner"
+    assert frame["runner"]["name"] == "cloud-1"
+    await comm.disconnect()

--- a/tests/test_realtime_turn_consumer.py
+++ b/tests/test_realtime_turn_consumer.py
@@ -14,7 +14,6 @@ from django.contrib.auth.models import AnonymousUser, User
 from apps.agents.models import Agent
 from apps.harness import services
 from apps.harness.models import Turn
-from apps.realtime import groups
 from apps.realtime.consumers import TurnConsumer
 from apps.workspaces.models import Workspace, WorkspaceMembership
 

--- a/tests/test_realtime_turn_consumer.py
+++ b/tests/test_realtime_turn_consumer.py
@@ -1,0 +1,94 @@
+"""SP1 Task 6 — TurnConsumer: auth gates, cursor replay, live tail.
+
+Unit-tests the consumer in isolation: we bypass the router+auth middleware and
+set scope['user'] / url_route / query_string directly on the communicator, so
+these tests cover the consumer's own logic (not the handshake, which Task 5 owns).
+"""
+from __future__ import annotations
+
+import pytest
+from channels.db import database_sync_to_async
+from channels.testing import WebsocketCommunicator
+from django.contrib.auth.models import AnonymousUser, User
+
+from apps.agents.models import Agent
+from apps.harness import services
+from apps.harness.models import Turn
+from apps.realtime import groups
+from apps.realtime.consumers import TurnConsumer
+from apps.workspaces.models import Workspace, WorkspaceMembership
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+
+def _member_turn():
+    user = User.objects.create_user("jj", "jj@dimagi.com", "pw")
+    ws = Workspace.objects.create(slug="canopy", display_name="Canopy", created_by=user)
+    WorkspaceMembership.objects.create(user=user, workspace=ws, role=WorkspaceMembership.OWNER)
+    agent = Agent.objects.create(slug="echo", name="Echo", workspace=ws, owner=user)
+    turn = Turn.objects.create(agent=agent, origin=Turn.ORIGIN_BOARD, idempotency_key="k1")
+    return user, turn
+
+
+async def _connect(turn, user, after=None):
+    path = f"/ws/turns/{turn.id}/"
+    if after is not None:
+        path += f"?after={after}"
+    comm = WebsocketCommunicator(TurnConsumer.as_asgi(), path)
+    comm.scope["user"] = user
+    comm.scope["url_route"] = {"kwargs": {"turn_id": str(turn.id)}}
+    return comm
+
+
+async def test_anonymous_rejected():
+    _user, turn = await database_sync_to_async(_member_turn)()
+    comm = await _connect(turn, AnonymousUser())
+    connected, code = await comm.connect()
+    assert connected is False
+    assert code == 4001
+
+
+async def test_non_member_forbidden():
+    _user, turn = await database_sync_to_async(_member_turn)()
+    outsider = await database_sync_to_async(User.objects.create_user)("no", "no@dimagi.com", "pw")
+    comm = await _connect(turn, outsider)
+    connected, code = await comm.connect()
+    assert connected is False
+    assert code == 4003
+
+
+async def test_member_gets_replay_then_live_tail():
+    user, turn = await database_sync_to_async(_member_turn)()
+    # A pre-existing event should be replayed on connect.
+    await database_sync_to_async(services.append_events)(
+        turn, [{"kind": "assistant", "payload": {"text": "old"}}]
+    )
+    comm = await _connect(turn, user)
+    connected, _ = await comm.connect()
+    assert connected is True
+
+    replayed = await comm.receive_json_from(timeout=2)
+    assert replayed["event"]["seq"] == 1
+    assert replayed["event"]["payload"]["text"] == "old"
+
+    # A new append after connect should arrive live over the group.
+    await database_sync_to_async(services.append_events)(
+        turn, [{"kind": "assistant", "payload": {"text": "new"}}]
+    )
+    live = await comm.receive_json_from(timeout=2)
+    assert live["event"]["seq"] == 2
+    assert live["event"]["payload"]["text"] == "new"
+    await comm.disconnect()
+
+
+async def test_cursor_replay_skips_seen_events():
+    user, turn = await database_sync_to_async(_member_turn)()
+    await database_sync_to_async(services.append_events)(
+        turn, [{"kind": "assistant", "payload": {}}, {"kind": "assistant", "payload": {}}]
+    )
+    comm = await _connect(turn, user, after=1)  # already saw seq 1
+    connected, _ = await comm.connect()
+    assert connected is True
+    frame = await comm.receive_json_from(timeout=2)
+    assert frame["event"]["seq"] == 2  # only the unseen one is replayed
+    await comm.disconnect()

--- a/tests/test_realtime_turn_consumer.py
+++ b/tests/test_realtime_turn_consumer.py
@@ -81,6 +81,24 @@ async def test_member_gets_replay_then_live_tail():
     await comm.disconnect()
 
 
+async def test_replay_pages_beyond_500_events():
+    # A turn with more than one replay page (500) must deliver ALL unseen events
+    # on connect — no silent truncation (the SP2 chat path routinely exceeds it).
+    user, turn = await database_sync_to_async(_member_turn)()
+    await database_sync_to_async(services.append_events)(
+        turn, [{"kind": "assistant", "payload": {"i": i}} for i in range(600)]
+    )
+    comm = await _connect(turn, user)
+    connected, _ = await comm.connect()
+    assert connected is True
+    seqs = []
+    for _ in range(600):
+        frame = await comm.receive_json_from(timeout=3)
+        seqs.append(frame["event"]["seq"])
+    assert seqs == list(range(1, 601))  # every event, in order, no gap
+    await comm.disconnect()
+
+
 async def test_cursor_replay_skips_seen_events():
     user, turn = await database_sync_to_async(_member_turn)()
     await database_sync_to_async(services.append_events)(

--- a/uv.lock
+++ b/uv.lock
@@ -222,6 +222,15 @@ wheels = [
 ]
 
 [[package]]
+name = "async-timeout"
+version = "5.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274, upload-time = "2024-11-06T16:41:39.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233, upload-time = "2024-11-06T16:41:37.9Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -341,6 +350,8 @@ dependencies = [
     { name = "anthropic" },
     { name = "canopy-agent-runs" },
     { name = "canopy-cron" },
+    { name = "channels" },
+    { name = "channels-redis" },
     { name = "django" },
     { name = "django-allauth", extra = ["socialaccount"] },
     { name = "django-cors-headers" },
@@ -371,6 +382,8 @@ requires-dist = [
     { name = "anthropic", specifier = ">=0.40,<1.0" },
     { name = "canopy-agent-runs", editable = "packages/canopy_agent_runs" },
     { name = "canopy-cron", editable = "packages/canopy_cron" },
+    { name = "channels", specifier = ">=4.1,<5.0" },
+    { name = "channels-redis", specifier = ">=4.2,<5.0" },
     { name = "django", specifier = ">=5.0,<6.0" },
     { name = "django-allauth", extras = ["socialaccount"], specifier = ">=0.61,<1.0" },
     { name = "django-cors-headers", specifier = ">=4.3,<5.0" },
@@ -471,6 +484,34 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
     { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
     { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
+name = "channels"
+version = "4.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "django" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/92/b18d4bb54d14986a8b35215a1c9e6a7f9f4d57ca63ac9aee8290ebb4957d/channels-4.3.2.tar.gz", hash = "sha256:f2bb6bfb73ad7fb4705041d07613c7b4e69528f01ef8cb9fb6c21d9295f15667", size = 27023, upload-time = "2025-11-20T15:13:05.102Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/34/c32915288b7ef482377b6adc401192f98c6a99b3a145423d3b8aed807898/channels-4.3.2-py3-none-any.whl", hash = "sha256:fef47e9055a603900cf16cef85f050d522d9ac4b3daccf24835bd9580705c176", size = 31313, upload-time = "2025-11-20T15:13:02.357Z" },
+]
+
+[[package]]
+name = "channels-redis"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "channels" },
+    { name = "msgpack" },
+    { name = "redis" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/69/fd3407ad407a80e72ca53850eb7a4c306273e67d5bbb71a86d0e6d088439/channels_redis-4.3.0.tar.gz", hash = "sha256:740ee7b54f0e28cf2264a940a24453d3f00526a96931f911fcb69228ef245dd2", size = 31440, upload-time = "2025-07-22T13:48:46.087Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/fe/b7224a401ad227b263e5ba84753ffb5a88df048f3b15efd2797903543ce4/channels_redis-4.3.0-py3-none-any.whl", hash = "sha256:48f3e902ae2d5fef7080215524f3b4a1d3cea4e304150678f867a1a822c0d9f5", size = 20641, upload-time = "2025-07-22T13:48:44.545Z" },
 ]
 
 [[package]]
@@ -1614,6 +1655,69 @@ wheels = [
 ]
 
 [[package]]
+name = "msgpack"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/f9/c0a1c127f9049db9155afc316952ea571720dd01833ff5e4d7e8e6352dbb/msgpack-1.2.1.tar.gz", hash = "sha256:04c721c2c7448767e9e3f2520a475663d8ee0f09c31890f6d2bd70fd636a9647", size = 183960, upload-time = "2026-06-18T16:13:52.594Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/6b/e9b1cdc042c4458801d2545ed782a95f3d6ba8e270cce8745b8603c7f748/msgpack-1.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:29a3f6e9667868429d8240dfd063ea5ffdc1321c13d783aa23827a38de0dcb22", size = 82812, upload-time = "2026-06-18T16:12:45.022Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/3a/dd518a1bf78ed1e9ad8afe57307c079a00eafe4b3068932a27ca1ea56b4f/msgpack-1.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:aded5bdf32609dc7987a49bbbd15a8ef096193f96dd8bbeb791de729e650acf5", size = 82739, upload-time = "2026-06-18T16:12:46.025Z" },
+    { url = "https://files.pythonhosted.org/packages/70/e0/7ba9e1542bf0771a27b8b37c1316e3f95ae9d748fd765284655c476ad4ef/msgpack-1.2.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:146ee4e9ce80b365c6d4c47073da9da7bcec473e58194ceee5dd7620ace77e06", size = 414233, upload-time = "2026-06-18T16:12:47.029Z" },
+    { url = "https://files.pythonhosted.org/packages/03/8d/671d81534ea0e2b0e8a121be100020da09eb78861fe3aa8f3ef7dcd3bed1/msgpack-1.2.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a28d076ca7c82b9c8728ad90b7147489449557038bed50e4241eb832395169b4", size = 423843, upload-time = "2026-06-18T16:12:48.19Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/b6/e5c737515ed1f166664b87601b532f58cbb73d8aa6a90b99f7c2c5037e8e/msgpack-1.2.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7d31c0ac0c640f877804c67cb2bc9f4e23dc2db97e96c2e67fa27d38283b41f8", size = 390772, upload-time = "2026-06-18T16:12:49.624Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/46/62ed8c2e87d7021eab19921594d961ef3aa3794eec76c716dc30f3bfd433/msgpack-1.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8ff92d7feeaf5bc26c51495b69e2f99ed97ab79346fb6555f44be7dd2ac6503b", size = 409559, upload-time = "2026-06-18T16:12:50.936Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ff/59aa3887b860bbf43532835e192b1c388a17590d6068ae4f8b2bc74c906e/msgpack-1.2.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:779197a6513bab3c3632265e3d0f7cb3227e62510841a6f34f1eaa37efbb345e", size = 387838, upload-time = "2026-06-18T16:12:52.161Z" },
+    { url = "https://files.pythonhosted.org/packages/09/11/f8563e471093420cf6478cb3271a0175d8402b82d879783d4035d2d03360/msgpack-1.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:67f6dd22fa72a93752643f07889796d62739a13415ee630169a8ce764f86cf9f", size = 421732, upload-time = "2026-06-18T16:12:53.556Z" },
+    { url = "https://files.pythonhosted.org/packages/57/cf/e673683c4c6c90c1022b24c65af4b03eda72b182a1176ef6449069d66acc/msgpack-1.2.1-cp311-cp311-win32.whl", hash = "sha256:91054a783328e0ea7954b8771095705c8d2243b814743fbaadf14552c9c52c5d", size = 64091, upload-time = "2026-06-18T16:12:54.821Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/07/ca212739d179f9083bff2c7c08c24101c3555a334fadc2b876b18768a3ae/msgpack-1.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:2eda0b7ebb1283a98d3e4492ac933c8af6aff59fd3df1c3ed024f536af4b1dc8", size = 70462, upload-time = "2026-06-18T16:12:55.898Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/be/6798347b425e26f35db82e69dd83c09716c856a3714e7bffc4c0860fd830/msgpack-1.2.1-cp311-cp311-win_arm64.whl", hash = "sha256:6ee967f7c7e1df2890c671ff2ee51a28ded0efc95da3e507176dee881ce36c66", size = 65059, upload-time = "2026-06-18T16:12:57.053Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/dd/9e8cbd8f5582ca4b590336f2b91ee5662f6a6ca562b565abaf696a0f81ff/msgpack-1.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2ef59c659f289eddf8aa6623823f19fa2f40a4029266889eac7a2505dd210c35", size = 83531, upload-time = "2026-06-18T16:12:58.249Z" },
+    { url = "https://files.pythonhosted.org/packages/50/2e/ebdb85a8da151397a2790363676b7ed7c125924fe618e4c6d8befb0cc62c/msgpack-1.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d3567748a5107cb40cdf66a275430c2f87c07777698f4bfd25c35f44d533258c", size = 82657, upload-time = "2026-06-18T16:12:59.396Z" },
+    { url = "https://files.pythonhosted.org/packages/26/aa/753ad8b007b464e1d8aa0c8e650b9c5f4f725e658fc5ac8a7635c55b7f6e/msgpack-1.2.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:60926b75d00c8e816ef98f3034f484a8bc64242d66839cef4cf7e503142316a0", size = 410634, upload-time = "2026-06-18T16:13:00.383Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/fd/6adabd4f6d5e686f97dd02ce7fce3fe4cf672cbac36b8f67ff4040e8ad8b/msgpack-1.2.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:020e881a764b20d8d7ca1a54fc01b8175519d108e3c3f194fddc200bda95951a", size = 419989, upload-time = "2026-06-18T16:13:01.776Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cc/85039b7b0eb168aaad7383a23c97e291a11f08351cb45a606ce865e4e3f1/msgpack-1.2.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4202c74688ca06591f78cb18988228bd4cca2cc75d57b60008372892d2f1e6e6", size = 377544, upload-time = "2026-06-18T16:13:03.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/bf/35963899493b32030c85fc513b723ae66144ac70c11ebc52e889e16e3d99/msgpack-1.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8b267ce94efb76fbd1b3373511420074ee3187f0f7811bf394531de13294735a", size = 400842, upload-time = "2026-06-18T16:13:05.012Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/df/8e2ac970c8f99264cd9997d1c73df5466bc19da3301d7dc5500862a9b089/msgpack-1.2.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:e4f1d0f8f98ade9634e01fb704a408f9336c0a8f1117b369f5db83dc7551d8b1", size = 374108, upload-time = "2026-06-18T16:13:06.232Z" },
+    { url = "https://files.pythonhosted.org/packages/17/dd/fa8bd265110dfa51c20cb529f9e6d240a16fafe7e645004c6af2d01353ba/msgpack-1.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f02cf17a6ca1abe29b5f980644f7551f94d71f2011509b26d8625ce038f0df64", size = 414939, upload-time = "2026-06-18T16:13:07.478Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b9/8377a5ad8953fc0437c70cc98d9ae29f27fe5ac5109fbec0812085865735/msgpack-1.2.1-cp312-cp312-win32.whl", hash = "sha256:0c0d9802354507bcba62af19c17918e3eb437cc25e6f50657d511b5856a77aac", size = 64504, upload-time = "2026-06-18T16:13:08.822Z" },
+    { url = "https://files.pythonhosted.org/packages/57/7f/ce1e377df7e62461fefd9eb23bfb93a4a523f40a517b377b8f844d836828/msgpack-1.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:5c24aa15d5963051e1a5c62b12c50cd705992502b5ec1f3bece6046f33c9fc24", size = 71421, upload-time = "2026-06-18T16:13:09.828Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/32/ebfe84c9929f08f188d56c7a2fd913406a9ddad76a634697c1c43b8112e6/msgpack-1.2.1-cp312-cp312-win_arm64.whl", hash = "sha256:4227224aaec8f7fbcbfbd4272319347b2bb4030366502600f8c45588c5187b07", size = 64775, upload-time = "2026-06-18T16:13:11.056Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ac/dcddcab6f6c20ecb387ca5e980371cdb3f87ff69aeca388be97eebc4c074/msgpack-1.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0a70e3cf2804a300d921bb0940426e35f4e489a23adfb77a808892241db0a064", size = 83151, upload-time = "2026-06-18T16:13:12.173Z" },
+    { url = "https://files.pythonhosted.org/packages/64/71/fbcfa83a1d6a9c6091942d1cfd070962244664b87427a9a49a6897b1b219/msgpack-1.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:491cc39455ca765fad51fb451bf2915eb2cf41192ab5801ce8d67c1d614fe056", size = 82351, upload-time = "2026-06-18T16:13:13.194Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/10/ddf7b06db879e8792d13934ddda09ff20bd2a583fd84c9b59aae9b0e650b/msgpack-1.2.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f310233ef7fb9c14e201c93639fe5f5260b005f56f0b29048e999c30935596cc", size = 407518, upload-time = "2026-06-18T16:13:14.233Z" },
+    { url = "https://files.pythonhosted.org/packages/79/d3/36a46a8ed992b781acbc05928bd5bee3c810cb0c3563bf81a7b0c04a1a76/msgpack-1.2.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:787c9bebb5833e8f6fc8abca3c0597683d8d87f56a8842b6b89c75a5f3176e2d", size = 416405, upload-time = "2026-06-18T16:13:15.435Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/84/e8e9598b557c0ba6ddae901a73780a4c75ac667dddf59414b1e56a42fb34/msgpack-1.2.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dc871b997a9370d855b7394465f2f350e847a5b806dd38dcc9c989e7d87da155", size = 376257, upload-time = "2026-06-18T16:13:17.022Z" },
+    { url = "https://files.pythonhosted.org/packages/40/16/738fe6d875ad7e2a9429c165322a4ec088f4f273cdfae63d96a89c467961/msgpack-1.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:85f57e960d877f2977f6430896191b04a21f8901b3b4baf2e4604329f4db5402", size = 397469, upload-time = "2026-06-18T16:13:18.287Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/be/6d5952df75a7f24f35833af764c3a6860780364cb3a0030beb8099e1b2b4/msgpack-1.2.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:1233ee2dd0cefba127583de50ea654677277047d238303521db35def3d7b2e7c", size = 372802, upload-time = "2026-06-18T16:13:19.685Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/39/e2ef7dbf0473bcb8dc7c50bf782a892d67414877b63e47fc88eb189ef5e6/msgpack-1.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e3dc2feb0876209d9c38aa56cb1de169bd6c4348f1aa48271f241226590993e6", size = 411273, upload-time = "2026-06-18T16:13:21.028Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/c5/133f4512a56e983a93445c836c9d94d88f3bc2e0980ff4b9e577bd8416ce/msgpack-1.2.1-cp313-cp313-win32.whl", hash = "sha256:6d09badf350af2be9d189184e04e64cf54ad93569ab3d96fca58bd3e84aad707", size = 64471, upload-time = "2026-06-18T16:13:22.293Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/98/577e10b055096a7dd40732358cabaf7180a20c79ed1dcdbb618e4b9deac7/msgpack-1.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:33f14fba63278b714efe6ad07e50ea5f03d91537aa6a1c5f1ceca4cf44013ca9", size = 71274, upload-time = "2026-06-18T16:13:23.455Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/ee/0c0048e7cfbef23c6a94791b8959ab28155232e7956de8a305b5ff588f05/msgpack-1.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:afc5febcd4c99effbc02b528e49d6fd0760b2b7d48c05239e345a5fa6e743d9a", size = 64795, upload-time = "2026-06-18T16:13:24.687Z" },
+    { url = "https://files.pythonhosted.org/packages/77/58/cce442852c6b9e1639c7c8ac8fd9143121cb32dab0f308df4d1426a8eb9c/msgpack-1.2.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:05f340e47e7e47d2da8db9b53e1bb1d294369e9ef45a747441309f6650b8351d", size = 83610, upload-time = "2026-06-18T16:13:25.724Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5c/15b4c7a0182f75ffa90751958ba36a9c01cafee367d49a3edc10ed140b01/msgpack-1.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:810b916696c86ef0deb3b74588480224df4c1b071136c34183e4a2a4284d7ac7", size = 83138, upload-time = "2026-06-18T16:13:26.781Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a6/99e58722feaffc5f2fbcc0c8c0d1451ab9f84097f7af87291b46af2390f4/msgpack-1.2.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ca0dacff965c47afdc3749a8469d7302a8f801d6a28758d55120d75e66ce6889", size = 406090, upload-time = "2026-06-18T16:13:28.072Z" },
+    { url = "https://files.pythonhosted.org/packages/19/03/8c63e8cf52958534ef688625965ab04c269a6cadd8caef16758b380a821a/msgpack-1.2.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0e2bf9280bceb5efca998435904b5d3e9fdbcc11d90dc9df30aec7973252b720", size = 412106, upload-time = "2026-06-18T16:13:29.427Z" },
+    { url = "https://files.pythonhosted.org/packages/63/d2/155d9e71b40e41fd934bc0c48b9b2770f22263e1ac20aad8e29fdca7be3f/msgpack-1.2.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aa6c4be5d1c02a42b066ca6ddb71adf36432868fdcdb6ee87e634e86e0674190", size = 374851, upload-time = "2026-06-18T16:13:30.631Z" },
+    { url = "https://files.pythonhosted.org/packages/98/48/deaf2326262a8d5ea3295ce9649912ecd3f551ba7ec8e33c665d2ba583f3/msgpack-1.2.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec0e675d59150a6269ddc9139087c722292664a37d071a849c05c473350f1f2d", size = 396168, upload-time = "2026-06-18T16:13:31.977Z" },
+    { url = "https://files.pythonhosted.org/packages/10/2a/b4410f906c2ec0008f1608d3ab5143afc3ad3f4e6da0fed3ea2231d0bef4/msgpack-1.2.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:dd3bfe82d53edfe4b7fc9a7ec9761e23a7a5b1dac22264505af428253c29ed24", size = 371959, upload-time = "2026-06-18T16:13:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/59/86/1edc67270099a528fa2093ea60fe191233cd238e4bd30cfacf7db79fc959/msgpack-1.2.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5ad5467fc3f68b5468e06c5f788d712e9f8ffc8b0cd1bcb160c105c1ee92dae7", size = 408457, upload-time = "2026-06-18T16:13:34.567Z" },
+    { url = "https://files.pythonhosted.org/packages/82/90/8b630fef07d8c5ab457b71ff2c217910c83d333c7a68472c186e87cc504a/msgpack-1.2.1-cp314-cp314-win32.whl", hash = "sha256:98b58bdb89c46190e4609bb36abe17c6d4105ad13f9c5f8f6f64d320f8ced3fb", size = 65942, upload-time = "2026-06-18T16:13:36.056Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f1/467b81e98b24dd3885d7b1857728797b4ffc76a7a7483af4fb321a07de3c/msgpack-1.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:74847557e28ce71bd3c438a447ca90e4b507e997ddbdef8a12a7b283b86c156b", size = 72627, upload-time = "2026-06-18T16:13:37.079Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/1d/5d8c4c89985feb6acefb82a09e501c60392261856d2408d20bfe4f0360b1/msgpack-1.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:b50b727bd652bdc37d950336c848ef20ec54a4cafc38dce19b1cd86ad625d0f7", size = 66908, upload-time = "2026-06-18T16:13:38.23Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/02/ad2afb678b4de94496cd432b581759b756a92c1192d8c767edd6b132efdc/msgpack-1.2.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:8d00f177ca88a77c1cf848d204a38f249751650b601cb6532acc68805d8a8273", size = 86000, upload-time = "2026-06-18T16:13:39.44Z" },
+    { url = "https://files.pythonhosted.org/packages/54/74/0b797484013128837f3b1cbb6cea019277c4de4e377dc512b4d9a0f92940/msgpack-1.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5bb9c386f0a329c035ddbab4b72d1028bf9627add8dda41070288563d57ed1b1", size = 86544, upload-time = "2026-06-18T16:13:40.447Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/b4/b774d7eb95561739907fec675582f83203cf41c597a418c2589b4bfb8e9d/msgpack-1.2.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:20466cca18c49c7292a8984bc15d65857b171e7264bdcb5f96baf8be238791fc", size = 427661, upload-time = "2026-06-18T16:13:41.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/f9/3243191dc9937e00756c8bc1b0272fed8f23758e43df2a3b46f533e5090f/msgpack-1.2.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:196300e7e5d6e74d50f1607ab9c06c4a1484c383cd22defd727902591f7e8dde", size = 426375, upload-time = "2026-06-18T16:13:42.936Z" },
+    { url = "https://files.pythonhosted.org/packages/23/c7/1693111db9944ba4ad4b67a1e788400d78a0b6af7a6523dc7e4e58f8274b/msgpack-1.2.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:575957e79cd51903a4e8495a242442949641e08f1efd5197b43bebd3ea7682b4", size = 380495, upload-time = "2026-06-18T16:13:44.306Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/2b/92f86956a0c13e8662f7e2ad630c4eb4db07497b967589bd5245e018b2c1/msgpack-1.2.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8c2ed1e48cc0f460bf3c7780e7137ff21a4e18433451916f2442c1b21036cd7d", size = 410897, upload-time = "2026-06-18T16:13:45.629Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ea/1479f72d200313a76fc2f823a79d1e07ed052ab7b8a0280640aa7b95de42/msgpack-1.2.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5f6277e5f783c36786a145e0247fc189a03f35f84b251646e53592d2bc12b355", size = 378519, upload-time = "2026-06-18T16:13:46.998Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/4d/fa006060ffa1011d32bfae826fe766fe73e02982183601633b7121058ab3/msgpack-1.2.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f9389552ecf4784886345ead0647e4edc96bee37cbab05b75540f542f766c48c", size = 419815, upload-time = "2026-06-18T16:13:48.205Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/aab6c946570496b78e67804721f3d5e2d62a93081b9b37df77764ef56347/msgpack-1.2.1-cp314-cp314t-win32.whl", hash = "sha256:c1c79a604a2969a868a78b6ebd27a887e00c624f14f66b3038e0590cb23332d1", size = 70914, upload-time = "2026-06-18T16:13:49.385Z" },
+    { url = "https://files.pythonhosted.org/packages/13/0a/e608956488a2af014cfe6e3d665e090b8ee42aa14b07f8f95b8880d66b09/msgpack-1.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:f12038a35fabd52e56a3547bab42401af49a45caa6dd00b34c44de235bc93ee2", size = 77999, upload-time = "2026-06-18T16:13:50.467Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/8a/27e2e57055176e366a46b85d02d68e7a5bcfbdd8474c9706375d965f24d3/msgpack-1.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:0adcf06ffde0777c0e1a9b771a2b1c4226ba1bbf748c8efcc02fcdeca3299107", size = 71160, upload-time = "2026-06-18T16:13:51.498Z" },
+]
+
+[[package]]
 name = "multidict"
 version = "6.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2502,6 +2606,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "redis"
+version = "8.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/c3/928b290c2c0ca99ab96eea5b4ff8f30be8112b075301a7d3ba214a3c8c12/redis-8.0.1.tar.gz", hash = "sha256:afc5a7a2f5a084f5b1880dec548dd45be17db7e43c82a30d84f952aefb05cfb0", size = 5114170, upload-time = "2026-06-23T14:52:37.728Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/0a/c2345ebf1ebe70840ce3f6c6ee612f8fa749cfbd1b03069c53bf0c62aaad/redis-8.0.1-py3-none-any.whl", hash = "sha256:47daa35a058c23468d6437f17a8c76882cb316b838ef763036af99b96cedd743", size = 502406, upload-time = "2026-06-23T14:52:36.137Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2,8 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
-    "python_full_version >= '3.13'",
-    "python_full_version < '3.13'",
+    "python_full_version >= '3.13' and platform_python_implementation == 'PyPy' and sys_platform == 'win32'",
+    "(python_full_version >= '3.13' and platform_python_implementation != 'PyPy') or (python_full_version >= '3.13' and sys_platform != 'win32')",
+    "python_full_version < '3.13' and platform_python_implementation == 'PyPy' and sys_platform == 'win32'",
+    "(python_full_version < '3.13' and platform_python_implementation != 'PyPy') or (python_full_version < '3.13' and sys_platform != 'win32')",
 ]
 
 [[package]]
@@ -253,6 +255,61 @@ wheels = [
 ]
 
 [[package]]
+name = "autobahn"
+version = "26.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cbor2" },
+    { name = "cffi" },
+    { name = "cryptography" },
+    { name = "hyperlink" },
+    { name = "msgpack", marker = "platform_python_implementation == 'CPython'" },
+    { name = "txaio" },
+    { name = "u-msgpack-python", marker = "platform_python_implementation != 'CPython'" },
+    { name = "ujson" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/73/f109f563c27e048e45d135d81af19e6ca391e24905550b06bd1c9d674c57/autobahn-26.7.1.tar.gz", hash = "sha256:c6949a2c6eb95fb1c218837dbda0a59abbbebafb8b11098551c01a7061dfd245", size = 14056542, upload-time = "2026-07-15T19:14:01.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/8c/381cdcab8016df2177adc93d25f84ca3a5fb8f8be4f9d784336416c7bee8/autobahn-26.7.1-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:3fe80550707f0affb5cb10f3e0f66ec7e6e52abb29edc66dd76734c2d7d51bf4", size = 1997747, upload-time = "2026-07-15T19:13:21.998Z" },
+    { url = "https://files.pythonhosted.org/packages/79/a9/9293c6c6bc8970f42c9675942de78f306e18eafa47edba52fd27f9dc71bd/autobahn-26.7.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:00fb9acd8775eaa0e272f36b76db903f10de56478f6a72f0bd07ee882ae1f2b8", size = 2082284, upload-time = "2026-07-15T19:13:23.582Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/ba/7396cb42a9c59df20c350ea05f75e6f25f582b474dee82b8e32823b2711e/autobahn-26.7.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:97c9674eddd55ad3ebd733824789175e5fb90c88afd523de507569ba0fcd6853", size = 2254260, upload-time = "2026-07-15T19:13:24.894Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/64/19753442770662ff45c4fe48db6345ac6fa3100fbbd989241c074e38ea6f/autobahn-26.7.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:30fa714de5c9903ef64084d3a938d8a3bac0bb42f1532d5de22f34b04a1c4819", size = 3173653, upload-time = "2026-07-15T19:13:26.261Z" },
+    { url = "https://files.pythonhosted.org/packages/04/a4/b690f272427acf1e8ea03b146e559dc67ade10dd4e0cccacc1d4c011b141/autobahn-26.7.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:c3362197f3b9d5b0df7f3365bd00dedba7ee8b649d652941377abe690d1c8b14", size = 3402880, upload-time = "2026-07-15T19:13:27.683Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/ca/4502dfafc07cdae9690ff1d7a24fad04d046f0c4348da4d563b01c112d5e/autobahn-26.7.1-cp311-cp311-win_amd64.whl", hash = "sha256:201e93eebfead7acc6924d8b17c57001bd5e377e8e2239a31f730831983ff43c", size = 2181533, upload-time = "2026-07-15T19:13:29.097Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/23/0769ef39e1cfb0bec15bacdd7f407aaedfda14c0ca3f7e818b856f2ed1a1/autobahn-26.7.1-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:6c9013e9aa9ea8a561c89d7be2709546b51fc7ac8fdf6cd71bc12a634672d9a8", size = 2000605, upload-time = "2026-07-15T19:13:30.391Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/ef/26833f38ecf3aef3ff0aa09feb12f5d472f7370104148a6b78e3c7afc286/autobahn-26.7.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:abd9ebe577dd1030f9a0c41d20dc00eca90d5cf338531abcb510d978825feeea", size = 2082844, upload-time = "2026-07-15T19:13:31.559Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/4c/00553ee9d57ee11df47bc9867d120cfe721a73bec0b58fb3a3b91cd7c797/autobahn-26.7.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:de491baa4cf52fb6d7f542e445c72d94ce52dc7aabb47b0b4d5191e452dd2c74", size = 2254852, upload-time = "2026-07-15T19:13:32.8Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/ca/7884f6ffb8410882df98cb939dea24225dd79e4f091ceb59f4b826e54f2f/autobahn-26.7.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9723561c820ed032fe5a8f1530cb6d5f91dc595eea6009f3b2de7044a3df892a", size = 3174235, upload-time = "2026-07-15T19:13:34.134Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/e7/c6704e8f6bef3aa552a851a34908a06d91317d35ca55ec04b5db14385c33/autobahn-26.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e81c86cf41adca8a56ca5621ecd9ba40037f6d90d338c334bd529c8ac94bd7b6", size = 3403687, upload-time = "2026-07-15T19:13:35.633Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ae/d0993f37f7ddce595dff8ddbe3cdbe5351a1454e4d9d30bbcb0a6e08e8e3/autobahn-26.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:b2ec0cfb913cc20f10feb3d63cd3eb2e08c9f28f9c1ba4e7776454cd5b345145", size = 2179395, upload-time = "2026-07-15T19:13:37.088Z" },
+    { url = "https://files.pythonhosted.org/packages/36/92/2f6e57d9f9e6b86b9db362f58aaa6cfeadc2f3a6901ec95aab27ef232b5c/autobahn-26.7.1-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:2ce48214b28f73338fabe0c7fd13d222cfab9e1dd2ef11660293522f64e76727", size = 1987052, upload-time = "2026-07-15T19:13:38.543Z" },
+    { url = "https://files.pythonhosted.org/packages/38/6d/f170134468e276fa9ea57eb1ae41f9cc0dcd0228e9d501f370fa50c0ee31/autobahn-26.7.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a5f285dce9b3dff3eb2ef6c818ac8ede24d96bd1edac340855170fc9825c38a9", size = 2082813, upload-time = "2026-07-15T19:13:39.686Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/ce/b735fa933e9ba4fa8c3f9aa9ae68b4e2d4aadb0a92b38ade30e37a7d4795/autobahn-26.7.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:66ab6e034e54f8c473df1a6b8031a3db46c16deebaf0c9b66db3e9137d2fab5e", size = 2254818, upload-time = "2026-07-15T19:13:40.951Z" },
+    { url = "https://files.pythonhosted.org/packages/df/3e/57855f4f52aa0ee64c6d8210637d0d9847de4c1082e03ddd2ffafd853d2d/autobahn-26.7.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:20b3eab7d483e93278f9d7345592eb6b465883a6e88c2823aad13c3f943452db", size = 682494, upload-time = "2026-07-15T19:13:42.193Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/3c/3944f17dd2a06aee7d0d9f1c37b5a94518434d13ba2c38e738d33ca10daf/autobahn-26.7.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cd840524ff190aee695a58e8acd8740ee66b4a0e6a58ccb41416ed2cbe48d43f", size = 3403666, upload-time = "2026-07-15T19:13:43.508Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/40/187f83f4048705160bdac91235183e9d0f3bbe002be4da552cce640c239b/autobahn-26.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d158b85f075975dd4d47e937c943588f7cbf8e46f3271544b55f5c6f6500071", size = 2174266, upload-time = "2026-07-15T19:13:45.161Z" },
+    { url = "https://files.pythonhosted.org/packages/51/3e/200471878093a502f8e8078c1ca19fd82acc68ae9ac363e395170da6dbe2/autobahn-26.7.1-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:f3d1be925e3fb33fff5280c1bd02027047519812c400d3efa5477d3968686c94", size = 1987070, upload-time = "2026-07-15T19:13:47.112Z" },
+    { url = "https://files.pythonhosted.org/packages/61/d1/704f881fd2c52b056dc0f14e6d0d640b1f3ff43f3b84cf85d3631e3243f4/autobahn-26.7.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:44f8094b0c0fa29a4963ce12130b7932469f89afa0242ff858d2b26541a81005", size = 2082939, upload-time = "2026-07-15T19:13:48.569Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/27/84e76aec7abbcb502d4cd34ef5c859eaa19a3b707cda68ab7ce68478dd92/autobahn-26.7.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a0fcf9c3ff6b9b2bc85d6e1814a94d1d941d62f7df36d350b523d77df85d66ea", size = 2254983, upload-time = "2026-07-15T19:13:49.802Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/81/a810732a10342c5d6b90d19f83fa2bc9b6126e7c0cda7c4df867e311aa2e/autobahn-26.7.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4f82e5a113f6c1ff14cec99aa411f7da8fceec3dcd4647d7ebdfc0278811e14d", size = 3174295, upload-time = "2026-07-15T19:13:51.227Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c6/4886fdaecfeda013e085288a9d83bad6f1ded9995b8088ca933d9ec37201/autobahn-26.7.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:919309cbe41b28b0a3028e7c6fed52aca9fd21639619f372d3270c44341b6bdc", size = 3403713, upload-time = "2026-07-15T19:13:52.744Z" },
+    { url = "https://files.pythonhosted.org/packages/42/08/0106af17fcbe65a85040a8d98015bdcf2ef68144e12df500a72b91a5873e/autobahn-26.7.1-cp314-cp314-win_amd64.whl", hash = "sha256:354298aa0ab79861578f45f5bf543e4757c32070ff801282beda80c6c4f2a41e", size = 2206827, upload-time = "2026-07-15T19:13:54.499Z" },
+    { url = "https://files.pythonhosted.org/packages/94/14/6485c29ad06a6bd7b3017558f99f6f89dcaa6ef6641930b25d9247adba4c/autobahn-26.7.1-pp311-pypy311_pp73-macosx_15_0_arm64.whl", hash = "sha256:9088acf790caf8cfd86590cb2b749279256ee210198f41d9858a38d1346e56c9", size = 1981962, upload-time = "2026-07-15T19:13:55.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/46/cb6d09604417beacdf485b414a05efa18511b0e78ac5451b3655bee711fa/autobahn-26.7.1-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ea4548ee15c6bdf8aa0a1e81bf47b42db350f2bef69f83bace27a95ed0d21276", size = 655967, upload-time = "2026-07-15T19:13:57.19Z" },
+    { url = "https://files.pythonhosted.org/packages/00/d9/b846bc5a37f25ac147879d6451c466968a54efbf9d0467f0732f37c6f3f3/autobahn-26.7.1-pp311-pypy311_pp73-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d4ee0fe13a5218831d60863becd8c3cf6558e6c5ccc5d9d0e722012bdb1459bf", size = 2207401, upload-time = "2026-07-15T19:13:58.392Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/74/e8c54049bb9a835fe298a573291300048c6da668a75efa63e023d69da38f/autobahn-26.7.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:9ff26c61d4392a09a73be5497296cd5d7bae3c1f476218b75ec3be789036bf39", size = 2180116, upload-time = "2026-07-15T19:13:59.943Z" },
+]
+
+[[package]]
+name = "automat"
+version = "25.4.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/0f/d40bbe294bbf004d436a8bcbcfaadca8b5140d39ad0ad3d73d1a8ba15f14/automat-25.4.16.tar.gz", hash = "sha256:0017591a5477066e90d26b0e696ddc143baafd87b588cfac8100bc6be9634de0", size = 129977, upload-time = "2025-04-16T20:12:16.002Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/ff/1175b0b7371e46244032d43a56862d0af455823b5280a50c63d99cc50f18/automat-25.4.16-py3-none-any.whl", hash = "sha256:04e9bce696a8d5671ee698005af6e5a9fa15354140a87f4870744604dcdd3ba1", size = 42842, upload-time = "2025-04-16T20:12:14.447Z" },
+]
+
+[[package]]
 name = "backoff"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -370,6 +427,7 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "daphne" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-django" },
@@ -384,6 +442,7 @@ requires-dist = [
     { name = "canopy-cron", editable = "packages/canopy_cron" },
     { name = "channels", specifier = ">=4.1,<5.0" },
     { name = "channels-redis", specifier = ">=4.2,<5.0" },
+    { name = "daphne", marker = "extra == 'dev'", specifier = ">=4.1,<5.0" },
     { name = "django", specifier = ">=5.0,<6.0" },
     { name = "django-allauth", extras = ["socialaccount"], specifier = ">=0.61,<1.0" },
     { name = "django-cors-headers", specifier = ">=4.3,<5.0" },
@@ -406,6 +465,43 @@ requires-dist = [
     { name = "whitenoise", specifier = ">=6.6,<7.0" },
 ]
 provides-extras = ["dev"]
+
+[[package]]
+name = "cbor2"
+version = "5.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/cb/09939728be094d155b5d4ac262e39877875f5f7e36eea66beb359f647bd0/cbor2-5.9.0.tar.gz", hash = "sha256:85c7a46279ac8f226e1059275221e6b3d0e370d2bb6bd0500f9780781615bcea", size = 111231, upload-time = "2026-03-22T15:56:50.638Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/aa/317c7118b8dda4c9563125c1a12c70c5b41e36677964a49c72b1aac061ec/cbor2-5.9.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0485d3372fc832c5e16d4eb45fa1a20fc53e806e6c29a1d2b0d3e176cedd52b9", size = 70578, upload-time = "2026-03-22T15:56:03.835Z" },
+    { url = "https://files.pythonhosted.org/packages/31/43/fe29b1f897770011a5e7497f4523c2712282ee4a6cbf775ea6383fb7afb9/cbor2-5.9.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a9d6e4e0f988b0e766509a8071975a8ee99f930e14a524620bf38083106158d2", size = 268738, upload-time = "2026-03-22T15:56:05.222Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/1a/e494568f3d8aafbcdfe361df44c3bcf5cdab5183e25ea08e3d3f9fcf4075/cbor2-5.9.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5326336f633cc89dfe543c78829c16c3a6449c2c03277d1ddba99086c3323363", size = 262571, upload-time = "2026-03-22T15:56:06.411Z" },
+    { url = "https://files.pythonhosted.org/packages/42/2e/92acd6f87382fd44a34d9d7e85cc45372e6ba664040b72d1d9df648b25d0/cbor2-5.9.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:5e702b02d42a5ace45425b595ffe70fe35aebaf9a3cdfdc2c758b6189c744422", size = 262356, upload-time = "2026-03-22T15:56:08.236Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/68/52c039a28688baeeb78b0be7483855e6c66ea05884a937444deede0c87b8/cbor2-5.9.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:2372d357d403e7912f104ff085950ffc82a5854d6d717f1ca1ce16a40a0ef5a7", size = 257604, upload-time = "2026-03-22T15:56:09.835Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e4/10d96a7f73ed9227090ce6e3df5d73329eb6a267dab7d5b989e6fbf6c504/cbor2-5.9.0-cp311-cp311-win_amd64.whl", hash = "sha256:1d02b65f070fd726bdc310d927228975bb655d155bf059b6eb7cacefb3dca86f", size = 69388, upload-time = "2026-03-22T15:56:11.28Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/c6/eea5829aa5a649db540f47ea35f4bf2313383d28246f0cbc50432cfad6b3/cbor2-5.9.0-cp311-cp311-win_arm64.whl", hash = "sha256:837754ece9052b3f607047e1741e5f852a538aa2b0ee3db11c82a8fa11804aa4", size = 65315, upload-time = "2026-03-22T15:56:12.326Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/39/72d8a5a4b06565561ec28f4fcb41aff7bb77f51705c01f00b8254a2aca4f/cbor2-5.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1f223dffb1bcdd2764665f04c1152943d9daa4bc124a576cd8dee1cad4264313", size = 71223, upload-time = "2026-03-22T15:56:13.68Z" },
+    { url = "https://files.pythonhosted.org/packages/09/fd/7ddf3d3153b54c69c3be77172b8d9aa3a9d74f62a7fbde614d53eaeed9a4/cbor2-5.9.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ae6c706ac1d85a0b3cb3395308fd0c4d55e3202b4760773675957e93cdff45fc", size = 287865, upload-time = "2026-03-22T15:56:14.813Z" },
+    { url = "https://files.pythonhosted.org/packages/db/9d/7ede2cc42f9bb4260492e7d29d2aab781eacbbcfb09d983de1e695077199/cbor2-5.9.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4cd43d8fc374b31643b2830910f28177a606a7bc84975a62675dd3f2e320fc7b", size = 288246, upload-time = "2026-03-22T15:56:16.113Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/9d/588ebc7c5bc5843f609b05fe07be8575c7dec987735b0bbc908ac9c1264a/cbor2-5.9.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4aa07b392cc3d76fb31c08a46a226b58c320d1c172ff3073e864409ced7bc50f", size = 280214, upload-time = "2026-03-22T15:56:17.519Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a1/6fc8f4b15c6a27e7fbb7966c30c2b4b18c274a3221fa2f5e6235502d34bc/cbor2-5.9.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:971d425b3a23b75953d8853d5f9911bdeefa09d759ee3b5e6b07b5ff3cbd9073", size = 282162, upload-time = "2026-03-22T15:56:18.975Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/20/9a22cfe08be16ddfeef2542cf4eeed1b29f3f57ddbba0b42f7e0bb8331fd/cbor2-5.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:34a6cb15e6ab6a8eae94ad2041731cd3ef786af43a8df99f847969af5b902ee7", size = 70049, upload-time = "2026-03-22T15:56:20.502Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/9e/695f92d09006614034e25a9f5b10620f3b219f79c1bec3c37b7c6f27a7a9/cbor2-5.9.0-cp312-cp312-win_arm64.whl", hash = "sha256:7d1ddc4541e7367ac58c2470cc0df847f7137167fe4f5729e2d3cc0b993d7da4", size = 65382, upload-time = "2026-03-22T15:56:21.526Z" },
+    { url = "https://files.pythonhosted.org/packages/81/c5/4901e21a8afe9448fd947b11e8f383903207cd6dd0800e5f5a386838de5b/cbor2-5.9.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:fbb06f34aa645b4deca66643bba3d400d20c15312d1fe88d429be60c1ab50f27", size = 71284, upload-time = "2026-03-22T15:56:22.836Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/10/df643a381aebc3f05486de4813662bc58accb640fc3275cb276a75e89694/cbor2-5.9.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac684fe195c39821fca70d18afbf748f728aefbfbf88456018d299e559b8cae0", size = 287682, upload-time = "2026-03-22T15:56:24.024Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0c/8aa6b766059ae4a0ca1ec3ff96fe3823a69a7be880dba2e249f7fbe2700b/cbor2-5.9.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2a54fbb32cb828c214f7f333a707e4aec61182e7efdc06ea5d9596d3ecee624a", size = 288009, upload-time = "2026-03-22T15:56:25.305Z" },
+    { url = "https://files.pythonhosted.org/packages/74/07/6236bc25c183a9cf7e8062e5dddf9eae9b0b14ebf14a58a69fe5a1e872c6/cbor2-5.9.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4753a6d1bc71054d9179557bc65740860f185095ccb401d46637fff028a5b3ec", size = 280437, upload-time = "2026-03-22T15:56:26.479Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/0a/84328d23c3c68874ac6497edb9b1900579a1028efa54734df3f1762bbc15/cbor2-5.9.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:380e534482b843e43442b87d8777a7bf9bed20cb7526f89b780c3400f617304b", size = 282247, upload-time = "2026-03-22T15:56:28.644Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/f6/89b4627e09d028c8e5fcaf7cb55f225c33ce6e037ec1844e65d02bcfa945/cbor2-5.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:dcf0f695873e5c94bd072d6af8698e72b8fb7f7a18f37e0bced1041b7111a6cf", size = 70089, upload-time = "2026-03-22T15:56:29.801Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/7c/efadcd5f0102db692490e4e206988a2f98d39a09912090db497a2b800885/cbor2-5.9.0-cp313-cp313-win_arm64.whl", hash = "sha256:f7c9751a9611601ab326d8f5837f01379195bbf06175fb4effeb552140e7c9e8", size = 65466, upload-time = "2026-03-22T15:56:30.823Z" },
+    { url = "https://files.pythonhosted.org/packages/08/7d/9ccc36d10ef96e6038e48046ebe1ce35a1e7814da0e1e204d09e6ef09b8d/cbor2-5.9.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23606d31ba1368bd1b6602e3020ee88fe9523ca80e8630faf6b2fc904fd84560", size = 71500, upload-time = "2026-03-22T15:56:31.876Z" },
+    { url = "https://files.pythonhosted.org/packages/70/e1/a6cca2cc72e13f00030c6a649f57ae703eb2c620806ab70c40db8eab33fa/cbor2-5.9.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0322296b9d52f55880e300ba8ba09ecf644303b99b51138bbb1c0fb644fa7c3e", size = 286953, upload-time = "2026-03-22T15:56:33.292Z" },
+    { url = "https://files.pythonhosted.org/packages/08/3c/24cd5ef488a957d90e016f200a3aad820e4c2f85edd61c9fe4523007a1ee/cbor2-5.9.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:422817286c1d0ce947fb2f7eca9212b39bddd7231e8b452e2d2cc52f15332dba", size = 285454, upload-time = "2026-03-22T15:56:34.703Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/35/dca96818494c0ba47cdd73e8d809b27fa91f8fa0ce32a068a09237687454/cbor2-5.9.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9a4907e0c3035bb8836116854ed8e56d8aef23909d601fa59706320897ec2551", size = 279441, upload-time = "2026-03-22T15:56:35.888Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/44/d3362378b16e53cf7e535a3f5aed8476e2109068154e24e31981ef5bde9e/cbor2-5.9.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fb7afe77f8d269e42d7c4b515c6fd14f1ccc0625379fb6829b269f493d16eddd", size = 279673, upload-time = "2026-03-22T15:56:37.08Z" },
+    { url = "https://files.pythonhosted.org/packages/43/d1/3533a697e5842fff7c2f64912eb251f8dcab3a8b5d88e228d6eebc3b5021/cbor2-5.9.0-cp314-cp314-win_amd64.whl", hash = "sha256:86baf870d4c0bfc6f79de3801f3860a84ab76d9c8b0abb7f081f2c14c38d79d3", size = 71940, upload-time = "2026-03-22T15:56:38.366Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/e2/c6ba75f3fb25dfa15ab6999cc8709c821987e9ed8e375d7f58539261bcb9/cbor2-5.9.0-cp314-cp314-win_arm64.whl", hash = "sha256:7221483fad0c63afa4244624d552abf89d7dfdbc5f5edfc56fc1ff2b4b818975", size = 67639, upload-time = "2026-03-22T15:56:39.39Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ff/b83492b096fbef26e9cb62c1a4bf2d3cef579ea7b33138c6c37c4ae66f67/cbor2-5.9.0-py3-none-any.whl", hash = "sha256:27695cbd70c90b8de5c4a284642c2836449b14e2c2e07e3ffe0744cb7669a01b", size = 24627, upload-time = "2026-03-22T15:56:48.847Z" },
+]
 
 [[package]]
 name = "certifi"
@@ -625,6 +721,15 @@ wheels = [
 ]
 
 [[package]]
+name = "constantly"
+version = "23.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/6f/cb2a94494ff74aa9528a36c5b1422756330a75a8367bf20bd63171fc324d/constantly-23.10.4.tar.gz", hash = "sha256:aa92b70a33e2ac0bb33cd745eb61776594dc48764b06c35e0efd050b7f1c7cbd", size = 13300, upload-time = "2023-10-28T23:18:24.316Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/40/c199d095151addf69efdb4b9ca3a4f20f70e20508d6222bffb9b76f58573/constantly-23.10.4-py3-none-any.whl", hash = "sha256:3fd9b4d1c3dc1ec9757f3c52aef7e53ad9323dbe39f51dfd4c43853b68dfa3f9", size = 13547, upload-time = "2023-10-28T23:18:23.038Z" },
+]
+
+[[package]]
 name = "croniter"
 version = "6.2.4"
 source = { registry = "https://pypi.org/simple" }
@@ -708,6 +813,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/34/07/bf61d13de86d96a4c46aff00c9ca0eced44bcc8c3e16280605c1253e5720/cyclopts-4.16.1.tar.gz", hash = "sha256:8aa47bf92a5fb33abca5af05e576eecdb0d2f79893ad29238046df78370fc4a8", size = 181196, upload-time = "2026-05-25T15:29:08.518Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/8d/7f362c2fb8ef4decd2160bc24d4292c6ca658cc6d9a161b89ca5122bbdbf/cyclopts-4.16.1-py3-none-any.whl", hash = "sha256:617795392c4113a2c2cc7af716f20244900e87f23daa05442d1268d81472a592", size = 219020, upload-time = "2026-05-25T15:29:09.646Z" },
+]
+
+[[package]]
+name = "daphne"
+version = "4.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "autobahn" },
+    { name = "twisted", extra = ["tls"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/d3/65ff32c01cc64d44441b038dbb7cfb0c6a5507a1c937b3d41bd99af7bdc4/daphne-4.2.2.tar.gz", hash = "sha256:6c3527d4ce32630ae054dfb0ef5578e9a35d2f39f0ebcd02ef4f9129a121ce8d", size = 47601, upload-time = "2026-06-03T10:53:13.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/ab/85534d9cbca09f3c10f58fc2093659062280ed5703707c0b41dbca8ec297/daphne-4.2.2-py3-none-any.whl", hash = "sha256:466ba8a7c31c5b758953095b451dbad9dc23e5783c68a3716e5fc7aa5f26d168", size = 29466, upload-time = "2026-06-03T10:53:11.841Z" },
 ]
 
 [[package]]
@@ -1202,6 +1321,18 @@ wheels = [
 ]
 
 [[package]]
+name = "hyperlink"
+version = "21.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/51/1947bd81d75af87e3bb9e34593a4cf118115a8feb451ce7a69044ef1412e/hyperlink-21.0.0.tar.gz", hash = "sha256:427af957daa58bc909471c6c40f74c5450fa123dd093fc53efd2e91d2705a56b", size = 140743, upload-time = "2021-01-08T05:51:20.972Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/aa/8caf6a0a3e62863cbb9dab27135660acba46903b703e224f14f447e57934/hyperlink-21.0.0-py2.py3-none-any.whl", hash = "sha256:e6b14c37ecb73e89c77d78cdb4c2cc8f3fb59a885c5b3f819ff4ed80f25af1b4", size = 74638, upload-time = "2021-01-08T05:51:22.906Z" },
+]
+
+[[package]]
 name = "hypothesis"
 version = "6.153.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1258,6 +1389,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
+]
+
+[[package]]
+name = "incremental"
+version = "24.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/3c/82e84109e02c492f382c711c58a3dd91badda6d746def81a1465f74dc9f5/incremental-24.11.0.tar.gz", hash = "sha256:87d3480dbb083c1d736222511a8cf380012a8176c2456d01ef483242abbbcf8c", size = 24000, upload-time = "2025-11-28T02:30:17.861Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/55/0f4df2a44053867ea9cbea73fc588b03c55605cd695cee0a3d86f0029cb2/incremental-24.11.0-py3-none-any.whl", hash = "sha256:a34450716b1c4341fe6676a0598e88a39e04189f4dce5dc96f656e040baa10b3", size = 21109, upload-time = "2025-11-28T02:30:16.442Z" },
 ]
 
 [[package]]
@@ -2400,6 +2543,19 @@ crypto = [
 ]
 
 [[package]]
+name = "pyopenssl"
+version = "26.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/51/27a5ad5f939d08f690a326ef9582cda7140555180db71695f6fb747d6a36/pyopenssl-26.2.0.tar.gz", hash = "sha256:8c6fcecd1183a7fc897548dfe388b0cdb7f37e018200d8409cf33959dbe35387", size = 182195, upload-time = "2026-05-04T23:06:09.72Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/b8/a0e2790ae249d6f38c9f66de7a211621a7ab2650217bcd04e1262f578a56/pyopenssl-26.2.0-py3-none-any.whl", hash = "sha256:4f9d971bc5298b8bc1fab282803da04bf000c755d4ad9d99b52de2569ca19a70", size = 55823, upload-time = "2026-05-04T23:06:08.395Z" },
+]
+
+[[package]]
 name = "pyparsing"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2879,12 +3035,27 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "platform_python_implementation != 'PyPy' or sys_platform != 'win32'" },
+    { name = "jeepney", marker = "platform_python_implementation != 'PyPy' or sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
+]
+
+[[package]]
+name = "service-identity"
+version = "24.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "cryptography" },
+    { name = "pyasn1" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/a5/dfc752b979067947261dbbf2543470c58efe735c3c1301dd870ef27830ee/service_identity-24.2.0.tar.gz", hash = "sha256:b8683ba13f0d39c6cd5d625d2c5f65421d6d707b013b375c355751557cbe8e09", size = 39245, upload-time = "2024-10-26T07:21:57.736Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/2c/ca6dd598b384bc1ce581e24aaae0f2bed4ccac57749d5c3befbb5e742081/service_identity-24.2.0-py3-none-any.whl", hash = "sha256:6b047fbd8a84fd0bb0d55ebce4031e400562b9196e1e0d3e0fe2b8a59f6d4a85", size = 11364, upload-time = "2024-10-26T07:21:56.302Z" },
 ]
 
 [[package]]
@@ -3026,6 +3197,40 @@ wheels = [
 ]
 
 [[package]]
+name = "twisted"
+version = "26.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "automat" },
+    { name = "constantly" },
+    { name = "hyperlink" },
+    { name = "incremental" },
+    { name = "typing-extensions" },
+    { name = "zope-interface" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/97/6e9beb1e78247ae6dc34114f27d538cf2cb183c4afcd3609dfdf2b0439c8/twisted-26.4.0.tar.gz", hash = "sha256:dbfd0fe1ee409d0243fdd7a6a6ff14f4948cec1fd78e0376291f805e1501fae9", size = 3575095, upload-time = "2026-05-11T11:24:51.861Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/57/bcf4e2370dd218c9aa68a9140a65d86729c73f1d529f7e94786c2766fc72/twisted-26.4.0-py3-none-any.whl", hash = "sha256:dc25ea0ebf6511c24f03232ee9f4afa54b291c5d897990e3a39cc4d14a1ef4c0", size = 3230362, upload-time = "2026-05-11T11:24:49.5Z" },
+]
+
+[package.optional-dependencies]
+tls = [
+    { name = "idna" },
+    { name = "pyopenssl" },
+    { name = "service-identity" },
+]
+
+[[package]]
+name = "txaio"
+version = "26.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/de/52729cab9d2c8de679ad015e87f11f69e092d6fb3084eb9a39735df09ce7/txaio-26.6.1.tar.gz", hash = "sha256:3ee900b2331c93457530fddbccc1a320c4e2d7ac8f9073d01c3fbe87762ccb35", size = 134555, upload-time = "2026-06-18T14:38:59.096Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/68/075bf851e11c9ef65bd6a0426791f0d9a0c7dae0e7f6e0b16ca67334b456/txaio-26.6.1-py3-none-any.whl", hash = "sha256:91a84a7825485a367c0b070c7399824c0e1a1e8c071cbdf3882dd3146dab587b", size = 31399, upload-time = "2026-06-18T14:38:57.774Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3053,6 +3258,102 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
+]
+
+[[package]]
+name = "u-msgpack-python"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/9d/a40411a475e7d4838994b7f6bcc6bfca9acc5b119ce3a7503608c4428b49/u-msgpack-python-2.8.0.tar.gz", hash = "sha256:b801a83d6ed75e6df41e44518b4f2a9c221dc2da4bcd5380e3a0feda520bc61a", size = 18167, upload-time = "2023-05-18T09:28:12.187Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/5e/512aeb40fd819f4660d00f96f5c7371ee36fc8c6b605128c5ee59e0b28c6/u_msgpack_python-2.8.0-py2.py3-none-any.whl", hash = "sha256:1d853d33e78b72c4228a2025b4db28cda81214076e5b0422ed0ae1b1b2bb586a", size = 10590, upload-time = "2023-05-18T09:28:10.323Z" },
+]
+
+[[package]]
+name = "ujson"
+version = "5.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/7a/c8bb37c8f6f3623d60c33d15d18cd6d6655d0f9c3eb31a9969f76361b199/ujson-5.13.0.tar.gz", hash = "sha256:d62e3d7625384c08082abad81a077af587fdef2761bb14c3822f4234b8d07d75", size = 7166784, upload-time = "2026-06-14T22:36:50.209Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/dc/2fcf821896803248122835c800e74f4582de9d6092efb37152acd7f79bdc/ujson-5.13.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4b7badefa73f96bad9e295ea22bd06967b851c8aad68c74196437e3584f25de5", size = 56496, upload-time = "2026-06-14T22:35:14.362Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/c6/83db69f96dc12509c9510084c0389c4aff4dcf427f9b613d1a23abd446ce/ujson-5.13.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:09effd42924a80df20a63b31a1ede905e66b0ce24aafe7a4cbedb05c783f8bb3", size = 54300, upload-time = "2026-06-14T22:35:15.522Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/6c/6d87206988172015781b9ff842c0a7eca897c026b2e7a95e11d86d46ddf5/ujson-5.13.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:89d0bfc986d02b4ce76b00e0f560bc8d30dfe8c05a1bfd8529e085eb6c1a77d9", size = 59976, upload-time = "2026-06-14T22:35:16.636Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/43/d28ca5e6c3d8c467a4c6296404067f4eee9d67dfeeebeb3c5fb0bd6cb958/ujson-5.13.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cdd9618e07b3b142a02f0ab8227fd52453688b8e8e60ac0511f13a25fa8009db", size = 53476, upload-time = "2026-06-14T22:35:17.664Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/99/d6bb0e18188954326b38499ae61b04ce8ead6425b8844384e537a491267b/ujson-5.13.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0806683e8171ec06817e6af22f14ba0cd2f16def8a2ffb22a28a10615249355d", size = 54962, upload-time = "2026-06-14T22:35:18.693Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/5f/8f1ce659a59ef9510fa47b95773442049a383c533a645b2da8beeeec90f1/ujson-5.13.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f1cf46c79498c81f088cad4165b1669a78bba7bfbeb778c7cc1aff316e062b0d", size = 58265, upload-time = "2026-06-14T22:35:19.775Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/8e/9d11af9d1d19ea239b0d289cf62a611cb4f2da9ec0d46b826767f4ab1768/ujson-5.13.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e2282039eb26f08ed1a1381360395f8a310f39a45ef7314cb0f258a7d2917ea3", size = 57874, upload-time = "2026-06-14T22:35:20.896Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e2/7891c4a1c954307ab6a575686897a4963aad36c284742216f52dc40cba4a/ujson-5.13.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2c75eb7fac0fe92925b959cf2fa18f88d9fb76b10781fd2a6ccb895d5fb89171", size = 1037746, upload-time = "2026-06-14T22:35:21.964Z" },
+    { url = "https://files.pythonhosted.org/packages/89/4e/8a4ce87d3eaaee398f4238f74f128c6eb34269f041659995b2c09710ae7c/ujson-5.13.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:12078e81def2790140583abefc1b979f3c77be15d53c524bf0e232f669822052", size = 1197022, upload-time = "2026-06-14T22:35:23.183Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/fb/a1d0a6a83a13adee3a13cad308dcd3251ac53c4bd781f737242ad2f10d19/ujson-5.13.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e12192a37c6c0e476554b62647acdf6139a47b6f13d8bad8dd2316763c4cee12", size = 1090116, upload-time = "2026-06-14T22:35:24.421Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/6c/4aed5dce0161d6b8c95c5da760477602a05e2a540a762424395acad9aec0/ujson-5.13.0-cp311-cp311-win32.whl", hash = "sha256:ae53b3f046529c193d533ca8111492330b204d6007611cdfa20e8b764c7c1389", size = 39974, upload-time = "2026-06-14T22:35:25.779Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c5/f9f3cf19f6ac29e07782eafed562fe0a7cb451b44bd1664c58fe8974235b/ujson-5.13.0-cp311-cp311-win_amd64.whl", hash = "sha256:2275bbaaea3eddd2e8ec0863e28a420f5f520b14a760fc3f1e49fd07a974448c", size = 40941, upload-time = "2026-06-14T22:35:26.774Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ec/46058bbbbe45e054cdb9f1dc0bf416fbbd5fec06bf3b4987c2437e496350/ujson-5.13.0-cp311-cp311-win_arm64.whl", hash = "sha256:32a59e7151fe2fec8fdf9a565ee66fcf87918d48827e21cdab5e15ff9f274b78", size = 38974, upload-time = "2026-06-14T22:35:27.871Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ae/b66deca15da1f7faf6952d8eddf55978482bcbfd294ed2afe2c526ea325f/ujson-5.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:bf81570ac056cb058f9117b52ca5dd800bfe9381d0076d0bb30a08a54591d654", size = 56743, upload-time = "2026-06-14T22:35:28.863Z" },
+    { url = "https://files.pythonhosted.org/packages/88/4f/b03bcc9eaf4621ac9008dec90918d8fb4839d611666cb99eb255696c67fe/ujson-5.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7edf16359c52ed53406e216565d83e6b98c23c3cb9a0a01673f2493f8fb15edf", size = 54390, upload-time = "2026-06-14T22:35:29.857Z" },
+    { url = "https://files.pythonhosted.org/packages/77/79/f98c6c1a4ed9d92d39d5d2d133f2b6fce5da11ea50c341117aedde8011c4/ujson-5.13.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:24539618fb3243cfdf27dab9a850acab80798a01501e9586b61fb9ecd016a891", size = 60047, upload-time = "2026-06-14T22:35:30.857Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/1d/f68e14cf476d149945211142f4c20782c1f232c489e8edcc4f4b58ce4997/ujson-5.13.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fdde6341d213b29f413b5fa9fad1392d5408074c75f0900ed949e97e546fa5df", size = 53437, upload-time = "2026-06-14T22:35:31.835Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/1a/5718237cf4141e5be46ff371387e90b01f27774cb6f0f79ff4803a2430ca/ujson-5.13.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:229faf041ef249ee3fd57bac1cedb123d2718ab63f6ccd50eca95ea902eb0dca", size = 55057, upload-time = "2026-06-14T22:35:32.897Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/6f/7f55c1e9e0be87beebaed553fa186ad5f6d5d639cbaa9d49f78f2f91c3a9/ujson-5.13.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d02f31c2f59cc6a1c2c3633b377701fc2d8e876cc01950735d7a01132ccc233", size = 58186, upload-time = "2026-06-14T22:35:34.055Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/c4/9a34ade542426f56a0bc042f774073d1c247ae7575363c27587788cb2b2f/ujson-5.13.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ea7204e9fa7538bfbb1396e1ee8c2bbcd3818b3633ef5bb14d4fdea52994d14d", size = 57935, upload-time = "2026-06-14T22:35:35.05Z" },
+    { url = "https://files.pythonhosted.org/packages/36/06/407633f0709e168107f56368bd5a0fa8fe07acd7f1d3000710bc0bb07470/ujson-5.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7c5a2478a3a1fa4421f7e035b87194eea0cf44c7971a3f32ad1b42a0dfd63c03", size = 1037685, upload-time = "2026-06-14T22:35:36.022Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/df/eb5bd92dc1b23254fea5b2022007baff5491a7478bfcf7e9260d3a10f1ac/ujson-5.13.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:b535e0970c96957e999cfe5ec89361f0e8d0bb987fb5d5144f6f495cb3ed9e19", size = 1197141, upload-time = "2026-06-14T22:35:37.38Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1c/65f2ce1a0411ec9a87339db01f0d5d554a49c4248ec68ab52a1b7e14e9c4/ujson-5.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3d0ad1207694988498fca7e0bb28eba7564fa33261d2f9fdf66a3aaab376b803", size = 1090225, upload-time = "2026-06-14T22:35:38.95Z" },
+    { url = "https://files.pythonhosted.org/packages/73/53/310aabff0704f9c7ef0d3f431ce8b8e3147c3cca25334a205615c511f65e/ujson-5.13.0-cp312-cp312-win32.whl", hash = "sha256:d6bc9fa43a49e403c68c7eb164eef0feee9dd29474a7c6e0d3b6267025371990", size = 40075, upload-time = "2026-06-14T22:35:40.44Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/23/d3536d8945d1bb00248d998c8dcbe678a884681ad181072daecfafe4eea6/ujson-5.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:6692d49ff970aaa5008f4a6fe06974bc91fd957bf13173f765e46d8ba44906ea", size = 41097, upload-time = "2026-06-14T22:35:41.39Z" },
+    { url = "https://files.pythonhosted.org/packages/72/a1/4b147c06ee5bb14bec6e26786358c8510c4d75e28b88146a6ac7620f1f71/ujson-5.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:5737ffe0740a788b0e6255f0ffb281db49305fd6e6a587be44c73d9e92b554c4", size = 38875, upload-time = "2026-06-14T22:35:42.357Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f1/fe8a467d8ff5821e076b96f398d3acfe3cd568d900e6ccb41b215592b152/ujson-5.13.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:46998fc8d11aec34a20e2010905e7059732a3d192d9a3c3fe4f9ffd146c87ec8", size = 56746, upload-time = "2026-06-14T22:35:43.398Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/c0/c7ab82d6471dfa7e4fd68ae6ff2c6a50d077c05d6ecdea0cec8af635b2c4/ujson-5.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ee03ce288ba25b05cf0de87203165642277a25caa4f00a437e13152e5214e310", size = 54388, upload-time = "2026-06-14T22:35:44.586Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e6/4e9e998d991ff88bbc93b21daa63bba2baa61c6f952dbcec937cf7304ebe/ujson-5.13.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:cdf33b588a81b05d0b585c66f83050c49cb670623424d10e4d1ad37ba2f7eed9", size = 60051, upload-time = "2026-06-14T22:35:45.567Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/11/876dff43f05417a01c6119f0fa10e01f1226631c5927ef08f56876b2bb67/ujson-5.13.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4cabd73c114ce93c21d7db2e2d8e16217fd8a5b2b3ec754629eebef5c262d47f", size = 53438, upload-time = "2026-06-14T22:35:46.623Z" },
+    { url = "https://files.pythonhosted.org/packages/09/02/f9dbf6c3e46d700eb1d9ed637567221a06eeb1ec289633be992ef54d7a34/ujson-5.13.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ffc61fc756a64f4d169a78cc638d769e3c324f45fc51997626abf4e5e5dd6460", size = 55060, upload-time = "2026-06-14T22:35:47.647Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/3d/7e49a70265a1e5ed1b5e8edd5f54d57ae41e2134faeae9b16f6f5a0eae20/ujson-5.13.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c00323c13a35822c9a67a26c0b2a0787510bf1ef490922b58009b362d1a3e21", size = 58189, upload-time = "2026-06-14T22:35:48.617Z" },
+    { url = "https://files.pythonhosted.org/packages/66/34/b64278f67e19052f09810576c7e50b3da8d4f5218b226046324d4d5c24b4/ujson-5.13.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:496e662a6b46d5f936d77fb68259cece19213bb2301ddd520dbd75ac7c90c5f4", size = 57941, upload-time = "2026-06-14T22:35:49.674Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/8c/51513357a5c75bf3e5bae46accfdb3e6e6f5caeb72ca8b253ec45ba853fb/ujson-5.13.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7fd41b86444df14f8b4b7afaaa9f27bacfbf8c18380872317aeab6cd125dcede", size = 1037688, upload-time = "2026-06-14T22:35:50.699Z" },
+    { url = "https://files.pythonhosted.org/packages/54/5a/dc6afe071d6b977390d2dc41e15800a2716f317988dd03187cffe7b4d624/ujson-5.13.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:bf3c2c4ea55d4187903fcdc689a9bf5b0fc72d8c0eaff39db18c1f337c8832c1", size = 1197141, upload-time = "2026-06-14T22:35:52.052Z" },
+    { url = "https://files.pythonhosted.org/packages/50/23/b473d101412c68527cb502a8728f96ab307aa7bfa75d6ea2037e2c7f74e8/ujson-5.13.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b6eca7751d61045a9b1e7f9a8c97ac24b164f085b60bef1c4668654bb2338011", size = 1090235, upload-time = "2026-06-14T22:35:53.589Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/0a/8e583cce90f9f91ca1bedb3e628b6f5642aed91feb29b197431268d4c4be/ujson-5.13.0-cp313-cp313-win32.whl", hash = "sha256:b63d3820f978bc8e98cc3f1fe26a33b0d2ea237733a23fe5e9cb5d51f466bd97", size = 40069, upload-time = "2026-06-14T22:35:55.019Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/b5/1fe203bc294e98fdd65606883692ad8dc0aaac73838b89c99c3513404424/ujson-5.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:17a59d5cf23ef98f7c9314524976b4b288374d83200add01d953024fb06404f9", size = 41098, upload-time = "2026-06-14T22:35:55.966Z" },
+    { url = "https://files.pythonhosted.org/packages/50/5e/aceadce24fdb7cbc67f02286b1d4e91a575aaef5afb876c9908d6e6e5769/ujson-5.13.0-cp313-cp313-win_arm64.whl", hash = "sha256:b49516fbe803ff30d6caa9ccc3799ec7f968992747ce3099eae4758928577b53", size = 38877, upload-time = "2026-06-14T22:35:56.936Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/9a/b5139d696f5328f3cab70b9ec046f15e3f49497a4de6280974640602f539/ujson-5.13.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:cc9dfd41fed397ab03bb9d9fe1cbd83301211c772a17536033ce7d68877ac82b", size = 56897, upload-time = "2026-06-14T22:35:57.974Z" },
+    { url = "https://files.pythonhosted.org/packages/53/55/477183aeddfdf0f88ae039ffee0ed866cfb993da0c0c9aa915807554aef8/ujson-5.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ca7ef2fa6c408a7c0f558e4d33d93b32ddc35ed6d3cfc505747931a64b7465d5", size = 54451, upload-time = "2026-06-14T22:35:58.932Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/63/55e5f23e156b4c8bca095d828b4cd3180c0b42aa3501ef88836d79606fea/ujson-5.13.0-cp314-cp314-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:a554b2e5bee85030369514cef8b0b913cebe1a4c2c0c13541966d50bcba22b1a", size = 60053, upload-time = "2026-06-14T22:35:59.969Z" },
+    { url = "https://files.pythonhosted.org/packages/26/b6/08c6cf5548bd6f4bb557c9fa7e8edf87324bb04c17249d1966028d61dde0/ujson-5.13.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ea939ff629ab03ae970d03eca6d1febd8ed55ba38ca44aec64ce997537cd3fa0", size = 53481, upload-time = "2026-06-14T22:36:01.007Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/b3/0ac9a03551467784067f505df1bb875c639ba32f1da79ce467ab15911ada/ujson-5.13.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b98bf2faa5e37ecfe752226ea08290031e375a0c43d425a0b955fb3e702a2a71", size = 55058, upload-time = "2026-06-14T22:36:02.297Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/be/ec91029aec067174473d022fa0f6c3c1431a173f888d7599739f05c668eb/ujson-5.13.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9a4b92344b16e414aeb609e57f62c466500e53c94f1698f5b149dc0b7223ec3e", size = 58225, upload-time = "2026-06-14T22:36:03.321Z" },
+    { url = "https://files.pythonhosted.org/packages/29/33/a948f329252ece3f9c93d177243de6e677927ebc6ac44256742dbbef3c39/ujson-5.13.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7df805aad707507a1fa165fb716218ca3a89f142125dc4b23c9fcc08fa402d97", size = 57930, upload-time = "2026-06-14T22:36:04.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/0c/c33655218b8e0a8adbf066de0b999cae5c324061f3eaa4dda17423145d9e/ujson-5.13.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7576bdbef327c3528f011002a2d74486f6fe4e33289bdb7a042b7f1a6e9d8285", size = 1037728, upload-time = "2026-06-14T22:36:05.467Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/bd/d286947525ea7ce3f2d8dc55c15b9ffbe425bc455c96af7b8f8a402599a9/ujson-5.13.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:6eee5d7cce3f32a468905f9ff61807a60287a90258d849460f6fa826e810870d", size = 1197146, upload-time = "2026-06-14T22:36:06.839Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/3c/9eb916377050b0785f048a34588c1c390ddd41ae00b78db68ee1ad022356/ujson-5.13.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:144e9d8a454cfa727e0f755e1863738ed68068583bda5463052cb446835bd56c", size = 1090223, upload-time = "2026-06-14T22:36:08.329Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/5f/242fd97a2628b842d4bfaa9b18e1f68187f934d67503291ebbaab1254637/ujson-5.13.0-cp314-cp314-win32.whl", hash = "sha256:576f35c35b918d67d41b933878062ec0a5c9f4d1e9e14e04aeef35384963feae", size = 41223, upload-time = "2026-06-14T22:36:09.644Z" },
+    { url = "https://files.pythonhosted.org/packages/23/f3/7f2bd9ca0c507142d0c22347b3d6f8803be1d8851c31707e57f5923fdbea/ujson-5.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:d5e206e9f849ead27e51ef8da44e52b38da7c6dbd929a7340ab44533edcda8d7", size = 42265, upload-time = "2026-06-14T22:36:11.043Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/29/3e9a8fba321c031315f6d263510969a5d01f41fc471b5be107e413c1b2f8/ujson-5.13.0-cp314-cp314-win_arm64.whl", hash = "sha256:dc470179775468f9a007d3a6a2734624248c94bf47c6645e808c7e50a5070d1a", size = 40205, upload-time = "2026-06-14T22:36:12.286Z" },
+    { url = "https://files.pythonhosted.org/packages/12/e9/1c543837c6a3c6672361882a0fa269bd02daf9cc4c0ca88a9dccd9df98d9/ujson-5.13.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:69b4e36bb7d5f413ba8c00c8006b2ec627cc5ace97301462f6aadb66ec9d2979", size = 57402, upload-time = "2026-06-14T22:36:13.238Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e4/39862f0f7174ff07cfd1e2d0c9065ded34aeebdb7db8daf2f0e5bf89b46f/ujson-5.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8b644d50f66de5490c1823c7176618cead5e8e8a88cba9f40a6308ca52e79267", size = 54973, upload-time = "2026-06-14T22:36:14.432Z" },
+    { url = "https://files.pythonhosted.org/packages/02/66/f53d3b32c3f177f846ca6b624e832f29000d8a213a2d8768e254bd470ced/ujson-5.13.0-cp314-cp314t-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:15107aaa4f559d55201165ec32abb35c283a861be1fa67229578cb7d93fcd93a", size = 60683, upload-time = "2026-06-14T22:36:15.806Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/d4/dddc4646d2633c85c938c2ded7d5a9711cdad5be1e13b31b7dad76f61c83/ujson-5.13.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6e343c5f0c058523f1edbf6ae4eceb4e0d934205a53bbdd8d9a945c83324662a", size = 54167, upload-time = "2026-06-14T22:36:16.952Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/c0/d8608c3f4d3f05e6441364b63fde1d279700135c1a6577a773662c07fbcc/ujson-5.13.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:02200035bc80e830f076ffc1b329a94c295aee6d9de8c9043647cb9a7bd4f76f", size = 55568, upload-time = "2026-06-14T22:36:17.975Z" },
+    { url = "https://files.pythonhosted.org/packages/22/8e/dd12b735aaba0806c3d70c18184d50e1f9712e0757c7c0a4f376450cfe28/ujson-5.13.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d7f19b81b73ff28f5c5022ee794f94122bfcda07a76423078e349465d71223a1", size = 59086, upload-time = "2026-06-14T22:36:19.071Z" },
+    { url = "https://files.pythonhosted.org/packages/48/43/ad41e8752d5ec3a590a5e7b426a54e36b7aab911d9b5a4f7384dc62507ab/ujson-5.13.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:82e1393e6dbe3c95fdfc95c6c528890e191351a1f024ef51126cf1f22543af52", size = 58667, upload-time = "2026-06-14T22:36:20.171Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/8e/b44a6afb77b94118655c029081b7932d64bb4c5b1c8ba2b7f5808b5d0bc2/ujson-5.13.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:38afcf994b28ed85ea2420e2a8d79a37d0a77348b3daf53850c16edda66f942d", size = 1038553, upload-time = "2026-06-14T22:36:21.245Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/93/fab1d786174c8780eb3e386c73f1925a435e97fbf77c957fea4fca83994d/ujson-5.13.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:1bdf2518971586f2b413156c49d9dd8b56cc990a8647081e1bd00af60564d469", size = 1197938, upload-time = "2026-06-14T22:36:22.585Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/bc/2f073bb708f9d128f5d1cb39063a5f6421b1ce94c61be8661c55a189f407/ujson-5.13.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:751ad01042472f1c7c02f5c597c7aee79834e82a6cc384ca302173bbc8e8deb8", size = 1090938, upload-time = "2026-06-14T22:36:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/67/cdaa50bba29d7dc9eb19212755b09bb96f56596e75957c3717c6b85454de/ujson-5.13.0-cp314-cp314t-win32.whl", hash = "sha256:74f3dd61aeb01b7b2a6754e400224e819279041b3867935a55ccf57fb86a43b2", size = 41802, upload-time = "2026-06-14T22:36:25.418Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/66/a6e669e90083febdf6c0600d3807f6017fd4d3962d5bd6ddc605c73a06e5/ujson-5.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:5c31317d5e4504dae8f98795358b6082fc0ef96e7394806db0a76a4a8717f446", size = 42790, upload-time = "2026-06-14T22:36:26.614Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/5f/fcc6c6a9d711fd8b020ca8ff65148212f0a712c809d173cd949e58de68c6/ujson-5.13.0-cp314-cp314t-win_arm64.whl", hash = "sha256:aefd3c9c95f9b62348956396ff7b31818476f8f54dc4a4e64cbd4f0491db6fca", size = 40708, upload-time = "2026-06-14T22:36:27.721Z" },
+    { url = "https://files.pythonhosted.org/packages/30/70/dbdd277d64bd3a149532567ceb082fe26f4ead58c39e0a97566ccbdf14a3/ujson-5.13.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3e074a1f7778d58aa3b3056bab7b6251aabb3f381808018ca2b7fb8dbdeef7ab", size = 58393, upload-time = "2026-06-14T22:36:28.702Z" },
+    { url = "https://files.pythonhosted.org/packages/71/48/592c70af94a67cafacd9c840ae2980f27d511dde2732a4c0dfac8f176ae8/ujson-5.13.0-graalpy312-graalpy250_312_native-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8bb53ef95d35875262b8d0aa28506ca612ddd07058bee2a90f609938e69dc801", size = 54447, upload-time = "2026-06-14T22:36:29.802Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/9d/2bb91e1e25a8584cb3b63544b9bd26f621173535c77ac6cae13bad8e7904/ujson-5.13.0-graalpy312-graalpy250_312_native-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fb296a0aa480ab88d895ddaa90372604c08ccc72323f02590612c775426ab413", size = 56066, upload-time = "2026-06-14T22:36:30.806Z" },
+    { url = "https://files.pythonhosted.org/packages/76/ec/8e3802fc4a4e31e817b972bbb0e704a484d8c75ec349b3feb45fa9fb54c4/ujson-5.13.0-graalpy312-graalpy250_312_native-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2862f81af44b3a7e74c5d80caa118d736be1991ce6f1d5c723716fa403060cc6", size = 54938, upload-time = "2026-06-14T22:36:32.051Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/48/d0e3e511039b86fd1ecfe2bf761c800552d273ef8f19e71de93bf38a909e/ujson-5.13.0-graalpy312-graalpy250_312_native-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c16e07581172f08585b409246f4535dab13ee85af0e3d3cfa8684b653ca44fa8", size = 56115, upload-time = "2026-06-14T22:36:33.349Z" },
+    { url = "https://files.pythonhosted.org/packages/81/b5/689613037fe691d18eae075cd141089f3a3156146be14512df92d8a9ae8f/ujson-5.13.0-graalpy312-graalpy250_312_native-win_amd64.whl", hash = "sha256:9bd0f2dd05937c3b089af316884de18c6f6182ddb8ffce597d2e7c7a9ba9f447", size = 41802, upload-time = "2026-06-14T22:36:34.523Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/7f/276f830bef4d530d50ff4d8f8c568002e7ebed9f64c06747b1d1c4325f02/ujson-5.13.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:96e7e019b097b4b25fccddadb369d13f412c13695fcf0680b6bf906376156151", size = 52479, upload-time = "2026-06-14T22:36:35.627Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/50/99b05555ef42a2ab2e26aa369c46bde6a64f8aeeb687628102e98cc78bed/ujson-5.13.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:7892ea6dd85ede6d30fbbd22af1239b9d81dabdf9b7a8f10ca6d4464d4d9b8ab", size = 49953, upload-time = "2026-06-14T22:36:36.72Z" },
+    { url = "https://files.pythonhosted.org/packages/78/15/399766e8ba002bd8e5e2e45828e0e12a5dbeb4145d6a604ba3787db5eec2/ujson-5.13.0-pp311-pypy311_pp73-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:e1842e10adc8f0db0d3e8aa3a1f8b05ce0456b39e180c8553d7f36dd0bf24b6b", size = 55716, upload-time = "2026-06-14T22:36:37.833Z" },
+    { url = "https://files.pythonhosted.org/packages/61/a6/825d92bce42cd442b57d89b4c20afc1737246321d3433c6194e5c35c6a11/ujson-5.13.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c8bbb1f5ab810954fb307b6c5e68af58210c31da8569f9e6498a3958c1859e72", size = 48648, upload-time = "2026-06-14T22:36:38.878Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/d6/7ea7a32f35457560806375193dbc4f0d8ffd8c8adae42f86686392a76c41/ujson-5.13.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3f6d55c68985654a84a9b47ac51f2655adac4fd264e4189f832960c2270dcf70", size = 49947, upload-time = "2026-06-14T22:36:40.022Z" },
+    { url = "https://files.pythonhosted.org/packages/af/b4/0bd6449ae35b6026d94f4d1a32dbc9f40c969ed1d6e36a7e26ccf56371be/ujson-5.13.0-pp311-pypy311_pp73-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4b266f182d4bce74a6a9e1f86988485e8cd422efdcc7c3f537e00cc956f52678", size = 51149, upload-time = "2026-06-14T22:36:41.129Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/2d/39da479a8461d1d78d533940a8426a84e23708a6a7a426f2178e04443252/ujson-5.13.0-pp311-pypy311_pp73-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bfaa8302eb9bb7f5e231f256caf83040760585e32751d19155c0f0c0225f8de1", size = 52456, upload-time = "2026-06-14T22:36:42.266Z" },
+    { url = "https://files.pythonhosted.org/packages/12/cc/91ff81c50b85a158878f06d6e9153227bbc04209db291a152c286a0ee4a8/ujson-5.13.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:43dee3081b00fe447c5b9e2fe7ebfd57f7bcc5dd25b8a439c26c8c174dd581be", size = 41155, upload-time = "2026-06-14T22:36:43.455Z" },
 ]
 
 [[package]]
@@ -3435,4 +3736,46 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
+]
+
+[[package]]
+name = "zope-interface"
+version = "8.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/dc/50550cfcbb2ea3cbca5f1d7ed05c8aa840f831a0f2d63aec0a953f7c590e/zope_interface-8.5.tar.gz", hash = "sha256:7a3ba1c5877f0f3e3906b02ddf793abed2becc2948116414ce0e1dd820b68d6d", size = 257957, upload-time = "2026-05-26T06:50:14.574Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/f1/83ad110fb847413affe71609bb50e59e1aa082e1236030122227c7c283d3/zope_interface-8.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:afc66ccaef2a3c0bef6ca02aad40d29a39276389dad16a8eac36f9f385e4d057", size = 211426, upload-time = "2026-05-26T06:49:12.595Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/a7/6b6e0c31ac240cb9fc015ae9ed45ca54be886c18fcf7bfa2377a4d7a8785/zope_interface-8.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c28044972187245d7a309e4699319bfdbd2ffcbf7176d1d4ddf5adffb2dea80f", size = 211850, upload-time = "2026-05-26T06:49:14.474Z" },
+    { url = "https://files.pythonhosted.org/packages/37/36/7599ecabcf80ce4fef2e1ef3c5ac0d4696b61f03f724cc44022f4d226af9/zope_interface-8.5-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:03bbecc7982af713d7499d4084bc03916413d17ffd45f89009348cc0c1d9e376", size = 260711, upload-time = "2026-05-26T06:49:16.568Z" },
+    { url = "https://files.pythonhosted.org/packages/03/3e/1774b0ee46ccbb5498ee3c33ece40315b6ef58bc71957be94bd345340bc1/zope_interface-8.5-cp311-cp311-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bf917009a4a7457c7290225a019f4a0aa706d96accd2cfdba2418d3bc1fcde2f", size = 265277, upload-time = "2026-05-26T06:49:18.656Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/09/e533b2ffabaae4e5d5730d6768a591cf335defe8e37bec2ad905d09be656/zope_interface-8.5-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:31cff25b2aaedb5267e6e77b1e9be6b0ec4f622032de8a069202b8ffacda7dc2", size = 266369, upload-time = "2026-05-26T06:49:20.174Z" },
+    { url = "https://files.pythonhosted.org/packages/49/4a/3ebe6a4c122b2d5340db45cbe7e490663d3228b172710ec71060cd5d541e/zope_interface-8.5-cp311-cp311-win_amd64.whl", hash = "sha256:17a3114bbdddb5e75e5784cdf318944636190cbbc72d357ef9fb1a8b0351f955", size = 215161, upload-time = "2026-05-26T06:49:21.799Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/59/056ad97af5b16db1975ee98ec7ab03d2ce3f3355efad904ced1dbce0e39f/zope_interface-8.5-cp311-cp311-win_arm64.whl", hash = "sha256:aab6bb5bee10f38ea688b95ba054396b67f613552d2c8378be7fcb2d2fba7646", size = 213481, upload-time = "2026-05-26T06:49:25.085Z" },
+    { url = "https://files.pythonhosted.org/packages/97/cc/b84123a948f3162a34623e188922827cd845244fdd043ed20f8d02228caa/zope_interface-8.5-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:8e6ee90c2e6de7c37058d5fa41f123c8b13a312db8d1e0fb5840d7f4bcdff9c9", size = 212165, upload-time = "2026-05-26T06:49:26.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/cbceec44f1b27208a76c1a688c131302685852406a23df5aab68324109cc/zope_interface-8.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c1adc90d3576b3b4c4de4953e6002c37bef28b78d7fa54c1bbfd0c50f022fe7c", size = 212341, upload-time = "2026-05-26T06:49:28.182Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/c3/005032195ff3b210c139b7c560ed5c534e844b0907d8e44d2b3d8919305e/zope_interface-8.5-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:e6347b8d8d12c5eca6502450a92be30079b7acfade2c4f693efa0deb8871b06e", size = 265296, upload-time = "2026-05-26T06:49:29.741Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/66/1036543d6a66bc04c19df3cf650f3ad938a002ab0a443c24e23e8de5e8b9/zope_interface-8.5-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5e970dabea777a24b0b0bbf9dae3ab75ce8b2d8e948edf4875627034b21f3560", size = 270689, upload-time = "2026-05-26T06:49:31.767Z" },
+    { url = "https://files.pythonhosted.org/packages/30/4c/8b56259558cace4414e753ca6740396a1f59d4a95ddb55b4658600408670/zope_interface-8.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f0b48ccadaa9839e09ff81e969703cecb3f402c813bfe8b958652e699bea69f5", size = 270280, upload-time = "2026-05-26T06:49:33.489Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/ea/649908c83aa8fdb7faf2ddca4d3cf6fb8f2157121267dc56e8f72681e26c/zope_interface-8.5-cp312-cp312-win_amd64.whl", hash = "sha256:e0e311f1277468c08fd59a2b41f71b43d25dff639789d364747acd1705c0df6e", size = 215019, upload-time = "2026-05-26T06:49:35.607Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/97/da13037b4c563e4df32eedbc819f8c00b754af494f68211e3dffd48d52da/zope_interface-8.5-cp312-cp312-win_arm64.whl", hash = "sha256:652b73107a04159ec6c020db6c1543d4f1e8f4d069bd2aac88a947820923517b", size = 213569, upload-time = "2026-05-26T06:49:37.317Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/8c/4c15755d701f2ec0e80d64a18e1ebaf5be2c584c0ec153fd516f5d13eada/zope_interface-8.5-cp313-cp313-macosx_10_9_x86_64.whl", hash = "sha256:28e80457c134d1fa57a7d758004dece348654e1b1467ac22dcdc20fc1d127c52", size = 212512, upload-time = "2026-05-26T06:49:38.996Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/2e/4360c54c465db042cc8fbeeec92abac28b4cedbf6ba63c1f092fd08a190f/zope_interface-8.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:09495ce9d559c06b70f2d4855b3e4f48a822a9ddc8be1d30c5b4e5be14ae1ace", size = 212541, upload-time = "2026-05-26T06:49:41.186Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a5/692a2b8d70f78e848793231d5fae5fecbf8d0cccd73430fdc34802a6d3c1/zope_interface-8.5-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:7849ad8fa90763cc1087f4dda78ca3a233e950b3e08fac7079297c9cafbbd7bb", size = 265191, upload-time = "2026-05-26T06:49:43.449Z" },
+    { url = "https://files.pythonhosted.org/packages/70/8d/454a9cfc7a050c394ab4f11b3371f7897828b7415e096afff724637e65e0/zope_interface-8.5-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5578c9421ca409a1f39f153d6f7803e4cde01da592ec75a9ac5e1b777d18d33b", size = 270626, upload-time = "2026-05-26T06:49:45.425Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8c/db8409cfa3575b8e9b4800babd7d49f8228433cd1f0c56814bd0ada49c33/zope_interface-8.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e1bd7d96b4ca5fa311f54c9eac16dce4886b428c1531dbe06067763ccdf123b4", size = 270444, upload-time = "2026-05-26T06:49:47.025Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/df/a386940e41469ef615e100a216d8b386521e9e598817147f87932ca203c4/zope_interface-8.5-cp313-cp313-win_amd64.whl", hash = "sha256:0c8123d2a4dfde2a613c7cb772605477724782c20bc2e0ad1d9435376a6a44a3", size = 215021, upload-time = "2026-05-26T06:49:48.478Z" },
+    { url = "https://files.pythonhosted.org/packages/89/75/477eb5669b6b2a7a843decd1a075e9b1971a8720017654143a7183abd3d9/zope_interface-8.5-cp313-cp313-win_arm64.whl", hash = "sha256:6d02be14f3173c6c7288bc2fdf530090c01c3cf8764ad46c68024686f364278e", size = 213610, upload-time = "2026-05-26T06:49:50.01Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/19/5032e954827fdf02db2d2f49737ac4378bb9cfc2cd95a8f2e2a5ae2ec01a/zope_interface-8.5-cp314-cp314-macosx_10_9_x86_64.whl", hash = "sha256:ffaecf013251a89d0de6feb49a46eba48ad8cbbf8a40aeb6045e459e7bec6784", size = 212597, upload-time = "2026-05-26T06:49:51.63Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/53/3ef644012cf8a6a234a2d6134aab5a5c65ac5467c86296865501d4fbc406/zope_interface-8.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:126fa9d1c52295ae076d4cf968634f0a1826afa408a20808b57ff72877b8f69f", size = 212626, upload-time = "2026-05-26T06:49:53.236Z" },
+    { url = "https://files.pythonhosted.org/packages/32/67/bc8b4f465d388039255003e230c284a175cedf1203c692f23cb7bff64efe/zope_interface-8.5-cp314-cp314-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:3090e3a663d20194756a59a272e0c8508b889341e31d5894223331fe6b4f9b21", size = 266827, upload-time = "2026-05-26T06:49:54.873Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/eb/37d05b935ede53d79690fecc8d201440084418e590bcfc05f384451c7593/zope_interface-8.5-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9342fb74e2afefdb081bf1df727d209ea56995c6e13f5a0540e6d7aff4beafb8", size = 270139, upload-time = "2026-05-26T06:49:57.116Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/0b/fd0c54579e2ce8dc6cf1a757903f3374bc6fbda929a46af9e0f53cb0e5f0/zope_interface-8.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6c54725d818f1b57a7efb8b16528326e1f3c257b602b32393fd255c45af8799d", size = 270338, upload-time = "2026-05-26T06:49:58.698Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/1d/c420dcd777bb761067ea92879ac766694a5ca78608185f1aecea64cbfc11/zope_interface-8.5-cp314-cp314-win_amd64.whl", hash = "sha256:29d74febbae1afeb6834c4ccbf42e242a673c860060f09e53142825270456140", size = 215789, upload-time = "2026-05-26T06:50:00.405Z" },
+    { url = "https://files.pythonhosted.org/packages/62/94/50b5eb8f94e527edceac14f9955e58917424ea79bb572ddc18548561cbc2/zope_interface-8.5-cp314-cp314-win_arm64.whl", hash = "sha256:633c8c49396f38df030340797c533e9fe460d1b5d1e42d88e55e938e525f548c", size = 213757, upload-time = "2026-05-26T06:50:01.973Z" },
+    { url = "https://files.pythonhosted.org/packages/17/6f/5d5f32c4dfcdb16ce2ec5363da686840f13c13e1a1214cb70b49e1cd6d9f/zope_interface-8.5-cp314-cp314t-macosx_10_9_x86_64.whl", hash = "sha256:133999820fdbae513c36c03d6f29ef87317aaa3edef39112222b155083664714", size = 213591, upload-time = "2026-05-26T06:50:03.529Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/55/de0c3459ff717fce3342f9a29464c281fdeb0d36c3171ee88d119d5f0650/zope_interface-8.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8bd75c96966e573232f0599deaff717564828031c7f05563ccc1ac35c5ee0304", size = 213733, upload-time = "2026-05-26T06:50:05.101Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/d97430abd5ae9677e8b9295b58720c0064a5b557dbb6b8bf5928484cf0d8/zope_interface-8.5-cp314-cp314t-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:14b0e9799351d4c34fe99afd67f0cdd76e55ba15c66a98699d5fc22ea8241e08", size = 294905, upload-time = "2026-05-26T06:50:07.384Z" },
+    { url = "https://files.pythonhosted.org/packages/41/ec/a0f8f3dad6e74992f4654bdd94802be0929eabca7b871cac3b6fbb5e961b/zope_interface-8.5-cp314-cp314t-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0cd6a732ac84b94eb1ef9222a117347a27efd294ee16810ffdf7ecd307677ed5", size = 300885, upload-time = "2026-05-26T06:50:08.997Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/da/6881b48803a0ee8d23eb5efa30fce3ed218a2bd9de5758ce489d224fee81/zope_interface-8.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:798b7c87d0e59a7d5d086d642208d0d8700ff0d55c4029134b3c479c3bfb110f", size = 304672, upload-time = "2026-05-26T06:50:10.563Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/0e/b4c01320859ff1d585438bc231fd60bd258d096359bccf6654fecdf0cffb/zope_interface-8.5-cp314-cp314t-win_amd64.whl", hash = "sha256:0fc3a9d45f114d27eaa1e53beeb144533689edca8a9f66505b1e8e8b3f075e42", size = 217241, upload-time = "2026-05-26T06:50:12.171Z" },
 ]


### PR DESCRIPTION
## Wave 4, SP1 — Realtime substrate

First slice of the **realtime + chat + canopy cloud runner** program (`docs/superpowers/specs/2026-07-16-realtime-chat-cloud-runner-program-design.md`). Brings ace-web's chat/multiplayer *approach* toward canopy-web, starting with the transport layer canopy-web was pre-wired for (`connectlabs.py`'s reserved "W4" Channels seam).

Adds a new **framework-tier `apps/realtime`** app and puts two surfaces live over Django Channels + Redis, **without introducing any new domain model** — it pushes data that already exists:

- **Turn tail** — live-tails a turn's append-only `TurnEvent` ledger (`turn.{id}` group), cursor-replay via the existing `?after=seq` read then live frames. This is the primitive SP2's chat streaming will build on.
- **Supervisor** — `/supervisor` gets live runner status + per-agent waiting counts (per-user group; snapshot on connect + deltas).

### How it works
- **Transport:** `channels` + `channels-redis`; in-memory layer by default, Redis when `REDIS_URL` is set; `config/asgi.py`'s Starlette router gains a Channels `ProtocolTypeRouter` for the `websocket` scope (http still hits Django; MCP + lifespan unchanged).
- **Fan-out:** mirrors `apps/push` — `transaction.on_commit` → `group_send`. `append_events` uses `bulk_create` (no `post_save`), so it now emits a dedicated `turn_events_appended` signal; runner + waiting deltas ride existing `post_save`. Every publish is null-safe — a realtime hiccup never breaks a write.
- **Auth:** cookie-then-Bearer WS handshake middleware (reads `settings.SESSION_COOKIE_NAME`, reuses `apps/tokens`), workspace-membership gated per turn.
- **Frontend:** `wsUrl` + `useLiveTurn` (`mergeEvents`) + `useLiveSupervisor` (`applyFrame`), pure reducers unit-tested per the repo's no-live-DOM convention; `SupervisorPage` overlays live status/counts/badge on its mount fetch.

### Verification
- **Backend:** full suite **877 passed, 1 skipped** (incl. new realtime + harness-signal tests; zero regressions from the ASGI rewire).
- **Frontend:** `npm run build` green; **105 vitest tests pass**.
- **Live smoke:** booted under uvicorn, both WS routes reachable through the full ASGI→Channels→auth→consumer chain and correctly reject anonymous handshakes.

### Boundary
`apps/realtime` classified **framework** in `ARCHITECTURE.md` + `tests/test_architecture_boundary.py`; imports only framework apps.

Part of a 4-SP program (SP2 cloud runner + unified execution → SP3 multiplayer → SP4 ace-web as first consumer). Opening as **draft** — it's a complete, self-contained increment, but I'm continuing the program on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
