### PR TITLE
fix(harness): dispatch enforces the workspace boundary (acting human must be a member)

### DIFF
--- a/apps/harness/dispatch.py
+++ b/apps/harness/dispatch.py
@@ -43,15 +43,22 @@ class TurnSpec:
         )
 
 
-def dispatch(item: Item) -> list[Turn]:
+def dispatch(item: Item, *, actor_workspace_slugs: set[str]) -> list[Turn]:
     """Enqueue an approved Item's work. Idempotent per (item, index).
 
-    Raises ValueError for an unknown target_agent rather than skipping it: an
-    approved item whose work silently never happens is the worst outcome here.
-    The caller (services.decide_item) runs this inside the same transaction as
-    the decision, so a raise rolls the decision back and leaves the item OPEN and
-    retryable — rather than stranding it decided-but-undispatched, which deciding
-    once (409) would make permanent.
+    `actor_workspace_slugs` is the deciding human's workspace memberships. A
+    cross-agent dispatch (`target_agent` set) is authorized ONLY if the target's
+    workspace is one of them — the hard tenant boundary. This preserves the fleet
+    manager (Ada dispatching hal→eva across workspaces works when the human driving
+    it is a member of both), while blocking a single-workspace user from landing a
+    prompt on another tenant's agent.
+
+    Raises ValueError for an unknown OR cross-tenant target_agent rather than
+    skipping it: an approved item whose work silently never happens is the worst
+    outcome here. The caller (services.decide_item) runs this inside the same
+    transaction as the decision, so a raise rolls the decision back and leaves the
+    item OPEN and retryable — rather than stranding it decided-but-undispatched,
+    which deciding once (409) would make permanent.
     """
     turns: list[Turn] = []
     for i, raw in enumerate(item.dispatch or []):
@@ -61,6 +68,15 @@ def dispatch(item: Item) -> list[Turn]:
             if target is None:
                 raise ValueError(
                     f"item {item.id} dispatch[{i}]: unknown target_agent {spec.target_agent!r}"
+                )
+            # Cross-agent dispatch is a cross-tenant action unless the actor is a
+            # member of the target's workspace. Self-dispatch (below) is already
+            # authorized — the actor could decide the item, which required its
+            # agent's workspace. Legacy null-workspace targets fall through.
+            if target.workspace_id is not None and target.workspace_id not in actor_workspace_slugs:
+                raise ValueError(
+                    f"item {item.id} dispatch[{i}]: not a member of target_agent "
+                    f"{spec.target_agent!r}'s workspace"
                 )
         else:
             target = item.agent

--- a/apps/harness/items_api.py
+++ b/apps/harness/items_api.py
@@ -20,6 +20,7 @@ from ninja.errors import HttpError
 
 from apps.agents.api import _get_agent_or_404, _visible_agent_workspace_ids
 from apps.api.auth import session_auth
+from apps.workspaces import services as wsvc
 
 from . import services
 from .models import Item
@@ -106,6 +107,7 @@ def decide_item(request: HttpRequest, item_id: uuid.UUID, payload: ItemDecideIn)
         item, _turns = services.decide_item(
             item, decision=payload.decision, comment=payload.comment,
             by=request.user.email or request.user.get_username(),
+            actor_workspace_slugs=wsvc.request_workspace_slugs(request),
         )
     except services.AlreadyDecidedError as exc:
         raise HttpError(409, str(exc)) from exc

--- a/apps/harness/services.py
+++ b/apps/harness/services.py
@@ -670,12 +670,18 @@ def create_items(*, agent, payloads: list[dict]) -> list[Item]:
     return out
 
 
-def decide_item(item: Item, *, decision: str, comment: str, by: str) -> tuple[Item, list[Turn]]:
+def decide_item(
+    item: Item, *, decision: str, comment: str, by: str, actor_workspace_slugs: set[str]
+) -> tuple[Item, list[Turn]]:
     """Resolve an open item. Only IMPLEMENT dispatches.
 
     A review needs a decision from the closed set; a question needs a non-empty
     answer (its `decision` stays blank). Deciding twice raises AlreadyDecidedError —
     the guard that stops a double-click becoming a second dispatch.
+
+    `actor_workspace_slugs` is the set of workspaces the DECIDING human belongs to;
+    it's the authorization for a cross-agent dispatch — you may only dispatch a
+    turn onto an agent in a workspace you're a member of (the hard tenant boundary).
     """
     from .dispatch import dispatch as dispatch_item  # local: dispatch imports services
 
