### PR TITLE
feat(runner): auto-start the menu-bar app on login

### DIFF
--- a/packages/canopy-runner-menubar/README.md
+++ b/packages/canopy-runner-menubar/README.md
@@ -41,3 +41,17 @@ Compiles `Sources/main.swift`, assembles `~/Applications/Canopy Runner.app` (ico
 copied from the committed `assets/brand/`), ad-hoc signs it, and registers it with
 Launch Services. Launch from Spotlight: **Canopy Runner**. Re-run after editing the
 source. Requires the Xcode command-line tools (`swiftc`).
+
+## Auto-start on login
+
+The build also installs a user LaunchAgent (`~/Library/LaunchAgents/com.canopy.runner.menubar.plist`)
+that `open`s the app at login — the durable fix for "the menu-bar icon disappeared."
+`open` is idempotent (it activates a running instance instead of duplicating), and
+the app respects Quit (no KeepAlive). It launches the app immediately on install too.
+
+Opt out: `CANOPY_MENUBAR_AUTOSTART=0 bash build.sh`. Remove an installed agent:
+
+```bash
+launchctl bootout gui/$(id -u)/com.canopy.runner.menubar
+rm ~/Library/LaunchAgents/com.canopy.runner.menubar.plist
+```

--- a/packages/canopy-runner-menubar/build.sh
+++ b/packages/canopy-runner-menubar/build.sh
@@ -54,4 +54,39 @@ codesign --force --sign - "$APP" 2>/dev/null || echo "  (codesign skipped)"
 /System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister \
   -f "$APP" 2>/dev/null || true
 
+# Auto-start on login (the durable fix for "the menu-bar icon disappeared"). A user
+# LaunchAgent that `open`s the app at login — `open` is idempotent, so it activates an
+# already-running instance rather than spawning a duplicate, and the app respects Quit
+# (no KeepAlive). Bootstrapping it also launches the app NOW, in the Aqua session.
+# Opt out with CANOPY_MENUBAR_AUTOSTART=0.
+AGENT="$HOME/Library/LaunchAgents/com.canopy.runner.menubar.plist"
+if [ "${CANOPY_MENUBAR_AUTOSTART:-1}" = "1" ]; then
+  echo "==> auto-start on login (LaunchAgent)"
+  mkdir -p "$HOME/Library/LaunchAgents"
+  cat > "$AGENT" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>com.canopy.runner.menubar</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/bin/open</string>
+    <string>$APP</string>
+  </array>
+  <key>RunAtLoad</key><true/>
+  <key>ProcessType</key><string>Interactive</string>
+</dict>
+</plist>
+PLIST
+  # Reload so it's active now and at every login (bootout is harmless if not loaded).
+  launchctl bootout "gui/$(id -u)/com.canopy.runner.menubar" 2>/dev/null || true
+  launchctl bootstrap "gui/$(id -u)" "$AGENT" 2>/dev/null \
+    || echo "    (could not bootstrap now — it will still load at next login)"
+  echo "    launches at login. Remove with:"
+  echo "      launchctl bootout gui/\$(id -u)/com.canopy.runner.menubar; rm \"$AGENT\""
+else
+  echo "==> auto-start skipped (CANOPY_MENUBAR_AUTOSTART=0)"
+fi
+
 echo "==> done. Launch from Spotlight: 'Canopy Runner'  (or: open \"$APP\")"


### PR DESCRIPTION
The durable fix for the problem that started the whole native-menu-bar rewrite: **the icon was gone because nothing relaunched the app after a logout/reboot.**

`build.sh` now installs a user LaunchAgent (`~/Library/LaunchAgents/com.canopy.runner.menubar.plist`) that `open`s the app at login:
- **`open` is idempotent** — activates a running instance instead of spawning a duplicate.
- **Respects Quit** — no `KeepAlive`, so a deliberate quit stays quit.
- **Launches immediately on install too**, in the Aqua session (verified: agent bootstrapped into `gui/<uid>`, app running as the real bundle executable).

Opt out: `CANOPY_MENUBAR_AUTOSTART=0 bash build.sh`. Removal is one `launchctl bootout` + `rm` — documented in the README and echoed by the build.

Runner/tooling only (no web, no deploy). Verified installed + loaded on this machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)