### PR TITLE
fix(runner): resolve emdash transcripts across real worktree layouts (Phase B follow-up)

### DIFF
--- a/packages/canopy_runner/canopy_runner/transcript.py
+++ b/packages/canopy_runner/canopy_runner/transcript.py
@@ -11,9 +11,17 @@ empty); the content lives in Claude Code's transcript .jsonl under
 ~/.claude/projects/<encoded-worktree>/<session>.jsonl. There is no session id or
 path in the DB, so the transcript is resolved by CONVENTION:
 
-    worktree  = ~/emdash/worktrees/<repo>/emdash/<task>
+    worktree  = ~/emdash/worktrees/<repo>/emdash/<task>[-<suffix>]   (see below)
     proj dir  = ~/.claude/projects/<worktree with '/' and '.' -> '-'>
     file      = newest *.jsonl in that dir
+
+The convention has two real-world wrinkles the naive path missed (both verified
+against the live fleet, 2026-07-20): emdash appends a short random de-dupe suffix
+to the worktree dir name (`-cysov`), and the layout is not uniform — some
+worktrees sit at `<repo>/<task>` with no `emdash` segment. `resolve_transcript`
+handles both by prefix-globbing each candidate base and accepting a `-<suffix>`
+tail; the prefix stays anchored at the parent segment so one task can't grab
+another's transcript.
 
 A wrong path is a silent wrong-answer, so resolution returns None rather than
 guess. Nothing here raises: a missing dir, unreadable file, or malformed line
@@ -23,11 +31,18 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
 MAX_MSG_CHARS = 2000
+
+# emdash appends a short random suffix to a worktree dir name to de-dupe it
+# (e.g. the task "ace-nutrition-demo-9619-0720-1352" lives in a worktree dir
+# "...-1352-cysov"). The Claude transcript project dir therefore ends in the
+# task name OR the task name + "-<suffix>". This matches that trailing suffix.
+_SUFFIX_RE = re.compile(r"-[0-9a-z]+$")
 
 
 def encode_project_dir(worktree: Path) -> str:
@@ -35,16 +50,40 @@ def encode_project_dir(worktree: Path) -> str:
     return str(worktree).replace("/", "-").replace(".", "-")
 
 
+def _worktree_bases(repo: str, task: str, home: Path) -> list[Path]:
+    """Candidate worktree paths for (repo, task). Verified against the live fleet
+    (2026-07-20): most agents nest under `<repo>/emdash/<task>`, but some worktrees
+    (e.g. echo's) sit directly at `<repo>/<task>` with no `emdash` segment. Try both;
+    a wrong guess simply doesn't match a project dir and degrades to no transcript."""
+    root = home / "emdash" / "worktrees" / repo
+    return [root / "emdash" / task, root / task]
+
+
 def resolve_transcript(repo: str, task: str, *, home: Path, claude_home: Path) -> Path | None:
-    """Newest .jsonl for (repo, task) by emdash's worktree convention, or None."""
-    if not repo or not task:
+    """Newest transcript .jsonl for (repo, task), or None.
+
+    Resolves by emdash's worktree convention, tolerant of two real-world facts the
+    original naive path missed: worktree dirs carry a random de-dupe suffix, and the
+    layout isn't uniform (see `_worktree_bases`). For each candidate base we glob the
+    encoded prefix and accept a project dir that is the exact encoding OR the encoding
+    plus a `-<suffix>` tail, then take the newest .jsonl across all matches. A wrong
+    guess returns None (empty tail), never a wrong transcript from an unrelated task —
+    the prefix is anchored at the parent segment, so `mobile` can't match `alt-mobile`.
+    """
+    if not repo or not task or not claude_home.is_dir():
         return None
-    worktree = home / "emdash" / "worktrees" / repo / "emdash" / task
-    proj_dir = claude_home / encode_project_dir(worktree)
-    if not proj_dir.is_dir():
+    candidates: list[Path] = []
+    for base in _worktree_bases(repo, task, home):
+        prefix = encode_project_dir(base)
+        for proj_dir in claude_home.glob(prefix + "*"):
+            if not proj_dir.is_dir():
+                continue
+            rest = proj_dir.name[len(prefix):]
+            if rest == "" or _SUFFIX_RE.fullmatch(rest):
+                candidates.extend(proj_dir.glob("*.jsonl"))
+    if not candidates:
         return None
-    jsonls = sorted(proj_dir.glob("*.jsonl"), key=lambda p: p.stat().st_mtime, reverse=True)
-    return jsonls[0] if jsonls else None
+    return max(candidates, key=lambda p: p.stat().st_mtime)
 
 
 def _extract_text(content) -> str:

