### PR TITLE
fix(runner): a scheduling dep failure disables scheduling, not the whole runner

### DIFF
--- a/packages/canopy_runner/canopy_runner/main.py
+++ b/packages/canopy_runner/canopy_runner/main.py
@@ -164,12 +164,16 @@ def _fire_due_schedules(cfg: Config, client: Client, paused: set[str] | None = N
     run_once, so a paused runner never fires (which would queue turns that all execute
     the instant it resumes). Per-agent pause is honored inside check_schedules.
     """
-    from . import schedules as schedules_mod
     now = dt.datetime.now(dt.UTC)
     try:
+        # Import INSIDE the guard, not above it: canopy_cron is scheduling's ONLY
+        # dependency, and a missing/broken one (an un-synced laptop env, a bad
+        # install) must disable scheduling alone — not crash claiming and the inbox
+        # with it. The import is the most likely failure, so it has to be caught too.
+        from . import schedules as schedules_mod
         schedules_mod.check_schedules(client, cfg.runner_id, now=now, paused=frozenset(paused or ()))
     except Exception as exc:  # noqa: BLE001 — scheduling never kills claiming or the inbox
-        logger.warning("schedule sync failed: %s", exc)
+        logger.warning("scheduling unavailable this tick (claiming + inbox continue): %s", exc)
 
 
 def _claim_and_execute(cfg: Config, client: Client, paused: set) -> str:

--- a/packages/canopy_runner/tests/test_main.py
+++ b/packages/canopy_runner/tests/test_main.py
@@ -544,3 +544,27 @@ def test_drain_one_honours_per_agent_pause_via_claim(monkeypatch, tmp_path):
 
     main_mod.drain_one(_cdp_cfg(tmp_path), C(None))
     assert passed["paused"] == ["eva"]
+
+
+def test_broken_scheduling_does_not_crash_the_tick(db, tmp_path, monkeypatch, caplog):
+    """A scheduling dependency failure — e.g. canopy_cron not installed in the
+    laptop daemon's env — must disable ONLY scheduling. Claiming and the inbox
+    keep running. The `from . import schedules` lives INSIDE _fire_due_schedules'
+    guard for exactly this reason: the import is the likeliest failure, and it
+    must not escape and take down the whole run_once cycle.
+
+    Regression for the outage where a missing canopy_cron crash-looped the runner
+    (no claim, no inbox) instead of gracefully skipping scheduling.
+    """
+    import sys
+
+    # Make `from . import schedules` raise ImportError, exactly as a missing
+    # canopy_cron did (schedules.py imports canopy_cron at module top, so its
+    # own import fails). setitem(..., None) is Python's "this import is halted".
+    monkeypatch.setitem(sys.modules, "canopy_runner.schedules", None)
+    caplog.set_level("WARNING")
+
+    # Must NOT raise — before the fix this propagated out of run_once.
+    _fire_due_schedules(_cfg(db, tmp_path), FakeClient(), paused=set())
+
+    assert "scheduling unavailable" in caplog.text.lower()


### PR DESCRIPTION
A scheduling dependency failure now disables **only** scheduling — the runner keeps claiming and polling inboxes — instead of crash-looping the entire daemon.

## The bug (found live)

`_fire_due_schedules` imported the `schedules` module **outside** its try/except:

```python
from . import schedules as schedules_mod   # ← outside the guard
now = dt.datetime.now(dt.UTC)
try:
    schedules_mod.check_schedules(...)      # ← only the CALL was guarded
except Exception as exc:  # "scheduling never kills claiming or the inbox"
    logger.warning(...)
```

`schedules.py` imports `canopy_cron` at module top. When `canopy_cron` was missing from the laptop daemon's env (it runs stdlib-only via PYTHONPATH, and my earlier runner-fire-loop change added `canopy_cron` as a new dep), the **import** raised `ModuleNotFoundError`, escaped the guard, and crash-looped the whole `run_once` cycle — no claim, no inbox, nothing. The guard's own comment promised "scheduling never kills claiming or the inbox," but the import — the likeliest failure — wasn't inside it.

## The fix

Move the import inside the try. Any scheduling failure (missing dep, bad cron, import error) now logs `scheduling unavailable this tick (claiming + inbox continue)` and the runner keeps working.

## Test

`test_broken_scheduling_does_not_crash_the_tick` drives a broken `schedules` import (`sys.modules["canopy_runner.schedules"] = None`) and asserts the tick survives + logs. Mutation-verified: reverting the import to its old placement makes the test fail with the exact `ModuleNotFoundError` propagation that caused the outage. Runner suite: 24 passed.

**Runner-package + laptop-daemon change** — no labs deploy. (The laptop daemon already works because `canopy_cron` was installed there manually; this makes that whole failure class graceful instead of fatal.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
