### PR TITLE
fix(realtime): WS keepalive + RC3 wake-listener + EC2 size fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,4 +63,8 @@ RUN chmod +x /entrypoint.sh
 
 EXPOSE 8000
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["uvicorn", "config.asgi:application", "--host", "0.0.0.0", "--port", "8000"]
+# --ws-ping-interval 5: the shared labs proxy drops IDLE WebSockets at ~8s, well
+# before uvicorn's default 20s ping. Pinging every 5s keeps every WS client (the
+# supervisor/turn tails AND the runner control channel) alive through the proxy.
+CMD ["uvicorn", "config.asgi:application", "--host", "0.0.0.0", "--port", "8000", \
+     "--ws-ping-interval", "5", "--ws-ping-timeout", "20"]

--- a/deploy/ec2-runner/cloud_runner.py
+++ b/deploy/ec2-runner/cloud_runner.py
@@ -298,6 +298,9 @@ def run_over_ws(runner_id: str) -> bool:
             continue
         connected_ever = True
         _log(f"ws connected: {url}")
+        # Heartbeat first so the runner registers ONLINE immediately (claim_next_turn
+        # gates on it) rather than waiting out the first idle timeout.
+        _ws_request(ws, {"action": "heartbeat", "active_turn_ids": []}, "heartbeat.ack", timeout=15)
         _claim_and_run(ws, runner_id)  # drain anything already queued (no wake for those)
         try:
             while not _stop:

--- a/deploy/ec2-runner/runner.cfn.yaml
+++ b/deploy/ec2-runner/runner.cfn.yaml
@@ -110,7 +110,7 @@ Resources:
           #cloud-config
           write_files:
             - path: /opt/canopy-runner/cloud_runner.py
-              encoding: b64
+              encoding: gz+b64
               permissions: '0755'
               content: CLOUD_RUNNER_PY_B64_PLACEHOLDER
             - path: /usr/local/bin/canopy-fetch-env

--- a/deploy/ec2-runner/up.sh
+++ b/deploy/ec2-runner/up.sh
@@ -30,7 +30,9 @@ echo ">> SSH allowed from ${MYIP}/32"
 # Render: splice cloud_runner.py (base64) into the template. cloud_runner.py stays
 # the single source of truth; the rendered template is a build artifact.
 RENDERED=".runner.cfn.rendered.yaml"
-B64=$(python3 -c "import base64;print(base64.b64encode(open('cloud_runner.py','rb').read()).decode())")
+# gzip+base64 (cloud-init decodes via `encoding: gz+b64`): the RC2 WS client pushed
+# the plain-base64 UserData past EC2's 25.6 KB limit; gzip keeps it well under.
+B64=$(python3 -c "import base64,gzip;print(base64.b64encode(gzip.compress(open('cloud_runner.py','rb').read())).decode())")
 python3 - "$B64" > "$RENDERED" <<'PY'
 import sys, pathlib
 b64 = sys.argv[1]

--- a/packages/canopy_runner/canopy_runner/main.py
+++ b/packages/canopy_runner/canopy_runner/main.py
@@ -413,6 +413,18 @@ def main() -> None:
         except OSError:
             pass
 
+    # RC3: a WS wake-listener lets the loop claim the INSTANT a turn is enqueued
+    # instead of waiting out poll_seconds. Additive + best-effort — polling stays the
+    # fallback and still owns heartbeat/claim/execute; off if websocket-client is absent.
+    from .wake import WakeListener
+    waker = WakeListener(cfg.base_url, cfg.token, cfg.runner_id)
+    if waker.start():
+        logger.info("  wake: WS control channel connected — claims fire on enqueue, not just poll")
+
+    def _wait(seconds: float) -> None:
+        if waker.event.wait(seconds):  # returns early on a wake nudge
+            waker.event.clear()
+
     idle_streak = 0
     paused = False
     while True:
@@ -454,7 +466,7 @@ def main() -> None:
             else:
                 logger.info("cycle: %s", result)
             idle_streak = 0
-        time.sleep(cfg.poll_seconds)
+        _wait(cfg.poll_seconds)  # wake-aware: claims fire on enqueue, not just poll
 
 
 if __name__ == "__main__":

--- a/packages/canopy_runner/canopy_runner/main.py
+++ b/packages/canopy_runner/canopy_runner/main.py
@@ -418,10 +418,20 @@ def main() -> None:
     # fallback and still owns heartbeat/claim/execute; off if websocket-client is absent.
     from .wake import WakeListener
     waker = WakeListener(cfg.base_url, cfg.token, cfg.runner_id)
-    if waker.start():
+    wake_on = waker.start()
+    if wake_on:
         logger.info("  wake: WS control channel connected — claims fire on enqueue, not just poll")
 
     def _wait(seconds: float) -> None:
+        # With a live wake channel, block until a nudge OR the poll interval,
+        # whichever comes first. Without one (websocket-client absent — the
+        # poll-only laptop, the cloud REST fallback, the test env), fall back to
+        # the exact prior behavior: a plain time.sleep. Routing the wait through
+        # the Event unconditionally would swallow the time.sleep the loop tests
+        # patch to break the loop — an infinite hang.
+        if not wake_on:
+            time.sleep(seconds)
+            return
         if waker.event.wait(seconds):  # returns early on a wake nudge
             waker.event.clear()
 

