### PR TITLE
fix(runner): last-active time from transcript mtime, not emdash UI timestamp

### DIFF
--- a/packages/canopy_runner/canopy_runner/transcript.py
+++ b/packages/canopy_runner/canopy_runner/transcript.py
@@ -29,10 +29,16 @@ degrades to an empty tail with a reason string, so the poll tick survives.
 """
 from __future__ import annotations
 
+import datetime
 import json
 import logging
 import re
 from pathlib import Path
+
+
+def _iso_utc(epoch: float) -> str:
+    """Epoch seconds -> ISO-8601 UTC string (what the report/API expect)."""
+    return datetime.datetime.fromtimestamp(epoch, tz=datetime.timezone.utc).isoformat()
 
 logger = logging.getLogger(__name__)
 
@@ -225,10 +231,28 @@ def attach_recent_tail(
 
     `count` caps how many transcripts are read per tick; `limit` caps messages per
     session. Sessions past `count`, or with no resolvable transcript, carry [].
+
+    Also overrides `last_interacted_at` with the transcript's mtime when we have it:
+    emdash's own last_interacted_at only tracks emdash's UI, NOT the Claude Code
+    session running in the worktree (which the runner drives), so an actively-running
+    session looked stale ("45m ago" while mid-turn). The transcript file's write time
+    is the real activity signal.
     """
+    home = home or Path.home()
+    claude_home = claude_home or (home / ".claude" / "projects")
     for s in sessions[:count]:
-        msgs, _reason = session_tail(
-            s.get("project", ""), s.get("emdash_task", ""),
-            limit=limit, home=home, claude_home=claude_home,
-        )
-        s["recent_messages"] = msgs
+        try:
+            path = resolve_transcript(
+                s.get("project", ""), s.get("emdash_task", ""),
+                home=home, claude_home=claude_home,
+            )
+        except Exception:  # noqa: BLE001 — a fragile-half failure must not crash the tick
+            path = None
+        if path is None:
+            s["recent_messages"] = []
+            continue
+        s["recent_messages"] = read_recent_messages(path, limit=limit)
+        try:
+            s["last_interacted_at"] = _iso_utc(path.stat().st_mtime)
+        except OSError:
+            pass

--- a/packages/canopy_runner/tests/test_transcript.py
+++ b/packages/canopy_runner/tests/test_transcript.py
@@ -283,3 +283,17 @@ def test_read_recent_messages_reads_only_tail_of_large_file(tmp_path):
     msgs = transcript.read_recent_messages(f, limit=3)
     assert msgs[-1] == {"role": "assistant", "text": "LAST"}
     assert len(msgs) <= 3
+
+
+def test_attach_recent_tail_sets_last_active_from_transcript_mtime(tmp_path):
+    import datetime as dt
+    home = tmp_path / "home"
+    claude_home = home / ".claude" / "projects"
+    wt = home / "emdash" / "worktrees" / "canopy-web" / "emdash" / "ddd"
+    f = _write_transcript(claude_home, wt, [{"type": "user", "message": {"content": "hi"}}])
+    sessions = [{"emdash_task": "ddd", "project": "canopy-web",
+                 "last_interacted_at": "2020-01-01 00:00:00"}]  # stale emdash value
+    transcript.attach_recent_tail(sessions, home=home, claude_home=claude_home)
+    # Overridden to the transcript's write time (the real activity), not the stale value.
+    expected = dt.datetime.fromtimestamp(f.stat().st_mtime, tz=dt.timezone.utc).isoformat()
+    assert sessions[0]["last_interacted_at"] == expected


### PR DESCRIPTION
emdash bumps `tasks.last_interacted_at` only on its own UI interaction, not when the Claude Code session (in a runner-driven worktree) does work — so an active session showed "45m ago" mid-turn. `attach_recent_tail` now overrides `last_interacted_at` with the transcript file's **mtime** (real activity) when it resolves one; transcript-less sessions keep the DB value. Verified live: active sessions now read 0-2m ago. 20/20 transcript tests. 🤖 Generated with [Claude Code](https://claude.com/claude-code)