### PR TITLE
fix(runner): preflight emdash CDP health before claiming turns (#277)

### DIFF
--- a/packages/canopy_runner/canopy_runner/cdp_control.py
+++ b/packages/canopy_runner/canopy_runner/cdp_control.py
@@ -11,6 +11,8 @@ import getpass
 import json
 import socket
 import subprocess
+import urllib.error
+import urllib.request
 from pathlib import Path
 
 SIDECAR = Path(__file__).parent / "cdp" / "emdash_control.mjs"
@@ -57,6 +59,26 @@ def host_id() -> str:
     except OSError:
         pass                    # unwritable — degrade rather than refuse to heartbeat
     return current
+
+
+def cdp_healthy(*, port: int = 9222, timeout: float = 1.0) -> bool:
+    """True iff emdash's CDP endpoint answers on `port` — a short-timeout preflight the
+    runner runs BEFORE claiming a turn, so a down emdash skips the claim instead of
+    claiming-then-failing (which burns the turn: a failed turn is not auto-re-claimed).
+
+    Probes DevTools' ``/json/version`` — the same endpoint playwright's connectOverCDP
+    hits — so a green probe means create/reuse will actually connect. Any failure
+    (connection refused → emdash closed/crashed/rebooted, or launched without
+    --remote-debugging-port; timeout; non-200) returns False. Never raises: this gates
+    the loop, so it must fail closed (skip the claim) rather than crash the tick."""
+    url = f"http://127.0.0.1:{port}/json/version"
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as resp:
+            return getattr(resp, "status", 200) == 200
+    except (urllib.error.URLError, OSError, ValueError):
+        # URLError (refused/timeout), OSError (socket), ValueError (odd url) — all mean
+        # "not reachable right now". TimeoutError is an OSError, so it's covered.
+        return False
 
 
 def _run(command: str, args: dict, *, node: str = "node", timeout: int = 90) -> dict:

--- a/packages/canopy_runner/canopy_runner/main.py
+++ b/packages/canopy_runner/canopy_runner/main.py
@@ -50,6 +50,23 @@ logger = logging.getLogger("canopy_runner")
 # wedged (skill error / crash that never called /finish) and fail+evict it.
 GRACE_SECONDS = 900
 
+# CDP-down throttle. The CDP executor is otherwise stateless (no state file — see
+# _run_once_cdp), but the human-facing "emdash is down" WARNING must fire ONCE per
+# outage, not per tick, so this small counter lives at module scope for the loop
+# process's lifetime. The per-tick machine signal is the degraded heartbeat (a status
+# field, not spam); this gates only the one loud log. Emit it after this many
+# consecutive unhealthy ticks so a brief emdash restart (a tick or two) doesn't cry wolf.
+CDP_DOWN_SIGNAL_TICKS = 3
+_cdp_down_ticks = 0
+_cdp_down_signalled = False
+
+
+def _reset_cdp_health_state() -> None:
+    """Clear the CDP-down throttle (on recovery, and between tests)."""
+    global _cdp_down_ticks, _cdp_down_signalled
+    _cdp_down_ticks = 0
+    _cdp_down_signalled = False
+
 
 def _load_state(cfg: Config) -> dict:
     p = Path(cfg.state_path)
@@ -201,26 +218,64 @@ def _claim_and_execute(cfg: Config, client: Client, paused: set) -> str:
 
 
 def _run_once_cdp(cfg: Config, client: Client) -> str:
-    """CDP executor: heartbeat (with macOS host, for reuse ownership) → claim one
-    turn → route it to an emdash session (reuse or create). Turns finish synchronously
-    (the runner owns the routing lifecycle; work continues in the visible session), so
-    there is no injection state to track or schema to guard."""
-    from .cdp_control import host_id
+    """CDP executor: preflight emdash's CDP health → heartbeat (with macOS host, for
+    reuse ownership) → claim one turn → route it to an emdash session (reuse or create).
+    Turns finish synchronously (the runner owns the routing lifecycle; work continues in
+    the visible session), so there is no injection state to track or schema to guard.
 
-    client.heartbeat(cfg.runner_id, [], host=host_id())
-    # Report the open emdash sessions the phone can continue. Best-effort: a read or
-    # POST failure must never stop the tick from claiming work.
+    Self-heal: the runner CONNECTS to emdash, it never launches it, so a closed/crashed
+    emdash (or one launched without --remote-debugging-port) can't run work. If we claimed
+    anyway, execute would hit the CDP-connect failure and fail the turn — and a failed turn
+    is NOT auto-re-claimed, so one outage burned a turn per hit agent (real incident
+    2026-07-17: 11 turns). So we PREFLIGHT: an unhealthy CDP skips the claim for this tick,
+    leaving queued turns queued to auto-drain when emdash returns. Inbox + schedule polling
+    still run (inbound work keeps ENQUEUING); only the claim is gated."""
+    from .cdp_control import cdp_healthy, host_id
+
+    global _cdp_down_ticks, _cdp_down_signalled
+    healthy = cdp_healthy(port=cfg.cdp_port)
+    host = host_id()
+    if healthy:
+        if _cdp_down_signalled:
+            logger.info("emdash CDP healthy again on :%s — resuming claims after %d down tick(s)",
+                        cfg.cdp_port, _cdp_down_ticks)
+        _reset_cdp_health_state()
+        client.heartbeat(cfg.runner_id, [], host=host)
+    else:
+        _cdp_down_ticks += 1
+        # Degraded heartbeat EVERY unhealthy tick — the machine-readable surface signal the
+        # control plane + menu-bar app read ("alive but can't execute"). It's a status field,
+        # overwritten each tick, so it is not spam.
+        client.heartbeat(cfg.runner_id, [], degraded=True,
+                         note=f"emdash CDP unreachable on :{cfg.cdp_port} — not claiming",
+                         host=host)
+        # ...and ONE loud WARNING after sustained downtime (not per tick), for the human log.
+        if _cdp_down_ticks >= CDP_DOWN_SIGNAL_TICKS and not _cdp_down_signalled:
+            logger.warning(
+                "emdash CDP unreachable on 127.0.0.1:%s for %d consecutive ticks — SKIPPING "
+                "the claim so queued turns wait instead of failing. Launch emdash with "
+                "--remote-debugging-port=%s; the backlog auto-drains when it returns.",
+                cfg.cdp_port, _cdp_down_ticks, cfg.cdp_port)
+            _cdp_down_signalled = True
+
+    # Report the open emdash sessions the phone can continue. A sqlite read of emdash's
+    # DB, not CDP — keep it even while CDP is down. Best-effort: a read or POST failure
+    # must never stop the tick.
     try:
         client.report_sessions(cfg.runner_id, emdash.list_open_sessions(cfg.emdash_db))
     except Exception:  # noqa: BLE001
         logger.debug("session report failed (non-fatal)", exc_info=True)
     paused = _paused_agents(cfg)
+    # Inbound triggers run whether or not CDP is up, so inbound work still ENQUEUES while
+    # emdash is down (it just waits, queued, until emdash is back). Only the claim is gated.
     _maybe_check_inboxes(cfg, client, paused=paused)
     # Fleet-audit review ingestion was removed when Ada moved to Items: approving
     # an Item dispatches its work server-side (in the decide transaction), so there
     # is no resolved review for the runner to poll. DDD findings reviews are applied
     # by the DDD orchestrator, never here.
     _fire_due_schedules(cfg, client, paused=paused)
+    if not healthy:
+        return "cdp_down"  # nothing claimed -> nothing burned; queued turns stay queued
     return _claim_and_execute(cfg, client, paused)
 
 
@@ -233,10 +288,19 @@ def drain_one(cfg: Config, client: Client) -> str:
     runs while the daemon is paused — the global PAUSED sentinel gates main()'s loop, not
     this — so you can take one turn with the fleet otherwise off. Per-agent pauses ARE
     honoured (the claim skips a paused agent's turns)."""
-    from .cdp_control import host_id
+    from .cdp_control import cdp_healthy, host_id
 
     if cfg.executor != "cdp":
         return run_once(cfg, client)  # legacy inject path has no targeted primitive
+    # Same self-heal as the loop: claiming with emdash down would immediately fail (=burn)
+    # the turn. Refuse instead — the caller re-runs once emdash is back on its debug port.
+    if not cdp_healthy(port=cfg.cdp_port):
+        logger.warning("emdash CDP unreachable on :%s — refusing to claim a turn (it would "
+                       "immediately fail). Launch emdash with --remote-debugging-port=%s.",
+                       cfg.cdp_port, cfg.cdp_port)
+        client.heartbeat(cfg.runner_id, [], degraded=True,
+                         note=f"emdash CDP unreachable on :{cfg.cdp_port}", host=host_id())
+        return "cdp_down"
     client.heartbeat(cfg.runner_id, [], host=host_id())
     return _claim_and_execute(cfg, client, _paused_agents(cfg))
 
@@ -605,10 +669,13 @@ def main() -> None:
             result = "crashed"
         # One scannable line per cycle. Idle is quiet (a heartbeat every ~15 min so the
         # log shows the runner is alive without flooding); everything else logs at INFO.
-        if result == "idle":
+        # "cdp_down" is quiet like "idle" — the throttled WARNING in _run_once_cdp and the
+        # degraded heartbeat already carry the reason, so logging it every tick would be the
+        # per-tick spam the preflight is meant to avoid.
+        if result in ("idle", "cdp_down"):
             idle_streak += 1
             if idle_streak % max(1, (900 // max(cfg.poll_seconds, 1))) == 0:
-                logger.info("cycle: idle (x%d) — runner alive, nothing to do", idle_streak)
+                logger.info("cycle: %s (x%d) — runner alive, nothing claimed", result, idle_streak)
         else:
             if idle_streak:
                 logger.info("cycle: %s (after %d idle)", result, idle_streak)

--- a/packages/canopy_runner/tests/test_cdp_control.py
+++ b/packages/canopy_runner/tests/test_cdp_control.py
@@ -1,6 +1,7 @@
 """Wrapper-level tests for the emdash CDP control (the sidecar itself needs a live
 emdash on the debug port — validated separately)."""
 import json
+import urllib.error
 from types import SimpleNamespace
 
 import pytest
@@ -51,6 +52,48 @@ def test_node_missing_raises(monkeypatch):
 def test_host_id_has_user_and_host():
     h = cdp_control.host_id()
     assert "@" in h and len(h) > 2
+
+
+# --------------------------------------------------------------------------------------
+# cdp_healthy — the claim preflight; a green probe means create/reuse will connect
+# --------------------------------------------------------------------------------------
+
+
+class _Resp:
+    def __init__(self, status):
+        self.status = status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def test_cdp_healthy_true_on_200(monkeypatch):
+    monkeypatch.setattr(cdp_control.urllib.request, "urlopen",
+                        lambda url, timeout: _Resp(200))
+    assert cdp_control.cdp_healthy(port=9222) is True
+
+
+def test_cdp_healthy_false_on_non_200(monkeypatch):
+    monkeypatch.setattr(cdp_control.urllib.request, "urlopen",
+                        lambda url, timeout: _Resp(500))
+    assert cdp_control.cdp_healthy() is False
+
+
+def test_cdp_healthy_false_on_connection_refused(monkeypatch):
+    def refused(url, timeout):
+        raise urllib.error.URLError("connection refused")
+    monkeypatch.setattr(cdp_control.urllib.request, "urlopen", refused)
+    assert cdp_control.cdp_healthy() is False
+
+
+def test_cdp_healthy_false_on_timeout(monkeypatch):
+    def slow(url, timeout):
+        raise TimeoutError("timed out")  # a TimeoutError IS an OSError — must be caught
+    monkeypatch.setattr(cdp_control.urllib.request, "urlopen", slow)
+    assert cdp_control.cdp_healthy() is False
 
 
 # --------------------------------------------------------------------------------------

--- a/packages/canopy_runner/tests/test_main.py
+++ b/packages/canopy_runner/tests/test_main.py
@@ -506,6 +506,7 @@ def test_drain_one_runs_exactly_one_turn_without_polling(monkeypatch, tmp_path):
     """The single-turn primitive: heartbeat → claim ONE → execute, and NEVER poll the
     inbox or fire schedules — those side effects are exactly what --once has and
     --drain-one deliberately avoids, so a single turn can't spawn work you didn't ask for."""
+    monkeypatch.setattr("canopy_runner.cdp_control.cdp_healthy", lambda **k: True)
     monkeypatch.setattr("canopy_runner.cdp_control.host_id", lambda: "u@h")
     monkeypatch.setattr(main_mod, "_paused_agents", lambda c: set())
     monkeypatch.setattr(main_mod, "_maybe_check_inboxes",
@@ -523,6 +524,7 @@ def test_drain_one_runs_exactly_one_turn_without_polling(monkeypatch, tmp_path):
 
 
 def test_drain_one_idle_when_nothing_queued(monkeypatch, tmp_path):
+    monkeypatch.setattr("canopy_runner.cdp_control.cdp_healthy", lambda **k: True)
     monkeypatch.setattr("canopy_runner.cdp_control.host_id", lambda: "u@h")
     monkeypatch.setattr(main_mod, "_paused_agents", lambda c: set())
     monkeypatch.setattr("canopy_runner.execute.execute_turn",
@@ -533,6 +535,7 @@ def test_drain_one_idle_when_nothing_queued(monkeypatch, tmp_path):
 def test_drain_one_honours_per_agent_pause_via_claim(monkeypatch, tmp_path):
     """Per-agent pauses ARE respected — the paused set is passed to claim, which the
     server uses to exclude that agent's turns."""
+    monkeypatch.setattr("canopy_runner.cdp_control.cdp_healthy", lambda **k: True)
     monkeypatch.setattr("canopy_runner.cdp_control.host_id", lambda: "u@h")
     monkeypatch.setattr(main_mod, "_paused_agents", lambda c: {"eva"})
     passed = {}
@@ -544,6 +547,30 @@ def test_drain_one_honours_per_agent_pause_via_claim(monkeypatch, tmp_path):
 
     main_mod.drain_one(_cdp_cfg(tmp_path), C(None))
     assert passed["paused"] == ["eva"]
+
+
+def test_drain_one_refuses_to_claim_when_cdp_down(monkeypatch, tmp_path):
+    """The self-heal reaches the single-turn primitive too: claiming with emdash down
+    would immediately fail (burn) the turn, so drain_one refuses instead."""
+    monkeypatch.setattr("canopy_runner.cdp_control.cdp_healthy", lambda **k: False)
+    monkeypatch.setattr("canopy_runner.cdp_control.host_id", lambda: "u@h")
+    monkeypatch.setattr(main_mod, "_paused_agents", lambda c: set())
+
+    class C(_CdpClient):
+        def __init__(self):
+            super().__init__(None)
+            self.degraded = None
+
+        def heartbeat(self, runner_id, active, degraded=False, note="", host=""):
+            self.beats += 1
+            self.degraded = degraded
+
+        def claim(self, runner_id, paused_agents=None):
+            pytest.fail("must NOT claim a turn while CDP is down")
+
+    c = C()
+    assert main_mod.drain_one(_cdp_cfg(tmp_path), c) == "cdp_down"
+    assert c.degraded is True  # surfaced as degraded to the control plane
 
 
 def test_broken_scheduling_does_not_crash_the_tick(db, tmp_path, monkeypatch, caplog):
@@ -568,3 +595,139 @@ def test_broken_scheduling_does_not_crash_the_tick(db, tmp_path, monkeypatch, ca
     _fire_due_schedules(_cfg(db, tmp_path), FakeClient(), paused=set())
 
     assert "scheduling unavailable" in caplog.text.lower()
+
+
+# --------------------------------------------------------------------------------------
+# CDP preflight — don't claim (and burn) a turn when emdash's CDP is unreachable
+# --------------------------------------------------------------------------------------
+
+
+class _CdpLoopClient:
+    """A CDP-path fake: records heartbeats (degraded flag) and how many times claim ran."""
+
+    def __init__(self, turns=None):
+        self.turns = list(turns or [])
+        self.claims = 0
+        self.heartbeats = []
+
+    def heartbeat(self, runner_id, active, degraded=False, note="", host=""):
+        self.heartbeats.append({"degraded": degraded, "note": note})
+
+    def report_sessions(self, runner_id, sessions):
+        pass
+
+    def sync_schedules(self, runner_id):
+        return []
+
+    def claim(self, runner_id, paused_agents=None):
+        self.claims += 1
+        return self.turns.pop(0) if self.turns else None
+
+
+def _cdp_loop_cfg(tmp_path):
+    # executor defaults to "cdp"; no mailboxes so the inbox poll is a no-op.
+    return Config(
+        base_url="http://x", token="t", runner_id="r-1",
+        emdash_db=str(tmp_path / "e.db"), automation_ids={}, expected_migration_id=19,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_cdp_throttle():
+    """The CDP-down throttle is module-level (one WARNING per outage over the loop's
+    lifetime) — reset it around every test so ordering can't leak signalled state."""
+    main_mod._reset_cdp_health_state()
+    yield
+    main_mod._reset_cdp_health_state()
+
+
+def _stub_cdp(monkeypatch, healthy):
+    monkeypatch.setattr("canopy_runner.cdp_control.cdp_healthy", lambda **k: healthy)
+    monkeypatch.setattr("canopy_runner.cdp_control.host_id", lambda: "u@h")
+    monkeypatch.setattr(main_mod.emdash, "list_open_sessions", lambda db: [])
+
+
+def test_cdp_healthy_claims_and_executes(monkeypatch, tmp_path):
+    _stub_cdp(monkeypatch, healthy=True)
+    monkeypatch.setattr("canopy_runner.execute.execute_turn",
+                        lambda cfg, client, rid, turn: f"created:{turn['id']}:task")
+    client = _CdpLoopClient(turns=[{"id": "t-1", "agent_slug": "eva"}])
+    assert run_once(_cdp_loop_cfg(tmp_path), client) == "created:t-1:task"
+    assert client.claims == 1
+    assert client.heartbeats[-1]["degraded"] is False  # healthy heartbeat
+
+
+def test_cdp_unhealthy_skips_claim_and_burns_nothing(monkeypatch, tmp_path):
+    """The core acceptance criterion: with emdash down a tick claims ZERO turns and
+    produces ZERO failed turns — queued turns stay queued."""
+    _stub_cdp(monkeypatch, healthy=False)
+    monkeypatch.setattr("canopy_runner.execute.execute_turn",
+                        lambda *a, **k: pytest.fail("must NOT execute while CDP is down"))
+    client = _CdpLoopClient(turns=[{"id": "t-1", "agent_slug": "eva"}])
+    assert run_once(_cdp_loop_cfg(tmp_path), client) == "cdp_down"
+    assert client.claims == 0  # nothing claimed -> nothing burned
+    assert client.heartbeats[-1]["degraded"] is True  # surfaced as degraded, every tick
+
+
+def test_cdp_down_still_polls_inbox_and_schedules(monkeypatch, tmp_path):
+    """Inbound work must keep ENQUEUING while CDP is down — only the claim is gated."""
+    _stub_cdp(monkeypatch, healthy=False)
+    ran = {}
+    monkeypatch.setattr(main_mod, "_maybe_check_inboxes",
+                        lambda *a, **k: ran.__setitem__("inbox", True))
+    monkeypatch.setattr(main_mod, "_fire_due_schedules",
+                        lambda *a, **k: ran.__setitem__("sched", True))
+    run_once(_cdp_loop_cfg(tmp_path), _CdpLoopClient())
+    assert ran == {"inbox": True, "sched": True}
+
+
+def test_cdp_recovery_drains_the_backlog(monkeypatch, tmp_path):
+    """When emdash comes back, the next tick claims + drains the queued turn normally."""
+    _stub_cdp(monkeypatch, healthy=False)
+    monkeypatch.setattr("canopy_runner.execute.execute_turn",
+                        lambda cfg, client, rid, turn: f"reused:{turn['id']}")
+    cfg = _cdp_loop_cfg(tmp_path)
+    client = _CdpLoopClient(turns=[{"id": "t-1", "agent_slug": "eva"}])
+
+    assert run_once(cfg, client) == "cdp_down"  # down: the queued turn waits
+    assert client.claims == 0
+
+    monkeypatch.setattr("canopy_runner.cdp_control.cdp_healthy", lambda **k: True)  # emdash returns
+    assert run_once(cfg, client) == "reused:t-1"  # back: drains the backlog
+    assert client.claims == 1
+
+
+def test_cdp_down_warning_is_throttled_to_one(monkeypatch, tmp_path, caplog):
+    """A single throttled surface signal after sustained downtime — NOT per-tick spam.
+    The degraded heartbeat still fires every tick (machine signal); the WARNING fires once."""
+    _stub_cdp(monkeypatch, healthy=False)
+    cfg = _cdp_loop_cfg(tmp_path)
+    client = _CdpLoopClient()
+    caplog.set_level("WARNING", logger="canopy_runner")
+    ticks = main_mod.CDP_DOWN_SIGNAL_TICKS + 5
+    for _ in range(ticks):
+        run_once(cfg, client)
+    warns = [r for r in caplog.records if "CDP unreachable" in r.getMessage()]
+    assert len(warns) == 1  # ONE loud log despite many down ticks
+    assert len(client.heartbeats) == ticks  # ...but a degraded heartbeat every tick
+    assert all(h["degraded"] for h in client.heartbeats)
+
+
+def test_cdp_recovery_logs_once_and_rearms(monkeypatch, tmp_path, caplog):
+    """After recovery the throttle re-arms, so a SECOND outage warns again (not muted forever)."""
+    cfg = _cdp_loop_cfg(tmp_path)
+    client = _CdpLoopClient()
+    caplog.set_level("INFO", logger="canopy_runner")
+
+    _stub_cdp(monkeypatch, healthy=False)
+    for _ in range(main_mod.CDP_DOWN_SIGNAL_TICKS):
+        run_once(cfg, client)
+    monkeypatch.setattr("canopy_runner.cdp_control.cdp_healthy", lambda **k: True)
+    run_once(cfg, client)  # recovery — logs "healthy again" and re-arms the throttle
+    assert any("healthy again" in r.getMessage() for r in caplog.records)
+
+    caplog.clear()
+    monkeypatch.setattr("canopy_runner.cdp_control.cdp_healthy", lambda **k: False)
+    for _ in range(main_mod.CDP_DOWN_SIGNAL_TICKS):
+        run_once(cfg, client)
+    assert sum("CDP unreachable" in r.getMessage() for r in caplog.records) == 1  # warns again

--- a/tests/test_mobile_loop_e2e.py
+++ b/tests/test_mobile_loop_e2e.py
@@ -63,6 +63,10 @@ def _record_cdp(monkeypatch):
         lambda project, prompt, **kw: (calls["create_task"].append((project, prompt)), {"task": f"{project}-new"})[1],
     )
     monkeypatch.setattr(cdp_control, "host_id", lambda: HOST)
+    # A healthy emdash is exactly what the recorder simulates — say the CDP preflight
+    # passes so the runner claims (instead of skipping the claim when :9222 is down,
+    # which it now does to avoid burning turns).
+    monkeypatch.setattr(cdp_control, "cdp_healthy", lambda **kw: True)
     # The reuse path asks sqlite "is this task live?" — say yes without a real DB.
     monkeypatch.setattr(emdash, "task_state", lambda db, name: "live")
     return calls


### PR DESCRIPTION
Closes #277.

## Problem

When emdash is unreachable over CDP (`127.0.0.1:9222`) — laptop reboot, emdash closed/crashed, or launched without `--remote-debugging-port=9222` — the runner **claimed queued turns and immediately burned them to `failed`**, one per hit agent. Failed turns aren't auto-re-claimed, so recovery was fully manual. Real incident (2026-07-17, `jj-mbp-cdp`): a single ~37min CDP outage produced 11 failed turns (eva ×6, ace ×3, echo ×2), each re-enqueued by hand.

## Fix — preflight CDP health before claiming (self-healing)

- **`cdp_control.cdp_healthy(port)`** — a short-timeout `GET /json/version` probe (the endpoint playwright's `connectOverCDP` hits). Fails closed on any error; never raises.
- **`_run_once_cdp`** gates the claim on it. Unhealthy CDP → degraded heartbeat + keep polling inbox/schedules (inbound work still **enqueues**) + **skip the claim**. Nothing claimed → nothing burned; queued turns auto-drain when emdash returns.
- **`drain_one`** gets the same guard, so the manual single-turn primitive can't burn a turn either.
- **Surface signal, no per-tick spam:** a degraded heartbeat every unhealthy tick (machine signal the control plane + menu-bar app already read) + **one** throttled WARNING after 3 consecutive misses (human log) + an INFO on recovery that re-arms the throttle. `cdp_down` is logged quietly like `idle` in the main loop.
- Runner stays **connect-only** — it never launches emdash (a GUI Electron app), per the issue.

### Note on the surface signal
The issue suggested an Ada needs-you item / push notification. The runner's client only speaks `/api/harness` and has no item-raise plumbing (that would cross tenancy + need an idempotency key), so I used the runner's existing "alive but can't work" surface — the degraded heartbeat + note — plus the throttled WARNING. A dedicated item/push is a clean follow-up.

## Acceptance criteria

- [x] emdash down → a tick claims **zero** turns, produces **zero** `failed` turns; queued turns stay `queued`.
- [x] emdash back → the next tick drains the queued backlog normally.
- [x] inbox/schedule polling still runs while CDP is down (inbound turns keep enqueuing).
- [x] a single, throttled surface signal after sustained downtime; no per-tick spam.
- [x] test coverage for healthy / unhealthy / recovered transitions (mock `cdp_healthy`).

## Out of scope (issue flags both as separate follow-ups)
- Transient `502` retry hardening on `POST /turns/<id>/events`.
- A login-item / launch-agent that opens emdash with `--remote-debugging-port=9222` on boot.

## Testing
`cd packages/canopy_runner && uv run --with pytest pytest` → **104 passed** (CI-equivalent invocation).

## Deploy note
The runner is a launchd service (`launchd/com.canopy.runner.plist`); it needs a restart to pick up this change after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)