### PR TITLE
feat(agents): needs-you is action-only — drop the FYI notify band

### DIFF
--- a/apps/agents/api.py
+++ b/apps/agents/api.py
@@ -141,7 +141,7 @@ def get_agent(request: HttpRequest, slug: str) -> AgentDetailOut:
 
 
 @router.get("/{slug}/needs-you", response=NeedsYouOut,
-            summary="What the human needs to act on — typed (review/question/notify) + ranked",
+            summary="What the human needs to act on — typed (review/question), ranked, action-only",
             openapi_extra={"x-mcp-expose": True})
 def needs_you(request: HttpRequest, slug: str) -> NeedsYouOut:
     agent = _get_agent_or_404(request, slug)

--- a/apps/agents/schemas.py
+++ b/apps/agents/schemas.py
@@ -280,7 +280,7 @@ class CommandResultOut(StrictModel):
 
 # ---- "Needs you" supervisor inbox ----
 class NeedsYouItem(StrictModel):
-    type: Literal["review", "question", "notify"]
+    type: Literal["review", "question"]
     # 'run' covers gate/step/completion items projected from the run lifecycle
     # (services._run_inbox_items) — task/sync/work_product are the board items.
     # 'schedule' is the unattended-occurrence nag (apps/harness) projected in via

--- a/apps/agents/services.py
+++ b/apps/agents/services.py
@@ -443,18 +443,21 @@ def _run_inbox_items(agent: Agent) -> tuple[list[dict], list[dict], list[dict]]:
     return review, question, notify
 
 
