### PR TITLE
feat(supervisor): faster session Continue + honest send status

### DIFF
--- a/frontend/src/api/harness.ts
+++ b/frontend/src/api/harness.ts
@@ -78,6 +78,15 @@ export async function enqueueTurn(input: {
   return unwrap(res, 'enqueueTurn')
 }
 
+// Poll a turn's lifecycle — the Continue flow watches queued -> running (i.e. the
+// runner has claimed it and is delivering the prompt into the live session).
+export async function getTurn(turnId: string): Promise<TurnOut> {
+  const res = await apiV2.GET('/api/harness/turns/{turn_id}', {
+    params: { path: { turn_id: turnId } },
+  })
+  return unwrap(res, 'getTurn')
+}
+
 // Un-queue a misfired turn (queued only; the server 409s a running turn).
 export async function cancelTurn(turnId: string): Promise<TurnOut> {
   const res = await apiV2.POST('/api/harness/turns/{turn_id}/cancel', {

--- a/frontend/src/components/supervisor/OpenSessions.tsx
+++ b/frontend/src/components/supervisor/OpenSessions.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState, type JSX } from 'react'
-import { listOpenSessions, enqueueTurn, type EmdashSessionOut } from '@/api/harness'
+import { useEffect, useRef, useState, type JSX } from 'react'
+import { listOpenSessions, enqueueTurn, getTurn, type EmdashSessionOut } from '@/api/harness'
 import { normalizeRecentMessages, type RecentMessage } from '@/lib/recentMessages'
 import { relTime, isRecentlyActive } from '@/lib/relTime'
 
@@ -94,28 +94,69 @@ function RecentActivity({ task, messages }: { task: string; messages: RecentMess
 function SessionRow({ session }: { session: EmdashSessionOut }): JSX.Element {
   const [prompt, setPrompt] = useState('')
   const [busy, setBusy] = useState(false)
-  const [sent, setSent] = useState<'ok' | string | null>(null)
+  // idle -> sending (queued, waiting for the runner) -> delivered (running in the
+  // session) | error. "delivered" is the honest confirmation: it lands only when the
+  // turn actually starts executing, not on enqueue (the old green fired too early).
+  const [phase, setPhase] = useState<'idle' | 'sending' | 'delivered' | 'error'>('idle')
+  const [errMsg, setErrMsg] = useState('')
   const messages = normalizeRecentMessages(session.recent_messages)
   const active = isRecentlyActive(session.last_interacted_at)
+  const mounted = useRef(true)
+  useEffect(() => () => { mounted.current = false }, [])
 
   async function send(): Promise<void> {
     if (busy || prompt.trim() === '') return
     setBusy(true)
-    setSent(null)
+    setPhase('sending')
+    setErrMsg('')
+    let turnId: string
     try {
-      await enqueueTurn({
+      const turn = await enqueueTurn({
         project: session.project,
         workspace: session.workspace,
         prompt: prompt.trim(),
         threadKey: `emdash:${session.emdash_task}`,
       })
-      setSent('ok')
+      turnId = turn.id
       setPrompt('')
     } catch (e) {
-      setSent(e instanceof Error ? e.message : 'Failed to send')
-    } finally {
+      if (!mounted.current) return
+      setPhase('error')
+      setErrMsg(e instanceof Error ? e.message : 'Failed to send')
       setBusy(false)
+      return
     }
+    // Poll the turn until the runner claims it and starts executing (running = the
+    // prompt has been delivered into the live session), or it finishes/fails. Give
+    // up after ~90s (runner offline) but keep the queued note so it's not lost.
+    const deadline = Date.now() + 90_000
+    const tick = async (): Promise<void> => {
+      if (!mounted.current) return
+      let status = ''
+      let note = ''
+      try {
+        const t = await getTurn(turnId)
+        status = t.status
+        note = t.result_note
+      } catch {
+        // transient error — fall through to retry
+      }
+      if (!mounted.current) return
+      if (status === 'running' || status === 'done' || status === 'needs_human') {
+        setPhase('delivered')
+        setBusy(false)
+        return
+      }
+      if (status === 'failed') {
+        setPhase('error')
+        setErrMsg(note || 'The session run failed.')
+        setBusy(false)
+        return
+      }
+      if (Date.now() < deadline) window.setTimeout(() => void tick(), 1500)
+      else setBusy(false) // still queued after 90s — stop the spinner, keep the note
+    }
+    window.setTimeout(() => void tick(), 1200)
   }
 
   return (
@@ -160,12 +201,21 @@ function SessionRow({ session }: { session: EmdashSessionOut }): JSX.Element {
           {busy ? 'Sending…' : 'Continue'}
         </button>
       </div>
-      {sent === 'ok' && (
-        <p className="mt-1 text-[12px] text-success" data-testid={`session-sent-${session.emdash_task}`}>
-          Sent to {session.emdash_task}.
+      {phase === 'sending' && (
+        <p
+          className="mt-1 flex items-center gap-1.5 text-[12px] text-muted-foreground"
+          data-testid={`session-sending-${session.emdash_task}`}
+        >
+          <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-muted-foreground" />
+          Sending to {session.emdash_task}… waiting for the runner
         </p>
       )}
-      {sent && sent !== 'ok' && <p className="mt-1 text-[12px] text-destructive">{sent}</p>}
+      {phase === 'delivered' && (
+        <p className="mt-1 text-[12px] text-success" data-testid={`session-sent-${session.emdash_task}`}>
+          ✓ Delivered — running in {session.emdash_task}.
+        </p>
+      )}
+      {phase === 'error' && <p className="mt-1 text-[12px] text-destructive">{errMsg}</p>}
     </div>
   )
 }

--- a/packages/canopy_runner/canopy_runner/config.py
+++ b/packages/canopy_runner/canopy_runner/config.py
@@ -15,8 +15,14 @@ class Config:
     automation_ids: dict[str, str]
     expected_migration_id: int
     emdash_fingerprint: str = ""
-    poll_seconds: int = 20
+    # Claim cadence — how fast a queued turn (e.g. a phone "Continue this session")
+    # gets picked up. Kept low so delivery feels near-immediate; the claim + heartbeat
+    # are cheap HTTP. The heavier session report is throttled separately below.
+    poll_seconds: int = 5
     heartbeat_seconds: int = 30
+    # Session report throttle: reading up to session_tail_count transcripts is the one
+    # expensive thing per tick, so do it at most this often even as poll_seconds drops.
+    session_report_seconds: int = 20
     state_path: str = ""
     # Executor: "cdp" drives emdash's real UI over CDP (create/reuse sessions —
     # the sanctioned path); "inject" is the legacy DB-injection path. cdp needs

--- a/packages/canopy_runner/canopy_runner/main.py
+++ b/packages/canopy_runner/canopy_runner/main.py
@@ -59,6 +59,7 @@ GRACE_SECONDS = 900
 CDP_DOWN_SIGNAL_TICKS = 3
 _cdp_down_ticks = 0
 _cdp_down_signalled = False
+_last_session_report = 0.0
 
 
 def _reset_cdp_health_state() -> None:
@@ -219,6 +220,26 @@ def _claim_and_execute(cfg: Config, client: Client, paused: set) -> str:
         return f"failed:{turn.get('id')}"
 
 
+def _maybe_report_sessions(cfg: Config, client: Client, now_fn=time.monotonic) -> None:
+    """Report the open emdash sessions the phone can continue — throttled to
+    session_report_seconds so lowering poll_seconds (for snappy claims) doesn't read
+    up to session_tail_count transcripts every tick. A sqlite read of emdash's DB, not
+    CDP, so it runs even while CDP is down. Best-effort: a read or POST failure must
+    never stop the tick. Reports on the first tick after start (last stamp is 0)."""
+    global _last_session_report
+    if now_fn() - _last_session_report < cfg.session_report_seconds:
+        return
+    _last_session_report = now_fn()
+    try:
+        sessions = emdash.list_open_sessions(cfg.emdash_db)
+        transcript.attach_recent_tail(
+            sessions, count=cfg.session_tail_count, limit=cfg.session_tail_limit
+        )
+        client.report_sessions(cfg.runner_id, sessions)
+    except Exception:  # noqa: BLE001
+        logger.debug("session report failed (non-fatal)", exc_info=True)
+
+
 def _run_once_cdp(cfg: Config, client: Client) -> str:
     """CDP executor: preflight emdash's CDP health → heartbeat (with macOS host, for
     reuse ownership) → claim one turn → route it to an emdash session (reuse or create).
@@ -263,18 +284,7 @@ def _run_once_cdp(cfg: Config, client: Client) -> str:
                 cfg.cdp_port, _cdp_down_ticks, cfg.cdp_port)
             _cdp_down_signalled = True
 
-    # Report the open emdash sessions the phone can continue. A sqlite read of emdash's
-    # DB, not CDP — keep it even while CDP is down. Best-effort: a read or POST failure
-    # must never stop the tick. The most-recently-active session also carries its recent
-    # message tail (Phase B) so the phone can read it on click-in with no extra round trip.
-    try:
-        sessions = emdash.list_open_sessions(cfg.emdash_db)
-        transcript.attach_recent_tail(
-            sessions, count=cfg.session_tail_count, limit=cfg.session_tail_limit
-        )
-        client.report_sessions(cfg.runner_id, sessions)
-    except Exception:  # noqa: BLE001
-        logger.debug("session report failed (non-fatal)", exc_info=True)
+    _maybe_report_sessions(cfg, client)
     paused = _paused_agents(cfg)
     # Inbound triggers run whether or not CDP is up, so inbound work still ENQUEUES while
     # emdash is down (it just waits, queued, until emdash is back). Only the claim is gated.

--- a/packages/canopy_runner/tests/test_config.py
+++ b/packages/canopy_runner/tests/test_config.py
@@ -20,4 +20,4 @@ def test_load_config_with_token_file(tmp_path: Path):
     assert cfg.token == "sekret"
     assert cfg.base_url == "https://labs.example.com/canopy"
     assert cfg.automation_ids["echo"] == "auto-1"
-    assert cfg.poll_seconds == 20  # default
+    assert cfg.poll_seconds == 5  # default (low, for snappy turn claims)

--- a/packages/canopy_runner/tests/test_main.py
+++ b/packages/canopy_runner/tests/test_main.py
@@ -756,3 +756,23 @@ def test_cdp_recovery_logs_once_and_rearms(monkeypatch, tmp_path, caplog):
     for _ in range(main_mod.CDP_DOWN_SIGNAL_TICKS):
         run_once(cfg, client)
     assert sum("CDP unreachable" in r.getMessage() for r in caplog.records) == 1  # warns again
+
+
+def test_maybe_report_sessions_throttled(db, tmp_path, monkeypatch):
+    """The session report (up to session_tail_count transcript reads) runs at most
+    every session_report_seconds, even though the claim tick polls far faster."""
+    from canopy_runner import main as m
+    from canopy_runner import transcript
+    cfg = _cfg(db, tmp_path)  # session_report_seconds defaults to 20
+    calls = []
+    monkeypatch.setattr(emdash, "list_open_sessions", lambda p: calls.append(1) or [])
+    monkeypatch.setattr(transcript, "attach_recent_tail", lambda *a, **k: None)
+    m._last_session_report = 0.0
+    clock = [1000.0]
+    now = lambda: clock[0]
+    client = FakeClient()
+    m._maybe_report_sessions(cfg, client, now_fn=now)   # first tick -> reports
+    m._maybe_report_sessions(cfg, client, now_fn=now)   # within window -> skipped
+    clock[0] += cfg.session_report_seconds + 1
+    m._maybe_report_sessions(cfg, client, now_fn=now)   # window elapsed -> reports
+    assert len(calls) == 2


### PR DESCRIPTION
Two fixes on the "Continue this session" round trip.

## 1. Speed
The runner claimed queued turns every `poll_seconds=20`, so a Continue could wait up to 20s to land. Dropped `poll_seconds` to **5**. To keep that cheap, the now-heavier session report (reads up to `session_tail_count` transcripts) is throttled to its own **`session_report_seconds=20`** via a new `_maybe_report_sessions` — so fast claims don't mean reading 30 transcripts every tick. (Local `runner.json` also updated to `poll_seconds: 5`.)

## 2. Honest send status
The green "Sent" fired on **enqueue** — while the turn was still queued, before it reached the session. Now the row shows **"Sending… waiting for the runner"** (pulsing), polls the turn via a new `getTurn`, and only flips to **"✓ Delivered — running"** once it's actually executing (`running`/`done`/`needs_human`). Failures surface the error. Unmount-safe (ref guard), gives up after 90s but keeps the queued note.

Tests: config default (5), `_maybe_report_sessions` throttle, frontend build clean. (Pre-existing `test_main` canopy_cron-venv failure is unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)