@@ -706,7 +712,7 @@ def decide_item(item: Item, *, decision: str, comment: str, by: str) -> tuple[It
 
         turns: list[Turn] = []
         if decision == Item.IMPLEMENT:
-            turns = dispatch_item(item)
+            turns = dispatch_item(item, actor_workspace_slugs=actor_workspace_slugs)
             item.dispatched_at = timezone.now()
 
         item.save(update_fields=[

--- a/tests/test_item_dispatch.py
+++ b/tests/test_item_dispatch.py
@@ -37,7 +37,7 @@ def _item(agent, **kw):
 def test_empty_target_agent_dispatches_to_the_items_own_agent(ada):
     item = _item(ada, dispatch=[{"prompt": "/ada:conduct"}])
 
-    turns = dispatch(item)
+    turns = dispatch(item, actor_workspace_slugs={wsvc.DEFAULT_WORKSPACE_SLUG})
 
     assert [t.agent for t in turns] == [ada]
     assert turns[0].prompt == "/ada:conduct"
@@ -47,7 +47,7 @@ def test_empty_target_agent_dispatches_to_the_items_own_agent(ada):
 def test_named_target_agent_dispatches_to_that_agent(ada, hal):
     item = _item(ada, dispatch=[{"target_agent": "hal", "prompt": "/hal:turn", "origin": "email"}])
 
-    turns = dispatch(item)
+    turns = dispatch(item, actor_workspace_slugs={wsvc.DEFAULT_WORKSPACE_SLUG})
 
     assert [t.agent for t in turns] == [hal]
     assert turns[0].origin == "email"
@@ -56,8 +56,8 @@ def test_named_target_agent_dispatches_to_that_agent(ada, hal):
 def test_dispatch_is_idempotent_per_entry(ada):
     item = _item(ada, dispatch=[{"prompt": "/ada:conduct"}])
 
-    first = dispatch(item)
-    second = dispatch(item)
+    first = dispatch(item, actor_workspace_slugs={wsvc.DEFAULT_WORKSPACE_SLUG})
+    second = dispatch(item, actor_workspace_slugs={wsvc.DEFAULT_WORKSPACE_SLUG})
 
     assert [t.id for t in first] == [t.id for t in second]
     assert Turn.objects.count() == 1
@@ -66,7 +66,7 @@ def test_dispatch_is_idempotent_per_entry(ada):
 def test_an_item_with_no_dispatch_enqueues_nothing(ada):
     item = _item(ada, dispatch=[])
 
-    assert dispatch(item) == []
+    assert dispatch(item, actor_workspace_slugs={wsvc.DEFAULT_WORKSPACE_SLUG}) == []
     assert Turn.objects.count() == 0
 
 
@@ -74,7 +74,7 @@ def test_an_unknown_target_agent_raises_rather_than_silently_dropping(ada):
     item = _item(ada, dispatch=[{"target_agent": "ghost", "prompt": "/ghost:turn"}])
 
     with pytest.raises(ValueError, match="ghost"):
-        dispatch(item)
+        dispatch(item, actor_workspace_slugs={wsvc.DEFAULT_WORKSPACE_SLUG})
 
 
 def test_each_entry_gets_its_own_turn(ada, hal):
@@ -83,7 +83,7 @@ def test_each_entry_gets_its_own_turn(ada, hal):
         {"prompt": "/ada:conduct"},
     ])
 
-    turns = dispatch(item)
+    turns = dispatch(item, actor_workspace_slugs={wsvc.DEFAULT_WORKSPACE_SLUG})
 
     assert [t.agent for t in turns] == [hal, ada]
 
@@ -91,10 +91,33 @@ def test_each_entry_gets_its_own_turn(ada, hal):
 def test_a_spec_with_no_prompt_falls_back_to_the_targets_turn(ada, hal):
     item = _item(ada, dispatch=[{"target_agent": "hal"}])
 
-    turns = dispatch(item)
+    turns = dispatch(item, actor_workspace_slugs={wsvc.DEFAULT_WORKSPACE_SLUG})
 
     assert turns[0].prompt == "/hal:turn"
 
 
 def test_turnspec_defaults_target_self():
     assert TurnSpec(prompt="/x").target_agent == ""
+
+
+def test_cross_workspace_dispatch_is_refused_for_a_non_member(ada):
+    # hal lives in "connect"; an actor who is NOT a member of connect must not be
+    # able to land a prompt on hal by dispatching from an item on their own agent.
+    from django.contrib.auth import get_user_model
+    from apps.workspaces.models import Workspace
+
+    owner = get_user_model().objects.create(username="o@connect.example", email="o@connect.example")
+    connect = Workspace.objects.create(
+        slug="connect", display_name="Connect", created_by=owner, auto_join_domains=[]
+    )
+    hal_connect = Agent.objects.create(slug="hal", name="Hal", workspace=connect)
+    item = _item(ada, dispatch=[{"target_agent": "hal", "prompt": "/hal:turn"}])
+
+    # Actor in "dimagi" only → cross-tenant dispatch to hal (connect) is refused.
+    with pytest.raises(ValueError, match="not a member"):
+        dispatch(item, actor_workspace_slugs={wsvc.DEFAULT_WORKSPACE_SLUG})
+    assert Turn.objects.count() == 0  # nothing landed on hal
+
+    # An actor who IS a member of connect (e.g. Jonathan, in both) can dispatch.
+    turns = dispatch(item, actor_workspace_slugs={wsvc.DEFAULT_WORKSPACE_SLUG, "connect"})
+    assert [t.agent for t in turns] == [hal_connect]

--- a/tests/test_item_services.py
+++ b/tests/test_item_services.py
@@ -28,7 +28,7 @@ def _item(ada, **kw):
 def test_implement_decides_and_dispatches(ada):
     item = _item(ada, dispatch=[{"prompt": "/ada:conduct"}])
 
-    item, turns = services.decide_item(item, decision=Item.IMPLEMENT, comment="", by="jj@dimagi.com")
+    item, turns = services.decide_item(item, decision=Item.IMPLEMENT, comment="", by="jj@dimagi.com", actor_workspace_slugs={wsvc.DEFAULT_WORKSPACE_SLUG})
 
     assert item.state == Item.DECIDED
     assert item.decision == Item.IMPLEMENT
@@ -41,7 +41,7 @@ def test_implement_decides_and_dispatches(ada):
 def test_skip_decides_and_dispatches_nothing(ada):
     item = _item(ada, dispatch=[{"prompt": "/ada:conduct"}])
 
-    item, turns = services.decide_item(item, decision=Item.SKIP, comment="", by="jj@dimagi.com")
+    item, turns = services.decide_item(item, decision=Item.SKIP, comment="", by="jj@dimagi.com", actor_workspace_slugs={wsvc.DEFAULT_WORKSPACE_SLUG})
 
     assert item.state == Item.DECIDED
     assert turns == []
@@ -52,7 +52,7 @@ def test_skip_decides_and_dispatches_nothing(ada):
 def test_defer_decides_and_dispatches_nothing(ada):
     item = _item(ada, dispatch=[{"prompt": "/ada:conduct"}])
 
-    item, turns = services.decide_item(item, decision=Item.DEFER, comment="", by="jj@dimagi.com")
+    item, turns = services.decide_item(item, decision=Item.DEFER, comment="", by="jj@dimagi.com", actor_workspace_slugs={wsvc.DEFAULT_WORKSPACE_SLUG})
 
     assert item.decision == Item.DEFER
     assert Turn.objects.count() == 0
@@ -60,10 +60,10 @@ def test_defer_decides_and_dispatches_nothing(ada):
 
 def test_deciding_twice_raises_rather_than_dispatching_again(ada):
     item = _item(ada, dispatch=[{"prompt": "/ada:conduct"}])
-    services.decide_item(item, decision=Item.IMPLEMENT, comment="", by="jj@dimagi.com")
+    services.decide_item(item, decision=Item.IMPLEMENT, comment="", by="jj@dimagi.com", actor_workspace_slugs={wsvc.DEFAULT_WORKSPACE_SLUG})
 
     with pytest.raises(services.AlreadyDecidedError):
-        services.decide_item(item, decision=Item.IMPLEMENT, comment="", by="jj@dimagi.com")
+        services.decide_item(item, decision=Item.IMPLEMENT, comment="", by="jj@dimagi.com", actor_workspace_slugs={wsvc.DEFAULT_WORKSPACE_SLUG})
 
     assert Turn.objects.count() == 1
 
@@ -72,9 +72,9 @@ def test_a_question_requires_an_answer(ada):
     item = _item(ada, kind=Item.QUESTION, title="which repo?")
 
     with pytest.raises(ValueError, match="answer"):
-        services.decide_item(item, decision="", comment="", by="jj@dimagi.com")
+        services.decide_item(item, decision="", comment="", by="jj@dimagi.com", actor_workspace_slugs={wsvc.DEFAULT_WORKSPACE_SLUG})
 
-    item, _ = services.decide_item(item, decision="", comment="canopy-web", by="jj@dimagi.com")
+    item, _ = services.decide_item(item, decision="", comment="canopy-web", by="jj@dimagi.com", actor_workspace_slugs={wsvc.DEFAULT_WORKSPACE_SLUG})
     assert item.state == Item.DECIDED
     assert item.comment == "canopy-web"
 
@@ -83,7 +83,7 @@ def test_a_review_rejects_a_decision_outside_the_closed_set(ada):
     item = _item(ada)
 
     with pytest.raises(ValueError, match="decision"):
-        services.decide_item(item, decision="yolo", comment="", by="jj@dimagi.com")
+        services.decide_item(item, decision="yolo", comment="", by="jj@dimagi.com", actor_workspace_slugs={wsvc.DEFAULT_WORKSPACE_SLUG})
 
 
 def test_a_failing_dispatch_rolls_the_decision_back(ada):
@@ -93,7 +93,7 @@ def test_a_failing_dispatch_rolls_the_decision_back(ada):
     item = _item(ada, dispatch=[{"target_agent": "ghost", "prompt": "/ghost:turn"}])
 
     with pytest.raises(ValueError, match="ghost"):
-        services.decide_item(item, decision=Item.IMPLEMENT, comment="", by="jj@dimagi.com")
+        services.decide_item(item, decision=Item.IMPLEMENT, comment="", by="jj@dimagi.com", actor_workspace_slugs={wsvc.DEFAULT_WORKSPACE_SLUG})
 
     item.refresh_from_db()
     assert item.state == Item.OPEN
@@ -109,7 +109,7 @@ def test_a_partly_bad_dispatch_enqueues_nothing(ada):
     ])
 
     with pytest.raises(ValueError):
