### PR TITLE
fix(insights,shareouts): scope mass-deletes + insight reads to the caller's workspaces

### DIFF
--- a/apps/mcp/tools/insights.py
+++ b/apps/mcp/tools/insights.py
@@ -17,6 +17,7 @@ from apps.mcp.audit import current_user_id, write_audit
 from apps.mcp.rate_limit import RateLimitError, check_write_limit
 from apps.mcp.server import mcp
 from apps.projects import services
+from apps.workspaces import services as wsvc
 
 
 @mcp.tool
@@ -35,9 +36,10 @@ async def list_insights(
       - limit: max rows (clamped to 100; default 20)
     """
     user_id = current_user_id()
+    slugs = await sync_to_async(wsvc.workspace_slugs_for_user_id, thread_sensitive=True)(user_id)
     try:
         rows = await sync_to_async(services.list_insights, thread_sensitive=True)(
-            category=category, source=source, project=project, limit=limit
+            workspace_slugs=slugs, category=category, source=source, project=project, limit=limit
         )
     except Exception as exc:  # noqa: BLE001
         await write_audit(
@@ -84,9 +86,11 @@ async def clear_insights(
             )
             raise
 
+    slugs = await sync_to_async(wsvc.workspace_slugs_for_user_id, thread_sensitive=True)(user_id)
     try:
         cleared = await sync_to_async(services.clear_insights, thread_sensitive=True)(
-            source=source, category=category, project=project, older_than_days=older_than_days
+            workspace_slugs=slugs, source=source, category=category,
+            project=project, older_than_days=older_than_days,
         )
     except Exception as exc:  # noqa: BLE001
         await write_audit(

--- a/apps/projects/api.py
+++ b/apps/projects/api.py
@@ -600,7 +600,8 @@ def list_insights(
     """Bearer-readable xfail (Phase 5.4)."""
     limit = clamp_limit(limit, cap=100)
     rows = services.list_insights(
-        category=category, source=source, project=project, limit=limit
+        workspace_slugs=wsvc.request_workspace_slugs(request),
+        category=category, source=source, project=project, limit=limit,
     )
     items = [InsightOut.model_validate(row) for row in rows]
     return paginate(items, offset=0, limit=limit)
@@ -627,6 +628,7 @@ def clear_insights(
     A body with no filters ({}) clears ALL insights — this is intended.
     """
     count = services.clear_insights(
+        workspace_slugs=wsvc.request_workspace_slugs(request),
         source=payload.source,
         category=payload.category,
         project=payload.project,
@@ -637,9 +639,15 @@ def clear_insights(
 
 @insights_router.delete("/{pk}/", response=InsightDismissOut, summary="Dismiss insight")
 def dismiss_insight(request: HttpRequest, pk: int) -> InsightDismissOut:
-    try:
-        insight = ProjectContext.objects.get(pk=pk, context_type="insight")
-    except ProjectContext.DoesNotExist:
+    # Scope by the caller's workspaces (via the insight's project) so a member of
+    # one workspace can't delete another's insight by enumerating pks. A row outside
+    # scope is indistinguishable from a missing one → 404, no existence leak.
+    insight = (
+        services.insights_queryset(workspace_slugs=wsvc.request_workspace_slugs(request))
+        .filter(pk=pk)
+        .first()
+    )
+    if insight is None:
         raise ProblemError(
             404,
             "Insight not found",

--- a/apps/projects/services.py
+++ b/apps/projects/services.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 
+from django.db.models import Q
 from django.utils import timezone
 
 from .models import ProjectContext
@@ -22,6 +23,7 @@ from .models import ProjectContext
 
 def insights_queryset(
     *,
+    workspace_slugs: set[str],
     category: str | None = None,
     source: str | None = None,
     project: str | None = None,
@@ -29,16 +31,20 @@ def insights_queryset(
 ):
     """Return a filtered, ordered queryset of insight ProjectContext rows.
 
-    All filters are optional and AND-combined:
+    `workspace_slugs` is REQUIRED and is the hard tenant boundary: only insights
+    whose project belongs to one of those workspaces (or a legacy null-workspace
+    project) are ever returned — so no caller can read or clear across the
+    boundary. Pass the empty set to match nothing.
+
+    The rest are optional, AND-combined:
       - category: content starts with "[<category>]"
       - source: ProjectContext.source exact match
       - project: project slug exact match
       - older_than_days: created_at older than N days ago
-
-    With no filters, returns every insight (newest first).
     """
     qs = (
         ProjectContext.objects.filter(context_type="insight")
+        .filter(Q(project__workspace_id__in=workspace_slugs) | Q(project__workspace__isnull=True))
         .select_related("project")
         .order_by("-created_at")
     )
@@ -56,18 +62,22 @@ def insights_queryset(
 
 def list_insights(
     *,
+    workspace_slugs: set[str],
     category: str | None = None,
     source: str | None = None,
     project: str | None = None,
     limit: int = 20,
 ) -> list[dict]:
-    """Return up to `limit` insights as plain serializable dicts.
+    """Return up to `limit` insights as plain serializable dicts, scoped to
+    `workspace_slugs` (required — the tenant boundary).
 
     Shape matches InsightOut: id, project_slug, project_name, content,
     source, created_at (ISO string). `limit` is clamped to 100.
     """
     limit = min(max(limit, 0), 100)
-    qs = insights_queryset(category=category, source=source, project=project)
+    qs = insights_queryset(
+        workspace_slugs=workspace_slugs, category=category, source=source, project=project
+    )
     return [
         {
             "id": ins.pk,
@@ -83,16 +93,18 @@ def list_insights(
 
 def clear_insights(
     *,
+    workspace_slugs: set[str],
     source: str | None = None,
     category: str | None = None,
     project: str | None = None,
     older_than_days: int | None = None,
 ) -> int:
-    """Delete insights matching the filters; return the count deleted.
-
-    A call with no filters clears ALL insights — intended behavior.
+    """Delete insights matching the filters; return the count deleted. Scoped to
+    `workspace_slugs` (required): a no-filter clear deletes everything in the
+    CALLER'S workspaces, never across the tenant boundary.
     """
     qs = insights_queryset(
+        workspace_slugs=workspace_slugs,
         category=category,
         source=source,
         project=project,

--- a/apps/projects/tests/test_workspace_scoping.py
+++ b/apps/projects/tests/test_workspace_scoping.py
@@ -5,8 +5,9 @@ unchanged flat client keeps working); domain teammates auto-join and see it;
 outsiders get 404 and an empty list. Also verifies the prefixed
 /api/w/{ws}/projects/ mount works for a member.
 
-Insights are deliberately NOT workspace-scoped (product decision), so there is
-no insight scoping test here.
+Insights ARE workspace-scoped (they belong to a project, which belongs to a
+workspace) — a member of one workspace must not list, clear, or dismiss another's
+insights. Those cases are at the bottom of this file.
 """
 from __future__ import annotations
 
@@ -103,3 +104,45 @@ def test_prefixed_workspace_mount_404s_for_non_member():
     # Non-member of "dimagi" is rejected by the tenancy middleware.
     resp = _client(outsider).get(f"/api/w/{DEFAULT_WORKSPACE_SLUG}/projects/")
     assert resp.status_code == 404
+
+
+# --- Insight workspace scoping (a member of A must not touch B's insights) ------
+
+
+def _workspace(slug):
+    from apps.workspaces.models import Workspace
+    owner = _user(f"owner-{slug}@{slug}.example")
+    ws, _ = Workspace.objects.get_or_create(
+        slug=slug, defaults={"display_name": slug, "created_by": owner, "auto_join_domains": []}
+    )
+    return ws
+
+
+def _insight_in(ws_slug):
+    from apps.projects.models import ProjectContext
+    ws = _workspace(ws_slug)
+    project = Project.objects.create(slug=f"proj-{ws_slug}", name=ws_slug, workspace=ws)
+    return ProjectContext.objects.create(
+        project=project, context_type="insight", content="[ship_gap] secret", source="s"
+    )
+
+
+def test_member_cannot_list_clear_or_dismiss_another_workspaces_insight():
+    from apps.projects.models import ProjectContext
+    insight = _insight_in("connect")
+    jj = _user("jj@dimagi.com", is_superuser=True)  # member of default only, not connect
+
+    # list: the connect insight is not visible
+    listing = _client(jj).get("/api/insights/").json()
+    rows = listing.get("items", listing) if isinstance(listing, dict) else listing
+    assert all(r["id"] != insight.pk for r in rows)
+
+    # clear-all: does not delete it
+    cleared = _client(jj).post("/api/insights/clear/", data=json.dumps({}), content_type="application/json")
+    assert cleared.status_code == 200
+    assert ProjectContext.objects.filter(pk=insight.pk).exists()
+
+    # dismiss by pk: 404, still there
+    dismissed = _client(jj).delete(f"/api/insights/{insight.pk}/")
+    assert dismissed.status_code == 404
+    assert ProjectContext.objects.filter(pk=insight.pk).exists()

--- a/apps/shareouts/api.py
+++ b/apps/shareouts/api.py
@@ -91,13 +91,14 @@ def clear_shareouts(
     request: HttpRequest,
     payload: ShareoutsClearIn,
 ) -> ShareoutsClearOut:
-    """Delete shareouts matching the filters. An empty body clears all — but on a
-    /w/{ws} request the clear is confined to that workspace's rows."""
+    """Delete shareouts matching the filters, scoped to the caller's workspaces.
+    An empty body clears all of THE CALLER'S shareouts (the pinned /w/{ws} one, or
+    the union of their memberships) — never another tenant's."""
     count = services.clear_shareouts(
+        workspace_slugs=wsvc.request_workspace_slugs(request),
         source=payload.source,
         project=payload.project,
         date_from=payload.date_from,
         date_to=payload.date_to,
-        workspace_slug=getattr(request, "workspace_slug", None),
     )
     return ShareoutsClearOut(cleared=count)

--- a/apps/shareouts/services.py
+++ b/apps/shareouts/services.py
@@ -97,26 +97,23 @@ def upsert_shareouts(items: list, *, workspace=None) -> dict:
 
 def clear_shareouts(
     *,
+    workspace_slugs: set[str],
     source: str | None = None,
     project: str | None = None,
     date_from: dt.date | None = None,
     date_to: dt.date | None = None,
-    workspace_slug: str | None = None,
 ) -> int:
     """Delete shareouts matching the filters (AND-combined); return the count.
 
-    - source:         exact source match (e.g. a prior run's source tag)
-    - project:        project slug exact match
-    - date_from:      period_end date >= date_from
-    - date_to:        period_start date <= date_to
-    - workspace_slug: when set (a /w/{ws} request), only clears that tenant's rows
-
-    A call with no filters (and no workspace) deletes ALL shareouts — intended
-    (matches the insights clear contract).
+    - workspace_slugs: REQUIRED tenant boundary — only rows in these workspaces are
+                       ever deleted. A no-filter clear wipes the caller's own
+                       workspaces, never all tenants.
+    - source:          exact source match (e.g. a prior run's source tag)
+    - project:         project slug exact match
+    - date_from:       period_end date >= date_from
+    - date_to:         period_start date <= date_to
     """
-    qs = Shareout.objects.all()
-    if workspace_slug:
-        qs = qs.filter(workspace_id=workspace_slug)
+    qs = Shareout.objects.filter(workspace_id__in=workspace_slugs)
     if source:
         qs = qs.filter(source=source)
     if project:

--- a/apps/shareouts/tests/test_workspace_scoping.py
+++ b/apps/shareouts/tests/test_workspace_scoping.py
@@ -94,3 +94,32 @@ def test_prefixed_workspace_route_works_for_member():
     assert resp.status_code == 200
     items = resp.json()["items"]
     assert any(i["title"] == "Weekly briefing" for i in items)
+
+
+def _workspace(slug):
+    from apps.workspaces.models import Workspace
+    owner = _user(f"owner-{slug}@{slug}.example")
+    ws, _ = Workspace.objects.get_or_create(
+        slug=slug, defaults={"display_name": slug, "created_by": owner, "auto_join_domains": []}
+    )
+    return ws
+
+
+def _shareout_in(ws):
+    return Shareout.objects.create(
+        project=None, workspace=ws,
+        period_start="2026-06-03T09:00:00Z", period_end="2026-06-03T17:30:00Z",
+        title="Other tenant's briefing", content="secret", source="s",
+    )
+
+
+def test_clear_with_no_filters_never_deletes_another_workspaces_shareouts():
+    # A dimagi-only user clearing "everything" must not wipe connect's shareouts —
+    # the empty-body clear is scoped to the caller's own workspaces.
+    connect_row = _shareout_in(_workspace("connect"))
+    jj = _user("jj@dimagi.com", is_superuser=True)
+    resp = _client(jj).post(
+        "/api/shareouts/clear/", data=json.dumps({}), content_type="application/json"
+    )
+    assert resp.status_code == 200
+    assert Shareout.objects.filter(pk=connect_row.pk).exists()  # survived the cross-tenant clear

--- a/apps/workspaces/services.py
+++ b/apps/workspaces/services.py
@@ -103,6 +103,22 @@ def request_workspace_slugs(request) -> set[str]:
     return user_workspace_slugs(user)
 
 
+def workspace_slugs_for_user_id(user_id) -> set[str]:
+    """The workspace slugs a user (by pk) may act within — the MCP-side counterpart
+    of `request_workspace_slugs`, for tools that carry a token subject rather than a
+    request. Empty set for an unresolvable user, so a scoped query fails CLOSED
+    (sees/clears nothing) instead of falling back to global."""
+    if user_id is None:
+        return set()
+    from django.contrib.auth import get_user_model
+
+    user = get_user_model().objects.filter(pk=user_id).first()
+    if user is None:
+        return set()
+    auto_join_workspaces(user)
+    return user_workspace_slugs(user)
+
+
 def user_default_workspace(user) -> Workspace | None:
     """The user's workspace when unambiguous — their sole membership, else None
     (0 or 2+ memberships). Used to resolve a default for headless PAT callers."""

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -753,8 +753,9 @@ export interface paths {
         readonly put?: never;
         /**
          * Clear shareouts by source / project / date (AND-combined)
-         * @description Delete shareouts matching the filters. An empty body clears all — but on a
-         *     /w/{ws} request the clear is confined to that workspace's rows.
+         * @description Delete shareouts matching the filters, scoped to the caller's workspaces.
+         *     An empty body clears all of THE CALLER'S shareouts (the pinned /w/{ws} one, or
+         *     the union of their memberships) — never another tenant's.
          */
         readonly post: operations["apps_shareouts_api_clear_shareouts"];
         readonly delete?: never;


### PR DESCRIPTION
The **widest-blast-radius** workspace-boundary leaks. On the flat mount, an empty-body `POST /api/insights/clear/` or `/api/shareouts/clear/` deleted **every** workspace's rows, and `list_insights`/`dismiss_insight` (plus the insights **MCP** tool) read/deleted across tenants by pk. Any authenticated user — or one PAT — could wipe or read all tenants' data.

## Fix (safe-by-default: scope is a *required* arg, no fail-open)
- **insights** — `workspace_slugs` is now required on `insights_queryset`/`list_insights`/`clear_insights`, scoped by the insight's project workspace (legacy null included). REST passes `request_workspace_slugs`; `dismiss_insight` resolves through the scoped queryset (404 for an out-of-scope pk).
- **shareouts** — `clear_shareouts` takes required `workspace_slugs` and filters `workspace_id__in`; a no-filter clear wipes only the caller's own workspaces.
- **MCP tools** — new `wsvc.workspace_slugs_for_user_id(user_id)` (the token-side counterpart of `request_workspace_slugs`). An unresolvable user → empty set → the query fails **closed**; this also closes the prior rate-limit fail-open (no user ⇒ sees/clears nothing).

## Tests
A dimagi-only user's clear-all leaves connect's shareouts + insights **intact**; its list omits them and dismiss-by-pk **404s**. Also corrects the stale "insights are NOT workspace-scoped" test note — that was the soft-boundary assumption. Full suite **856 passed**.

Builds on #259's `request_workspace_slugs` primitive. Walkthroughs by-id next; dispatch + `apps/issues` await your design confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)