### PR TITLE
feat(menubar): add "Force refresh (clear cache)" — bulletproof hard-refresh

### DIFF
--- a/packages/canopy-runner-menubar/Sources/main.swift
+++ b/packages/canopy-runner-menubar/Sources/main.swift
@@ -301,6 +301,7 @@ final class Controller: NSObject, NSApplicationDelegate {
 
         add(menu, "Open Supervisor in browser…", #selector(openSupervisor))
         add(menu, "Reload panel", #selector(reloadPanel))
+        add(menu, "Force refresh (clear cache)", #selector(forceRefresh))
         add(menu, "Open Log", #selector(openLog))
         menu.addItem(.separator())
         add(menu, "Quit Canopy Runner", #selector(quit))
@@ -363,6 +364,22 @@ final class Controller: NSObject, NSApplicationDelegate {
     }
     @objc func reloadPanel() {
         authenticateThenLoad()  // re-mint the session cookie, then reload /supervisor
+    }
+    // The bulletproof hard-refresh. "Reload panel" is a normal navigation, so a stale
+    // service worker keeps serving the cached bundle. This PURGES the WebKit data
+    // (service-worker registrations + every cache) so the next load must fetch the
+    // current /supervisor from the server and register the fresh (auto-updating) SW.
+    // We clear cookies too — harmless, because authenticateThenLoad re-mints the
+    // session cookie immediately after. Use this if the panel ever looks out of date.
+    @objc func forceRefresh() {
+        let store = web.configuration.websiteDataStore
+        store.removeData(
+            ofTypes: WKWebsiteDataStore.allWebsiteDataTypes(),
+            modifiedSince: Date(timeIntervalSince1970: 0)
+        ) { [weak self] in
+            self?.authed = false
+            self?.authenticateThenLoad()
+        }
     }
     @objc func openLog() {
         NSWorkspace.shared.open(logFile)


### PR DESCRIPTION
The macOS menu-bar app (`canopy-runner-menubar`) is a WKWebView with a *persistent* data store, so it caches the app + runs the service worker like a browser — and got stuck serving a pre-feature `/supervisor` bundle with no in-app way to bust it. "Reload panel" is a normal navigation that goes *through* the SW, so it can't help.

## Change

New menu item **"Force refresh (clear cache)"** → `forceRefresh()`:
- `websiteDataStore.removeData(ofTypes: allWebsiteDataTypes, modifiedSince: 0)` — purges service-worker registrations + every cache (and cookies).
- then `authenticateThenLoad()` re-mints the session cookie and reloads, so the next load must fetch the current bundle from the server and register the fresh (auto-updating) SW.

Pairs with #292 (always-auto-update): after one Force refresh onto the #292 build, the app self-updates on focus going forward — this is the one-time escape hatch.

Compiles clean (swiftc 6.3.3); built + installed locally via `build.sh`. Not in CI (native app), so no test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)