-        services.decide_item(item, decision=Item.IMPLEMENT, comment="", by="jj@dimagi.com")
+        services.decide_item(item, decision=Item.IMPLEMENT, comment="", by="jj@dimagi.com", actor_workspace_slugs={wsvc.DEFAULT_WORKSPACE_SLUG})
 
     item.refresh_from_db()
     assert item.state == Item.OPEN
@@ -130,7 +130,7 @@ def test_dismiss_refuses_an_already_decided_item(ada):
     # turns keep running. Dismiss guards on state exactly like decide does.
     item = _item(ada, dispatch=[{"prompt": "/ada:conduct"}])
     item, _turns = services.decide_item(
-        item, decision=Item.IMPLEMENT, comment="", by="approver@dimagi.com"
+        item, decision=Item.IMPLEMENT, comment="", by="approver@dimagi.com", actor_workspace_slugs={wsvc.DEFAULT_WORKSPACE_SLUG}
     )
     assert item.state == Item.DECIDED
 

--- a/tests/test_needs_you_items.py
+++ b/tests/test_needs_you_items.py
@@ -59,7 +59,7 @@ def test_an_open_question_item_lands_in_the_question_band(ada):
 def test_a_decided_item_is_gone_from_the_inbox(ada):
     item = _item(ada, title="done with this")
     services_h = __import__("apps.harness.services", fromlist=["x"])