--- a/packages/canopy_runner/canopy_runner/wake.py
+++ b/packages/canopy_runner/canopy_runner/wake.py
@@ -1,0 +1,89 @@
+"""RC3 — a WebSocket wake-listener for the laptop runner.
+
+A daemon thread holds a socket to canopy-web's runner control channel
+(/ws/runner/{id}/) and sets `event` on every `wake` frame, so the poll loop can
+claim IMMEDIATELY instead of waiting out poll_seconds. Deliberately additive: it
+does NOT claim, heartbeat, or execute — the existing loop still owns all of that
+(and remains the fallback). A wake we miss (socket down, no websocket-client
+installed) only costs latency, never correctness — the loop's timeout still fires.
+
+Kept stdlib-friendly: the one dependency (websocket-client) is imported lazily, so
+the runner still starts (poll-only) if it isn't installed.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import threading
+
+logger = logging.getLogger(__name__)
+
+
+def ws_url(base_url: str, runner_id: str) -> str:
+    b = base_url.replace("https://", "wss://", 1).replace("http://", "ws://", 1).rstrip("/")
+    return f"{b}/ws/runner/{runner_id}/"
+
+
+class WakeListener:
+    def __init__(self, base_url: str, token: str, runner_id: str, *, recv_timeout: int = 30):
+        self.event = threading.Event()
+        self._url = ws_url(base_url, runner_id)
+        self._token = token
+        self._recv_timeout = recv_timeout
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def _handle(self, raw: str) -> None:
+        """Set the wake event on a `wake` frame; ignore everything else."""
+        try:
+            msg = json.loads(raw)
+        except (ValueError, TypeError):
+            return
+        if msg.get("type") == "wake":
+            self.event.set()
+
+    def start(self) -> bool:
+        """Begin listening. Returns False (poll-only) if websocket-client is absent."""
+        try:
+            import websocket  # noqa: F401
+        except ImportError:
+            logger.info("websocket-client not installed — wake listener off, polling only")
+            return False
+        self._thread = threading.Thread(target=self._run, name="wake-listener", daemon=True)
+        self._thread.start()
+        return True
+
+    def stop(self) -> None:
+        self._stop.set()
+
+    def _run(self) -> None:
+        import websocket
+
+        while not self._stop.is_set():
+            try:
+                ws = websocket.create_connection(
+                    self._url, header=[f"Authorization: Bearer {self._token}"],
+                    timeout=self._recv_timeout,
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("wake ws connect failed (%s); retrying", exc)
+                self._stop.wait(15)
+                continue
+            logger.info("wake listener connected: %s", self._url)
+            try:
+                while not self._stop.is_set():
+                    try:
+                        raw = ws.recv()
+                    except websocket.WebSocketTimeoutException:
+                        continue  # idle; keep the socket open
+                    if not raw:
+                        break
+                    self._handle(raw)
+            except Exception as exc:  # noqa: BLE001 — a socket error is recoverable
+                logger.debug("wake ws loop error (%s); reconnecting", exc)
+            finally:
+                try:
+                    ws.close()
+                except Exception:  # noqa: BLE001
+                    pass
+            self._stop.wait(2)  # brief backoff before reconnect

--- a/packages/canopy_runner/tests/test_main.py
+++ b/packages/canopy_runner/tests/test_main.py
@@ -13,6 +13,30 @@ from canopy_runner.config import Config
 from canopy_runner.main import _fire_due_schedules, run_once
 
 
+@pytest.fixture(autouse=True)
+def _wake_off(monkeypatch):
+    """Keep the RC3 wake listener inert so `main()`'s poll wait falls back to the
+    plain time.sleep these loop tests patch to break the loop. Without this, an env
+    that HAS websocket-client installed would give `main()` a live wake channel, the
+    wait would block on the Event instead of time.sleep, the patched break would
+    never fire, and the loop would hang — the exact 6h CI hang, made env-dependent."""
+    import threading
+
+    import canopy_runner.wake as wake_mod
+
+    class _InertWaker:
+        def __init__(self, *a, **k):
+            self.event = threading.Event()
+
+        def start(self) -> bool:
+            return False
+
+        def stop(self) -> None:
+            pass
+
+    monkeypatch.setattr(wake_mod, "WakeListener", _InertWaker)
+
+
 @pytest.fixture()
 def db(tmp_path: Path) -> str:
     """A minimal emdash DB — just the read surface (tasks + projects). The runner never

--- a/packages/canopy_runner/tests/test_wake.py
+++ b/packages/canopy_runner/tests/test_wake.py
@@ -1,0 +1,26 @@
+"""RC3 — WakeListener frame handling + URL (pure logic; no socket, no WS lib)."""
+from __future__ import annotations
+
+from canopy_runner.wake import WakeListener, ws_url
+
+
+def test_ws_url_builds_the_control_channel_url():
+    assert ws_url("https://labs.connect.dimagi.com/canopy", "abc") == \
+        "wss://labs.connect.dimagi.com/canopy/ws/runner/abc/"
+    assert ws_url("http://localhost:8000", "x") == "ws://localhost:8000/ws/runner/x/"
+
+
+def test_handle_sets_event_only_on_wake():
+    w = WakeListener("https://x", "t", "r")
+    assert not w.event.is_set()
+    w._handle('{"type": "heartbeat.ack"}')   # unrelated frame
+    assert not w.event.is_set()
+    w._handle('{"type": "wake"}')
+    assert w.event.is_set()
+
+
+def test_handle_ignores_malformed_frames():
+    w = WakeListener("https://x", "t", "r")
+    w._handle("not json")
+    w._handle("")
+    assert not w.event.is_set()


### PR DESCRIPTION
Keeps WebSockets alive through the labs proxy (uvicorn --ws-ping-interval 5 — the proxy drops idle WS at ~8s, before uvicorn's 20s default), so the runner control channel (and idle supervisor/turn tails) stay connected. Plus RC3 (laptop wake-listener, additive + poll-fallback) and the EC2 gz+b64 UserData size fix. 3 wake tests. 🤖 Generated with [Claude Code](https://claude.com/claude-code)