### PR TITLE
feat(supervisor): group open sessions by project + cover all rows with tails

### DIFF
--- a/frontend/src/components/supervisor/OpenSessions.tsx
+++ b/frontend/src/components/supervisor/OpenSessions.tsx
@@ -119,8 +119,9 @@ function SessionRow({ session }: { session: EmdashSessionOut }): JSX.Element {
   return (
     <div className="rounded-lg border border-border bg-card p-3" data-testid={`session-${session.emdash_task}`}>
       <div className="flex items-center gap-2">
+        {/* Project is the group header now; the row shows just the task. */}
         <span className="min-w-0 flex-1 truncate text-[13px] font-semibold text-foreground">
-          {session.project} · {session.emdash_task}
+          {session.emdash_task}
         </span>
         <span className="shrink-0 text-[11px] text-muted-foreground">{session.status}</span>
       </div>
@@ -198,10 +199,29 @@ export function OpenSessions(): JSX.Element {
       </p>
     )
   }
+  // Group by project (a header per project), projects alphabetical, sessions within
+  // each group left in the server's most-recently-active order.
+  const groups = new Map<string, EmdashSessionOut[]>()
+  for (const s of sessions) {
+    const key = s.project || '(no project)'
+    const arr = groups.get(key)
+    if (arr) arr.push(s)
+    else groups.set(key, [s])
+  }
+  const ordered = [...groups.entries()].sort((a, b) => a[0].localeCompare(b[0]))
+
   return (
-    <div className="flex flex-col gap-2" data-testid="open-sessions">
-      {sessions.map((s) => (
-        <SessionRow key={s.id} session={s} />
+    <div className="flex flex-col gap-4" data-testid="open-sessions">
+      {ordered.map(([project, rows]) => (
+        <div key={project} className="flex flex-col gap-2" data-testid={`session-group-${project}`}>
+          <h3 className="flex items-baseline gap-1.5 px-1 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+            {project}
+            <span className="font-normal normal-case text-foreground-subtle">{rows.length}</span>
+          </h3>
+          {rows.map((s) => (
+            <SessionRow key={s.id} session={s} />
+          ))}
+        </div>
       ))}
     </div>
   )

--- a/packages/canopy_runner/canopy_runner/config.py
+++ b/packages/canopy_runner/canopy_runner/config.py
@@ -36,7 +36,10 @@ class Config:
     # messages per session (a "recent tail", not the full transcript); `_count` caps
     # how many of the top (most-recently-active) sessions get a tail each tick.
     session_tail_limit: int = 8
-    session_tail_count: int = 8
+    # Cover every reported session (report cap is 30), not just the most-recent few,
+    # so a project-grouped list doesn't show tails on some rows and not others. The
+    # bounded tail-read (TAIL_BYTES) keeps ~30 transcript reads/tick cheap.
+    session_tail_count: int = 30
 
     @classmethod
     def load(cls, path: Path) -> "Config":


### PR DESCRIPTION
Two asks from using it: **organize the Sessions list by project** (it was a flat most-recently-active order), and the earlier finding that **only the top 8 sessions had a tail**.

## Changes

- **Grouped by project** — the list now renders a per-project header (`ACE 3`, `CANOPY-WEB 1`, …), projects alphabetical, sessions within kept in the server's newest-first order. The row shows just the **task** now (project moved to the header).
- **Full tail coverage** — runner `session_tail_count` 8 → 30 (the report cap), so every grouped row shows its tail instead of a scattered few. The bounded 256 KB tail-read keeps ~30 transcript reads/tick cheap.

Grouping without full coverage would look broken (tails on some rows, not others), so they ship together.

Verified the grouped layout at 390px against real built CSS. Frontend build + `test_config.py` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)