### PR TITLE
feat(realtime): RC1 — runner WebSocket control channel (server side)

### DIFF
--- a/apps/realtime/consumers.py
+++ b/apps/realtime/consumers.py
@@ -12,10 +12,25 @@ import uuid
 
 from channels.db import database_sync_to_async
 from channels.generic.websocket import AsyncJsonWebsocketConsumer
+from django.db.models import Q
 
-from apps.harness.models import Turn
+from apps.harness import services as harness_services
+from apps.harness.models import Runner, Turn
+from apps.workspaces.services import user_workspace_slugs
 
 from . import groups
+
+
+def _serialize_turn(turn: Turn) -> dict:
+    """The fields a runner needs to run a claimed turn, over the WS."""
+    return {
+        "id": str(turn.id),
+        "prompt": turn.prompt,
+        "target": turn.agent.slug if turn.agent_id else turn.project,
+        "agent_slug": turn.agent.slug if turn.agent_id else None,
+        "project": turn.project,
+        "routing": turn.routing,
+    }
 
 
 class TurnConsumer(AsyncJsonWebsocketConsumer):
@@ -123,3 +138,92 @@ class SupervisorConsumer(AsyncJsonWebsocketConsumer):
         from .snapshot import supervisor_snapshot
 
         return supervisor_snapshot(user)
+
+
+class RunnerConsumer(AsyncJsonWebsocketConsumer):
+    """A runner's persistent control channel (RC1).
+
+    PAT-authed via the handshake (channels_auth sets scope["user"]); the runner may
+    connect only to a runner it owns (paired_by == user, or null — legacy-ungated,
+    matching the REST _runner_visibility_q). Joins the per-runner group + its
+    workspaces' runnable groups, so:
+      - server → runner: a `wake` frame when a turn becomes claimable (enqueue
+        publishes to runnable.{ws}); the runner responds by claiming.
+      - runner → server: `claim` / `heartbeat` frames that call the SAME harness
+        services the REST routes call, so the two surfaces can't drift.
+
+    REST claim/heartbeat stay fully working alongside — this ADDS a real-time
+    channel, it does not replace the durable claim/lease path (Postgres remains the
+    source of truth; a dropped socket loses no work).
+    """
+
+    async def connect(self):
+        user = self.scope.get("user")
+        if not getattr(user, "is_authenticated", False):
+            await self.close(code=4001)
+            return
+        raw_id = self.scope["url_route"]["kwargs"]["runner_id"]
+        runner = await self._runner_for_user(user, raw_id)
+        if runner is None:
+            await self.close(code=4003)  # unknown or not owned — no existence leak
+            return
+        self._runner_pk = runner.id
+        self._groups = [groups.runner_group(runner.id)]
+        for ws in await self._runner_workspaces(runner):
+            self._groups.append(groups.runnable_group(ws))
+        for group in self._groups:
+            await self.channel_layer.group_add(group, self.channel_name)
+        await self.accept()
+
+    async def disconnect(self, code):
+        for group in getattr(self, "_groups", []):
+            await self.channel_layer.group_discard(group, self.channel_name)
+
+    async def runner_wake(self, message):
+        # runnable.{ws} group_send type="runner.wake" dispatches here.
+        await self.send_json({"type": "wake"})
+
+    async def receive_json(self, content, **kwargs):
+        action = content.get("action")
+        if action == "claim":
+            turn = await self._claim()
+            await self.send_json({"type": "claim.result", "turn": turn})
+        elif action == "heartbeat":
+            await self._heartbeat(content.get("active_turn_ids") or [])
+            await self.send_json({"type": "heartbeat.ack"})
+        else:
+            await self.send_json({"type": "error", "detail": f"unknown action {action!r}"})
+
+    # -- helpers (sync ORM, bridged) --
+    @database_sync_to_async
+    def _runner_for_user(self, user, raw_id):
+        try:
+            rid = uuid.UUID(str(raw_id))
+        except (ValueError, TypeError):
+            return None
+        return (
+            Runner.objects.exclude(status=Runner.RETIRED)
+            .filter(pk=rid)
+            .filter(Q(paired_by=user) | Q(paired_by__isnull=True))
+            .first()
+        )
+
+    @database_sync_to_async
+    def _runner_workspaces(self, runner):
+        if not runner.paired_by_id:
+            return []
+        return sorted(user_workspace_slugs(runner.paired_by))
+
+    @database_sync_to_async
+    def _claim(self):
+        runner = Runner.objects.filter(pk=self._runner_pk).first()
+        if runner is None:
+            return None
+        turn = harness_services.claim_next_turn(runner)
+        return _serialize_turn(turn) if turn else None
+
+    @database_sync_to_async
+    def _heartbeat(self, active_turn_ids):
+        runner = Runner.objects.filter(pk=self._runner_pk).first()
+        if runner is not None:
+            harness_services.heartbeat(runner, active_turn_ids=active_turn_ids)

