### PR TITLE
feat(supervisor): last-active time instead of fake status; drop automation-runs

### DIFF
--- a/frontend/src/components/supervisor/OpenSessions.tsx
+++ b/frontend/src/components/supervisor/OpenSessions.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, type JSX } from 'react'
 import { listOpenSessions, enqueueTurn, type EmdashSessionOut } from '@/api/harness'
 import { normalizeRecentMessages, type RecentMessage } from '@/lib/recentMessages'
+import { relTime, isRecentlyActive } from '@/lib/relTime'
 
 // The open emdash sessions the runner reported — glance at what each is doing (the
 // recent-message tail), and drop a prompt into a specific one. Continue dispatches a
@@ -95,6 +96,7 @@ function SessionRow({ session }: { session: EmdashSessionOut }): JSX.Element {
   const [busy, setBusy] = useState(false)
   const [sent, setSent] = useState<'ok' | string | null>(null)
   const messages = normalizeRecentMessages(session.recent_messages)
+  const active = isRecentlyActive(session.last_interacted_at)
 
   async function send(): Promise<void> {
     if (busy || prompt.trim() === '') return
@@ -123,7 +125,16 @@ function SessionRow({ session }: { session: EmdashSessionOut }): JSX.Element {
         <span className="min-w-0 flex-1 truncate text-[13px] font-semibold text-foreground">
           {session.emdash_task}
         </span>
-        <span className="shrink-0 text-[11px] text-muted-foreground">{session.status}</span>
+        {/* Last-active time, not emdash's always-"in_progress" status. A recent
+            timestamp (green dot) is the best "running now" signal available. */}
+        <span
+          className={`flex shrink-0 items-center gap-1 text-[11px] ${
+            active ? 'text-success' : 'text-muted-foreground'
+          }`}
+        >
+          {active && <span className="inline-block h-1.5 w-1.5 rounded-full bg-success" />}
+          {relTime(session.last_interacted_at) || session.status}
+        </span>
       </div>
 
       <RecentActivity task={session.emdash_task} messages={messages} />

--- a/frontend/src/lib/relTime.test.ts
+++ b/frontend/src/lib/relTime.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { relTime, isRecentlyActive } from './relTime'
+
+const NOW = Date.parse('2026-07-21T12:00:00Z')
+
+describe('relTime', () => {
+  it('formats buckets', () => {
+    expect(relTime('2026-07-21T11:59:30Z', NOW)).toBe('just now')
+    expect(relTime('2026-07-21T11:45:00Z', NOW)).toBe('15m ago')
+    expect(relTime('2026-07-21T09:00:00Z', NOW)).toBe('3h ago')
+    expect(relTime('2026-07-18T12:00:00Z', NOW)).toBe('3d ago')
+  })
+  it('returns "" for missing or unparseable input', () => {
+    expect(relTime(null, NOW)).toBe('')
+    expect(relTime(undefined, NOW)).toBe('')
+    expect(relTime('not-a-date', NOW)).toBe('')
+  })
+})
+
+describe('isRecentlyActive', () => {
+  it('true within the window, false outside', () => {
+    expect(isRecentlyActive('2026-07-21T11:59:00Z', NOW)).toBe(true) // 60s
+    expect(isRecentlyActive('2026-07-21T11:57:00Z', NOW)).toBe(false) // 180s > 120s
+    expect(isRecentlyActive(null, NOW)).toBe(false)
+  })
+})

--- a/frontend/src/lib/relTime.ts
+++ b/frontend/src/lib/relTime.ts
@@ -1,0 +1,30 @@
+// Relative "last active" time for a session, from an ISO timestamp.
+// emdash's task.status is always "in_progress" (never updated), so last_interacted_at
+// is the real signal for "what ran recently / when it last finished".
+export function relTime(iso: string | null | undefined, now: number = Date.now()): string {
+  if (!iso) return ''
+  const then = new Date(iso).getTime()
+  if (Number.isNaN(then)) return ''
+  const s = Math.max(0, (now - then) / 1000)
+  if (s < 60) return 'just now'
+  const m = Math.floor(s / 60)
+  if (m < 60) return `${m}m ago`
+  const h = Math.floor(m / 60)
+  if (h < 24) return `${h}h ago`
+  const d = Math.floor(h / 24)
+  return `${d}d ago`
+}
+
+// Approximate "running now" signal: emdash bumps last_interacted_at as a session works,
+// so a very recent timestamp means it's actively going (or just finished). Not a hard
+// live flag — the honest label is "active", with relTime saying how recently.
+export function isRecentlyActive(
+  iso: string | null | undefined,
+  now: number = Date.now(),
+  withinSeconds: number = 120,
+): boolean {
+  if (!iso) return false
+  const then = new Date(iso).getTime()
+  if (Number.isNaN(then)) return false
+  return (now - then) / 1000 < withinSeconds
+}

--- a/packages/canopy_runner/canopy_runner/emdash.py
+++ b/packages/canopy_runner/canopy_runner/emdash.py
@@ -181,7 +181,14 @@ def list_open_sessions(db_path: str, limit: int = 30) -> list[dict]:
     pure read — NOT behind the write-vet pin — and it must NEVER raise: a missing DB,
     a renamed column, or an emdash schema change degrades to [] so the runner loop
     survives. The task NAME is the identity open_and_send targets; project is joined
-    from `projects` for display + the continue turn's target."""
+    from `projects` for display + the continue turn's target.
+
+    Only `type='task'` rows — the real sessions emdash shows in its project list.
+    `type='automation-run'` rows are un-promoted automation triggers that emdash hides
+    under "Automations", not sessions a human opened; including them leaked phantom rows
+    into the supervisor (e.g. an 8-day-old `plain-keys-rescue`) that don't appear in the
+    emdash UI. `status` is always 'in_progress' in practice (emdash never updates it), so
+    the display leans on last_interacted_at instead."""
     if not Path(db_path).exists():
         return []
     try:
@@ -194,7 +201,7 @@ def list_open_sessions(db_path: str, limit: int = 30) -> list[dict]:
                        t.last_interacted_at AS last_interacted_at
                 FROM tasks t
                 LEFT JOIN projects p ON p.id = t.project_id
-                WHERE t.archived_at IS NULL
+                WHERE t.archived_at IS NULL AND t.type = 'task'
                 ORDER BY t.last_interacted_at DESC
                 LIMIT ?
                 """,

--- a/packages/canopy_runner/tests/test_emdash_sessions.py
+++ b/packages/canopy_runner/tests/test_emdash_sessions.py
@@ -8,11 +8,13 @@ def _make_db(path):
         """
         CREATE TABLE projects (id TEXT, name TEXT, path TEXT);
         CREATE TABLE tasks (id TEXT, project_id TEXT, name TEXT, status TEXT,
-                            archived_at TEXT, last_interacted_at TEXT);
+                            archived_at TEXT, last_interacted_at TEXT, type TEXT);
         INSERT INTO projects VALUES ('p1','canopy-web','/x/canopy-web');
-        INSERT INTO tasks VALUES ('t1','p1','cloud-runner','in_progress',NULL,'2026-07-16T15:52:00');
-        INSERT INTO tasks VALUES ('t2','p1','ddd','in_progress',NULL,'2026-07-16T12:41:00');
-        INSERT INTO tasks VALUES ('t3','p1','old','done','2026-07-15T00:00:00','2026-07-15T00:00:00');
+        INSERT INTO tasks VALUES ('t1','p1','cloud-runner','in_progress',NULL,'2026-07-16T15:52:00','task');
+        INSERT INTO tasks VALUES ('t2','p1','ddd','in_progress',NULL,'2026-07-16T12:41:00','task');
+        INSERT INTO tasks VALUES ('t3','p1','old','done','2026-07-15T00:00:00','2026-07-15T00:00:00','task');
+        -- an un-promoted automation-run: emdash hides it under "Automations", so must NOT show.
+        INSERT INTO tasks VALUES ('t4','p1','plain-keys-rescue','in_progress',NULL,'2026-07-13T15:01:00','automation-run');
         """
     )
     conn.commit()
@@ -23,9 +25,10 @@ def test_lists_unarchived_tasks_newest_first(tmp_path):
     db = tmp_path / "emdash4.db"
     _make_db(str(db))
     out = emdash.list_open_sessions(str(db))
-    assert [s["emdash_task"] for s in out] == ["cloud-runner", "ddd"]  # 'old' archived → excluded
+    # 'old' archived → excluded; 'plain-keys-rescue' is an automation-run → excluded.
+    assert [s["emdash_task"] for s in out] == ["cloud-runner", "ddd"]
     assert out[0]["project"] == "canopy-web"
-    assert out[0]["status"] == "in_progress"
+    assert out[0]["last_interacted_at"] == "2026-07-16T15:52:00"
 
 
 def test_missing_db_returns_empty_not_raises(tmp_path):


### PR DESCRIPTION
Two things surfaced by real use of the Sessions tab.

## 1. Every row said "in_progress"
emdash never updates `tasks.status` — it's always `in_progress`, so it carried no information. Replaced with a **relative last-active time** from `last_interacted_at` (the signal emdash's own UI uses — "17h", "20h"). Sessions active in the last ~2 min get a green dot as the best available "running now" hint (emdash bumps `last_interacted_at` as a session works). Answers "what's running / when did it last run".

## 2. Phantom `plain-keys-rescue`
An 8-day-old `plain-keys-rescue` showed in the supervisor but **not** in emdash's project UI. Cause: it's `type='automation-run'` (an un-promoted automation trigger emdash files under "Automations"), while `list_open_sessions` returned *all* un-archived tasks. Now filtered to **`type='task'`**, matching what emdash surfaces as real sessions.

**Tradeoff (flagged):** this also drops other agents' automation-runs — notably **echo's** (echo runs entirely via automation, so all its rows are `automation-run`). Same category as `plain-keys-rescue`, same rationale (emdash hides them from project lists), and it clears a lot of stale transcript-less clutter. If we want fleet automation activity visible in the supervisor, a follow-up can include *recent* automation-runs.

Runner + frontend; deploy + runner restart. Tests: runner emdash-sessions (automation-run excluded) + new `relTime` vitest; build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)