### PR TITLE
fix(harness): dedupe duplicate emdash task names in a session report

### DIFF
--- a/apps/harness/services.py
+++ b/apps/harness/services.py
@@ -614,6 +614,22 @@ def replace_reported_sessions(runner: Runner, workspace, sessions: list) -> int:
     """
     from .models import EmdashSession
 
+    # emdash task NAMES are not unique — two un-archived tasks can share a name
+    # (see task_state's "Names aren't unique in emdash's schema" note) — but
+    # (runner, emdash_task) is UNIQUE here. Collapse duplicates before the wholesale
+    # insert, or bulk_create raises IntegrityError and the ENTIRE report 500s. That
+    # failure is silent (the runner's report call is best-effort) and strands the
+    # whole session list, not just the dup — observed 2026-07-20 with two "mobile"
+    # tasks. The runner sends newest-first, so the first occurrence is the live
+    # session; an older namesake is stale and correctly dropped.
+    deduped: list = []
+    seen: set[str] = set()
+    for s in sessions:
+        if s.emdash_task in seen:
+            continue
+        seen.add(s.emdash_task)
+        deduped.append(s)
+
     EmdashSession.objects.filter(runner=runner).delete()
     EmdashSession.objects.bulk_create([
         EmdashSession(
@@ -622,9 +638,9 @@ def replace_reported_sessions(runner: Runner, workspace, sessions: list) -> int:
             last_interacted_at=_aware(s.last_interacted_at),
             recent_messages=list(s.recent_messages or []),
         )
-        for s in sessions
+        for s in deduped
     ])
-    for s in sessions:
+    for s in deduped:
         if s.project:
             # live_session_id intentionally left blank here — a session report has
             # no session_id to give; reuse keys on live_emdash_task_id +
@@ -633,7 +649,7 @@ def replace_reported_sessions(runner: Runner, workspace, sessions: list) -> int:
                 None, f"emdash:{s.emdash_task}", runner=runner, project=s.project,
                 workspace=workspace, emdash_task_id=s.emdash_task,
             )
-    return len(sessions)
+    return len(deduped)
 
 
 def list_visible_sessions(user) -> list:

--- a/tests/test_harness_emdash_sessions.py
+++ b/tests/test_harness_emdash_sessions.py
@@ -80,6 +80,34 @@ def test_report_is_wholesale_and_upserts_a_sessionlink_for_continue():
     assert tasks == {"cloud-runner"}
 
 
+def test_report_dedupes_duplicate_task_names_keeping_newest():
+    """emdash task names are NOT unique — a report can carry two open sessions that
+    share a name. Because (runner, emdash_task) is unique, the wholesale bulk_create
+    would 500 on the duplicate (regression: two "mobile" tasks stranded the whole
+    list, 2026-07-20). The report must instead dedupe, keeping the newest (the runner
+    sends newest-first, so the first occurrence wins)."""
+    from django.test import Client
+
+    jj = _user("jj")
+    ws = _ws("dimagi", jj)
+    runner = _runner(jj, ws)
+    c = Client()
+    c.force_login(jj)
+
+    resp = _report(c, runner.id, [
+        {"emdash_task": "mobile", "project": "canopy-web", "status": "in_progress",
+         "last_interacted_at": "2026-07-20T20:20:00Z"},
+        {"emdash_task": "mobile", "project": "canopy-web", "status": "done",
+         "last_interacted_at": "2026-07-17T15:48:00Z"},
+    ])
+    assert resp.status_code == 200, resp.content
+    rows = EmdashSession.objects.filter(runner=runner)
+    assert rows.count() == 1
+    kept = rows.get()
+    assert kept.emdash_task == "mobile"
+    assert kept.status == "in_progress"  # the newer (first) namesake won
+
+
 def test_a_non_owner_cannot_report_for_another_users_runner():
     from django.test import Client
 


### PR DESCRIPTION
Second bug surfaced by testing Phase B (#287) against the live fleet — and the one that actually broke the feature.

## Symptom

`GET /api/harness/sessions` was serving a **stale** list and no session ever carried a `recent_messages` tail, even after the runner shipped the transcript reader (#288).

## Root cause

`EmdashSession` has a unique `(runner, emdash_task)` constraint, but emdash task names are **not** unique — two un-archived tasks can share a name (emdash's own `task_state` documents this). The wholesale report `bulk_create`'d every reported row, so a payload with two same-named sessions raised `IntegrityError` → **HTTP 500**. The runner's report call is best-effort and swallows the error, so the *entire* session list silently stopped updating — not just the duplicate.

Reproduced on the live fleet: two open tasks both named `mobile` under `canopy-web` → every report 500'd → the list froze and no tails landed. Each session reports fine alone (a 1-item wholesale replace can't collide); only the combined list fails, which is why it stayed invisible until now.

## Fix

`replace_reported_sessions` dedupes by `emdash_task` before the insert, keeping the newest (the runner sends newest-first). Regression test added (verified red→green locally: without the fix the report 500s; with it, one row is kept with the newer session's data).

This is a **latent Phase A bug** (predates the tail feature) — the report path has been fragile to duplicate task names since it shipped; Phase B's end-to-end testing is what exposed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)