--- a/apps/realtime/groups.py
+++ b/apps/realtime/groups.py
@@ -32,6 +32,25 @@ def supervisor_user_group(user_id: int) -> str:
     return f"supervisor.user.{user_id}"
 
 
+def runner_group(runner_id) -> str:
+    """Per-runner control-channel group — targeted server→runner frames (a specific
+    interject, a cancel). The runner's WS consumer joins this plus its workspaces'
+    runnable groups."""
+    hexid = runner_id.hex if hasattr(runner_id, "hex") else str(runner_id).replace("-", "")
+    return f"runner.{hexid}"
+
+
+def runnable_group(workspace_slug: str) -> str:
+    """Per-tenant 'a turn is claimable' wake group. Runners long-polling /claim
+    join their workspaces' runnable groups; enqueue publishes a wake here so a
+    blocked claim returns immediately instead of waiting out its poll interval.
+    Deliberately coarse (per-workspace, not per-agent): the wake only prompts a
+    re-attempt — claim_next_turn still does all the capability/tenant/preference
+    gating — so a small thundering herd (a few runners re-attempt, one wins) is
+    fine and keeps the publish side from re-deriving eligibility."""
+    return f"runnable.{workspace_slug}"
+
+
 def session_group(session_id) -> str:
     """Per-session multiplayer group (SP3). A pure string helper so realtime's
     fan-out can target it without importing the chat app."""

--- a/apps/realtime/routing.py
+++ b/apps/realtime/routing.py
@@ -10,4 +10,5 @@ from . import consumers
 websocket_urlpatterns = [
     re_path(r"^ws/turns/(?P<turn_id>[0-9a-fA-F-]+)/$", consumers.TurnConsumer.as_asgi()),
     path("ws/supervisor/", consumers.SupervisorConsumer.as_asgi()),
+    re_path(r"^ws/runner/(?P<runner_id>[0-9a-fA-F-]+)/$", consumers.RunnerConsumer.as_asgi()),
 ]

--- a/apps/realtime/signals.py
+++ b/apps/realtime/signals.py
@@ -19,7 +19,7 @@ from django.db import transaction
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
-from apps.harness.models import Runner
+from apps.harness.models import Runner, Turn
 from apps.harness.signals import turn_events_appended
 from apps.push.models import AgentWaitingSnapshot
 from apps.workspaces.services import workspace_member_ids
@@ -40,6 +40,22 @@ def _on_turn_events(sender, turn, rows, **kwargs):
         sgroup = groups.session_group(turn.chat_session_id)
         for event in events:
             groups.publish(sgroup, {"type": "chat.turn_event", "event": event})
+
+
+@receiver(post_save, sender=Turn, dispatch_uid="realtime_runnable_wake")
+def _on_turn_enqueued(sender, instance: Turn, created, **kwargs):
+    """A newly-QUEUED turn wakes runners in its tenant so a blocked/idle runner
+    claims it now instead of waiting out its poll interval. Coarse per-workspace
+    wake — it only PROMPTS a claim; claim_next_turn still gates everything. Deferred
+    to on_commit (create fires mid-transaction) and null-safe like every publish."""
+    if not created or instance.status != Turn.QUEUED:
+        return
+    slug = groups.turn_workspace_slug(instance)
+    if not slug:
+        return
+    transaction.on_commit(
+        lambda: groups.publish(groups.runnable_group(slug), {"type": "runner.wake"})
+    )
 
 
 @receiver(post_save, sender=Runner, dispatch_uid="realtime_runner")

