### PR TITLE
feat(supervisor): fix RunnerDetail fields (availability, paired-by, drop workspace noise)

### DIFF
--- a/apps/harness/schemas.py
+++ b/apps/harness/schemas.py
@@ -46,10 +46,21 @@ class RunnerOut(Schema):
     host: str
     code_branch: str
     workspace: str | None
+    # The human who paired the runner. This — NOT `workspace` — is what governs
+    # what the runner may WORK FOR (claim_next_turn derives the tenant from the
+    # pairer's workspace memberships, so a runner serves agents across every
+    # workspace its pairer belongs to). `workspace` is only the home/visibility
+    # tenant. Surfaced so the supervisor can show the meaningful owner instead of
+    # implying a single-workspace serving scope.
+    paired_by_email: str | None
 
     @staticmethod
     def resolve_workspace(obj) -> str | None:
         return obj.workspace_id
+
+    @staticmethod
+    def resolve_paired_by_email(obj) -> str | None:
+        return obj.paired_by.email if obj.paired_by_id else None
 
     @staticmethod
     def resolve_status(obj) -> str:

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -5602,6 +5602,8 @@ export interface components {
             readonly code_branch: string;
             /** Workspace */
             readonly workspace: string | null;
+            /** Paired By Email */
+            readonly paired_by_email: string | null;
         };
         /** RunnerIn */
         readonly RunnerIn: {

--- a/frontend/src/components/supervisor/RunnerDetail.tsx
+++ b/frontend/src/components/supervisor/RunnerDetail.tsx
@@ -5,8 +5,10 @@ import { RunnerOrder } from '@/components/agents/RunnerOrder'
 import { agentsForKind, ordinal } from './runnerPriority'
 
 // A runner's full state — the click-through from the Runners tab's runner list.
-// Surfaces the two health signals that matter (ON / READY), the runner's info,
-// and which agents prioritize this runner's KIND — editable in place.
+// Leads with the signals that actually matter: is it AVAILABLE to fire a turn
+// (online ∧ ready — a stale runner reporting last-known ready=true is NOT), what
+// agents/repos it can drive, and who paired it (the owner that governs what it may
+// work for). Plus which agents prioritize this runner's KIND — editable in place.
 export function RunnerDetail({
   runner,
   agents,
@@ -21,6 +23,14 @@ export function RunnerDetail({
   onBack: () => void
 }): JSX.Element {
   const online = runner.status === 'online'
+  // Real availability, not last-known ready: a stale runner's ready flag is
+  // whatever it reported on its final heartbeat and no longer reflects reality.
+  const available = online && runner.ready
+  const badge = available
+    ? { text: 'available', cls: 'bg-success/15 text-success' }
+    : online
+      ? { text: 'not ready', cls: 'bg-destructive/15 text-destructive' }
+      : { text: runner.status || 'offline', cls: 'bg-muted text-muted-foreground' }
   const caps = (runner.capabilities ?? {}) as { agents?: string[]; projects?: string[] }
   const { ranked, acceptsAll } = agentsForKind(agents, runner.kind)
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set())
@@ -75,21 +85,23 @@ export function RunnerDetail({
         <span className="text-[15px] font-semibold text-foreground">{runner.name}</span>
         <span
           data-testid="runner-detail-ready"
-          className={`ml-auto rounded px-1.5 py-0.5 text-[11px] ${runner.ready ? 'bg-success/15 text-success' : 'bg-destructive/15 text-destructive'}`}
+          className={`ml-auto rounded px-1.5 py-0.5 text-[11px] ${badge.cls}`}
         >
-          {runner.ready ? 'ready' : 'not ready'}
+          {badge.text}
         </span>
       </div>
-      {!runner.ready && runner.ready_note && (
+      {online && !runner.ready && runner.ready_note && (
         <p className="text-[12px] text-destructive" data-testid="runner-detail-why">{runner.ready_note}</p>
       )}
       <div className="rounded-lg border border-border bg-card p-3">
-        {row('status', online ? 'online' : (runner.status ?? 'unknown'))}
-        {row('kind', runner.kind ?? '')}
-        {row('host', runner.host ?? '')}
-        {row('workspace', runner.workspace ?? '')}
         {row('agents', (caps.agents ?? []).join(', ') || '—')}
         {row('projects', (caps.projects ?? []).join(', ') || '—')}
+        {row('kind', runner.kind ?? '')}
+        {row('paired by', runner.paired_by_email ?? '—')}
+        {/* host only matters for emdash (per-macOS-account session reuse); cloud
+            runners report no host, so skip the empty row entirely. */}
+        {runner.host && row('host', runner.host)}
+        {row('status', runner.status ?? 'unknown')}
       </div>
 
       {/* Which agents route work to this runner's KIND, and how strongly. */}


### PR DESCRIPTION
## Why

Follow-up to #311. Auditing the runner detail card (prompted by "why does a runner list a workspace?"): it led with **misleading/low-value fields** and hid the meaningful ones.

- `workspace` is only the runner's **home/visibility tenant** — it is explicitly **not** what the runner serves (`claim_next_turn` derives tenancy from the *pairer's* workspace memberships, so one runner serves agents across several workspaces). Showing it implied a serving scope it doesn't have.
- `ready` was shown raw, so a **stale** runner still read `ready` — it's last-known, not current.
- The field that actually governs what a runner works for — **`paired_by`** — wasn't exposed at all.
- `capabilities.agents` (the most useful thing) was buried at the bottom; the `host` row rendered empty for every cloud runner.

## Changes

**Frontend (`RunnerDetail.tsx`):**
- Header badge now shows real **availability** = `online && ready`. A stale runner shows its live status (`stale`/`disconnected`); online-but-not-ready shows `not ready` + `ready_note`.
- Card **leads with agents + projects**, then kind.
- **`workspace` row → `paired by <email>`** — the true owner/serving-scope signal.
- **`host` renders only for emdash** (cloud reports none) — no empty N/A row.

**Backend (`apps/harness/schemas.py`):** expose `paired_by_email` on `RunnerOut` (+ resolver). Regenerated OpenAPI types.

## Not in this PR (done separately, operationally)
Retired 3 stale/duplicate cloud runner rows on labs (`cloud-ec2-1`, `cloud-echo-hello`, plus one earlier) that were lingering because pairing mints a new row and nothing retires the old — the "why are there 4 runners" surprise. Down to laptop + the one live EC2 runner. (No code change; noting for context. A future improvement worth considering: auto-retire a superseded pairing, or hide long-stale runners.)

## Testing
- `cd frontend && npm run build` — passes (0 TS errors).
- `cd frontend && npm run test` — 147/147 pass.
- `uv run pytest tests/ -k "harness or runner"` — 167 pass (RunnerOut serialization with the new field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)