### PR TITLE
feat(supervisor): read a live emdash session's recent tail (Phase B)

### DIFF
--- a/frontend/src/components/supervisor/OpenSessions.tsx
+++ b/frontend/src/components/supervisor/OpenSessions.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, type JSX } from 'react'
 import { listOpenSessions, enqueueTurn, type EmdashSessionOut } from '@/api/harness'
+import { normalizeRecentMessages } from '@/lib/recentMessages'
 
 // The open emdash sessions the runner reported — see them, and drop a prompt into a
 // specific one. Continue dispatches a repo turn carrying the session's emdash:{task}
@@ -10,6 +11,8 @@ function SessionRow({ session }: { session: EmdashSessionOut }): JSX.Element {
   const [prompt, setPrompt] = useState('')
   const [busy, setBusy] = useState(false)
   const [sent, setSent] = useState<'ok' | string | null>(null)
+  const [expanded, setExpanded] = useState(false)
+  const messages = normalizeRecentMessages(session.recent_messages)
 
   async function send(): Promise<void> {
     if (busy || prompt.trim() === '') return
@@ -39,6 +42,32 @@ function SessionRow({ session }: { session: EmdashSessionOut }): JSX.Element {
         </span>
         <span className="shrink-0 text-[11px] text-muted-foreground">{session.status}</span>
       </div>
+      <button
+        type="button"
+        data-testid={`session-tail-toggle-${session.emdash_task}`}
+        onClick={() => setExpanded((v) => !v)}
+        className="mt-1 text-[11px] text-muted-foreground hover:text-foreground-secondary"
+      >
+        {expanded ? 'Hide recent' : 'Recent'}
+      </button>
+      {expanded && (
+        <div className="mt-1 flex flex-col gap-1" data-testid={`session-tail-${session.emdash_task}`}>
+          {messages.length === 0 ? (
+            <p className="text-[12px] text-muted-foreground">Recent messages unavailable.</p>
+          ) : (
+            messages.map((m, i) => (
+              <div key={i} className="rounded border border-border bg-muted/40 p-1.5">
+                <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                  {m.role}
+                </span>
+                <p className="whitespace-pre-wrap break-words text-[12px] text-foreground-secondary">
+                  {m.text}
+                </p>
+              </div>
+            ))
+          )}
+        </div>
+      )}
       <div className="mt-2 flex gap-2">
         <input
           data-testid={`session-input-${session.emdash_task}`}

--- a/frontend/src/lib/recentMessages.test.ts
+++ b/frontend/src/lib/recentMessages.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { normalizeRecentMessages } from './recentMessages'
+
+describe('normalizeRecentMessages', () => {
+  it('keeps well-formed {role,text} entries', () => {
+    expect(
+      normalizeRecentMessages([
+        { role: 'user', text: 'hi' },
+        { role: 'assistant', text: 'hello' },
+      ]),
+    ).toEqual([
+      { role: 'user', text: 'hi' },
+      { role: 'assistant', text: 'hello' },
+    ])
+  })
+
+  it('drops malformed entries and defaults a missing role', () => {
+    expect(
+      normalizeRecentMessages([
+        null,
+        'nope',
+        { text: 'orphan' },
+        { role: 'user' }, // no text -> dropped
+      ]),
+    ).toEqual([{ role: 'assistant', text: 'orphan' }])
+  })
+
+  it('returns [] for an empty tail', () => {
+    expect(normalizeRecentMessages([])).toEqual([])
+  })
+})

--- a/frontend/src/lib/recentMessages.ts
+++ b/frontend/src/lib/recentMessages.ts
@@ -1,0 +1,18 @@
+export type RecentMessage = { role: string; text: string }
+
+// The server serializes recent_messages as an untyped list (unknown[] in the
+// generated OpenAPI types). Coerce defensively so a malformed tail can never
+// crash the render: keep only entries with a non-empty text, defaulting a
+// missing/blank role to "assistant".
+export function normalizeRecentMessages(raw: readonly unknown[]): RecentMessage[] {
+  const out: RecentMessage[] = []
+  for (const item of raw) {
+    if (item && typeof item === 'object') {
+      const rec = item as Record<string, unknown>
+      const role = typeof rec.role === 'string' ? rec.role : ''
+      const text = typeof rec.text === 'string' ? rec.text : ''
+      if (text) out.push({ role: role || 'assistant', text })
+    }
+  }
+  return out
+}

--- a/packages/canopy_runner/canopy_runner/config.py
+++ b/packages/canopy_runner/canopy_runner/config.py
@@ -32,6 +32,9 @@ class Config:
     # Hard safety cap: at most this many threads become turns per mailbox per poll,
     # so a flooded/misconfigured inbox can't spawn dozens of sessions at once.
     inbox_max_threads: int = 8
+    # Phase B: how many recent messages to include for the most-recently-active
+    # session in each session report. "Recent tail", not the full transcript.
+    session_tail_limit: int = 8
 
     @classmethod
     def load(cls, path: Path) -> "Config":

--- a/packages/canopy_runner/canopy_runner/main.py
+++ b/packages/canopy_runner/canopy_runner/main.py
@@ -39,7 +39,7 @@ import sqlite3
 import time
 from pathlib import Path
 
-from . import emdash
+from . import emdash, transcript
 from .client import Client, ClientError
 from .config import Config
 
@@ -265,9 +265,12 @@ def _run_once_cdp(cfg: Config, client: Client) -> str:
 
     # Report the open emdash sessions the phone can continue. A sqlite read of emdash's
     # DB, not CDP — keep it even while CDP is down. Best-effort: a read or POST failure
-    # must never stop the tick.
+    # must never stop the tick. The most-recently-active session also carries its recent
+    # message tail (Phase B) so the phone can read it on click-in with no extra round trip.
     try:
-        client.report_sessions(cfg.runner_id, emdash.list_open_sessions(cfg.emdash_db))
+        sessions = emdash.list_open_sessions(cfg.emdash_db)
+        transcript.attach_recent_tail(sessions, limit=cfg.session_tail_limit)
+        client.report_sessions(cfg.runner_id, sessions)
     except Exception:  # noqa: BLE001
         logger.debug("session report failed (non-fatal)", exc_info=True)
     paused = _paused_agents(cfg)

--- a/packages/canopy_runner/canopy_runner/transcript.py
+++ b/packages/canopy_runner/canopy_runner/transcript.py
@@ -120,3 +120,26 @@ def session_tail(
     if not msgs:
         return [], "empty-transcript"
     return msgs, ""
+
+
+def attach_recent_tail(
+    sessions: list[dict],
+    *,
+    limit: int = 8,
+    home: Path | None = None,
+    claude_home: Path | None = None,
+) -> None:
+    """Eagerly fill recent_messages on the MOST-RECENTLY-ACTIVE session (index 0).
+
+    That is the session the supervisor is most likely to open ("this session"),
+    so its click-in is instant with no extra round trip. In place, best-effort,
+    never raises. Other sessions carry [] until Task 4 (watch) fills them.
+    """
+    if not sessions:
+        return
+    top = sessions[0]
+    msgs, _reason = session_tail(
+        top.get("project", ""), top.get("emdash_task", ""),
+        limit=limit, home=home, claude_home=claude_home,
+    )
+    top["recent_messages"] = msgs

--- a/packages/canopy_runner/canopy_runner/transcript.py
+++ b/packages/canopy_runner/canopy_runner/transcript.py
@@ -1,0 +1,118 @@
+"""Read the recent message tail of a live emdash session's Claude transcript.
+
+Phase B of the emdash session controller (docs/superpowers/specs/
+2026-07-16-emdash-session-controller-design.md). STDLIB ONLY — the runner is
+Django-free and cannot import apps.session_sharing.parser; this is the runner's
+own minimal tail reader (user/assistant text for the last ~8 messages), not the
+full ParsedTurn model the server uses.
+
+emdash stores no conversation content in emdash4.db (the `messages` table is
+empty); the content lives in Claude Code's transcript .jsonl under
+~/.claude/projects/<encoded-worktree>/<session>.jsonl. There is no session id or
+path in the DB, so the transcript is resolved by CONVENTION:
+
+    worktree  = ~/emdash/worktrees/<repo>/emdash/<task>
+    proj dir  = ~/.claude/projects/<worktree with '/' and '.' -> '-'>
+    file      = newest *.jsonl in that dir
+
+A wrong path is a silent wrong-answer, so resolution returns None rather than
+guess. Nothing here raises: a missing dir, unreadable file, or malformed line
+degrades to an empty tail with a reason string, so the poll tick survives.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+MAX_MSG_CHARS = 2000
+
+
+def encode_project_dir(worktree: Path) -> str:
+    """Claude Code's ~/.claude/projects/<name> encoding: '/' and '.' -> '-'."""
+    return str(worktree).replace("/", "-").replace(".", "-")
+
+
+def resolve_transcript(repo: str, task: str, *, home: Path, claude_home: Path) -> Path | None:
+    """Newest .jsonl for (repo, task) by emdash's worktree convention, or None."""
+    if not repo or not task:
+        return None
+    worktree = home / "emdash" / "worktrees" / repo / "emdash" / task
+    proj_dir = claude_home / encode_project_dir(worktree)
+    if not proj_dir.is_dir():
+        return None
+    jsonls = sorted(proj_dir.glob("*.jsonl"), key=lambda p: p.stat().st_mtime, reverse=True)
+    return jsonls[0] if jsonls else None
+
+
+def _extract_text(content) -> str:
+    """Human-readable text of a Claude message `content` (str or block list)."""
+    if isinstance(content, str):
+        return content.strip()
+    if not isinstance(content, list):
+        return ""
+    parts: list[str] = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        btype = block.get("type")
+        if btype == "text":
+            parts.append(block.get("text", ""))
+        elif btype == "tool_use":
+            parts.append(f"[tool: {block.get('name', 'unknown')}]")
+        elif btype == "tool_result":
+            parts.append(f"[result: {str(block.get('content', ''))[:200]}]")
+    return " ".join(p for p in parts if p).strip()
+
+
+def read_recent_messages(path: Path, limit: int = 8) -> list[dict]:
+    """Last `limit` user/assistant messages as [{"role", "text"}], oldest→newest.
+
+    Never raises: an unreadable file yields []; a malformed line is skipped.
+    """
+    try:
+        lines = path.read_text("utf-8", errors="replace").splitlines()
+    except OSError:
+        return []
+    msgs: list[dict] = []
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        kind = payload.get("type")
+        if kind not in ("user", "assistant"):
+            continue
+        text = _extract_text(payload.get("message", {}).get("content", ""))
+        if text:
+            msgs.append({"role": kind, "text": text[:MAX_MSG_CHARS]})
+    return msgs[-limit:]
+
+
+def session_tail(
+    repo: str,
+    task: str,
+    *,
+    limit: int = 8,
+    home: Path | None = None,
+    claude_home: Path | None = None,
+) -> tuple[list[dict], str]:
+    """(messages, reason). reason == "" on success. NEVER raises — see module docstring."""
+    home = home or Path.home()
+    claude_home = claude_home or (home / ".claude" / "projects")
+    try:
+        path = resolve_transcript(repo, task, home=home, claude_home=claude_home)
+    except Exception:  # noqa: BLE001 — a fragile-half failure must not crash the tick
+        logger.debug("transcript resolve failed for %s/%s", repo, task, exc_info=True)
+        return [], "resolve-error"
+    if path is None:
+        return [], "no-transcript"
+    msgs = read_recent_messages(path, limit=limit)
+    if not msgs:
+        return [], "empty-transcript"
+    return msgs, ""

--- a/packages/canopy_runner/canopy_runner/transcript.py
+++ b/packages/canopy_runner/canopy_runner/transcript.py
@@ -85,10 +85,14 @@ def read_recent_messages(path: Path, limit: int = 8) -> list[dict]:
             payload = json.loads(line)
         except json.JSONDecodeError:
             continue
+        if not isinstance(payload, dict):
+            continue
         kind = payload.get("type")
         if kind not in ("user", "assistant"):
             continue
-        text = _extract_text(payload.get("message", {}).get("content", ""))
+        message = payload.get("message")
+        content = message.get("content", "") if isinstance(message, dict) else ""
+        text = _extract_text(content)
         if text:
             msgs.append({"role": kind, "text": text[:MAX_MSG_CHARS]})
     return msgs[-limit:]

--- a/packages/canopy_runner/canopy_runner/transcript.py
+++ b/packages/canopy_runner/canopy_runner/transcript.py
@@ -87,6 +87,8 @@ def read_recent_messages(path: Path, limit: int = 8) -> list[dict]:
             continue
         if not isinstance(payload, dict):
             continue
+        if payload.get("isSidechain"):
+            continue
         kind = payload.get("type")
         if kind not in ("user", "assistant"):
             continue
@@ -137,7 +139,7 @@ def attach_recent_tail(
     """
     if not sessions:
         return
-    top = sessions[0]
+    top = sessions[0]  # most-recently-active: emdash.list_open_sessions returns newest-first
     msgs, _reason = session_tail(
         top.get("project", ""), top.get("emdash_task", ""),
         limit=limit, home=home, claude_home=claude_home,

--- a/packages/canopy_runner/tests/test_transcript.py
+++ b/packages/canopy_runner/tests/test_transcript.py
@@ -82,3 +82,56 @@ def test_text_truncated_to_max(tmp_path):
     f.write_text(json.dumps({"type": "user", "message": {"content": "z" * 5000}}), "utf-8")
     msgs = transcript.read_recent_messages(f, limit=8)
     assert len(msgs[0]["text"]) == transcript.MAX_MSG_CHARS
+
+
+def test_read_recent_messages_skips_wrong_shape_message_field(tmp_path):
+    # Valid JSON, but "message" is a str instead of a dict — .get() on it
+    # would raise AttributeError if not guarded. Surrounding good messages
+    # must still come through.
+    f = tmp_path / "x.jsonl"
+    f.write_text(
+        '{"type":"user","message":{"content":"ok"}}\n'
+        '{"type":"user","message":"not-a-dict"}\n'
+        '{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]}}\n',
+        "utf-8",
+    )
+    msgs = transcript.read_recent_messages(f, limit=8)
+    assert [m["text"] for m in msgs] == ["ok", "hi"]
+
+
+def test_read_recent_messages_skips_bare_json_list_line(tmp_path):
+    # A line that is valid JSON but not an object at all (a bare list) —
+    # payload.get(...) would raise AttributeError if not guarded.
+    f = tmp_path / "x.jsonl"
+    f.write_text(
+        '{"type":"user","message":{"content":"ok"}}\n'
+        "[1,2,3]\n"
+        '{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]}}\n',
+        "utf-8",
+    )
+    msgs = transcript.read_recent_messages(f, limit=8)
+    assert [m["text"] for m in msgs] == ["ok", "hi"]
+
+
+def test_session_tail_wrong_shape_only_returns_empty_transcript_not_raise(tmp_path):
+    home = tmp_path / "home"
+    claude_home = home / ".claude" / "projects"
+    worktree = home / "emdash" / "worktrees" / "canopy-web" / "emdash" / "ddd"
+    _write_transcript(claude_home, worktree, [
+        {"type": "system", "subtype": "init", "session_id": "s1"},
+    ])
+    # Overwrite with content lines that are all wrong-shape (valid JSON,
+    # bad shape) — session_tail must degrade to ([], "empty-transcript"),
+    # never raise.
+    proj = claude_home / transcript.encode_project_dir(worktree)
+    f = proj / "sess.jsonl"
+    f.write_text(
+        '{"type":"user","message":"not-a-dict"}\n'
+        "[1,2,3]\n",
+        "utf-8",
+    )
+    msgs, reason = transcript.session_tail(
+        "canopy-web", "ddd", limit=8, home=home, claude_home=claude_home
+    )
+    assert msgs == []
+    assert reason == "empty-transcript"

--- a/packages/canopy_runner/tests/test_transcript.py
+++ b/packages/canopy_runner/tests/test_transcript.py
@@ -1,0 +1,84 @@
+import json
+from pathlib import Path
+
+from canopy_runner import transcript
+
+
+def test_encode_project_dir_replaces_slash_and_dot():
+    wt = Path("/Users/j/emdash/worktrees/canopy-web/emdash/mobile-kn063")
+    assert transcript.encode_project_dir(wt) == (
+        "-Users-j-emdash-worktrees-canopy-web-emdash-mobile-kn063"
+    )
+    # dots also become dashes (Claude Code's convention)
+    assert transcript.encode_project_dir(Path("/a/b.c")) == "-a-b-c"
+
+
+def _write_transcript(claude_home: Path, worktree: Path, lines: list[dict]) -> Path:
+    proj = claude_home / transcript.encode_project_dir(worktree)
+    proj.mkdir(parents=True)
+    f = proj / "sess.jsonl"
+    f.write_text("\n".join(json.dumps(x) for x in lines), "utf-8")
+    return f
+
+
+def test_session_tail_reads_recent_user_and_assistant_text(tmp_path):
+    home = tmp_path / "home"
+    claude_home = home / ".claude" / "projects"
+    worktree = home / "emdash" / "worktrees" / "canopy-web" / "emdash" / "ddd"
+    _write_transcript(claude_home, worktree, [
+        {"type": "system", "subtype": "init", "session_id": "s1"},
+        {"type": "user", "message": {"content": "fix the header"}},
+        {"type": "assistant", "message": {"content": [{"type": "text", "text": "On it."}]}},
+        {"type": "assistant", "message": {"content": [{"type": "tool_use", "name": "Edit"}]}},
+    ])
+    msgs, reason = transcript.session_tail(
+        "canopy-web", "ddd", limit=8, home=home, claude_home=claude_home
+    )
+    assert reason == ""
+    assert msgs[0] == {"role": "user", "text": "fix the header"}
+    assert msgs[1] == {"role": "assistant", "text": "On it."}
+    assert msgs[2] == {"role": "assistant", "text": "[tool: Edit]"}
+
+
+def test_session_tail_limits_to_last_n(tmp_path):
+    home = tmp_path / "home"
+    claude_home = home / ".claude" / "projects"
+    worktree = home / "emdash" / "worktrees" / "canopy-web" / "emdash" / "ddd"
+    lines = [{"type": "system", "subtype": "init", "session_id": "s1"}]
+    for i in range(20):
+        lines.append({"type": "user", "message": {"content": f"m{i}"}})
+    _write_transcript(claude_home, worktree, lines)
+    msgs, reason = transcript.session_tail(
+        "canopy-web", "ddd", limit=8, home=home, claude_home=claude_home
+    )
+    assert reason == ""
+    assert [m["text"] for m in msgs] == [f"m{i}" for i in range(12, 20)]
+
+
+def test_session_tail_missing_transcript_returns_reason_not_raise(tmp_path):
+    home = tmp_path / "home"
+    claude_home = home / ".claude" / "projects"
+    msgs, reason = transcript.session_tail(
+        "canopy-web", "nope", limit=8, home=home, claude_home=claude_home
+    )
+    assert msgs == []
+    assert reason == "no-transcript"
+
+
+def test_read_recent_messages_skips_malformed_lines(tmp_path):
+    f = tmp_path / "x.jsonl"
+    f.write_text(
+        '{"type":"user","message":{"content":"ok"}}\n'
+        "NOT JSON\n"
+        '{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]}}\n',
+        "utf-8",
+    )
+    msgs = transcript.read_recent_messages(f, limit=8)
+    assert [m["text"] for m in msgs] == ["ok", "hi"]
+
+
+def test_text_truncated_to_max(tmp_path):
+    f = tmp_path / "x.jsonl"
+    f.write_text(json.dumps({"type": "user", "message": {"content": "z" * 5000}}), "utf-8")
+    msgs = transcript.read_recent_messages(f, limit=8)
+    assert len(msgs[0]["text"]) == transcript.MAX_MSG_CHARS

--- a/packages/canopy_runner/tests/test_transcript.py
+++ b/packages/canopy_runner/tests/test_transcript.py
@@ -77,6 +77,21 @@ def test_read_recent_messages_skips_malformed_lines(tmp_path):
     assert [m["text"] for m in msgs] == ["ok", "hi"]
 
 
+def test_read_recent_messages_skips_sidechain(tmp_path):
+    # Subagent (Task tool) turns are recorded as top-level entries with
+    # "isSidechain": true — the recent-message tail is meant to show the
+    # MAIN conversation thread, so these must be excluded.
+    f = tmp_path / "x.jsonl"
+    f.write_text(
+        '{"type":"user","message":{"content":"main ask"}}\n'
+        '{"type":"assistant","isSidechain":true,"message":{"content":[{"type":"text","text":"subagent noise"}]}}\n'
+        '{"type":"assistant","message":{"content":[{"type":"text","text":"main reply"}]}}\n',
+        "utf-8",
+    )
+    msgs = transcript.read_recent_messages(f, limit=8)
+    assert [m["text"] for m in msgs] == ["main ask", "main reply"]
+
+
 def test_text_truncated_to_max(tmp_path):
     f = tmp_path / "x.jsonl"
     f.write_text(json.dumps({"type": "user", "message": {"content": "z" * 5000}}), "utf-8")

--- a/packages/canopy_runner/tests/test_transcript.py
+++ b/packages/canopy_runner/tests/test_transcript.py
@@ -135,3 +135,31 @@ def test_session_tail_wrong_shape_only_returns_empty_transcript_not_raise(tmp_pa
     )
     assert msgs == []
     assert reason == "empty-transcript"
+
+
+def test_attach_recent_tail_fills_first_session_only(tmp_path):
+    home = tmp_path / "home"
+    claude_home = home / ".claude" / "projects"
+    worktree = home / "emdash" / "worktrees" / "canopy-web" / "emdash" / "ddd"
+    _write_transcript(claude_home, worktree, [
+        {"type": "user", "message": {"content": "hello"}},
+    ])
+    sessions = [
+        {"emdash_task": "ddd", "project": "canopy-web", "status": "in_progress"},
+        {"emdash_task": "turn", "project": "canopy-web", "status": "in_progress"},
+    ]
+    transcript.attach_recent_tail(sessions, limit=8, home=home, claude_home=claude_home)
+    assert sessions[0]["recent_messages"] == [{"role": "user", "text": "hello"}]
+    assert "recent_messages" not in sessions[1]  # only the most-recent is enriched eagerly
+
+
+def test_attach_recent_tail_empty_list_is_noop(tmp_path):
+    sessions: list[dict] = []
+    transcript.attach_recent_tail(sessions, home=tmp_path)  # must not raise
+    assert sessions == []
+
+
+def test_attach_recent_tail_missing_transcript_sets_empty(tmp_path):
+    sessions = [{"emdash_task": "nope", "project": "canopy-web"}]
+    transcript.attach_recent_tail(sessions, home=tmp_path, claude_home=tmp_path)
+    assert sessions[0]["recent_messages"] == []


### PR DESCRIPTION
## What

Phase B of the emdash session controller: **read the recent message tail of a live emdash session** on `/supervisor` → Sessions. Completes the "see" verb the Phase A "list + continue" loop left as a plumbed-but-empty `recent_messages` field.

Spec: `docs/superpowers/specs/2026-07-16-emdash-session-controller-design.md` (§Phase B).
Plan: `docs/superpowers/plans/2026-07-20-emdash-session-tail-phase-b.md` (Tasks 1–3; Task 4 "watch" intentionally deferred).

## How

- **Runner transcript reader** (`packages/canopy_runner/canopy_runner/transcript.py`, new) — stdlib-only (the runner is Django-free and can't import `apps.session_sharing.parser`). Resolves the Claude Code transcript `.jsonl` by emdash's worktree convention (`~/emdash/worktrees/<repo>/emdash/<task>` → dash-encoded `~/.claude/projects/<name>`), parses the last ~8 user/assistant messages into `{role, text}`, and **never raises** — a missing/renamed/malformed transcript degrades to `([], reason)` so the poll tick survives. Subagent/sidechain turns are excluded so the tail shows the main thread.
- **Runner wiring** — `attach_recent_tail` eagerly fills the tail for the most-recently-active session ("this session", instant on click-in); `Config.session_tail_limit` (default 8); the `main.py` report block stays inside its best-effort try/except.
- **Frontend** — `frontend/src/lib/recentMessages.ts` defensively coerces the untyped `recent_messages` list; `OpenSessions.tsx` renders it behind a "Recent" toggle with a "Recent messages unavailable." fallback, Continue composer unchanged.

No server schema change (the `recent_messages` field was already plumbed end-to-end); no `gen:api`.

## Testing

- Runner: `cd packages/canopy_runner && uv run pytest tests/test_transcript.py tests/test_config.py` → 14/14. Covers resolve-by-convention, tail limit, truncation, never-raises on wrong-shape/malformed lines, sidechain exclusion, eager-first-only enrichment.
- Frontend: `npm run test` (129/129, incl. 3 new `recentMessages` tests) + `npm run build` clean.
- Reviewed per-task + a final whole-branch review (ready-to-merge, 0 Critical/Important).

## Still owed (not blocking review)

**Live-PWA render check.** No human has yet seen the tail render against real data — it needs the updated `canopy_runner` deployed and live emdash sessions reporting tails. Everything type-checks and unit-tests green; this is the "verify frontend render, not curl" step to do post-deploy.

## Deferred

Task 4 — **on-demand tail for _any_ session (the "watch" mechanism)**. Today only the most-recently-active session carries an eager tail; other rows show "unavailable" until interacted with. The plan documents a decision point: spec-faithful watch (new endpoint + model + migration) vs. a cheaper eager top-K. Punted pending that call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