--- a/docs/superpowers/specs/2026-07-22-runner-control-channel-design.md
+++ b/docs/superpowers/specs/2026-07-22-runner-control-channel-design.md
@@ -1,0 +1,100 @@
+# Runner control channel — one real-time layer for humans and runners
+
+**Status:** Draft for review · **Date:** 2026-07-22 · **Author:** Jonathan + Claude
+
+> Replace the runner's poll-for-work loop with a **persistent WebSocket control
+> channel** to canopy-web, so the whole system is one coherent real-time layer:
+> humans and runners both connect to canopy-web over WebSockets, and canopy-web
+> bridges them. This is what near-real-time chat and multiplayer require — a human
+> message must reach a *running* agent live, which polling can't do well.
+
+## Why WebSocket (and not long-poll)
+
+Long-poll is the right pattern for **batch** dispatch (Temporal, GitHub Actions,
+k8s-watch): a worker grabs a task and runs it to completion with no human in the
+loop. Our target is the opposite — **interactive, multiplayer sessions** where
+humans watch and interject *while the agent runs*. The distinguishing move is a
+**human message injected mid-turn** reaching the agent's runner:
+
+- **Agent → humans** already works over WS (turn events fan out through the
+  turn/session group to every participant — SP1–3).
+- **Humans → running agent** is the hard part. With poll/REST the runner would have
+  to poll for new session messages mid-turn — laggy. A persistent WS pushes the
+  message down instantly.
+- **Presence + liveness** fall out of connection state for free (disconnect =
+  instant), instead of heartbeat polling.
+
+So WebSocket wins on the exact axes multiplayer needs. Durability stays in
+Postgres: the socket is the *transport*; `Turn` rows + `claim_next_turn` + the lease
+remain the *source of truth*. A dropped socket loses no work — reconnect, DB intact,
+lease sweep backstops. WebSocket for real-time, DB for durability — both, not either.
+
+## Architecture: canopy-web as the real-time bridge
+
+Everything on the existing Channels layer (`apps/realtime`):
+
+```
+ humans ──WS──▶ canopy-web (Channels) ◀──WS── runners
+   │  chat / multiplayer / transcript / presence   │  dispatch / events / interject / heartbeat
+   └───────────── one real-time hub ───────────────┘
+                        │
+                   Postgres (Turn rows + lease = durable truth)
+```
+
+- **Runner ↔ canopy-web:** a `RunnerConsumer` WebSocket at `/ws/runner/{id}/`,
+  PAT-authed (reusing `channels_auth`), that joins the runner's groups: `runner.{id}`
+  and `runnable.{ws}` for each workspace the runner serves.
+- **Server → runner frames:** `wake` (a turn is claimable — go claim), `interject`
+  (a human message for a running session), `cancel`.
+- **Runner → server frames:** `heartbeat`, `claim` (request the next turn), `event`
+  (append turn events), `finish`. These map onto the same service functions the REST
+  routes call, so the two surfaces can't drift.
+- **Dispatch:** `enqueue_turn` publishes to `runnable.{ws}` (the wake group). The
+  consumer relays `wake` to its runner; the runner claims via `claim_next_turn`
+  (which still does all capability/tenant/preference gating and the atomic lease).
+  The wake only *prompts* — a lost frame is covered by a slow heartbeat re-poll.
+
+### Pull-on-wake, not server-push-assign (for now)
+
+The wake tells the runner "attempt a claim"; the runner pulls via the existing,
+tested `claim_next_turn`. We keep the delicate claim logic as the single source of
+routing truth rather than moving the decision server-side. (A later evolution can
+make the server pick the best *connected* runner and push-assign — which would make
+the preference truly availability-based and retire the head-start timer — but that
+is a follow-on, not this slice.)
+
+## Decomposition
+
+```
+RC1  Server RunnerConsumer + wake     WS consumer (PAT auth, groups), enqueue→runnable
+     (canopy-web)                     wake, claim/heartbeat/event/finish over WS mapping
+                                      the same services. Tested with WebsocketCommunicator.
+RC2  Cloud runner WS client           cloud_runner.py opens the WS (websockets lib),
+                                      claims on wake, streams events up, heartbeats.
+                                      REST claim/lease kept as durable fallback.
+RC3  Laptop runner WS client          the emdash/canopy_runner path onto the same channel.
+RC4  Human interjection               a session message for a RUNNING turn pushes down
+                                      to the assigned runner; the agent sees it live.
+RC5  Migrate + retire polling         heartbeat/claim polling → heartbeat-only fallback;
+                                      liveness from connection state.
+```
+**Sequencing:** RC1 (foundation) → RC2 → RC4 (the multiplayer payoff) → RC3 → RC5.
+
+## RC1 — the foundation (this slice)
+- `apps/realtime`: `RunnerConsumer` (`AsyncJsonWebsocketConsumer`), routing entry,
+  PAT auth. Joins `runner.{id}` + `runnable.{ws}` groups.
+- `groups.runnable_group(ws)` (added) + a receiver publishing a `wake` on enqueue.
+- Frame handlers that call the SAME `apps/harness/services` functions as REST
+  (`claim_next_turn`, `heartbeat`, `append_events`, `finish_turn`), so no drift.
+- Tests with Channels `WebsocketCommunicator` (InMemory layer): connect+auth,
+  wake-on-enqueue reaches the socket, claim-over-WS returns a turn.
+
+Out of scope for RC1: the runner-side WS clients (RC2/RC3), human interjection
+(RC4), retiring the REST poll (RC5). REST claim/heartbeat stay fully working
+alongside, so nothing regresses while the channel is built out.
+
+## Non-goals
+- Not moving durable state off Postgres — the socket never becomes the source of
+  truth; a reconnect always reconciles against the DB.
+- Not server-push-assign yet (RC1 is pull-on-wake); the head-start preference stays
+  until push-assign makes availability exact.

