### PR TITLE
fix: header horizontal-scroll at 1280px + a stale needs-you test

### DIFF
--- a/frontend/e2e/agents.spec.ts
+++ b/frontend/e2e/agents.spec.ts
@@ -29,8 +29,9 @@ test('needs-you is the default landing with typed, ranked actionable items', asy
   await expect(page.getByTestId('needsyou-band-review')).toContainText('ZEGCAWIS polio AFP story')
   // question band: the in-progress task blocked on a human
   await expect(page.getByTestId('needsyou-band-question')).toContainText('PRIDE cholera story')
-  // notify band: a recent FYI (the sync)
-  await expect(page.getByTestId('needsyou-band-notify')).toContainText('Manager sync 1')
+  // needs-you is action-only (#273 dropped the FYI 'notify' band — syncs like
+  // "Manager sync 1" no longer surface here). Only review + question bands remain.
+  await expect(page.getByTestId('needsyou-band-notify')).toHaveCount(0)
   // nothing Echo is actively working appears in the inbox
   await expect(page.getByText('Ideas backlog upkeep')).toHaveCount(0)
   // the badge counts the gated items only (t1 + t2 suggested, t3 waiting = 3)

--- a/frontend/src/components/AppLayout/AppLayout.tsx
+++ b/frontend/src/components/AppLayout/AppLayout.tsx
@@ -268,10 +268,10 @@ function AppShell() {
           ) : (
             <span className="text-lg font-semibold text-foreground shrink-0">Canopy<span className="text-primary">.</span></span>
           )}
-          <div className="flex items-center gap-3 xl:gap-6">
+          <div className="flex min-w-0 items-center gap-2 xl:gap-3">
             {/* Full inline nav only once all items fit (~xl); below that it
                 overflows the viewport, so we collapse it into the menu below. */}
-            <nav className="hidden xl:flex gap-1">
+            <nav className="hidden min-w-0 xl:flex gap-0.5">
               {navItems.map((item) => (
                 <Link key={item.path} to={item.path} className={navLinkClass(item.path, false)}>
                   {item.label}


### PR DESCRIPTION
Two pre-existing main-branch failures that CI misses (it doesn't run Playwright), fixed. Neither was caused by the runner-cascade feature — both were already red on `origin/main`.

## Bug 1 — app-wide horizontal scrollbar at 1280px
`#282` added the 12th header nav item (Activity), tipping the inline nav 26px past a 1280px viewport → a horizontal scrollbar app-wide at that width (caught by `/supervisor`'s no-horizontal-scroll Playwright test, which runs at exactly 1280).

**Fix:** reclaim the width from the header's own spacing (`gap-3 xl:gap-6` → `gap-2 xl:gap-3`, nav `gap-1` → `gap-0.5`, `+ min-w-0`) — **not** a breakpoint bump, so the inline nav is preserved on all desktops. (Bumping the collapse to `2xl` would have pushed every 1280–1535px laptop to the hamburger menu — a real downgrade for the most common desktop widths.) Verified with a DOM probe: zero elements exceed the viewport at 1280 on every tab.

## Bug 2 — a stale needs-you test
`agents.spec.ts` asserted the needs-you `notify` band contains "Manager sync 1", but `#273` ("needs-you is action-only") intentionally dropped that FYI band. The code is correct; the test was stale. Strengthened the assertion to prove the band is **gone**.

## Verification
Build clean, vitest 126, **Playwright 40/40** (both previously-failing tests now green). No backend/runtime change — CSS + a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)