### PR TITLE
feat(supervisor): pulsing "running" indicator for active sessions

### DIFF
--- a/frontend/src/components/supervisor/OpenSessions.tsx
+++ b/frontend/src/components/supervisor/OpenSessions.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState, type JSX } from 'react'
 import { listOpenSessions, enqueueTurn, getTurn, type EmdashSessionOut } from '@/api/harness'
 import { normalizeRecentMessages, type RecentMessage } from '@/lib/recentMessages'
-import { relTime, isRecentlyActive } from '@/lib/relTime'
+import { relTime, isRunning } from '@/lib/relTime'
 
 // The open emdash sessions the runner reported — glance at what each is doing (the
 // recent-message tail), and drop a prompt into a specific one. Continue dispatches a
@@ -101,7 +101,7 @@ function SessionRow({ session }: { session: EmdashSessionOut }): JSX.Element {
   const [errMsg, setErrMsg] = useState('')
   const [deliveredRunner, setDeliveredRunner] = useState('')
   const messages = normalizeRecentMessages(session.recent_messages)
-  const active = isRecentlyActive(session.last_interacted_at)
+  const running = isRunning(session.last_interacted_at)
   const mounted = useRef(true)
   useEffect(() => () => { mounted.current = false }, [])
 
@@ -170,16 +170,18 @@ function SessionRow({ session }: { session: EmdashSessionOut }): JSX.Element {
         <span className="min-w-0 flex-1 truncate text-[13px] font-semibold text-foreground">
           {session.emdash_task}
         </span>
-        {/* Last-active time, not emdash's always-"in_progress" status. A recent
-            timestamp (green dot) is the best "running now" signal available. */}
-        <span
-          className={`flex shrink-0 items-center gap-1 text-[11px] ${
-            active ? 'text-success' : 'text-muted-foreground'
-          }`}
-        >
-          {active && <span className="inline-block h-1.5 w-1.5 rounded-full bg-success" />}
-          {relTime(session.last_interacted_at) || session.status}
-        </span>
+        {/* "running" (pulsing) when the transcript was just written — the agent is
+            working now; otherwise the last-active age. Never emdash's fake status. */}
+        {running ? (
+          <span className="flex shrink-0 items-center gap-1 text-[11px] font-medium text-success">
+            <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-success" />
+            running
+          </span>
+        ) : (
+          <span className="shrink-0 text-[11px] text-muted-foreground">
+            {relTime(session.last_interacted_at) || session.status}
+          </span>
+        )}
       </div>
 
       <RecentActivity task={session.emdash_task} messages={messages} />

--- a/frontend/src/lib/relTime.test.ts
+++ b/frontend/src/lib/relTime.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { relTime, isRecentlyActive } from './relTime'
+import { relTime, isRecentlyActive, isRunning } from './relTime'
 
 const NOW = Date.parse('2026-07-21T12:00:00Z')
 
@@ -22,5 +22,13 @@ describe('isRecentlyActive', () => {
     expect(isRecentlyActive('2026-07-21T11:59:00Z', NOW)).toBe(true) // 60s
     expect(isRecentlyActive('2026-07-21T11:57:00Z', NOW)).toBe(false) // 180s > 120s
     expect(isRecentlyActive(null, NOW)).toBe(false)
+  })
+})
+
+describe('isRunning', () => {
+  it('true within ~45s (accounts for report+poll lag), false outside', () => {
+    expect(isRunning('2026-07-21T11:59:30Z', NOW)).toBe(true) // 30s ago
+    expect(isRunning('2026-07-21T11:59:00Z', NOW)).toBe(false) // 60s ago
+    expect(isRunning(null, NOW)).toBe(false)
   })
 })

--- a/frontend/src/lib/relTime.ts
+++ b/frontend/src/lib/relTime.ts
@@ -28,3 +28,14 @@ export function isRecentlyActive(
   if (Number.isNaN(then)) return false
   return (now - then) / 1000 < withinSeconds
 }
+
+// The transcript was written in the last ~RUNNING_WINDOW_S seconds, i.e. the agent is
+// (very likely) generating output RIGHT NOW. The window is deliberately wider than the
+// pipeline lag (runner reports every ~10s + the phone polls every ~10s) so an actively
+// working session doesn't flicker off between updates. Caveat: a session mid-way through
+// one long tool call writes nothing for a while, so it can briefly read as not-running —
+// this tracks message activity, not raw CPU.
+export const RUNNING_WINDOW_S = 45
+export function isRunning(iso: string | null | undefined, now: number = Date.now()): boolean {
+  return isRecentlyActive(iso, now, RUNNING_WINDOW_S)
+}


### PR DESCRIPTION
Sessions showed "Xm ago" but no live "working right now" signal. When an agent generates, it writes its transcript continuously, so a fresh `last_interacted_at` (transcript mtime, reported ~10s) = running now. Rows now show a **pulsing green "running"** when written in the last 45s (wider than the ~20s report+poll lag so it doesn't flicker), else the last-active age. Caveat (in code): a session mid-long-tool-call writes nothing for a while and can briefly read idle. Frontend-only; 4/4 relTime tests, build clean. 🤖 Generated with [Claude Code](https://claude.com/claude-code)