### PR TITLE
fix(realtime): app-level data-frame WS keepalive (the real proxy fix)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,3 +11,11 @@ node_modules
 .pytest_cache
 .ruff_cache
 staticfiles
+
+# The laptop/cloud runner daemon (packages/canopy_runner) is NOT a dependency of
+# the web image (canopy-web depends only on canopy-agent-runs + canopy-cron) and no
+# app imports it. Excluding it from the build context means editing the runner never
+# busts the expensive `uv pip install` layer — the web image rebuilds only when the
+# web app actually changes. deploy/ is likewise runtime-irrelevant to the container.
+packages/canopy_runner
+deploy

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,8 +63,11 @@ RUN chmod +x /entrypoint.sh
 
 EXPOSE 8000
 ENTRYPOINT ["/entrypoint.sh"]
-# --ws-ping-interval 5: the shared labs proxy drops IDLE WebSockets at ~8s, well
-# before uvicorn's default 20s ping. Pinging every 5s keeps every WS client (the
-# supervisor/turn tails AND the runner control channel) alive through the proxy.
+# WS keepalive note: the shared labs proxy drops an idle WebSocket at ~6-8s and —
+# proven empirically — does NOT count ws ping/pong CONTROL frames as activity, only
+# application DATA frames. So these uvicorn ping flags do NOT by themselves keep a
+# client alive through the proxy; the real keepalive is an app-level data frame sent
+# every ~4s by each client (the runner's `keepalive` action; browser clients send
+# their own). The flags stay as sane dead-peer detection defaults.
 CMD ["uvicorn", "config.asgi:application", "--host", "0.0.0.0", "--port", "8000", \
      "--ws-ping-interval", "5", "--ws-ping-timeout", "20"]

--- a/apps/realtime/consumers.py
+++ b/apps/realtime/consumers.py
@@ -78,6 +78,14 @@ class TurnConsumer(AsyncJsonWebsocketConsumer):
         # group_send type="turn.event" dispatches here (dots -> underscores).
         await self.send_json({"event": message["event"]})
 
+    async def receive_json(self, content, **kwargs):
+        # The only inbound frame is the client's keepalive: the shared labs proxy
+        # drops an idle WS at ~6-8s and counts only application DATA frames as
+        # activity (not ws ping/pong), so the browser sends one every few seconds.
+        # Ack it so data flows both ways, exactly as the proven-live pattern does.
+        if content.get("action") == "keepalive":
+            await self.send_json({"type": "keepalive.ack"})
+
     # -- helpers --
     @database_sync_to_async
     def _get_turn(self, raw_id):
@@ -132,6 +140,12 @@ class SupervisorConsumer(AsyncJsonWebsocketConsumer):
 
     async def supervisor_waiting(self, message):
         await self.send_json(message)
+
+    async def receive_json(self, content, **kwargs):
+        # Client keepalive (see TurnConsumer.receive_json) — the proxy needs a data
+        # frame every few seconds or it drops this idle status socket.
+        if content.get("action") == "keepalive":
+            await self.send_json({"type": "keepalive.ack"})
 
     @database_sync_to_async
     def _snapshot(self, user):
@@ -198,6 +212,13 @@ class RunnerConsumer(AsyncJsonWebsocketConsumer):
         if action == "claim":
             turn = await self._claim()
             await self.send_json({"type": "claim.result", "turn": turn})
+        elif action == "keepalive":
+            # A cheap, DB-free liveness frame. The shared labs proxy drops a WS
+            # that sends no APPLICATION DATA for ~6-8s (it ignores ws ping/pong
+            # control frames as activity), so an idle-waiting runner must emit a
+            # data frame faster than that window. Kept distinct from heartbeat so
+            # the sub-window cadence doesn't hammer the DB on every tick.
+            await self.send_json({"type": "keepalive.ack"})
         elif action == "heartbeat":
             await self._heartbeat(content.get("active_turn_ids") or [])
             await self.send_json({"type": "heartbeat.ack"})

--- a/deploy/ec2-runner/cloud_runner.py
+++ b/deploy/ec2-runner/cloud_runner.py
@@ -53,8 +53,14 @@ RUNNER_WORKSPACE = os.environ.get("RUNNER_WORKSPACE", "")
 CLAUDE_BIN = os.environ.get("CLAUDE_BIN", "claude")
 WORK_DIR = os.environ.get("WORK_DIR", "/tmp/canopy-runner-work")
 POLL_SECONDS = int(os.environ.get("POLL_SECONDS", "15"))
-# Idle WS recv timeout → app-level heartbeat cadence (keeps the lease + status fresh).
+# Full heartbeat cadence (keeps the runner's lease + ONLINE status fresh via a DB write).
 HEARTBEAT_SECONDS = int(os.environ.get("HEARTBEAT_SECONDS", "20"))