--- a/packages/canopy_runner/tests/test_transcript.py
+++ b/packages/canopy_runner/tests/test_transcript.py
@@ -178,3 +178,53 @@ def test_attach_recent_tail_missing_transcript_sets_empty(tmp_path):
     sessions = [{"emdash_task": "nope", "project": "canopy-web"}]
     transcript.attach_recent_tail(sessions, home=tmp_path, claude_home=tmp_path)
     assert sessions[0]["recent_messages"] == []
+
+
+def _write_at(claude_home: Path, worktree: Path, lines: list[dict]) -> Path:
+    """Write a transcript at an ARBITRARY worktree path (helper for layout tests)."""
+    proj = claude_home / transcript.encode_project_dir(worktree)
+    proj.mkdir(parents=True)
+    f = proj / "sess.jsonl"
+    f.write_text("\n".join(json.dumps(x) for x in lines), "utf-8")
+    return f
+
+
+def test_resolve_transcript_matches_random_dedupe_suffix(tmp_path):
+    # emdash's real dir carries a random suffix ("-cysov"); the DB task name does not.
+    home = tmp_path / "home"
+    claude_home = home / ".claude" / "projects"
+    worktree = home / "emdash" / "worktrees" / "ace" / "emdash" / "ace-demo-1352-cysov"
+    _write_at(claude_home, worktree, [{"type": "user", "message": {"content": "hi"}}])
+    msgs, reason = transcript.session_tail(
+        "ace", "ace-demo-1352", limit=8, home=home, claude_home=claude_home
+    )
+    assert reason == ""
+    assert msgs == [{"role": "user", "text": "hi"}]
+
+
+def test_resolve_transcript_matches_layout_without_emdash_segment(tmp_path):
+    # Some worktrees (e.g. echo's) sit at <repo>/<task> with no `emdash` segment.
+    home = tmp_path / "home"
+    claude_home = home / ".claude" / "projects"
+    worktree = home / "emdash" / "worktrees" / "echo" / "spotty-cities-mix"
+    _write_at(claude_home, worktree, [{"type": "user", "message": {"content": "yo"}}])
+    msgs, reason = transcript.session_tail(
+        "echo", "spotty-cities-mix", limit=8, home=home, claude_home=claude_home
+    )
+    assert reason == ""
+    assert msgs == [{"role": "user", "text": "yo"}]
+
+
+def test_resolve_transcript_does_not_grab_a_sibling_task_prefix(tmp_path):
+    # Anti-collision: task "mobile" must not resolve to sibling "alt-mobile"'s dir.
+    # The prefix is anchored at the parent segment (...-emdash-mobile), so a dir
+    # whose leaf is "alt-mobile" (…-emdash-alt-mobile) can't match.
+    home = tmp_path / "home"
+    claude_home = home / ".claude" / "projects"
+    sibling = home / "emdash" / "worktrees" / "canopy-web" / "emdash" / "alt-mobile"
+    _write_at(claude_home, sibling, [{"type": "user", "message": {"content": "sibling"}}])
+    msgs, reason = transcript.session_tail(
+        "canopy-web", "mobile", limit=8, home=home, claude_home=claude_home
+    )
+    assert msgs == []
+    assert reason == "no-transcript"


### PR DESCRIPTION
Follow-up to #287. Testing Phase B against the **live fleet** exposed that the tail resolver never matched a real session — `recent_messages` was empty for all 23 open sessions.

## Root cause

`resolve_transcript` assumed the worktree dir was exactly `~/emdash/worktrees/<repo>/emdash/<task>`. Two real facts break that:
1. **Random de-dupe suffix** — emdash appends `-<5char>` to the worktree dir. DB task `ace-nutrition-demo-9619-0720-1352` → dir `…-1352-cysov`.
2. **Non-uniform layout** — most agents nest under `<repo>/emdash/<task>`, but some worktrees (echo's) sit at `<repo>/<task>` with no `emdash` segment.

Both degrade *safely* (empty tail, no crash) — which is why #287's tests, CI, and type-checks were all green while the feature produced no data. Only running it against real transcripts caught it.

## Fix

`resolve_transcript` now prefix-globs **both** candidate bases and accepts an optional `-<suffix>` tail, anchored at the parent path segment so one task can't grab a sibling's transcript (`mobile` ≠ `alt-mobile`). Newest `.jsonl` across matches wins.

## Validation

Ran the new resolver against all 23 live open sessions: **18/18 transcript-bearing sessions resolve**; the other 5 are genuinely transcript-less (no `.jsonl` on disk) and correctly stay "unavailable".

Tests: 3 new (suffix layout, no-`emdash`-segment layout, anti-collision guard) + 13 existing → 16/16 in `test_transcript.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)