--- a/tests/test_realtime_routing.py
+++ b/tests/test_realtime_routing.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import uuid
 
-from apps.realtime.consumers import SupervisorConsumer, TurnConsumer
+from apps.realtime.consumers import RunnerConsumer, SupervisorConsumer, TurnConsumer
 from apps.realtime.routing import websocket_urlpatterns
 
 
@@ -16,12 +16,16 @@ def _match(path: str):
     return None
 
 
-def test_two_routes_registered():
-    assert len(websocket_urlpatterns) == 2
+def test_routes_registered():
+    assert len(websocket_urlpatterns) == 3
 
 
 def test_turn_route_resolves():
     assert _match(f"ws/turns/{uuid.uuid4().hex}/") is TurnConsumer
+
+
+def test_runner_route_resolves():
+    assert _match(f"ws/runner/{uuid.uuid4().hex}/") is RunnerConsumer
 
 
 def test_supervisor_route_resolves():

--- a/tests/test_realtime_runner_consumer.py
+++ b/tests/test_realtime_runner_consumer.py
@@ -1,0 +1,112 @@
+"""RC1 — RunnerConsumer: PAT-authed control channel, wake-on-enqueue, claim over WS.
+
+The runner keeps a persistent socket; enqueue publishes a wake to its workspace's
+runnable group (the runner claims on it), and claim/heartbeat frames call the same
+harness services the REST routes do. Postgres stays the source of truth."""
+from __future__ import annotations
+
+import pytest
+from channels.db import database_sync_to_async
+from channels.testing import WebsocketCommunicator
+from django.contrib.auth.models import AnonymousUser, User
+from django.utils import timezone
+
+from apps.agents.models import Agent
+from apps.harness import services
+from apps.harness.models import Runner, Turn
+from apps.realtime.consumers import RunnerConsumer
+from apps.workspaces.models import Workspace, WorkspaceMembership
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+
+def _setup():
+    user = User.objects.create_user("jj", "jj@dimagi.com", "pw")
+    ws = Workspace.objects.create(slug="connect", display_name="Connect", created_by=user)
+    WorkspaceMembership.objects.create(user=user, workspace=ws, role=WorkspaceMembership.OWNER)
+    agent = Agent.objects.create(slug="echo", name="Echo", workspace=ws, owner=user)
+    runner = Runner.objects.create(
+        name="jj-mbp", kind=Runner.EMDASH, paired_by=user,
+        status=Runner.ONLINE, last_heartbeat_at=timezone.now(),
+        capabilities={"agents": ["echo"]},
+    )
+    return user, ws, agent, runner
+
+
+async def _connect(runner_id, user):
+    comm = WebsocketCommunicator(RunnerConsumer.as_asgi(), f"/ws/runner/{runner_id}/")
+    comm.scope["user"] = user
+    comm.scope["url_route"] = {"kwargs": {"runner_id": str(runner_id)}}
+    return comm
+
+
+# --- auth / ownership --------------------------------------------------------
+async def test_anonymous_rejected():
+    user, _ws, _a, runner = await database_sync_to_async(_setup)()
+    comm = await _connect(runner.id, AnonymousUser())
+    connected, code = await comm.connect()
+    assert connected is False and code == 4001
+
+
+async def test_non_owner_rejected():
+    user, _ws, _a, runner = await database_sync_to_async(_setup)()
+    other = await database_sync_to_async(User.objects.create_user)("x", "x@dimagi.com", "pw")
+    comm = await _connect(runner.id, other)
+    connected, code = await comm.connect()
+    assert connected is False and code == 4003
+
+
+async def test_owner_connects():
+    user, _ws, _a, runner = await database_sync_to_async(_setup)()
+    comm = await _connect(runner.id, user)
+    connected, _ = await comm.connect()
+    assert connected is True
+    await comm.disconnect()
+
+
+# --- wake on enqueue ---------------------------------------------------------
+async def test_enqueue_wakes_the_runner():
+    user, ws, agent, runner = await database_sync_to_async(_setup)()
+    comm = await _connect(runner.id, user)
+    await comm.connect()
+
+    @database_sync_to_async
+    def _enqueue():
+        services.enqueue_turn(agent=agent, origin=Turn.ORIGIN_MANUAL,
+                              idempotency_key="w1", prompt="hi")
+
+    await _enqueue()
+    frame = await comm.receive_json_from(timeout=2)
+    assert frame == {"type": "wake"}
+    await comm.disconnect()
+
+
+# --- claim over the socket ---------------------------------------------------
+async def test_claim_over_ws_returns_a_turn():
+    user, ws, agent, runner = await database_sync_to_async(_setup)()
+
+    @database_sync_to_async
+    def _enqueue():
+        services.enqueue_turn(agent=agent, origin=Turn.ORIGIN_MANUAL,
+                              idempotency_key="c1", prompt="do the thing")
+
+    await _enqueue()  # queued before connect — so no wake reaches this socket
+    comm = await _connect(runner.id, user)
+    await comm.connect()
+
+    await comm.send_json_to({"action": "claim"})
+    frame = await comm.receive_json_from(timeout=2)
+    assert frame["type"] == "claim.result"
+    assert frame["turn"]["target"] == "echo"
+    assert frame["turn"]["prompt"] == "do the thing"
+    await comm.disconnect()
+
+
+async def test_claim_over_ws_empty_when_nothing_queued():
+    user, _ws, _a, runner = await database_sync_to_async(_setup)()
+    comm = await _connect(runner.id, user)
+    await comm.connect()
+    await comm.send_json_to({"action": "claim"})
+    frame = await comm.receive_json_from(timeout=2)
+    assert frame == {"type": "claim.result", "turn": None}
+    await comm.disconnect()


