### PR TITLE
fix(reviews): enforce the workspace boundary on by-id read/submit/delete

### DIFF
--- a/apps/reviews/api.py
+++ b/apps/reviews/api.py
@@ -81,18 +81,30 @@ def _is_owner(request: HttpRequest, review: ReviewRequest) -> bool:
     )
 
 
+def _in_caller_workspaces(request: HttpRequest, review: ReviewRequest) -> bool:
+    """The hard tenant boundary: a workspace-assigned review is reachable only by a
+    member of that workspace. Legacy null-workspace rows (pre-FK migration) fall
+    back to any authenticated user — there is no workspace to check, and the API
+    has assigned one on every create since the migration, so this shrinks to zero."""
+    if review.workspace_id is None:
+        return request.user.is_authenticated
+    return review.workspace_id in wsvc.request_workspace_slugs(request)
+
+
 def _can_read(request: HttpRequest, review: ReviewRequest) -> bool:
-    """Authenticated users see all reviews; public (link) reviews are readable by anyone."""
-    return (
-        request.user.is_authenticated
-        or review.visibility == ReviewRequest.VISIBILITY_LINK
-    )
+    """A member of the review's workspace can read it; a public (link) review is
+    readable by anyone with the URL. NOT every authenticated user — that was a
+    cross-workspace read leak."""
+    if review.visibility == ReviewRequest.VISIBILITY_LINK:
+        return True
+    return request.user.is_authenticated and _in_caller_workspaces(request, review)
 
 
 def _can_write(request: HttpRequest, review: ReviewRequest) -> bool:
-    """Submitting a decision (approve/redraft) requires a Dimagi login —
-    public-readable does NOT grant anonymous write."""
-    return request.user.is_authenticated
+    """Submitting a decision resolves the gate — a member-of-the-workspace action.
+    Public-readable does NOT grant write, and neither does membership of some OTHER
+    workspace."""
+    return request.user.is_authenticated and _in_caller_workspaces(request, review)
 
 
 def _detail_payload(review: ReviewRequest, *, is_owner: bool) -> dict:
@@ -409,11 +421,15 @@ def delete_review(request: HttpRequest, rid: UUID):
     """
     Delete a review request.
 
-    Team-internal cleanup: any authenticated user (session or PAT) may delete —
-    reviews are owned by whichever identity posted them (often the orchestrator's
-    PAT, not the human browsing), so restricting to owner would make the human
-    unable to tidy up. The router's session_auth already blocks anonymous callers.
+    Workspace-internal cleanup: any MEMBER of the review's workspace (session or
+    PAT) may delete — reviews are owned by whichever identity posted them (often the
+    orchestrator's PAT, not the human browsing), so restricting to owner would make
+    the human unable to tidy up. Membership (not ownership) is the right gate, and
+    it's the tenant boundary: a non-member gets a 404, not the ability to delete
+    another workspace's review.
     """
     review = _get_or_404(rid)
+    if not _in_caller_workspaces(request, review):
+        raise ProblemError(404, "Review request not found", type_=TYPE_NOT_FOUND)
     review.delete()
     return Status(204, None)

--- a/apps/reviews/tests/test_workspace_scoping.py
+++ b/apps/reviews/tests/test_workspace_scoping.py
@@ -76,10 +76,71 @@ def test_outsider_does_not_see_workspace_scoped_review():
     assert all(r["id"] != rid for r in listing)
 
 
