### PR TITLE
feat(supervisor): inline session tail + top-K coverage, mobile-friendly

### DIFF
--- a/frontend/src/components/supervisor/OpenSessions.tsx
+++ b/frontend/src/components/supervisor/OpenSessions.tsx
@@ -1,17 +1,99 @@
 import { useEffect, useState, type JSX } from 'react'
 import { listOpenSessions, enqueueTurn, type EmdashSessionOut } from '@/api/harness'
-import { normalizeRecentMessages } from '@/lib/recentMessages'
+import { normalizeRecentMessages, type RecentMessage } from '@/lib/recentMessages'
 
-// The open emdash sessions the runner reported — see them, and drop a prompt into a
-// specific one. Continue dispatches a repo turn carrying the session's emdash:{task}
-// thread_key; the runner resolves that to the SessionLink the report upserted and
-// open_and_sends into that exact task. No new send path.
+// The open emdash sessions the runner reported — glance at what each is doing (the
+// recent-message tail), and drop a prompt into a specific one. Continue dispatches a
+// repo turn carrying the session's emdash:{task} thread_key; the runner resolves that
+// to the SessionLink the report upserted and open_and_sends into that exact task.
+
+function Chevron({ open }: { open: boolean }): JSX.Element {
+  return (
+    <svg
+      className={`mt-0.5 h-3 w-3 shrink-0 text-muted-foreground transition-transform ${open ? 'rotate-180' : ''}`}
+      viewBox="0 0 12 12"
+      fill="none"
+      aria-hidden="true"
+    >
+      <path d="M3 4.5 6 7.5 9 4.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  )
+}
+
+function RoleChip({ role }: { role: string }): JSX.Element {
+  const isAssistant = role === 'assistant'
+  return (
+    <span
+      className={`mt-0.5 shrink-0 rounded px-1.5 py-0.5 text-[9px] font-semibold uppercase leading-none tracking-wide ${
+        isAssistant ? 'bg-primary/10 text-primary' : 'bg-muted text-muted-foreground'
+      }`}
+    >
+      {isAssistant ? 'agent' : 'you'}
+    </span>
+  )
+}
+
+function MessageBubble({ msg }: { msg: RecentMessage }): JSX.Element {
+  return (
+    <div className="flex items-start gap-2 rounded-md bg-muted/40 p-2">
+      <RoleChip role={msg.role} />
+      <p className="min-w-0 flex-1 whitespace-pre-wrap break-words text-[12px] leading-snug text-foreground-secondary">
+        {msg.text}
+      </p>
+    </div>
+  )
+}
+
+function RecentActivity({ task, messages }: { task: string; messages: RecentMessage[] }): JSX.Element | null {
+  const [expanded, setExpanded] = useState(false)
+  if (messages.length === 0) return null
+  const latest = messages[messages.length - 1]
+
+  return (
+    <div className="mt-2" data-testid={`session-tail-${task}`}>
+      {!expanded ? (
+        <>
+          <button
+            type="button"
+            data-testid={`session-tail-toggle-${task}`}
+            onClick={() => setExpanded(true)}
+            className="flex w-full items-start gap-2 rounded-md bg-muted/40 p-2 text-left active:bg-muted"
+          >
+            <RoleChip role={latest.role} />
+            <span className="line-clamp-2 min-w-0 flex-1 text-[12px] leading-snug text-foreground-secondary">
+              {latest.text}
+            </span>
+            <Chevron open={false} />
+          </button>
+          {messages.length > 1 && (
+            <p className="mt-1 pl-1 text-[10px] text-muted-foreground">
+              {messages.length} recent messages · tap to expand
+            </p>
+          )}
+        </>
+      ) : (
+        <div className="flex flex-col gap-1.5">
+          {messages.map((m, i) => (
+            <MessageBubble key={i} msg={m} />
+          ))}
+          <button
+            type="button"
+            data-testid={`session-tail-toggle-${task}`}
+            onClick={() => setExpanded(false)}
+            className="flex items-center gap-1 self-start py-1 text-[11px] text-muted-foreground hover:text-foreground-secondary"
+          >
+            <Chevron open={true} /> Collapse
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
 
 function SessionRow({ session }: { session: EmdashSessionOut }): JSX.Element {
   const [prompt, setPrompt] = useState('')
   const [busy, setBusy] = useState(false)
   const [sent, setSent] = useState<'ok' | string | null>(null)
-  const [expanded, setExpanded] = useState(false)
   const messages = normalizeRecentMessages(session.recent_messages)
 
   async function send(): Promise<void> {
@@ -42,47 +124,26 @@ function SessionRow({ session }: { session: EmdashSessionOut }): JSX.Element {
         </span>
         <span className="shrink-0 text-[11px] text-muted-foreground">{session.status}</span>
       </div>
-      <button
-        type="button"
-        data-testid={`session-tail-toggle-${session.emdash_task}`}
-        onClick={() => setExpanded((v) => !v)}
-        className="mt-1 text-[11px] text-muted-foreground hover:text-foreground-secondary"
-      >
-        {expanded ? 'Hide recent' : 'Recent'}
-      </button>
-      {expanded && (
-        <div className="mt-1 flex flex-col gap-1" data-testid={`session-tail-${session.emdash_task}`}>
-          {messages.length === 0 ? (
-            <p className="text-[12px] text-muted-foreground">Recent messages unavailable.</p>
-          ) : (
-            messages.map((m, i) => (
-              <div key={i} className="rounded border border-border bg-muted/40 p-1.5">
-                <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
-                  {m.role}
-                </span>
-                <p className="whitespace-pre-wrap break-words text-[12px] text-foreground-secondary">
-                  {m.text}
-                </p>
-              </div>
-            ))
-          )}
-        </div>
-      )}
+
+      <RecentActivity task={session.emdash_task} messages={messages} />
+
       <div className="mt-2 flex gap-2">
         <input
           data-testid={`session-input-${session.emdash_task}`}
           value={prompt}
           onChange={(e) => setPrompt(e.target.value)}
-          onKeyDown={(e) => { if (e.key === 'Enter') void send() }}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') void send()
+          }}
           placeholder="Continue this session…"
-          className="min-w-0 flex-1 rounded border border-input bg-input px-2 py-1.5 text-[13px] text-foreground placeholder:text-muted-foreground"
+          className="min-w-0 flex-1 rounded border border-input bg-input px-2 py-2 text-[13px] text-foreground placeholder:text-muted-foreground"
         />
         <button
           type="button"
           data-testid={`session-send-${session.emdash_task}`}
           onClick={() => void send()}
           disabled={busy || prompt.trim() === ''}
-          className="rounded bg-primary px-3 py-1.5 text-[13px] font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+          className="rounded bg-primary px-3 py-2 text-[13px] font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
         >
           {busy ? 'Sending…' : 'Continue'}
         </button>
@@ -106,13 +167,17 @@ export function OpenSessions(): JSX.Element {
   useEffect(() => {
     let cancelled = false
     listOpenSessions()
-      .then((s) => { if (!cancelled) setSessions(s) })
+      .then((s) => {
+        if (!cancelled) setSessions(s)
+      })
       .catch((e) => {
         if (cancelled) return
         setError(e instanceof Error ? e.message : 'Failed to load sessions')
         setSessions([])
       })
-    return () => { cancelled = true }
+    return () => {
+      cancelled = true
+    }
   }, [])
 
   if (sessions === null) return <p className="text-[12px] text-muted-foreground">Loading sessions…</p>
@@ -127,11 +192,17 @@ export function OpenSessions(): JSX.Element {
     )
   }
   if (sessions.length === 0) {
-    return <p className="text-[12px] text-muted-foreground" data-testid="sessions-empty">No open sessions.</p>
+    return (
+      <p className="text-[12px] text-muted-foreground" data-testid="sessions-empty">
+        No open sessions.
+      </p>
+    )
   }
   return (
     <div className="flex flex-col gap-2" data-testid="open-sessions">
-      {sessions.map((s) => <SessionRow key={s.id} session={s} />)}
+      {sessions.map((s) => (
+        <SessionRow key={s.id} session={s} />
+      ))}
     </div>
   )
 }

--- a/packages/canopy_runner/canopy_runner/config.py
+++ b/packages/canopy_runner/canopy_runner/config.py
@@ -32,9 +32,11 @@ class Config:
     # Hard safety cap: at most this many threads become turns per mailbox per poll,
     # so a flooded/misconfigured inbox can't spawn dozens of sessions at once.
     inbox_max_threads: int = 8
-    # Phase B: how many recent messages to include for the most-recently-active
-    # session in each session report. "Recent tail", not the full transcript.
+    # Phase B: the recent-message tail attached to reported sessions. `_limit` caps
+    # messages per session (a "recent tail", not the full transcript); `_count` caps
+    # how many of the top (most-recently-active) sessions get a tail each tick.
     session_tail_limit: int = 8
+    session_tail_count: int = 8
 
     @classmethod
     def load(cls, path: Path) -> "Config":

--- a/packages/canopy_runner/canopy_runner/main.py
+++ b/packages/canopy_runner/canopy_runner/main.py
@@ -269,7 +269,9 @@ def _run_once_cdp(cfg: Config, client: Client) -> str:
     # message tail (Phase B) so the phone can read it on click-in with no extra round trip.
     try:
         sessions = emdash.list_open_sessions(cfg.emdash_db)
-        transcript.attach_recent_tail(sessions, limit=cfg.session_tail_limit)
+        transcript.attach_recent_tail(
+            sessions, count=cfg.session_tail_count, limit=cfg.session_tail_limit
+        )
         client.report_sessions(cfg.runner_id, sessions)
     except Exception:  # noqa: BLE001
         logger.debug("session report failed (non-fatal)", exc_info=True)

--- a/packages/canopy_runner/canopy_runner/transcript.py
+++ b/packages/canopy_runner/canopy_runner/transcript.py
@@ -37,6 +37,10 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 MAX_MSG_CHARS = 2000
+# Only the last few messages are ever shown, so read at most this many bytes from
+# the END of the transcript rather than the whole file — a long session's .jsonl can
+# be tens of MB, and the runner reads several of them on every poll tick (top-K).
+TAIL_BYTES = 256 * 1024
 
 # emdash appends a short random suffix to a worktree dir name to de-dupe it
 # (e.g. the task "ace-nutrition-demo-9619-0720-1352" lives in a worktree dir
@@ -110,11 +114,18 @@ def read_recent_messages(path: Path, limit: int = 8) -> list[dict]:
     """Last `limit` user/assistant messages as [{"role", "text"}], oldest→newest.
 
     Never raises: an unreadable file yields []; a malformed line is skipped.
+    Reads only the last TAIL_BYTES of the file (the tail is all we need); if that
+    cuts the first line mid-JSON, json.loads skips it — harmless, since we only want
+    complete recent messages.
     """
     try:
-        lines = path.read_text("utf-8", errors="replace").splitlines()
+        with path.open("rb") as f:
+            size = f.seek(0, 2)
+            f.seek(max(0, size - TAIL_BYTES))
+            raw = f.read()
     except OSError:
         return []
+    lines = raw.decode("utf-8", errors="replace").splitlines()
     msgs: list[dict] = []
     for line in lines:
         line = line.strip()
@@ -166,21 +177,22 @@ def session_tail(
 def attach_recent_tail(
     sessions: list[dict],
     *,
+    count: int = 8,
     limit: int = 8,
     home: Path | None = None,
     claude_home: Path | None = None,
 ) -> None:
-    """Eagerly fill recent_messages on the MOST-RECENTLY-ACTIVE session (index 0).
+    """Fill recent_messages on the first `count` sessions (the most-recently-active,
+    since emdash.list_open_sessions returns newest-first) — the ones the phone shows
+    at the top of the list, so each has a glanceable tail without a round trip. In
+    place, best-effort, never raises; the bounded tail read keeps K reads/tick cheap.
 
-    That is the session the supervisor is most likely to open ("this session"),
-    so its click-in is instant with no extra round trip. In place, best-effort,
-    never raises. Other sessions carry [] until Task 4 (watch) fills them.
+    `count` caps how many transcripts are read per tick; `limit` caps messages per
+    session. Sessions past `count`, or with no resolvable transcript, carry [].
     """
-    if not sessions:
-        return
-    top = sessions[0]  # most-recently-active: emdash.list_open_sessions returns newest-first
-    msgs, _reason = session_tail(
-        top.get("project", ""), top.get("emdash_task", ""),
-        limit=limit, home=home, claude_home=claude_home,
-    )
-    top["recent_messages"] = msgs
+    for s in sessions[:count]:
+        msgs, _reason = session_tail(
+            s.get("project", ""), s.get("emdash_task", ""),
+            limit=limit, home=home, claude_home=claude_home,
+        )
+        s["recent_messages"] = msgs

--- a/packages/canopy_runner/tests/test_transcript.py
+++ b/packages/canopy_runner/tests/test_transcript.py
@@ -152,20 +152,36 @@ def test_session_tail_wrong_shape_only_returns_empty_transcript_not_raise(tmp_pa
     assert reason == "empty-transcript"
 
 
-def test_attach_recent_tail_fills_first_session_only(tmp_path):
+def test_attach_recent_tail_fills_multiple_top_sessions(tmp_path):
     home = tmp_path / "home"
     claude_home = home / ".claude" / "projects"
-    worktree = home / "emdash" / "worktrees" / "canopy-web" / "emdash" / "ddd"
-    _write_transcript(claude_home, worktree, [
-        {"type": "user", "message": {"content": "hello"}},
-    ])
+    for task, text in [("ddd", "hello ddd"), ("turn", "hello turn")]:
+        wt = home / "emdash" / "worktrees" / "canopy-web" / "emdash" / task
+        _write_transcript(claude_home, wt, [
+            {"type": "user", "message": {"content": text}},
+        ])
     sessions = [
         {"emdash_task": "ddd", "project": "canopy-web", "status": "in_progress"},
         {"emdash_task": "turn", "project": "canopy-web", "status": "in_progress"},
     ]
-    transcript.attach_recent_tail(sessions, limit=8, home=home, claude_home=claude_home)
-    assert sessions[0]["recent_messages"] == [{"role": "user", "text": "hello"}]
-    assert "recent_messages" not in sessions[1]  # only the most-recent is enriched eagerly
+    transcript.attach_recent_tail(sessions, home=home, claude_home=claude_home)
+    assert sessions[0]["recent_messages"] == [{"role": "user", "text": "hello ddd"}]
+    assert sessions[1]["recent_messages"] == [{"role": "user", "text": "hello turn"}]
+
+
+def test_attach_recent_tail_respects_count_cap(tmp_path):
+    home = tmp_path / "home"
+    claude_home = home / ".claude" / "projects"
+    for task in ("a", "b", "c"):
+        wt = home / "emdash" / "worktrees" / "canopy-web" / "emdash" / task
+        _write_transcript(claude_home, wt, [
+            {"type": "user", "message": {"content": task}},
+        ])
+    sessions = [{"emdash_task": t, "project": "canopy-web"} for t in ("a", "b", "c")]
+    transcript.attach_recent_tail(sessions, count=2, home=home, claude_home=claude_home)
+    assert sessions[0]["recent_messages"] == [{"role": "user", "text": "a"}]
+    assert sessions[1]["recent_messages"] == [{"role": "user", "text": "b"}]
+    assert "recent_messages" not in sessions[2]  # beyond count -> untouched
 
 
 def test_attach_recent_tail_empty_list_is_noop(tmp_path):
@@ -228,3 +244,18 @@ def test_resolve_transcript_does_not_grab_a_sibling_task_prefix(tmp_path):
     )
     assert msgs == []
     assert reason == "no-transcript"
+
+
+def test_read_recent_messages_reads_only_tail_of_large_file(tmp_path):
+    # A transcript larger than TAIL_BYTES: the reader seeks to the end and must
+    # still return the final message (proving it doesn't need the whole file).
+    f = tmp_path / "big.jsonl"
+    filler = json.dumps({"type": "user", "message": {"content": "x" * 1000}})
+    n = transcript.TAIL_BYTES // len(filler) + 50  # comfortably exceed the tail window
+    lines = [filler] * n
+    lines.append(json.dumps({"type": "assistant", "message": {"content": [{"type": "text", "text": "LAST"}]}}))
+    f.write_text("\n".join(lines), "utf-8")
+    assert f.stat().st_size > transcript.TAIL_BYTES
+    msgs = transcript.read_recent_messages(f, limit=3)
+    assert msgs[-1] == {"role": "assistant", "text": "LAST"}
+    assert len(msgs) <= 3


### PR DESCRIPTION
Follow-up to the Phase B session-tail work (#287–#289). Testing it on the phone showed the tail was effectively invisible — hidden behind a tiny "Recent" text toggle, and only the single most-recently-active session ever had content, so ~1 of 20+ rows showed anything. It read as "nothing here."

## Changes

**Frontend (`OpenSessions.tsx`) — inline + mobile-first**
- Each row shows the **latest message inline** (role chip + 2-line preview) — no hidden toggle.
- **Tap to expand** the full recent thread as message bubbles; tap to collapse.
- Clean empty rows (no "unavailable" noise across every transcript-less session).
- Mobile: text wraps, no horizontal scroll, larger tap targets, `agent`/`you` role chips.

**Runner — real coverage + bounded reads**
- `attach_recent_tail` now fills the **top-K** most-recently-active sessions (`session_tail_count`, default 8) instead of only index 0, so multiple rows have a glanceable tail.
- `read_recent_messages` reads only the last `TAIL_BYTES` (256 KB) of the transcript — a long `.jsonl` is tens of MB and the runner now reads K of them per tick.

## Verification

- Iterated the visual at 390px against the real built CSS before shipping (agent/you chips, inline preview, expanded bubbles, empty state).
- Runner tests: 19/19 in `test_transcript.py` (top-K fill, count cap, bounded large-file read, plus the existing resolver/never-raises/sidechain cases). Frontend `npm run build` + vitest clean.
- Full live-page screenshot to follow after deploy.

Not the on-demand "watch" (tapping a session past the top-K to fetch its tail) — top-K covers the visible rows cheaply; watch remains a later option if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)