+# Idle WS keepalive cadence. The shared labs proxy drops a WebSocket that sends no
+# application DATA for ~6-8s — it does NOT count ws ping/pong control frames as
+# activity (proven empirically). So on an idle control channel we must emit a data
+# frame well under that window; 4s leaves margin. This is a cheap DB-free keepalive;
+# a real heartbeat still fires every HEARTBEAT_SECONDS.
+KEEPALIVE_SECONDS = int(os.environ.get("KEEPALIVE_SECONDS", "4"))
 STATE_FILE = pathlib.Path(os.environ.get("STATE_FILE", str(pathlib.Path.home() / ".canopy-cloud-runner.json")))
 
 _stop = False
@@ -302,12 +308,24 @@ def run_over_ws(runner_id: str) -> bool:
         # gates on it) rather than waiting out the first idle timeout.
         _ws_request(ws, {"action": "heartbeat", "active_turn_ids": []}, "heartbeat.ack", timeout=15)
         _claim_and_run(ws, runner_id)  # drain anything already queued (no wake for those)
+        # Recv on the KEEPALIVE window (not the heartbeat window): the proxy kills an
+        # idle socket in ~6-8s, so we must send a data frame every few seconds or the
+        # channel flaps. A wake frame arriving mid-window is returned by recv() at
+        # once, so keepalive cadence never adds wake latency.
+        ws.settimeout(KEEPALIVE_SECONDS)
+        last_heartbeat = time.time()
         try:
             while not _stop:
                 try:
                     raw = ws.recv()
                 except websocket.WebSocketTimeoutException:
-                    _ws_request(ws, {"action": "heartbeat", "active_turn_ids": []}, "heartbeat.ack", timeout=15)
+                    # Idle tick: a real heartbeat when its cadence is due (keeps the
+                    # lease/ONLINE fresh), else the cheap DB-free keepalive.
+                    if time.time() - last_heartbeat >= HEARTBEAT_SECONDS:
+                        _ws_request(ws, {"action": "heartbeat", "active_turn_ids": []}, "heartbeat.ack", timeout=15)
+                        last_heartbeat = time.time()
+                    else:
+                        _ws_request(ws, {"action": "keepalive"}, "keepalive.ack", timeout=15)
                     continue
                 if not raw:
                     break
@@ -315,6 +333,7 @@ def run_over_ws(runner_id: str) -> bool:
                 mtype = msg.get("type")
                 if mtype == "wake":
                     _claim_and_run(ws, runner_id)
+                    last_heartbeat = time.time()  # _claim_and_run just exchanged frames
                 elif mtype == "interject":
                     _log(f"interject turn={msg.get('turn_id')}: {msg.get('message')!r}")
         except Exception as exc:

--- a/frontend/src/hooks/useLiveSupervisor.ts
+++ b/frontend/src/hooks/useLiveSupervisor.ts
@@ -56,6 +56,7 @@ export function useLiveSupervisor(): LiveSupervisor {
   useEffect(() => {
     let ws: WebSocket | null = null
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+    let keepaliveTimer: ReturnType<typeof setInterval> | null = null
     let closed = false
 
     const connect = () => {
@@ -64,6 +65,13 @@ export function useLiveSupervisor(): LiveSupervisor {
       ws.onopen = () => {
         attemptRef.current = 0
         setConnected(true)
+        // The shared labs proxy drops an idle WS at ~6-8s and counts only
+        // application DATA frames as activity (not ws ping/pong). Browsers can't
+        // send ws pings, so push a small keepalive data frame every 4s.
+        if (keepaliveTimer) clearInterval(keepaliveTimer)
+        keepaliveTimer = setInterval(() => {
+          if (ws && ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify({ action: 'keepalive' }))
+        }, 4000)
       }
       ws.onmessage = (msg) => {
         try {
@@ -76,6 +84,7 @@ export function useLiveSupervisor(): LiveSupervisor {
       }
       ws.onclose = () => {
         setConnected(false)
+        if (keepaliveTimer) { clearInterval(keepaliveTimer); keepaliveTimer = null }
         if (closed) return
         const delay = BACKOFFS_MS[Math.min(attemptRef.current, BACKOFFS_MS.length - 1)]
         attemptRef.current += 1
@@ -87,6 +96,7 @@ export function useLiveSupervisor(): LiveSupervisor {
     return () => {
       closed = true
       if (reconnectTimer) clearTimeout(reconnectTimer)
+      if (keepaliveTimer) clearInterval(keepaliveTimer)
       if (ws) ws.close()
     }
   }, [])

--- a/frontend/src/hooks/useLiveTurn.ts
+++ b/frontend/src/hooks/useLiveTurn.ts
@@ -46,6 +46,7 @@ export function useLiveTurn(turnId: string | null): LiveTurn {
 
     let ws: WebSocket | null = null
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+    let keepaliveTimer: ReturnType<typeof setInterval> | null = null
     let closed = false
 
     const connect = () => {
@@ -56,6 +57,13 @@ export function useLiveTurn(turnId: string | null): LiveTurn {
         attemptRef.current = 0
         setConnected(true)
         setLastError(null)
+        // The shared labs proxy drops an idle WS at ~6-8s, counting only
+        // application DATA frames as activity (not ws ping/pong). Send a small
+        // keepalive data frame every 4s so a quiet turn tail stays connected.
+        if (keepaliveTimer) clearInterval(keepaliveTimer)
+        keepaliveTimer = setInterval(() => {
+          if (ws && ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify({ action: 'keepalive' }))
+        }, 4000)
       }
       ws.onmessage = (msg) => {
         try {
@@ -72,6 +80,7 @@ export function useLiveTurn(turnId: string | null): LiveTurn {
       ws.onerror = () => setLastError('connection error')
       ws.onclose = () => {
         setConnected(false)
+        if (keepaliveTimer) { clearInterval(keepaliveTimer); keepaliveTimer = null }
         if (closed) return
         const delay = BACKOFFS_MS[Math.min(attemptRef.current, BACKOFFS_MS.length - 1)]
         attemptRef.current += 1
@@ -84,6 +93,7 @@ export function useLiveTurn(turnId: string | null): LiveTurn {
     return () => {
       closed = true
       if (reconnectTimer) clearTimeout(reconnectTimer)
+      if (keepaliveTimer) clearInterval(keepaliveTimer)
       if (ws) ws.close()
     }
   }, [turnId])

--- a/packages/canopy_runner/canopy_runner/wake.py
+++ b/packages/canopy_runner/canopy_runner/wake.py
@@ -25,7 +25,13 @@ def ws_url(base_url: str, runner_id: str) -> str:
 
 
 class WakeListener:
-    def __init__(self, base_url: str, token: str, runner_id: str, *, recv_timeout: int = 30):
+    # The shared labs proxy drops a WS that sends no application DATA for ~6-8s (it
+    # ignores ws ping/pong control frames as activity). So even this read-only wake
+    # socket must emit a data frame under that window or it flaps every few seconds;
+    # 4s leaves margin. It's a cheap DB-free keepalive on the server side.
+    KEEPALIVE_SECONDS = 4
+
+    def __init__(self, base_url: str, token: str, runner_id: str, *, recv_timeout: int = KEEPALIVE_SECONDS):
         self.event = threading.Event()
         self._url = ws_url(base_url, runner_id)
         self._token = token
@@ -75,7 +81,16 @@ class WakeListener:
                     try:
                         raw = ws.recv()
                     except websocket.WebSocketTimeoutException:
-                        continue  # idle; keep the socket open
+                        # Idle: send a keepalive data frame so the proxy keeps the
+                        # socket open (ping/pong control frames don't count as
+                        # activity for it). Best-effort — a send error just drops us
+                        # into reconnect, exactly as a dead socket would.
+                        try:
+                            ws.send(json.dumps({"action": "keepalive"}))
+                            continue
+                        except Exception as exc:  # noqa: BLE001
+                            logger.debug("wake keepalive send failed (%s); reconnecting", exc)
+                            break
                     if not raw:
                         break
                     self._handle(raw)

--- a/tests/test_realtime_runner_consumer.py
+++ b/tests/test_realtime_runner_consumer.py
@@ -112,6 +112,19 @@ async def test_claim_over_ws_empty_when_nothing_queued():
     await comm.disconnect()
 
 
+async def test_keepalive_acks_without_touching_the_db():
+    # The idle-channel keepalive (the shared labs proxy drops a WS that sends no
+    # DATA for ~6-8s) must ack cheaply so the client can pace data frames under
+    # that window without a heartbeat's DB write on every tick.
+    user, _ws, _a, runner = await database_sync_to_async(_setup)()
+    comm = await _connect(runner.id, user)
+    await comm.connect()
+    await comm.send_json_to({"action": "keepalive"})
+    frame = await comm.receive_json_from(timeout=2)
+    assert frame == {"type": "keepalive.ack"}
+    await comm.disconnect()
+
+
 # --- run a whole turn over the socket (start/event/finish) -------------------
 async def test_run_turn_end_to_end_over_ws():
     user, ws, agent, runner = await database_sync_to_async(_setup)()


### PR DESCRIPTION
The shared labs proxy drops an idle WebSocket at ~6-8s and — proven empirically against the live server — counts **only application data frames** as activity; ws ping/pong control frames (server or client) do not reset its idle timer. So the earlier `--ws-ping-interval` fix (#316) was at the wrong layer and every runner/browser WS kept flapping.

**Fix:** each client sends a cheap `keepalive` **data** frame every ~4s (under the window), server acks it with no DB work.
- Runner control channel (cloud_runner + laptop wake.py) + `RunnerConsumer` action.
- Browser tails (`useLiveSupervisor`, `useLiveTurn`) + `Turn`/`Supervisor` consumer `receive_json`.

**Also:** `.dockerignore` excludes `packages/canopy_runner` + `deploy/` (not image deps) so editing the runner/IaC no longer busts the `uv pip install` layer — deploys rebuild the web image only when the web app changes.

Verified: backend realtime 17 passed (new keepalive test), canopy_runner 116 passed (no hang), frontend build clean. Live-proven: a 4s data-frame cadence holds the labs WS 35s+ where pings dropped at ~8s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)