### PR TITLE
feat(runner): take a single turn without the daemon (--drain-one + menu-bar)

### DIFF
--- a/packages/canopy-runner-menubar/Sources/main.swift
+++ b/packages/canopy-runner-menubar/Sources/main.swift
@@ -261,6 +261,9 @@ final class Controller: NSObject, NSApplicationDelegate {
         } else {
             add(menu, "Stop daemon", #selector(stopDaemon))
         }
+        // Take exactly ONE queued turn without running the whole daemon — works even
+        // while paused. Dispatch a turn (composer / a session Continue), then tap this.
+        add(menu, "Take one turn", #selector(takeOneTurn))
         menu.addItem(.separator())
 
         add(menu, "Open Supervisor in browser…", #selector(openSupervisor))
@@ -296,6 +299,31 @@ final class Controller: NSObject, NSApplicationDelegate {
     @objc func stopDaemon() {
         run(["launchctl", "bootout", "gui/\(getuid())/\(launchLabel)"])
         rebuild()
+    }
+
+    // Run the runner CLI ONCE with --drain-one: claim + execute a single queued turn,
+    // then exit. We reuse the daemon's OWN launchd plist (same interpreter, PYTHONPATH,
+    // config) so this can't drift from how the daemon runs — just with --drain-one and no
+    // KeepAlive loop. Fire-and-forget on a background queue so the menu stays responsive.
+    @objc func takeOneTurn() {
+        guard let data = try? Data(contentsOf: plistPath),
+              let plist = try? PropertyListSerialization.propertyList(from: data, format: nil)
+                  as? [String: Any],
+              let argv = plist["ProgramArguments"] as? [String], !argv.isEmpty else {
+            return
+        }
+        let extraEnv = plist["EnvironmentVariables"] as? [String: String] ?? [:]
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: argv[0])
+        proc.arguments = Array(argv.dropFirst()) + ["--drain-one"]
+        var env = ProcessInfo.processInfo.environment
+        for (k, v) in extraEnv { env[k] = v }
+        proc.environment = env
+        DispatchQueue.global(qos: .userInitiated).async {
+            try? proc.run()
+            proc.waitUntilExit()
+            DispatchQueue.main.async { self.rebuild() }
+        }
     }
     @objc func openSupervisor() {
         if let url = URL(string: baseURL() + "/supervisor") { NSWorkspace.shared.open(url) }

--- a/packages/canopy_runner/canopy_runner/main.py
+++ b/packages/canopy_runner/canopy_runner/main.py
@@ -172,28 +172,12 @@ def _fire_due_schedules(cfg: Config, client: Client, paused: set[str] | None = N
         logger.warning("schedule sync failed: %s", exc)
 
 
-def _run_once_cdp(cfg: Config, client: Client) -> str:
-    """CDP executor: heartbeat (with macOS host, for reuse ownership) → claim one
-    turn → route it to an emdash session (reuse or create). Turns finish synchronously
-    (the runner owns the routing lifecycle; work continues in the visible session), so
-    there is no injection state to track or schema to guard."""
+def _claim_and_execute(cfg: Config, client: Client, paused: set) -> str:
+    """Claim at most one eligible turn and route it to an emdash session. The shared
+    core of both the loop's iteration and the single-turn primitive, so they can't
+    drift. Returns reused:/created:/failed:<id> or "idle" when nothing is queued."""
     from . import execute
-    from .cdp_control import host_id
 
-    client.heartbeat(cfg.runner_id, [], host=host_id())
-    # Report the open emdash sessions the phone can continue. Best-effort: a read or
-    # POST failure must never stop the tick from claiming work.
-    try:
-        client.report_sessions(cfg.runner_id, emdash.list_open_sessions(cfg.emdash_db))
-    except Exception:  # noqa: BLE001
-        logger.debug("session report failed (non-fatal)", exc_info=True)
-    paused = _paused_agents(cfg)
-    _maybe_check_inboxes(cfg, client, paused=paused)
-    # Fleet-audit review ingestion was removed when Ada moved to Items: approving
-    # an Item dispatches its work server-side (in the decide transaction), so there
-    # is no resolved review for the runner to poll. DDD findings reviews are applied
-    # by the DDD orchestrator, never here.
-    _fire_due_schedules(cfg, client, paused=paused)
     try:
         turn = client.claim(cfg.runner_id, paused_agents=sorted(paused))
     except ClientError as exc:
@@ -210,6 +194,47 @@ def _run_once_cdp(cfg: Config, client: Client) -> str:
         except ClientError:
             pass
         return f"failed:{turn.get('id')}"
+
+
+def _run_once_cdp(cfg: Config, client: Client) -> str:
+    """CDP executor: heartbeat (with macOS host, for reuse ownership) → claim one
+    turn → route it to an emdash session (reuse or create). Turns finish synchronously
+    (the runner owns the routing lifecycle; work continues in the visible session), so
+    there is no injection state to track or schema to guard."""
+    from .cdp_control import host_id
+
+    client.heartbeat(cfg.runner_id, [], host=host_id())
+    # Report the open emdash sessions the phone can continue. Best-effort: a read or
+    # POST failure must never stop the tick from claiming work.
+    try:
+        client.report_sessions(cfg.runner_id, emdash.list_open_sessions(cfg.emdash_db))
+    except Exception:  # noqa: BLE001
+        logger.debug("session report failed (non-fatal)", exc_info=True)
+    paused = _paused_agents(cfg)
+    _maybe_check_inboxes(cfg, client, paused=paused)
+    # Fleet-audit review ingestion was removed when Ada moved to Items: approving
+    # an Item dispatches its work server-side (in the decide transaction), so there
+    # is no resolved review for the runner to poll. DDD findings reviews are applied
+    # by the DDD orchestrator, never here.
+    _fire_due_schedules(cfg, client, paused=paused)
+    return _claim_and_execute(cfg, client, paused)
+
+
+def drain_one(cfg: Config, client: Client) -> str:
+    """Take exactly ONE queued turn, then exit — the "take a single turn" primitive.
+
+    Unlike --once (a full loop iteration), this does NOT poll the inbox or fire
+    schedules, so it can only run a turn that is ALREADY queued (dispatch one from the
+    composer/API first); it never enqueues or spawns work you didn't ask for. It also
+    runs while the daemon is paused — the global PAUSED sentinel gates main()'s loop, not
+    this — so you can take one turn with the fleet otherwise off. Per-agent pauses ARE
+    honoured (the claim skips a paused agent's turns)."""
+    from .cdp_control import host_id
+
+    if cfg.executor != "cdp":
+        return run_once(cfg, client)  # legacy inject path has no targeted primitive
+    client.heartbeat(cfg.runner_id, [], host=host_id())
+    return _claim_and_execute(cfg, client, _paused_agents(cfg))
 
 
 def run_once(cfg: Config, client: Client) -> str:
@@ -469,12 +494,17 @@ def _build_parser() -> argparse.ArgumentParser:
     # subcommand, and that must keep behaving like `run`.
     parser.add_argument("--config", help="path to runner.json")
     parser.add_argument("--once", action="store_true", help="single iteration (for cron/tests)")
+    parser.add_argument("--drain-one", action="store_true",
+                        help="claim + run exactly ONE queued turn, then exit (no inbox poll, "
+                             "no schedules; runs even while paused)")
 
     subparsers = parser.add_subparsers(dest="command")
 
     run_parser = subparsers.add_parser("run", help="run the main loop (default)")
     run_parser.add_argument("--config", required=True)
     run_parser.add_argument("--once", action="store_true", help="single iteration (for cron/tests)")
+    run_parser.add_argument("--drain-one", action="store_true",
+                            help="claim + run exactly ONE queued turn, then exit")
 
     vet_parser = subparsers.add_parser(
         "vet", help="re-vet the emdash schema pin after an emdash update"
@@ -502,6 +532,9 @@ def main() -> None:
         parser.error("--config is required")
     cfg = Config.load(Path(args.config))
     client = Client(cfg.base_url, cfg.token)
+    if getattr(args, "drain_one", False):
+        print(drain_one(cfg, client))
+        return
     if args.once:
         print(run_once(cfg, client))
         return

--- a/packages/canopy_runner/tests/test_main.py
+++ b/packages/canopy_runner/tests/test_main.py
@@ -474,3 +474,73 @@ def test_unpaused_loop_fires_schedules_every_poll(tmp_path, monkeypatch):
         main_mod.main()
 
     assert calls == ["r-1"]  # synced on the poll — the poll IS the tick
+
+
+# --------------------------------------------------------------------------------------
+# drain_one — the "take a single turn" primitive (CDP executor)
+# --------------------------------------------------------------------------------------
+
+def _cdp_cfg(tmp_path):
+    return Config(
+        base_url="http://x", token="t", runner_id="r-1",
+        emdash_db=str(tmp_path / "e.db"), automation_ids={},
+        expected_migration_id=19,  # executor defaults to "cdp"
+    )
+
+
+class _CdpClient:
+    def __init__(self, turn):
+        self._turn = turn
+        self.beats = 0
+        self.claims = 0
+
+    def heartbeat(self, runner_id, active, host="", **kw):
+        self.beats += 1
+
+    def claim(self, runner_id, paused_agents=None):
+        self.claims += 1
+        return self._turn
+
+
+def test_drain_one_runs_exactly_one_turn_without_polling(monkeypatch, tmp_path):
+    """The single-turn primitive: heartbeat → claim ONE → execute, and NEVER poll the
+    inbox or fire schedules — those side effects are exactly what --once has and
+    --drain-one deliberately avoids, so a single turn can't spawn work you didn't ask for."""
+    monkeypatch.setattr("canopy_runner.cdp_control.host_id", lambda: "u@h")
+    monkeypatch.setattr(main_mod, "_paused_agents", lambda c: set())
+    monkeypatch.setattr(main_mod, "_maybe_check_inboxes",
+                        lambda *a, **k: pytest.fail("drain_one must NOT poll the inbox"))
+    monkeypatch.setattr(main_mod, "_fire_due_schedules",
+                        lambda *a, **k: pytest.fail("drain_one must NOT fire schedules"))
+    seen = {}
+    monkeypatch.setattr("canopy_runner.execute.execute_turn",
+                        lambda cfg, client, rid, turn: seen.update(turn=turn) or f"reused:{turn['id']}")
+
+    client = _CdpClient({"id": "t-9", "agent_slug": "eva"})
+    assert main_mod.drain_one(_cdp_cfg(tmp_path), client) == "reused:t-9"
+    assert seen["turn"]["id"] == "t-9"
+    assert client.beats == 1 and client.claims == 1
+
+
+def test_drain_one_idle_when_nothing_queued(monkeypatch, tmp_path):
+    monkeypatch.setattr("canopy_runner.cdp_control.host_id", lambda: "u@h")
+    monkeypatch.setattr(main_mod, "_paused_agents", lambda c: set())
+    monkeypatch.setattr("canopy_runner.execute.execute_turn",
+                        lambda *a, **k: pytest.fail("nothing queued — must not execute"))
+    assert main_mod.drain_one(_cdp_cfg(tmp_path), _CdpClient(None)) == "idle"
+
+
+def test_drain_one_honours_per_agent_pause_via_claim(monkeypatch, tmp_path):
+    """Per-agent pauses ARE respected — the paused set is passed to claim, which the
+    server uses to exclude that agent's turns."""
+    monkeypatch.setattr("canopy_runner.cdp_control.host_id", lambda: "u@h")
+    monkeypatch.setattr(main_mod, "_paused_agents", lambda c: {"eva"})
+    passed = {}
+
+    class C(_CdpClient):
+        def claim(self, runner_id, paused_agents=None):
+            passed["paused"] = paused_agents
+            return None
+
+    main_mod.drain_one(_cdp_cfg(tmp_path), C(None))
+    assert passed["paused"] == ["eva"]


### PR DESCRIPTION
Closes the earlier ask: *instruct an agent to take one turn without turning the whole daemon back on.*

## Why not `--once`
`--once` runs a **full loop iteration** — it also polls the inbox and fires schedules, so it can enqueue/spawn work you didn't ask for, and claims whatever's next-queued.

## `--drain-one`
The targeted primitive: **heartbeat → claim ONE queued turn → execute → exit.**
- **No inbox poll, no schedule firing** — it only runs a turn that's *already* queued (dispatch one from the composer, or a session **Continue**, first).
- **Runs while paused** — the global `PAUSED` sentinel gates `main()`'s loop, not this — so you can take one turn with the fleet otherwise off.
- **Per-agent pauses honoured** — the claim skips a paused agent's turns.

## Menu-bar "Take one turn"
Runs it without a terminal: reads the daemon's **own launchd plist** (same interpreter, PYTHONPATH, config) and invokes it with `--drain-one`, fire-and-forget. Dispatch → tap → one turn runs. This is the local execute-half that pairs with the session controller's **Continue** and the agent-view **Take a turn**.

## Refactor + merge note
The claim+execute core is extracted to `_claim_and_execute`, shared by the loop iteration and `drain_one` so the single-turn path **can't drift** from how the daemon runs a turn. Resolved against #263's session-report cleanly — that belongs on the loop tick (`_run_once_cdp`), not the single-turn primitive.

## Tests
3 new: runs exactly one turn with **no** inbox/schedule polling (asserts they're never called); `idle` when nothing's queued; per-agent pause passed to `claim`. Full runner suite: **92 pass**. Swift typechecks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)