### PR TITLE
fix(walkthroughs): enforce the workspace boundary on detail + content reads

### DIFF
--- a/apps/walkthroughs/api.py
+++ b/apps/walkthroughs/api.py
@@ -380,7 +380,7 @@ def list_walkthroughs(
 def get_walkthrough(request: HttpRequest, wid: UUID, t: str = "") -> WalkthroughDetailOut:
     _require_enabled()
     w = _get_or_404(wid)
-    if not (request.user.is_authenticated or w.token_matches(t)):
+    if not w.readable_by(request):  # member of its workspace, or a matching ?t token
         raise Http404("walkthrough not found")  # don't leak private existence
     is_owner = request.user.is_authenticated and w.owner_id == request.user.id
     return WalkthroughDetailOut.model_validate(

--- a/apps/walkthroughs/models.py
+++ b/apps/walkthroughs/models.py
@@ -132,3 +132,16 @@ class Walkthrough(models.Model):
                 self.share_token.encode("utf-8"), token.encode("utf-8")
             )
         )
+
+    def readable_by(self, request) -> bool:
+        """The read gate for detail + content: a MEMBER of the walkthrough's
+        workspace, or anyone presenting a matching ?t=<share_token> (visibility=
+        link). Being merely authenticated is NOT enough — that was a cross-workspace
+        read leak. Legacy null-workspace rows fall back to any authenticated user."""
+        from apps.workspaces import services as wsvc
+
+        if self.workspace_id is None:
+            member = request.user.is_authenticated
+        else:
+            member = self.workspace_id in wsvc.request_workspace_slugs(request)
+        return member or self.token_matches(request.GET.get("t"))

--- a/apps/walkthroughs/streaming.py
+++ b/apps/walkthroughs/streaming.py
@@ -63,13 +63,11 @@ def walkthrough_content(request, wid):
     if w is None:
         raise Http404("walkthrough not found")
 
-    # Token-gated public access (spec 2026-07-13): anonymous read requires
-    # visibility=link AND a matching ?t=<share_token>. Bare-UUID anonymous
-    # access 404s exactly like private, so existence never leaks.
-    if not (
-        request.user.is_authenticated
-        or w.token_matches(request.GET.get("t"))
-    ):
+    # Readable by a MEMBER of the walkthrough's workspace, or by anyone with a
+    # matching ?t=<share_token> (visibility=link). A non-member (even authenticated)
+    # 404s exactly like private, so existence never leaks — and can't stream another
+    # workspace's file bytes.
+    if not w.readable_by(request):
         raise Http404("walkthrough not found")
 
     range_hdr = request.META.get("HTTP_RANGE", "")

--- a/apps/walkthroughs/tests/test_workspace_scoping.py
+++ b/apps/walkthroughs/tests/test_workspace_scoping.py
@@ -2,10 +2,11 @@
 token-gated public (visibility=link) detail reads survive scoping.
 
 The authenticated LIST is workspace-scoped (a member sees their workspace's
-walkthroughs; an outsider does not). The single-object public detail GET resolves
-by UUID and self-enforces visibility — it must keep serving `visibility=link`
-walkthroughs to anonymous callers presenting the matching ?t=<share_token>, with
-NO workspace filter.
+walkthroughs; an outsider does not). The single-object detail GET and the content
+stream are now ALSO member-scoped for private walkthroughs — a non-member 404s
+rather than reading another workspace's metadata or file bytes — while a
+`visibility=link` walkthrough stays readable by anyone presenting the matching
+?t=<share_token> (the public path must survive scoping).
 """
 from __future__ import annotations
 
@@ -106,3 +107,20 @@ def test_anonymous_can_still_get_link_visibility_detail_after_scoping():
     resp = Client().get(f"/api/walkthroughs/{w.id}/?t={token}")
     assert resp.status_code == 200
     assert resp.json()["id"] == str(w.id)
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_non_member_cannot_get_private_detail_or_stream_content():
+    # A private walkthrough in "connect" must 404 for a dimagi-only user on both the
+    # detail read and the content stream — no cross-workspace metadata or file bytes.
+    connect_owner = _user("owner@connect.example")
+    connect = _workspace("connect", connect_owner, auto_join=())  # no dimagi auto-join
+    w = _make(connect_owner, connect, title="Secret")  # default (private) visibility
+
+    jj = _user("jj@dimagi.com", is_superuser=True)  # member of dimagi only
+    assert _client(jj).get(f"/api/walkthroughs/{w.id}/").status_code == 404
+    assert _client(jj).get(f"/walkthrough/{w.id}/content").status_code == 404
+
+    # The connect owner (a member) reads the detail fine — proves it's the boundary,
+    # not a total lock. (Content 200 would hit Drive, so detail is the member proof.)
+    assert _client(connect_owner).get(f"/api/walkthroughs/{w.id}/").status_code == 200


### PR DESCRIPTION
Last of the unambiguous workspace-boundary read leaks. `get_walkthrough` and the content stream gated only on `is_authenticated`, so any user could read another workspace's walkthrough metadata — or **stream its raw video/HTML file bytes** — by knowing the UUID. `list` was already scoped; the by-id reads had drifted.

- New `Walkthrough.readable_by(request)`: a **member** of the walkthrough's workspace, or anyone with a matching `?t=<share_token>` (visibility=link). Both the detail endpoint and the streaming view use it.
- Public share-token path unchanged; legacy null-workspace rows fall back to any authenticated user.

Tests: a non-member **404s** on both detail and content for a private walkthrough in another workspace; a member reads it; public `?t` links still serve. Full suite **857 passed**.

Completes the by-id/read/mass-delete boundary series (#259 reviews, #260 insights+shareouts, this). Remaining: **dispatch** (needs the "acting human must be a member of the target agent's workspace" rule confirmed) and **`apps/issues`** (no workspace FK — needs a tenancy decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)