+def _workspace(slug):
+    from apps.workspaces.models import Workspace
+    owner = _user(f"owner-{slug}@{slug}.example")
+    ws, _ = Workspace.objects.get_or_create(
+        slug=slug,
+        defaults={"display_name": slug, "created_by": owner, "auto_join_domains": []},  # no domain auto-join
+    )
+    return ws
+
+
+def _private_review_in(ws):
+    return ReviewRequest.objects.create(
+        run_id="secret-2026-01-01-001",
+        gate="narrative-agreement",
+        narrative_slug="secret",
+        version=1,
+        status=ReviewRequest.STATUS_PENDING,
+        request_json={"run_id": "secret-2026-01-01-001", "gate": "narrative-agreement"},
+        visibility=ReviewRequest.VISIBILITY_PRIVATE,
+        workspace=ws,
+    )
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_non_member_cannot_read_a_private_review_in_another_workspace():
+    # jj is a dimagi-domain user (auto-joins the default workspace) but NOT a member
+    # of "connect"; a private connect review must be a 404, not a cross-tenant read.
+    jj = _user("jj@dimagi.com", is_superuser=True)
+    review = _private_review_in(_workspace("connect"))
+    resp = _client(jj).get(f"/api/reviews/{review.id}/")
+    assert resp.status_code == 404
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_non_member_cannot_submit_or_delete_another_workspaces_review():
+    from apps.workspaces.services import ensure_member
+    from apps.workspaces.models import WorkspaceMembership
+
+    jj = _user("jj@dimagi.com", is_superuser=True)
+    connect = _workspace("connect")
+    review = _private_review_in(connect)
+
+    submit = _client(jj).post(
+        f"/api/reviews/{review.id}/submit/",
+        data=json.dumps({"response_json": {"decision": "approve"}}),
+        content_type="application/json",
+    )
+    assert submit.status_code == 404  # can't even read it → 404, not a resolved gate
+    assert ReviewRequest.objects.get(pk=review.id).status == ReviewRequest.STATUS_PENDING
+
+    delete = _client(jj).delete(f"/api/reviews/{review.id}/")
+    assert delete.status_code == 404
+    assert ReviewRequest.objects.filter(pk=review.id).exists()  # not deleted
+
+    # A member of connect CAN act on it — proving it's the boundary, not a total lock.
+    member = _user("m@connect.example")
+    ensure_member(connect, member, WorkspaceMembership.EDITOR)
+    assert _client(member).get(f"/api/reviews/{review.id}/").status_code == 200
+    assert _client(member).delete(f"/api/reviews/{review.id}/").status_code == 204
+
+
 @override_settings(REQUIRE_AUTH=True)
 def test_anonymous_can_still_read_public_link_review_after_scoping():
     """The detail read path must keep serving visibility=link reviews to anon —
-    scoping applies only to the authenticated LIST, never the single-object read."""
+    membership scoping applies to private reviews, but a public link stays public."""
     jj = _user("jj@dimagi.com", is_superuser=True)
     resp = _create_review(_client(jj), visibility="link")
     rid = resp.json()["id"]

--- a/apps/workspaces/services.py
+++ b/apps/workspaces/services.py
@@ -78,6 +78,31 @@ def is_member(user, slug: str) -> bool:
     return WorkspaceMembership.objects.filter(user=user, workspace_id=slug).exists()
 
 
+def request_workspace_slugs(request) -> set[str]:
+    """The workspace slugs THIS request may act within — the single place a flat
+    (`/api/…`) handler gets its tenant scope, so scoping can't drift per endpoint.
+
+    A pinned `/api/w/{ws}/…` request was already membership-checked by
+    WorkspaceResolveMiddleware, so trust that one slug. Otherwise it's the UNION of
+    the authenticated user's memberships (so a human in dimagi+connect+family sees
+    all three), and the empty set for anonymous callers.
+
+    Filter list querysets by `workspace_id__in=request_workspace_slugs(request)`,
+    and gate a by-id read/mutation with `obj.workspace_id in` it. This is the hard
+    tenant boundary: data outside the caller's workspaces is unreachable."""
+    pinned = getattr(request, "workspace_slug", None)
+    if pinned:
+        return {pinned}
+    user = getattr(request, "user", None)
+    if user is None or not user.is_authenticated:
+        return set()
+    # Domain teammates join their org's workspaces on first touch of any scoped
+    # endpoint — the same "join on first touch" this repo already does per-handler,
+    # centralized here so by-id gates and lists agree on who's a member.
+    auto_join_workspaces(user)
+    return user_workspace_slugs(user)
+
+
 def user_default_workspace(user) -> Workspace | None:
     """The user's workspace when unambiguous — their sole membership, else None
     (0 or 2+ memberships). Used to resolve a default for headless PAT callers."""

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -586,10 +586,12 @@ export interface paths {
          * Delete a review request (dashboard cleanup)
          * @description Delete a review request.
          *
-         *     Team-internal cleanup: any authenticated user (session or PAT) may delete —
-         *     reviews are owned by whichever identity posted them (often the orchestrator's
-         *     PAT, not the human browsing), so restricting to owner would make the human
-         *     unable to tidy up. The router's session_auth already blocks anonymous callers.
+         *     Workspace-internal cleanup: any MEMBER of the review's workspace (session or
+         *     PAT) may delete — reviews are owned by whichever identity posted them (often the
+         *     orchestrator's PAT, not the human browsing), so restricting to owner would make
+         *     the human unable to tidy up. Membership (not ownership) is the right gate, and
+         *     it's the tenant boundary: a non-member gets a 404, not the ability to delete
+         *     another workspace's review.
          */
         readonly delete: operations["apps_reviews_api_delete_review"];
         readonly options?: never;


### PR DESCRIPTION
First slice of the workspace-boundary hardening (workspaces are a **hard** tenant boundary; a boundary audit found the leaks are all in by-id / mass-delete paths that skipped the scoping their own `list` applies).

## The leak
`get_review` / `submit_review` / `delete_review` resolved a review by UUID and gated only on `is_authenticated`, so **any** authenticated user could read, irreversibly resolve, or **delete** another workspace's review — and its DDD pause-gate — by knowing the UUID. `list_reviews` was already workspace-scoped; the by-id paths had drifted.

## Fix
- **New shared primitive** `wsvc.request_workspace_slugs(request)` — the single "objects in my workspaces" helper the boundary was missing: the pinned `/w/{ws}` slug (already membership-checked by middleware), else the **union** of the caller's memberships (so a human in dimagi + connect + a future family workspace sees all three), empty for anonymous. Auto-joins domain teammates on touch so by-id gates and lists agree.
- `_can_read`/`_can_write` now require membership of the review's workspace; `delete_review` 404s a non-member. The **public `visibility=link` path is unchanged** — anonymous share links still work. Membership (not ownership) is the gate, because reviews are owned by the orchestrator's PAT, not the human browsing.
- Legacy null-workspace rows (pre-FK) fall back to any authenticated user; new rows always carry a workspace.

## Tests
A non-member gets **404** on read/submit/delete of another workspace's private review (and it's left un-resolved / un-deleted); a member of that workspace can; public-link reads still serve anonymously. Full suite **854 passed**.

Part of a series — walkthroughs, the `clear_*` mass-deletes, and insights follow. Dispatch + `apps/issues` tenancy are pending a design confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)