-    services_h.decide_item(item, decision=Item.SKIP, comment="", by="jj@dimagi.com")
+    services_h.decide_item(item, decision=Item.SKIP, comment="", by="jj@dimagi.com", actor_workspace_slugs={wsvc.DEFAULT_WORKSPACE_SLUG})
 
     out = services.needs_you(ada)
 


### PR DESCRIPTION
The **last** workspace-boundary leak, and the highest-severity one: `dispatch()` resolved `target_agent` by **global** slug, so a member of workspace A could raise an item on their own agent whose `dispatch[]` targets **B's agent** with an arbitrary prompt → cross-tenant **remote execution** (B's runner claims and runs it).

## Fix (your confirmed rule)
A cross-agent dispatch is authorized only if the **deciding human is a member of the target agent's workspace**.
- `decide_item` now takes `actor_workspace_slugs` (required, no fail-open); `items_api` passes `request_workspace_slugs(request)`.
- `dispatch()` raises → **422** (rolls the decision back atomically, item stays OPEN and retryable) if the target's workspace isn't in the actor's memberships. Self-dispatch is untouched; legacy null-workspace targets fall through.

This **preserves the fleet manager**: Ada dispatching hal→eva across workspaces works when the human driving it is a member of both (as you are, in dimagi + connect), while a single-workspace user can't reach another tenant's agents.

## Test
A dimagi-only actor is **refused** dispatching to hal-in-connect (nothing lands on hal); an actor in **both** succeeds. Full suite **901 passed**.

Completes the workspace-boundary series (#259 reviews, #260 insights/shareouts, #262 walkthroughs, this = dispatch). Remaining from the audit: `apps/issues` tenancy (next) + the ownership-attribution pass (schedules `created_by`, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)