### PR DESCRIPTION
First slice (**RC1**) of the [runner control channel](../blob/emdash/runner-push/docs/superpowers/specs/2026-07-22-runner-control-channel-design.md) — one real-time layer over humans **and** runners, which is what near-real-time chat + multiplayer need (a human message must reach a *running* agent live; polling can't).

## What
- **`RunnerConsumer`** (`/ws/runner/{id}/`): PAT-authed, owner-gated (`paired_by`), joins the per-runner group + its workspaces' `runnable.{ws}` groups.
  - server → runner: **`wake`** when a turn is claimable
  - runner → server: **`claim`** / **`heartbeat`** frames that call the *same* harness services the REST routes do (no drift)
- **`enqueue` → wake:** a post_save receiver publishes `wake` to `runnable.{ws}` on a newly-queued turn (`on_commit`, null-safe).
- **Postgres stays the source of truth.** The socket is transport; `claim_next_turn` + the lease remain durable. REST claim/heartbeat keep working alongside — this *adds* a channel, it doesn't replace the durable path. Nothing regresses.

## Test
6 `RunnerConsumer` tests (auth/ownership, wake-on-enqueue, claim-over-WS, empty-claim) via `WebsocketCommunicator`; full backend suite **988 passed / 1 skipped**.

## Next (design doc RC2–RC5)
RC2 cloud-runner WS client → RC4 human interjection (the multiplayer payoff) → RC3 laptop client → RC5 retire polling. Server-push-assign (retiring the head-start timer) is a later evolution noted in the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)