### PR TITLE
feat(harness): SP2b — chat runs on the cloud runner (session-turn routing)

### DIFF
--- a/apps/chat/api.py
+++ b/apps/chat/api.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import uuid
 
-from django.db import IntegrityError
 from django.http import HttpRequest
 from django.shortcuts import get_object_or_404
 from ninja import Router
@@ -16,11 +15,9 @@ from ninja.errors import HttpError
 
 from apps.agents import services as agent_services
 from apps.api.auth import session_auth
-from apps.harness.models import Turn
 from apps.workspaces import services as wsvc
 
 from . import services
-from .executor import execute_turn_stub
 from .models import Session
 from .schemas import MessageOut, SendIn, SendOut, SessionCreateIn, SessionDetailOut, SessionOut
 
@@ -100,13 +97,6 @@ def send(request: HttpRequest, session_id: uuid.UUID, payload: SendIn):
     message, turn = services.send_message(
         session=session, text=payload.text, user=request.user, client_id=payload.client_id,
     )
-    # SP2a: run the stub inline. SP2b: the cloud runner claims the queued turn.
-    # Guard against the one_executing_turn_per_session race (a truly concurrent
-    # send to the same session): leave the turn queued rather than 500 the
-    # already-committed user message. Moot once SP2b makes execution async.
-    if turn is not None and turn.status == Turn.QUEUED:
-        try:
-            execute_turn_stub(turn)
-        except IntegrityError:
-            pass
+    # Dev/test: run the stub inline. Production: leave it queued for a cloud runner.
+    services.maybe_execute_inline(turn)
     return {"turn_id": turn.id if turn else None, "message": MessageOut.from_orm(message)}

--- a/apps/chat/consumers.py
+++ b/apps/chat/consumers.py
@@ -10,14 +10,11 @@ import uuid
 
 from channels.db import database_sync_to_async
 from channels.generic.websocket import AsyncJsonWebsocketConsumer
-from django.db import IntegrityError
 
-from apps.harness.models import Turn
 from apps.realtime.groups import session_group
 
 from . import drafts, participants, presence
 from . import services as chat_services
-from .executor import execute_turn_stub
 from .models import Session, SessionParticipant
 
 _EDIT_ROLES = {SessionParticipant.OWNER, SessionParticipant.EDITOR}
@@ -116,14 +113,10 @@ class SessionConsumer(AsyncJsonWebsocketConsumer):
 
     def _send_and_execute(self, text):
         _msg, turn = chat_services.send_message(session=self.session, text=text, user=self.user)
-        # Mirror the REST send guard: only drive a queued turn, and survive the
-        # one_executing_turn_per_session race (a concurrent send) rather than
-        # tearing down the socket. SP2b's async runner replaces this inline call.
-        if turn is not None and turn.status == Turn.QUEUED:
-            try:
-                execute_turn_stub(turn)
-            except IntegrityError:
-                pass
+        # Dev/test: stub inline. Production: leave queued for a cloud runner. The
+        # helper guards QUEUED + the one_executing_turn_per_session race so a
+        # concurrent send never tears down the socket.
+        chat_services.maybe_execute_inline(turn)
 
     # -- group frame handlers (dots -> underscores) --
     async def chat_turn_event(self, message):

--- a/apps/chat/services.py
+++ b/apps/chat/services.py
@@ -8,7 +8,8 @@ serializes a conversation, turn_index assignment never races within a session.
 """
 from __future__ import annotations
 
-from django.db import transaction
+from django.conf import settings
+from django.db import IntegrityError, transaction
 from django.db.models import Max
 
 from apps.harness import services as harness_services
@@ -79,6 +80,26 @@ def send_message(*, session: Session, text: str, user, client_id: str = "") -> t
             prompt=text,
         )
     return message, turn
+
+
+def maybe_execute_inline(turn: Turn | None) -> None:
+    """The chat send's executor hop. In dev/test (CHAT_STUB_EXECUTOR=True) run the
+    stub inline so the turn completes with no runner. In production (False) leave it
+    QUEUED for a session-capable cloud runner to claim + run real claude — the same
+    ledger + Message projection either way. The one seam between stub and cloud.
+
+    Guarded on QUEUED + IntegrityError so a truly-concurrent same-session send (the
+    one_executing_turn_per_session race) never 500s the already-committed message."""
+    if not getattr(settings, "CHAT_STUB_EXECUTOR", True):
+        return
+    if turn is None or turn.status != Turn.QUEUED:
+        return
+    from .executor import execute_turn_stub
+
+    try:
+        execute_turn_stub(turn)
+    except IntegrityError:
+        pass
 
 
 def project_events(turn: Turn, rows) -> int:

--- a/apps/harness/models.py
+++ b/apps/harness/models.py
@@ -101,6 +101,13 @@ class Runner(models.Model):
         gate, and the two intersect (b4f5ead)."""
         return list(self.capabilities.get("projects", []))
 
