### PR TITLE
fix(spa): catch-all route self-heals a stale PWA bundle instead of erroring

### DIFF
--- a/frontend/src/components/NotFound.tsx
+++ b/frontend/src/components/NotFound.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { reloadOnceForStaleBundle } from "./staleBundle";
+
+/**
+ * Catch-all (`path: '*'`) route. An unmatched path usually means one of two
+ * things: a genuine bad URL, or — right after a deploy that added a new
+ * route — a browser still running the PREVIOUS bundle out of the PWA service
+ * worker's precache, whose router doesn't know the new route yet.
+ *
+ * We treat it as the latter FIRST: reload once (the SW autoUpdates, so the
+ * reload lands on the freshened bundle that DOES have the route). If we reload
+ * and still end up here, `reloadOnceForStaleBundle` refuses to loop and we
+ * render an honest "page not found" instead. This turns "Something broke" into
+ * silent self-healing for the common post-deploy case.
+ */
+export function NotFound() {
+  // Start as null: if we're going to reload, never flash the 404 first.
+  const [reloading] = useState(() => reloadOnceForStaleBundle());
+  useEffect(() => {
+    /* the reload (if any) was already kicked off synchronously above */
+  }, []);
+
+  if (reloading) return null;
+
+  return (
+    <div className="max-w-2xl px-6 py-8">
+      <div className="rounded-lg border border-border bg-card p-5">
+        <span className="inline-flex rounded border border-border bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground">
+          Page not found
+        </span>
+        <h2 className="mt-3 text-sm font-medium text-foreground">There’s nothing at this address.</h2>
+        <p className="mt-1 text-[13px] text-foreground-secondary">
+          The link may be out of date. If you just updated Canopy, a reload will pick up the latest
+          version.
+        </p>
+        <p className="mt-2 text-[11px] text-foreground-subtle">
+          <span className="font-mono break-all">{window.location.pathname}</span>
+        </p>
+        <div className="mt-4 flex gap-2">
+          <button
+            type="button"
+            onClick={() => window.location.reload()}
+            className="rounded bg-primary px-3 py-1 text-[11px] font-medium text-primary-foreground hover:bg-primary/90"
+          >
+            Reload
+          </button>
+          <Link
+            to="/"
+            className="rounded border border-input px-3 py-1 text-[11px] text-foreground-secondary hover:bg-muted"
+          >
+            Back to Canopy
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/staleBundle.test.ts
+++ b/frontend/src/components/staleBundle.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { shouldReloadForStaleBundle, STALE_RELOAD_WINDOW_MS } from "./staleBundle";
+
+describe("shouldReloadForStaleBundle", () => {
+  it("reloads when we have never reloaded (lastReloadAt = 0)", () => {
+    expect(shouldReloadForStaleBundle(0, 1_000_000)).toBe(true);
+  });
+
+  it("does NOT reload again within the window (we just reloaded and still landed here)", () => {
+    const now = 1_000_000;
+    expect(shouldReloadForStaleBundle(now - 1, now)).toBe(false);
+    expect(shouldReloadForStaleBundle(now - (STALE_RELOAD_WINDOW_MS - 1), now)).toBe(false);
+  });
+
+  it("reloads again once the window has fully elapsed (a genuinely new stale deploy later)", () => {
+    const now = 1_000_000;
+    expect(shouldReloadForStaleBundle(now - (STALE_RELOAD_WINDOW_MS + 1), now)).toBe(true);
+  });
+});

--- a/frontend/src/components/staleBundle.ts
+++ b/frontend/src/components/staleBundle.ts
@@ -1,0 +1,48 @@
+// When a new build ships a NEW top-level route, a browser still running the
+// PREVIOUS bundle (served from the PWA service worker's precache until it
+// updates) has no such route in its router. React Router then throws a
+// "no match" for that path, which surfaces as the scary RouteErrorBoundary.
+// The catch-all route (NotFound) recovers by reloading ONCE to pick up the
+// freshened bundle — self-healing, exactly like `shouldBounceToLogin` in
+// client.v2.ts recovers a lapsed session with a single bounce.
+//
+// The window makes the reload single-shot: if we reload and STILL land on the
+// catch-all (the SW hadn't updated yet, or the URL is a genuine typo), we do
+// NOT reload again — we show a real "page not found" instead of looping.
+export const STALE_RELOAD_WINDOW_MS = 20_000;
+const STALE_RELOAD_AT_KEY = "canopy:staleBundle:lastReloadAt";
+
+/**
+ * Pure decision, split out so it's unit-testable without a DOM (this codebase's
+ * convention — see `shouldBounceToLogin`). Reload only if we have NOT already
+ * reloaded within the window; a second landing inside it means the reload
+ * didn't fix it, so stop and let the caller render a 404.
+ */
+export function shouldReloadForStaleBundle(lastReloadAt: number, now: number): boolean {
+  return !(lastReloadAt > 0 && now - lastReloadAt < STALE_RELOAD_WINDOW_MS);
+}
+
+/**
+ * Effectful wrapper: read the last-reload stamp, decide, and if we should,
+ * stamp + reload. Returns true when it triggered a reload (so the caller can
+ * render nothing while the navigation happens), false when it gave up and the
+ * caller should render the not-found UI. sessionStorage (not a module var) so
+ * the stamp survives the full-page reload; best-effort, since it can throw in
+ * private mode.
+ */
+export function reloadOnceForStaleBundle(): boolean {
+  let last = 0;
+  try {
+    last = Number(sessionStorage.getItem(STALE_RELOAD_AT_KEY)) || 0;
+  } catch {
+    /* sessionStorage unavailable — treat as "never reloaded" and allow the one reload */
+  }
+  if (!shouldReloadForStaleBundle(last, Date.now())) return false;
+  try {
+    sessionStorage.setItem(STALE_RELOAD_AT_KEY, String(Date.now()));
+  } catch {
+    /* unavailable — a best-effort guard is better than blocking the recovery */
+  }
+  window.location.reload();
+  return true;
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -4,6 +4,7 @@ import { createBrowserRouter, Navigate, useLocation, useParams } from 'react-rou
 import { useWorkspace } from './workspace/WorkspaceProvider'
 import { AppLayout } from './components/AppLayout/AppLayout'
 import { RouteErrorBoundary } from './components/RouteErrorBoundary'
+import { NotFound } from './components/NotFound'
 import { ShareRouteErrorBoundary } from './components/ShareRouteErrorBoundary'
 import { ProjectsPage } from './pages/ProjectsPage'
 import { InsightsPage } from './pages/InsightsPage'
@@ -181,6 +182,12 @@ export const router = createBrowserRouter(guarded([
       { path: '/ddd/*', element: <TenantRedirect to="ddd" /> },
       { path: '/ddd-plans', element: <Navigate to="/" replace /> },
       { path: '/reviews', element: <Navigate to="/" replace /> },
+
+      // Catch-all (LAST): an unmatched path is a bad URL OR a browser still on
+      // a pre-deploy bundle (PWA precache) whose router lacks a route this
+      // deploy added. NotFound reloads once to self-heal the latter, then shows
+      // a real 404 — so a new route never surfaces as the RouteErrorBoundary.
+      { path: '*', element: <NotFound /> },
     ],
   },
   // Public, chrome-less route — mounted OUTSIDE AppLayout so anonymous


### PR DESCRIPTION
## Root cause (from a real report)

After deploying the fleet Turn Log (#282), \`/activity\` threw an error for a user — while **every** server-side check passed: the deploy built the right commit, the bundle registered the route, the backend returned 200 for all turn shapes, and the page rendered cleanly in jsdom.

The reason they all passed: **`curl` and tests bypass the service worker.** The app is a PWA (`registerType: 'autoUpdate'`, Workbox precache, `navigateFallback: index.html`). A browser that cached the app **before** #282 keeps serving the **old bundle** from precache until the SW updates. That old bundle's router has no `/activity` route — and since there was **no catch-all route**, React Router threw "no match", which surfaced as the scary `RouteErrorBoundary` ("Something broke").

This will recur for **any** future deploy that adds a new top-level route.

## Fix

Add a catch-all `{ path: '*' }` → `NotFound` that treats an unmatched path as a probable stale bundle **first**: it reloads once to pick up the freshened bundle (which has the route), then — if the reload didn't resolve it (SW not yet updated, or a genuine bad URL) — shows an honest "page not found" instead of looping.

The one-shot reload is loop-guarded via `sessionStorage`, mirroring the existing `shouldBounceToLogin` lapsed-session recovery in `client.v2.ts`. The pure decision `shouldReloadForStaleBundle(lastReloadAt, now)` is unit-tested.

## Files
- `frontend/src/components/staleBundle.ts` — pure guard + effectful `reloadOnceForStaleBundle()`
- `frontend/src/components/staleBundle.test.ts` — vitest (3 cases: never-reloaded, within-window, window-elapsed)
- `frontend/src/components/NotFound.tsx` — the catch-all component (design tokens only, both themes)
- `frontend/src/router.tsx` — wire `{ path: '*' }` as the last route

## Testing
- `npx vitest run` — staleBundle (3) + turnLog (13) green
- `npm run build` green; palette-literal/`dark:` guard clean on new files
- Confirmed the new ActivityPage renders real-shaped data (agent / project / #279 chat-session turns) in a jsdom render without throwing — the browser-render check that was missing from #282.

## Note
This does not retroactively fix a browser **currently** stuck on the pre-#282 bundle (that client doesn't have this catch-all yet) — those need one manual reload. It prevents the failure for this deploy forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)