-def needs_you(agent: Agent, notify_limit: int = 5) -> dict:
+def needs_you(agent: Agent) -> dict:
     """The supervisor's "what does the agent need from me right now?" view.
 
-    Aggregates human-actionable items across the board AND the run lifecycle,
-    typed and ranked:
+    ACTION-ONLY, by rule: an item is here ONLY when a human must decide or
+    unblock something. Two bands, ranked Review → Question:
       - review:   Suggested tasks awaiting validate/decline; runs with an OPEN
                   gate awaiting a human decision.
-      - question: In-progress tasks blocked on a human; runs with a FAILED step.
-      - notify:   Recent FYI with no gate (a sync posted, a work product shipped,
-                  a run completed).
-    Ranked Review → Question → Notify. `waiting_count` counts only the gated
-    (review + question) items — the "N waiting on you" badge."""
+      - question: In-progress tasks blocked on a named human; runs with a FAILED
+                  step.
+    There is deliberately NO "notify"/FYI band: a posted sync, a shipped work
+    product, or a completed run needs nothing from the human, and it already
+    lives in its own tab (Syncs / Work Products / Turns). Pushing that activity
+    into the action queue only manufactures a false "N waiting / stale" signal.
+    Activity is PULLED (open a tab), never PUSHED here. `waiting_count` == the
+    number of items, since every item is gated."""
     review: list[dict] = []
     question: list[dict] = []
 
@@ -468,8 +471,8 @@ def needs_you(agent: Agent, notify_limit: int = 5) -> dict:
             question.append(_task_item("question", t))
 
     # Run-state projection (spec §5): open gates → review, failed steps →
-    # question, completed runs → notify.
-    run_review, run_question, run_notify = _run_inbox_items(agent)
+    # question. Completed runs are FYI — intentionally dropped (no notify band).
+    run_review, run_question, _run_notify = _run_inbox_items(agent)
     review.extend(run_review)
     question.extend(run_question)
 
@@ -487,27 +490,7 @@ def needs_you(agent: Agent, notify_limit: int = 5) -> dict:
     question.extend(item_question)
 
     items: list[dict] = review + question
-    waiting_count = len(items)  # review + question are the gated items
-
-    # Notify — recent FYI, newest first, capped. Merge syncs + work products +
-    # completed runs.
-    notify: list[dict] = list(run_notify)
-    for s in agent.syncs.all()[:notify_limit]:
-        notify.append({
-            "type": "notify", "ref_kind": "sync", "ref_id": s.id,
-            "title": s.title, "subtitle": "Sync posted", "url": s.doc_url,
-            "created_at": s.created_at,
-        })
-    for w in agent.work_products.all()[:notify_limit]:
-        notify.append({
-            "type": "notify", "ref_kind": "work_product", "ref_id": w.id,
-            "title": w.title, "subtitle": w.kind or "Work product", "url": w.url,
-            "created_at": w.created_at,
-        })
-    notify.sort(key=lambda i: i["created_at"], reverse=True)
-    items.extend(notify[:notify_limit])
-
-    return {"agent_slug": agent.slug, "waiting_count": waiting_count, "items": items}
+    return {"agent_slug": agent.slug, "waiting_count": len(items), "items": items}
 
 
 def apply_command(cmd: AgentTaskCommand, result_note: str = "") -> AgentTaskCommand:

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -3843,7 +3843,7 @@ export interface components {
              * Type
              * @enum {string}
              */
-            readonly type: "review" | "question" | "notify";
+            readonly type: "review" | "question";
             /**
              * Ref Kind
              * @enum {string}

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -952,7 +952,7 @@ export interface paths {
             readonly path?: never;
             readonly cookie?: never;
         };
-        /** What the human needs to act on — typed (review/question/notify) + ranked */
+        /** What the human needs to act on — typed (review/question), ranked, action-only */
         readonly get: operations["apps_agents_api_needs_you"];
         readonly put?: never;
         readonly post?: never;

--- a/frontend/src/lib/needsYouBands.ts
+++ b/frontend/src/lib/needsYouBands.ts
@@ -16,10 +16,9 @@ import type { NeedsYouType } from '@/api/agents'
  */
 
 /** Rank order, matching the server's own (apps/agents/services.py::needs_you). */
-export const NEEDS_YOU_RANK: NeedsYouType[] = ['review', 'question', 'notify']
+export const NEEDS_YOU_RANK: NeedsYouType[] = ['review', 'question']
 
 export const NEEDS_YOU_BAND: Record<NeedsYouType, { label: string; dot: string }> = {
   review: { label: 'Review', dot: 'bg-muted-foreground' },
   question: { label: 'Question', dot: 'bg-warning' },
-  notify: { label: 'Notify', dot: 'bg-primary/50' },
 }

--- a/frontend/src/pages/agents/NeedsYouSection.tsx
+++ b/frontend/src/pages/agents/NeedsYouSection.tsx
@@ -26,7 +26,6 @@ import { WorkbenchSubHeader, WorkbenchSkeleton } from 'canopy-ui'
 const BLURBS: Record<NeedsYouType, string> = {
   review: 'Suggestions awaiting your validate / decline',
   question: 'Echo is blocked and needs a decision',
-  notify: 'Recent work — no action needed',
 }
 
 const BANDS: { type: NeedsYouType; label: string; blurb: string; dot: string }[] =

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -164,7 +164,7 @@ def test_needs_you_types_ranks_and_excludes_echo():
                                       owner="Matt", assigned="Echo", position=2))
     # excluded: a done task is no longer actionable
     services.create_task(agent, _task(ext_id="d1", title="Shipped", status="done", position=3))
-    # notify: a recent FYI sync (no gate)
+    # FYI: a recent sync — action-only inbox must NOT surface it (it lives on the Syncs tab)
     services.upsert_sync(agent, SimpleNamespace(
         period_start=dt.datetime(2026, 6, 3, tzinfo=dt.timezone.utc),
         period_end=dt.datetime(2026, 6, 17, tzinfo=dt.timezone.utc),
@@ -174,19 +174,21 @@ def test_needs_you_types_ranks_and_excludes_echo():
     pairs = [(i["type"], i["title"]) for i in res["items"]]
     assert pairs[0] == ("review", "Polio story")        # review band leads
     assert ("question", "Cholera story") in pairs
-    assert ("notify", "Sync 1") in pairs
     titles = [t for _, t in pairs]
+    assert "Sync 1" not in titles                        # FYI sync is NOT a needs-you item
+    assert not any(t == "notify" for t, _ in pairs)      # no notify band at all
     assert "Backlog upkeep" not in titles               # nothing Echo is working
     assert "Shipped" not in titles                       # nothing done
-    rank = {"review": 0, "question": 1, "notify": 2}
+    rank = {"review": 0, "question": 1}
     order = [rank[i["type"]] for i in res["items"]]
     assert order == sorted(order)                        # typed bands, ranked
-    assert res["waiting_count"] == 2                      # gated (review+question) only
+    assert res["waiting_count"] == 2                      # every item is gated
+    assert res["waiting_count"] == len(res["items"])      # action-only: count == items
 
 
 def test_needs_you_projects_run_state():
-    """Run lifecycle surfaces on /needs-you reusing review/question/notify
-    (spec §5): open gate → review, failed step → question, completed → notify."""
+    """Run lifecycle surfaces on /needs-you (spec §5): open gate → review, failed
+    step → question. A COMPLETED run is FYI and is intentionally NOT surfaced."""
     agent = _agent()
     # Run A: an OPEN gate awaiting a human decision → review (gated/waiting).
     run_a = AgentRun.objects.create(agent=agent, label="Render demo", current_step="render")
@@ -195,7 +197,7 @@ def test_needs_you_projects_run_state():
     # Run B: a FAILED step → question (gated/waiting).
     run_b = AgentRun.objects.create(agent=agent, label="Build app", current_step="build")
     AgentRunStep.objects.create(run=run_b, key="build", ordinal=0, status=AgentRunStep.FAILED, error="boom")
-    # Run C: all steps terminal → completed run → notify (NOT waiting).
+    # Run C: all steps terminal → completed run. FYI only — must NOT appear.
     run_c = AgentRun.objects.create(agent=agent, label="Shipped run")
     AgentRunStep.objects.create(run=run_c, key="done", ordinal=0, status=AgentRunStep.COMPLETE)
 
@@ -203,14 +205,15 @@ def test_needs_you_projects_run_state():
     triples = [(i["type"], i["ref_kind"], i["title"]) for i in res["items"]]
     assert ("review", "run", "Render demo") in triples          # open gate
     assert ("question", "run", "Build app") in triples           # failed step
-    assert ("notify", "run", "Shipped run") in triples           # completed run
-    # open gate + failed step are gated → bump the "waiting on you" badge
-    assert res["waiting_count"] >= 2
+    assert "Shipped run" not in [t for _, _, t in triples]       # completed run is NOT surfaced
+    assert not any(ty == "notify" for ty, _, _ in triples)       # no notify band
+    # every surfaced item is gated → waiting_count == item count
+    assert res["waiting_count"] == len(res["items"]) >= 2
     # the review item's subtitle carries the gate's step
     review_run = next(i for i in res["items"] if i["ref_kind"] == "run" and i["type"] == "review")
     assert "render" in review_run["subtitle"]
     # ranking preserved across the merged task + run bands
-    rank = {"review": 0, "question": 1, "notify": 2}
+    rank = {"review": 0, "question": 1}
     order = [rank[i["type"]] for i in res["items"]]
     assert order == sorted(order)
 


### PR DESCRIPTION
## The rule (answering "when/why do we generate notifications at all?")
An item belongs in the **needs-you** inbox **only when a human must decide or unblock something.** Two honest triggers:
- **review** — validate/decline a suggested task, or an open run gate
- **question** — a task/failed step blocked on a named person

The third band, **notify** (a posted sync / shipped work product / completed run), broke that rule:
- it needs **nothing** from the human,
- it **duplicates** the dedicated Syncs / Work-Products / Turns tabs, and
- because `agent_health` marks any aged needs-you item stale, those ungated FYIs manufactured a **false `stale_needs_you: N (M stale)`** flag on otherwise-idle agents (this is what Echo was showing: "needs-you 5 (4 stale)", all FYI, `waiting_count: 0`).

**Activity is pulled (open a tab), never pushed into an action queue.** So the notify band is removed.

## Changes
- `services.needs_you`: drop the notify assembly → `items = review + question`, `waiting_count == len(items)`. Completed-run FYI dropped too.
- `schemas`: `NeedsYouItem.type` → `Literal["review","question"]` (regenerates the frontend `NeedsYouType`; `generated.ts` hand-synced so the build is green before the regen bot runs).
- `frontend`: remove `notify` from the shared band lib + blurbs — auto-cleans **both** the agent needs-you rail and `/supervisor`'s WaitingOnYou (both map the shared `RANK`).

## Effect
- The "N waiting on you" badge is now honest — `0` when nothing is gated.
- The false `stale_needs_you` health flag disappears (nothing ungated is left to age).
- No information lost: syncs/work-products/turns each still live in their own tab.

## Tests
A recent sync and a completed run must NOT surface in needs-you; no notify band; `waiting_count == item count`. **21 passed.**

No human code review per convention; merging on green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)