+    def session_capable(self) -> bool:
+        """Whether this runner executes chat-session turns (the interactive
+        front-door — SP2b). Opt-in via `capabilities.sessions: true` so a chat send
+        only reaches a runner built for it (a cloud runner with claude), never a
+        laptop emdash daemon. Like the other capabilities, a hint gated by tenant."""
+        return bool(self.capabilities.get("sessions", False))
+
     @property
     def live_status(self) -> str:
         """What we can OBSERVE, not what the runner last claimed.

--- a/apps/harness/models.py
+++ b/apps/harness/models.py
@@ -98,8 +98,10 @@ class Runner(models.Model):
     def project_names(self) -> list[str]:
         """The repos this runner declares it can drive. Like `agents`, this is a
         self-declared ROUTING hint, not a security boundary — the workspace is the
-        gate, and the two intersect (b4f5ead)."""
-        return list(self.capabilities.get("projects", []))
+        gate, and the two intersect (b4f5ead). Empties are stripped: a session turn
+        has project="", so a stray "" here would let a non-session runner match it
+        via `project__in`."""
+        return [p for p in self.capabilities.get("projects", []) if p]
 
     def session_capable(self) -> bool:
         """Whether this runner executes chat-session turns (the interactive

--- a/apps/harness/services.py
+++ b/apps/harness/services.py
@@ -145,13 +145,14 @@ def claim_next_turn(runner: Runner, *, lease_seconds: int = DEFAULT_LEASE_SECOND
     release_stale_occurrence_turns_all()
     slugs = runner.agent_slugs()
     projects = runner.project_names()
+    session_capable = runner.session_capable()
     if exclude_slugs:
         # Per-agent pause: the runner locally paused these agents; never claim their
         # queued turns (they stay QUEUED, resumed the moment the pause is lifted).
         # Scoped to agents by name and by nature — pausing an agent says nothing
         # about a repo, so project turns keep flowing.
         slugs = [s for s in slugs if s not in set(exclude_slugs)]
-    if not slugs and not projects:
+    if not slugs and not projects and not session_capable:
         return None
     routing_q = Q(routing__in=[Turn.PREFER_LOCAL, Turn.LOCAL_ONLY, Turn.ANY])
     if runner.kind == Runner.CLOUD:
@@ -160,6 +161,13 @@ def claim_next_turn(runner: Runner, *, lease_seconds: int = DEFAULT_LEASE_SECOND
         # Phase 0 has no cloud runners, so keep the simple rule: cloud never
         # takes local_only.
     busy_agents = Turn.objects.filter(status__in=EXECUTING).values("agent_id")
+    # A session serializes like an agent: never claim a session that already has
+    # an executing turn (one_executing_turn_per_session would reject the claim
+    # anyway; this avoids the wasted attempt). Filtered to non-null so the exclude
+    # can't NULL-propagate away agent/project turns (chat_session_id NULL).
+    busy_sessions = Turn.objects.filter(
+        status__in=EXECUTING, chat_session__isnull=False
+    ).values("chat_session_id")
     # Tenant boundary. capabilities is a caller-supplied routing hint declared at
     # pairing and never validated (b4f5ead, Critical); the workspace is the actual
     # gate, and the two INTERSECT — one never substitutes for the other.
@@ -198,8 +206,15 @@ def claim_next_turn(runner: Runner, *, lease_seconds: int = DEFAULT_LEASE_SECOND
     # any tenant. The two legs must therefore be split by target kind, and the
     # project leg fails closed on a NULL workspace.
     agent_tenant_q = Q(agent__workspace_id__in=ws_slugs) | Q(agent__workspace_id__isnull=True)
-    tenant_q = (Q(agent__isnull=False) & agent_tenant_q) | (
-        Q(agent__isnull=True) & Q(workspace_id__in=ws_slugs)
+    # Three target kinds, each tenant-gated on its own workspace source: agent
+    # turns via agent.workspace; project turns via their own workspace FK; session
+    # turns via chat_session.workspace. Session turns get NO null-workspace escape
+    # (like project turns): a session always has a workspace, so a NULL there fails
+    # closed rather than becoming claimable by any tenant.
+    tenant_q = (
+        (Q(agent__isnull=False) & agent_tenant_q)
+        | (Q(agent__isnull=True) & Q(chat_session__isnull=True) & Q(workspace_id__in=ws_slugs))
+        | (Q(chat_session__isnull=False) & Q(chat_session__workspace_id__in=ws_slugs))
     )
     # `busy_agents` serializes AGENTS only, and a project turn (agent_id NULL)
     # must not be swept up by it. This plain exclude() is correct: Django compiles
@@ -207,10 +222,17 @@ def claim_next_turn(runner: Runner, *, lease_seconds: int = DEFAULT_LEASE_SECOND
     # survive rather than falling into SQL's NULL-propagation trap. Verified by
     # test_a_busy_agent_does_not_block_a_project_turn, which is what makes it safe
     # to rely on.
+    # Target match: this runner's declared agents/projects, plus every session
+    # turn when it is session-capable (a chat send targets no specific agent — any
+    # session-capable runner in the tenant may take it).
+    target_q = Q(agent__slug__in=slugs) | Q(project__in=projects)
+    if session_capable:
+        target_q = target_q | Q(chat_session__isnull=False)
     candidates = (
         Turn.objects.filter(status=Turn.QUEUED)
-        .filter(Q(agent__slug__in=slugs) | Q(project__in=projects))
+        .filter(target_q)
         .exclude(agent_id__in=busy_agents)
+        .exclude(chat_session_id__in=busy_sessions)
         .filter(routing_q)
         .filter(tenant_q)
         .order_by("created_at")

--- a/apps/harness/services.py
+++ b/apps/harness/services.py
@@ -163,8 +163,13 @@ def claim_next_turn(runner: Runner, *, lease_seconds: int = DEFAULT_LEASE_SECOND
     busy_agents = Turn.objects.filter(status__in=EXECUTING).values("agent_id")
     # A session serializes like an agent: never claim a session that already has
     # an executing turn (one_executing_turn_per_session would reject the claim
-    # anyway; this avoids the wasted attempt). Filtered to non-null so the exclude
-    # can't NULL-propagate away agent/project turns (chat_session_id NULL).
+    # anyway; this avoids the wasted attempt). The chat_session__isnull=False filter
+    # is load-bearing: without it, executing agent/project turns (chat_session_id
+    # NULL) would inject a NULL into this IN-list, and every queued SESSION turn
+    # would then evaluate `id IN (…, NULL)` -> NULL -> get wrongly excluded whenever
+    # any agent turn is running. (Agent/project turns are already protected on the
+    # exclude's LEFT side by Django's `AND chat_session_id IS NOT NULL` negation
+    # guard — that's a separate mechanism from this filter.)
     busy_sessions = Turn.objects.filter(
         status__in=EXECUTING, chat_session__isnull=False
     ).values("chat_session_id")

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -304,6 +304,13 @@ VAPID_SUBJECT = env("VAPID_SUBJECT", default="mailto:jjackson@dimagi.com")
 AI_BACKEND = env("AI_BACKEND", default="api")
 ANTHROPIC_API_KEY = env("ANTHROPIC_API_KEY", default="")
 
+# --- Chat execution (apps/chat, SP2b) ---
+# When True (dev/test default), a chat "send" runs the stub executor INLINE so the
+# turn completes with no runner present. When False (production, connectlabs), the
+# send just enqueues the session turn and a session-capable cloud runner claims +
+# executes it (real claude). The one knob that flips chat from stub to cloud runner.
+CHAT_STUB_EXECUTOR = env.bool("CHAT_STUB_EXECUTOR", default=True)
+
 # CORS
 if DEBUG:
     CORS_ALLOW_ALL_ORIGINS = True

--- a/docs/superpowers/specs/2026-07-20-sp4-ace-web-consumer-design.md
+++ b/docs/superpowers/specs/2026-07-20-sp4-ace-web-consumer-design.md
@@ -1,0 +1,76 @@
+# SP4 — ace-web as the first cloud-runner consumer
+
+**Status:** Draft for review · **Date:** 2026-07-20 · **Author:** Jonathan + Claude
+
+> Sub-project 4 — the finale of the Wave 4 program
+> (`2026-07-16-realtime-chat-cloud-runner-program-design.md`). ace-web stops
+> spawning `claude -p` **inside its own Fargate container** and instead routes
+> execution through **canopy-web's cloud runner** — becoming tenant #1 of the
+> shared substrate. This is the payoff: it validates the framework-harvest thesis
+> (ACE → Canopy) with a real second consumer and fixes ace-web's deploy-kills-runs
+> pain for free (execution moves off the web tier onto a reclaimable runner tier).
+>
+> **Deploy-gated + cross-repo (ace-web).** This spec is the plan; it can't be
+> end-to-end tested until SP2b is deployed (a live cloud runner) — but the canopy
+> side (SP1/SP2a/SP2b) is already built to receive it.
+
+## Where SP1–SP2b leave us
+- canopy-web is the hub: `harness` (queue/claim/lease/ledger), `realtime` (live
+  push), `chat` (Session/Message/Draft/presence unified on the ledger), and — from
+  SP2b — session turns routable to a `kind=cloud` runner that runs real `claude`.
+- The seam that makes SP4 non-breaking is already in place: `CHAT_STUB_EXECUTOR`
+  flips chat from the inline stub to the cloud runner with **no data-model/API
+  change**, and `claim_next_turn` already routes session/agent/project turns to a
+  session-capable runner by tenant.
+
+## The change (ace-web side)
+ace-web today: human chats → `apps/sessions` `turn_driver` spawns `claude -p` via
+`CLIBackend` in-container → streams over ace-web's own Channels WS.
+
+SP4: ace-web enqueues the work to **canopy-web's harness** and observes the result,
+instead of executing it locally. Two integration shapes (decide during brainstorm):
+
+- **A — Delegate execution only (recommended first cut).** ace-web keeps its own
+  chat UI + `Session`/`Message`, but its `turn_driver` stops calling `CLIBackend`
+  and instead `POST`s a `Turn` to canopy-web (`/api/w/{ws}/harness/turns/`, target
+  = an ace project/agent or a canopy chat session), then tails the `TurnEvent`
+  ledger (`GET …/events?after=seq`, or canopy's realtime `turn.{id}` socket) and
+  projects those events into its existing `Message` rows. A canopy **cloud runner**
+  executes. ace-web's in-container subprocess pool is retired. Minimal ace-web
+  churn; opp-specific concerns (Drive, decisions) stay in ace-web as opaque Turn
+  metadata.
+- **B — Full delegation to canopy chat.** ace-web's chat becomes a thin skin over
+  canopy's `chat` app (Session/Message/Draft live in canopy). Bigger cutover; only
+  if we want one chat store. Deferred — A proves the runner path with less risk.
+
+## Auth / tenancy (cross-app)
+- ace-web authenticates to canopy-web with a **PAT** (both apps have a PAT model).
+  The Turn is enqueued into a canopy workspace ace-web's PAT-user belongs to.
+- The cloud runner already pairs with a canopy PAT and claims by tenant; ace-web's
+  turns are just more queued work in that tenant. No new canopy auth.
+- CORS/WS-origin: canopy-web must allow ace-web's origin for the realtime socket
+  (or ace-web polls the events cursor server-side — simpler first cut).
+
+## The credential question (settled by SP2b)
+The cloud runner runs claude on a **dedicated `claude setup-token`** (long-lived,
+non-rotating, Max subscription), NOT a copy of ace-web's rotating OAuth blob —
+which was proven to rotation-conflict. So ace-web and the runner do **not** share a
+claude credential; the runner has its own. (See SP2b.)
+
+## Sequencing
+1. **SP2b deploy** — a live canopy cloud runner (needs the setup-token). Prove a
+   canopy chat turn runs on it end-to-end.
+2. **SP4a — execution delegation (shape A):** ace-web `turn_driver` enqueues to
+   canopy + projects the ledger back; retire `CLIBackend`. Behind a per-env flag so
+   it's a reversible cutover.
+3. **SP4b — retire ace-web's in-container claude** entirely once A is proven; the
+   deploy-kills-live-runs pain and the ALB-stickiness requirement go away.
+
+## Non-goals / risks
+- Not moving ace-web's opp/Drive/decision product logic into canopy (it stays
+  product-side, travels as opaque Turn metadata — the framework/product boundary).
+- Long autonomous ACE runs (multi-hour) vs. snappy chat: the warm-pool cloud runner
+  fits chat; task-per-run isolation for long runs is a later runner option (SP2b
+  §deferred), not an SP4 blocker.
+- Real end-to-end validation requires the deployed runner + an ace-web deploy — so
+  SP4 lands after SP2b is live, and ships behind a reversible flag.

--- a/tests/test_chat_send.py
+++ b/tests/test_chat_send.py
@@ -87,3 +87,26 @@ def test_status_events_are_not_transcript_rows():
     harness.append_events(turn, [{"kind": "status", "payload": {"status": "running"}}])
     # Only the user message exists; status is not a transcript row.
     assert [m.role for m in session.messages.all()] == ["user"]
+
+
+def test_maybe_execute_inline_leaves_turn_for_runner_when_disabled(settings):
+    # Production (CHAT_STUB_EXECUTOR=False): a send enqueues and waits for a
+    # session-capable cloud runner — no inline stub, no assistant message yet.
+    settings.CHAT_STUB_EXECUTOR = False
+    user, _ws, _agent, session = _ctx()
+    _msg, turn = chat.send_message(session=session, text="hi", user=user)
+    chat.maybe_execute_inline(turn)
+    turn.refresh_from_db()
+    assert turn.status == Turn.QUEUED
+    assert [m.role for m in session.messages.all()] == ["user"]
+
+
+def test_maybe_execute_inline_runs_stub_when_enabled(settings):
+    # Dev/test (default True): the stub runs inline and completes the turn.
+    settings.CHAT_STUB_EXECUTOR = True
+    user, _ws, _agent, session = _ctx()
+    _msg, turn = chat.send_message(session=session, text="hi", user=user)
+    chat.maybe_execute_inline(turn)
+    turn.refresh_from_db()
+    assert turn.status == Turn.DONE
+    assert [m.role for m in session.messages.order_by("turn_index")] == ["user", "assistant"]

--- a/tests/test_harness_claim_sessions.py
+++ b/tests/test_harness_claim_sessions.py
@@ -1,0 +1,123 @@
+"""claim_next_turn, widened to chat-session turns (SP2b).
+
+A chat "send" makes a session turn (agent=NULL, project="", chat_session set). A
+session-capable runner (capabilities.sessions=true — a cloud runner with claude)
+claims it for its tenant; a plain runner never does. Sessions serialize like
+agents (one executing turn per session), but distinct sessions run in parallel.
+"""
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+
+from apps.chat.models import Session
+from apps.harness import services
+from apps.harness.models import Runner, Turn
+from apps.workspaces.models import Workspace, WorkspaceMembership
+
+pytestmark = pytest.mark.django_db
+
+
+def _user(name):
+    return get_user_model().objects.create_user(username=name, email=f"{name}@dimagi.com")
+
+
+def _ws(slug, owner):
+    ws = Workspace.objects.create(slug=slug, display_name=slug.title(), created_by=owner)
+    WorkspaceMembership.objects.create(workspace=ws, user=owner, role=WorkspaceMembership.OWNER)
+    return ws
+
+
+def _runner(pairer, **kw):
+    defaults = dict(
+        name="jj-mbp", kind=Runner.EMDASH, host="jj-mac", paired_by=pairer,
+        status=Runner.ONLINE, last_heartbeat_at=timezone.now(),
+        capabilities={"projects": ["canopy-web"]},
+    )
+    defaults.update(kw)
+    return Runner.objects.create(**defaults)
+
+
+def _session_runner(pairer, **kw):
+    return _runner(pairer, name="cloud-1", kind=Runner.CLOUD, host="",
+                   capabilities={"sessions": True}, **kw)
+
+
+def _session(ws, user):
+    return Session.objects.create(workspace=ws, created_by=user)
+
+
+def _session_turn(session, key, **kw):
+    return Turn.objects.create(
+        chat_session=session, origin=Turn.ORIGIN_API, idempotency_key=key, **kw
+    )
+
+
+def test_session_capable_runner_claims_a_session_turn():
+    jj = _user("jj")
+    ws = _ws("canopy", jj)
+    runner = _session_runner(jj)
+    turn = _session_turn(_session(ws, jj), "s1", prompt="hi")
+
+    claimed = services.claim_next_turn(runner)
+
+    assert claimed is not None and claimed.pk == turn.pk
+
+
+def test_plain_runner_never_claims_a_session_turn():
+    jj = _user("jj")
+    ws = _ws("canopy", jj)
+    runner = _runner(jj)  # no sessions capability
+    _session_turn(_session(ws, jj), "s1")
+
+    assert services.claim_next_turn(runner) is None
+
+
+def test_session_turn_is_tenant_gated():
+    jj = _user("jj")
+    other_owner = _user("o2")
+    ws_other = _ws("other", other_owner)  # jj is NOT a member
+    runner = _session_runner(jj)
+    _session_turn(_session(ws_other, other_owner), "s1")
+
+    assert services.claim_next_turn(runner) is None
+
+
+def test_busy_session_is_not_reclaimed():
+    jj = _user("jj")
+    ws = _ws("canopy", jj)
+    runner = _session_runner(jj)
+    session = _session(ws, jj)
+    _session_turn(session, "s1", status=Turn.RUNNING)  # already executing
+    _session_turn(session, "s2", status=Turn.QUEUED)   # same session, queued
+
+    assert services.claim_next_turn(runner) is None
+
+
+def test_distinct_sessions_claim_in_parallel():
+    jj = _user("jj")
+    ws = _ws("canopy", jj)
+    runner = _session_runner(jj)
+    t1 = _session_turn(_session(ws, jj), "s1")
+    t2 = _session_turn(_session(ws, jj), "s2")
+
+    c1 = services.claim_next_turn(runner)
+    c2 = services.claim_next_turn(runner)
+    assert c1 is not None and c2 is not None
+    assert {c1.pk, c2.pk} == {t1.pk, t2.pk}
+
+
+def test_busy_session_exclude_does_not_strand_project_turns():
+    """The .exclude(chat_session_id__in=busy_sessions) must NOT NULL-propagate away
+    agent/project turns (chat_session_id NULL) when a session is executing."""
+    jj = _user("jj")
+    ws = _ws("canopy", jj)
+    runner = _runner(jj, kind=Runner.CLOUD, capabilities={"projects": ["canopy-web"], "sessions": True})
+    _session_turn(_session(ws, jj), "sx", status=Turn.RUNNING)  # a busy session exists
+    pturn = Turn.objects.create(
+        project="canopy-web", workspace=ws, origin=Turn.ORIGIN_MANUAL, idempotency_key="p1"
+    )
+
+    claimed = services.claim_next_turn(runner)
+    assert claimed is not None and claimed.pk == pturn.pk


### PR DESCRIPTION
## SP2b — chat runs on the cloud runner

The harness/chat piece that lets a chat "send" execute on a real **`kind=cloud`** runner (claude) instead of the SP2a inline **stub**. No deploy needed to build/test this — it's all canopy-web.

### What's here
- **`Runner.session_capable()`** — opt-in via `capabilities.sessions=true`, so a chat send only reaches a runner built for it (a cloud runner with claude), never a laptop emdash daemon.
- **`claim_next_turn` widened to session turns** — a session-capable runner claims queued session turns for its **tenant** (`chat_session.workspace` ∈ the pairer's workspaces), serialized **per-session** (`busy_sessions`), with distinct sessions running in **parallel**. The `busy_sessions` exclude is NULL-safe so it never strands agent/project turns (regression-tested).
- **`CHAT_STUB_EXECUTOR` setting + `chat.services.maybe_execute_inline()`** — dev/test run the stub inline (default `True`); production leaves the turn **queued for a cloud runner** to execute real claude (same ledger + `Message` projection either way). Flipping it `False` in `connectlabs.py` is the **cutover**, done once a runner is live (left `True` for now so labs chat isn't stranded).

### Verification
Full suite **960 passed, 1 skipped**; ruff clean; migrations in sync. New tests: session-turn claim (capable claims / plain ignores / tenant-gated / busy-session / parallel / project-turn-not-stranded) + executor-selection (queued-for-runner vs stub-inline). The `claim_next_turn` change — delicate, with prior outage history — is unregressed.

### Program context
Part of **SP2b** (cloud runner). The EC2 IaC scaffolding is on `emdash/cloud-runner-ec2`; its pipeline is proven end-to-end and it's blocked only on a dedicated claude token. This PR + that scaffolding + the cutover flag together give: **chat → session Turn → cloud runner → claude → ledger → live stream + transcript.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
