### PR TITLE
feat(pwa): always auto-update (poll for new service worker on interval + focus)

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,5 +1,8 @@
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { registerPwa } from './pwa/registerPwa'
+
+registerPwa()
 
 createRoot(document.getElementById('root')!).render(<App />)

--- a/frontend/src/pwa/registerPwa.ts
+++ b/frontend/src/pwa/registerPwa.ts
@@ -1,0 +1,48 @@
+import { registerSW } from 'virtual:pwa-register'
+
+// Always auto-update.
+//
+// `registerType: 'autoUpdate'` (vite.config.ts) makes the app adopt a new service
+// worker + reload — but ONLY checks for one on page load. A long-lived open client
+// (the installed PWA, the menubar WKWebView, a tab left open for days) therefore
+// never notices a new deploy and serves a stale bundle forever. That is exactly how
+// the Sessions surface got stuck on a pre-feature bundle.
+//
+// So we poll: check for a new SW on an interval AND whenever the app regains focus
+// (menubar reopened, tab refocused). When update() finds one, autoUpdate skips
+// waiting and reloads on its own — no prompt, no manual hard-refresh.
+const UPDATE_INTERVAL_MS = 60_000
+
+export function registerPwa(): void {
+  if (typeof window === 'undefined' || !('serviceWorker' in navigator)) return
+
+  registerSW({
+    immediate: true,
+    onRegisteredSW(swUrl, registration) {
+      if (!registration) return
+
+      const check = async (): Promise<void> => {
+        // Skip while an install is mid-flight or we're offline — retry next tick.
+        if (registration.installing || !navigator.onLine) return
+        try {
+          // Bypass the HTTP cache so we actually see a freshly deployed sw.js;
+          // a 200 means the server is reachable, so it's worth asking the browser
+          // to re-evaluate the registration.
+          const resp = await fetch(swUrl, {
+            cache: 'no-store',
+            headers: { 'cache-control': 'no-cache' },
+          })
+          if (resp.status === 200) await registration.update()
+        } catch {
+          // Offline / transient network error — the next tick will retry.
+        }
+      }
+
+      setInterval(() => void check(), UPDATE_INTERVAL_MS)
+      window.addEventListener('focus', () => void check())
+      document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'visible') void check()
+      })
+    },
+  })
+}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="vite/client" />
+/// <reference types="vite-plugin-pwa/client" />
 
 // Django's CSRF cookie name, inlined at build time via Vite `define`
 // (VITE_CSRF_COOKIE_NAME → "csrftoken" default, "csrftoken_canopy" for the


### PR DESCRIPTION
The Sessions surface showed a stale, pre-feature bundle with no way to update but a manual hard-refresh. Root cause: `registerType: 'autoUpdate'` only checks for a new service worker **on page load**, so a long-lived open client (installed PWA, the menubar WKWebView, a tab open for days) never notices a new deploy.

## Fix

`registerPwa()` (called from `main.tsx`) registers the SW immediately and then polls for a new one **every 60s and on every focus / visibility regain**. When `update()` finds one, `autoUpdate` skips waiting and reloads on its own — no prompt, no hard-refresh.

- Registered manually via `virtual:pwa-register`; `injectRegister: 'auto'` defers to the import, so there's no double registration (verified: no inline `registerSW` in the built `index.html`).
- The `focus` / `visibilitychange` checks are what specifically save the menubar app and installed PWA — they're reopened/refocused far more often than they're fully closed.
- The prior stale-bundle self-heal (`reloadOnceForStaleBundle`) only fired on a 404 route, so a valid-but-stale surface like Sessions could sit forever. This closes that gap.

Build clean (`virtual:pwa-register` resolves via the added `vite-plugin-pwa/client` type ref; sw.js precaches the new bundle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)