### PR TITLE
feat(runner): collision-aware injection into live emdash sessions

### DIFF
--- a/packages/canopy_runner/canopy_runner/cdp/emdash_control.mjs
+++ b/packages/canopy_runner/canopy_runner/cdp/emdash_control.mjs
@@ -6,6 +6,13 @@
 //   list                              -> {ok, tasks:[names], projects:[names]}
 //   create {project, prompt}          -> {ok, action:"created"}    (new session)
 //   open-send {task, text}            -> {ok, action:"sent", task} (REUSE existing)
+//                                        -> {ok, action:"collision", line} if the prompt
+//                                           already holds UNSENT text (human was typing when
+//                                           emdash switched tasks) — does NOT clobber it.
+//   open-send {task, text, clearFirst}-> {ok, action:"sent-cleared"} kills the current input
+//                                           line first, then sends (the human's "Clear & send").
+// Text is delivered via CDP Input.insertText (one atomic commit, not char-by-char
+// typing) so it lands fast and narrows the window for a keystroke collision.
 // All output is a single JSON line on stdout. Occlusion-proof: uses JS-dispatched
 // clicks so it works while emdash is backgrounded (no foreground focus needed).
 import { chromium } from 'playwright-core';
@@ -104,7 +111,7 @@ try {
     // Initial-conversation prompt is a contenteditable in the Create Task dialog.
     const ce = page.locator('[role=dialog] [contenteditable="true"], [class*=Dialog] [contenteditable="true"]').first();
     await ce.click();
-    await page.keyboard.type(prompt);
+    await page.keyboard.insertText(prompt);   // atomic commit, not char-by-char
     const created = await page.evaluate(() => {
       const dlg = document.querySelector('[role=dialog],[class*=Dialog],[class*=modal]');
       if (!dlg) return false;
@@ -127,7 +134,7 @@ try {
     // so with dozens of tasks the target is usually absent from the DOM despite being
     // live (observed 2026-07-15: eva's org-research session, present in emdash's DB,
     // reported TASK_NOT_FOUND and duplicated).
-    const { task, text } = args;
+    const { task, text, clearFirst } = args;
     const found = await scrollToFind(`Open task ${task}`);
     // TASK_NOT_FOUND is a claim about the WHOLE sidebar, only trustworthy now that we
     // scan all of it. Even so the caller cross-checks it against emdash's sqlite before
@@ -138,10 +145,10 @@ try {
       fail(`could not click task "${task}" after locating it in the sidebar`);
     }
     await page.waitForTimeout(1200);
-    // Focus the ACTIVE terminal's input, then type. xterm's real input is an
-    // off-screen `.xterm-helper-textarea`, so a Playwright .click() fails its
-    // viewport check — we focus it via JS (viewport-agnostic) instead, picking the
-    // visible xterm (the active task's pane) when several are mounted.
+    // Focus the ACTIVE terminal's input. xterm's real input is an off-screen
+    // `.xterm-helper-textarea`, so a Playwright .click() fails its viewport check — we
+    // focus it via JS (viewport-agnostic) instead, picking the visible xterm (the active
+    // task's pane) when several are mounted.
     const focused = await page.evaluate(() => {
       const terms = [...document.querySelectorAll('.xterm')]
         .filter(t => t.offsetParent !== null && t.getBoundingClientRect().width > 0);
@@ -153,9 +160,58 @@ try {
       return true;
     });
     if (!focused) fail(`could not focus the terminal input for task "${task}"`);
-    await page.keyboard.type(text);
-    await page.keyboard.press('Enter');
-    out({ ok: true, action: 'sent', task });
+
+    // Read whatever is ALREADY sitting in the prompt. claude's TUI renders its input
+    // inside a bordered box; the input line is the last visible row carrying a '>'
+    // prompt marker. A non-empty line here means the human was typing when emdash
+    // switched to this task and their keystrokes leaked in — a COLLISION we must NOT
+    // clobber blindly. Heuristic + version-fragile: on any ambiguity it returns '',
+    // which takes the fast send path (never worse than the pre-collision behaviour, and
+    // no false-positive dialog).
+    const readLine = () => page.evaluate(() => {
+      const terms = [...document.querySelectorAll('.xterm')]
+        .filter(t => t.offsetParent !== null && t.getBoundingClientRect().width > 0);
+      const term = terms[0];
+      if (!term) return '';
+      const rows = [...term.querySelectorAll('.xterm-rows > div')]
+        .map(r => (r.textContent || '').replace(/\u00a0/g, ' '));
+      for (let i = rows.length - 1; i >= 0 && i >= rows.length - 14; i--) {
+        const m = rows[i].match(/(?:^|[│|])\s*>\s?(.*)$/);
+        if (m) return (m[1] || '').replace(/[│|─╭╮╰╯]/g, '').trim();
+      }
+      return '';
+    });
+    // Ghost/placeholder hints claude shows in an EMPTY input — treat as empty so the
+    // fast path still fires instead of popping a spurious collision dialog.
+    const PLACEHOLDER = /^(Try |Ask |\/ for |\? for )/i;
+    const isEmpty = (s) => !s || PLACEHOLDER.test(s);
+
+    if (clearFirst) {
+      // The human chose "Clear & send": deterministically empty the input, then send.
+      // Ctrl+U (kill-to-start) as a fast path, then backspace the MEASURED content and
+      // re-read until empty (self-correcting; robust to whatever line editing claude's
+      // TUI actually honors). Leaked text is "the last few words", so this is short.
+      await page.keyboard.press('Control+U');
+      for (let i = 0; i < 6; i++) {
+        const n = Math.min((await readLine()).length, 300);
+        if (n === 0) break;
+        await page.keyboard.press('End');
+        for (let k = 0; k < n; k++) await page.keyboard.press('Backspace');
+      }
+      await page.keyboard.insertText(text);
+      await page.keyboard.press('Enter');
+      out({ ok: true, action: 'sent-cleared', task });
+    } else {
+      const line = await readLine();
+      if (!isEmpty(line)) {
+        // Don't touch it — hand the collision back to the runner to ask the human.
+        out({ ok: true, action: 'collision', task, line });
+      } else {
+        await page.keyboard.insertText(text);   // atomic commit, not char-by-char
+        await page.keyboard.press('Enter');
+        out({ ok: true, action: 'sent', task });
+      }
+    }
 
   } else {
     fail(`unknown command: ${command}`);

--- a/packages/canopy_runner/canopy_runner/cdp_control.py
+++ b/packages/canopy_runner/canopy_runner/cdp_control.py
@@ -120,7 +120,18 @@ def create_task(project: str, prompt: str, *, task_name: str = "", port: int = 9
     return _run("create", args)
 
 
-def open_and_send(task: str, text: str, *, port: int = 9222) -> dict:
-    """REUSE: open an existing task and send `text` into its live terminal.
+def open_and_send(task: str, text: str, *, clear_first: bool = False, port: int = 9222) -> dict:
+    """REUSE: open an existing task and deliver `text` into its live terminal.
+
+    Returns the sidecar dict — normally ``{"action": "sent"}``. If the prompt already
+    holds UNSENT text (the human was typing when emdash switched tasks and their
+    keystrokes leaked in), returns ``{"action": "collision", "line": "<preview>"}``
+    WITHOUT clobbering it — the caller asks the human what to do (see `dialog.py`) and
+    may re-call with ``clear_first=True`` to kill the current line first, then send
+    (``{"action": "sent-cleared"}``).
+
     Raises CDPError if the task isn't present (caller falls back to create+rehydrate)."""
-    return _run("open-send", {"port": port, "task": task, "text": text})
+    args = {"port": port, "task": task, "text": text}
+    if clear_first:
+        args["clearFirst"] = True
+    return _run("open-send", args)

--- a/packages/canopy_runner/canopy_runner/dialog.py
+++ b/packages/canopy_runner/canopy_runner/dialog.py
@@ -1,0 +1,69 @@
+"""Native macOS dialog for runner↔human collision resolution.
+
+When the runner goes to deliver a turn into a live emdash session and finds the
+prompt already holds unsent text — almost always the human's own words, leaked in
+when emdash switched to that task while they were typing elsewhere — it asks the
+human where to send instead of clobbering the line.
+
+Renders via `osascript display dialog`, which only works when the runner runs in
+the user's Aqua GUI session (a launchd **LaunchAgent**, which
+`com.canopy.runner` is — not a LaunchDaemon). If osascript is unavailable or the
+dialog times out with nobody answering, the choice comes back as NEW — the
+non-destructive default (route to a fresh session, leave the existing prompt
+untouched). We NEVER delete the human's text without an explicit "Clear & send".
+"""
+from __future__ import annotations
+
+import subprocess
+
+# The three button labels — also the return values. Kept identical to the AppleScript
+# button strings below so a returned label round-trips by equality.
+CLEAR = "Clear & send"
+NEW = "New session"
+CANCEL = "Cancel"
+
+# argv: item 1 = message, item 2 = timeout seconds. Any error (no GUI session,
+# osascript quirk) OR "gave up" (timed out) resolves to the safe default: New session.
+_APPLESCRIPT = """on run argv
+    set theMsg to item 1 of argv
+    set theTimeout to (item 2 of argv) as integer
+    try
+        set r to display dialog theMsg with title "canopy runner — session busy" ¬
+            buttons {"Cancel", "New session", "Clear & send"} ¬
+            default button "Clear & send" giving up after theTimeout
+    on error
+        return "New session"
+    end try
+    if gave up of r then return "New session"
+    return button returned of r
+end run"""
+
+
+def collision_choice(task: str, line: str, *, timeout: int = 30) -> str:
+    """Ask the human where to deliver when session `task`'s prompt already has text.
+
+    Returns one of CLEAR / NEW / CANCEL. Falls back to NEW on any error or timeout —
+    the existing prompt is never destroyed without an explicit human Clear."""
+    preview = (line or "").strip()
+    if len(preview) > 120:
+        preview = preview[:117] + "…"
+    msg = (
+        f'Session "{task}" already has unsent text in its prompt:\n\n'
+        f"“{preview}”\n\n"
+        f"Where should the agent's message go?\n\n"
+        f"•  Clear & send — delete that text, send here\n"
+        f"•  New session — leave it, send to a fresh session\n"
+        f"•  Cancel — do nothing (retry later)"
+    )
+    try:
+        proc = subprocess.run(
+            ["osascript", "-", msg, str(timeout)],
+            input=_APPLESCRIPT,
+            capture_output=True,
+            text=True,
+            timeout=timeout + 10,   # osascript self-times-out at `timeout`; this is a backstop
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return NEW
+    choice = (proc.stdout or "").strip()
+    return choice if choice in (CLEAR, NEW, CANCEL) else NEW

--- a/packages/canopy_runner/canopy_runner/execute.py
+++ b/packages/canopy_runner/canopy_runner/execute.py
@@ -22,7 +22,7 @@ import datetime as dt
 import logging
 import re
 
-from . import cdp_control, emdash, readiness
+from . import cdp_control, dialog, emdash, readiness
 
 logger = logging.getLogger("canopy_runner.execute")
 
@@ -55,6 +55,89 @@ def _task_name(agent: str, turn: dict, now=None) -> str:
     disc = re.sub(r"[^a-z0-9]", "", _thread_key(turn).lower())[-4:]
     bits = [agent] + ([label] if label else []) + [b for b in (disc, stamp) if b]
     return "-".join(bits)
+
+
+def _deliver_to_existing(cfg, client, runner_id, turn, task, state, work_prompt):
+    """Deliver a turn into the linked LIVE emdash session `task`.
+
+    Returns a terminal action string (``reused:`` / ``failed:`` / ``deferred:``) when the
+    turn is fully handled, or ``None`` to tell the caller to route to a NEW session
+    (reuse fell back, or the human/timeout chose a fresh session on a collision).
+
+    The collision case: `open_and_send` finds unsent text already in the prompt (the
+    human's keystrokes leaked in when emdash switched to this task) and returns without
+    clobbering it. We ask the human via a native dialog:
+      Clear & send → kill the line, send here (``reused:``)
+      New session  → leave it, create fresh (return ``None`` → caller creates)
+      Cancel       → deliver nothing, requeue the turn (``deferred:``)
+      timeout/no-GUI → treated as New session (non-destructive default).
+    """
+    turn_id = turn["id"]
+    agent = _target(turn)
+    thread_key = _thread_key(turn)
+
+    try:
+        res = cdp_control.open_and_send(task, work_prompt, port=cfg.cdp_port)
+    except cdp_control.CDPError as exc:
+        if state == "unknown" and "TASK_NOT_FOUND" in str(exc):
+            # Degraded: emdash's DB was unreadable, so CDP's verdict is all we have.
+            # Loud, because reuse is running blind until the db path is fixed.
+            logger.warning("reuse: emdash DB unreadable — trusting CDP's TASK_NOT_FOUND "
+                           "for '%s' (agent=%s); fix the db path to make reuse deterministic",
+                           task, agent)
+            client.post_events(turn_id, [{"kind": "status",
+                "payload": {"status": "reuse_task_gone", "task": task, "task_state": state}}])
+            return None                         # create + rehydrate
+        # The task EXISTS (sqlite says so) but we couldn't drive it. Creating a fresh
+        # session here would DUPLICATE the live one and orphan its context — the bug that
+        # spawned two Hal sessions. Fail the turn instead (it retries); never duplicate.
+        logger.error("reuse FAILED on '%s' which emdash's DB says is %s (agent=%s): %s "
+                     "— NOT creating a duplicate; failing the turn for retry",
+                     task, state, agent, str(exc)[:200])
+        client.post_events(turn_id, [{"kind": "error",
+            "payload": {"status": "reuse_send_failed", "task": task,
+                        "task_state": state, "detail": str(exc)[:300]}}])
+        _note = (f"reuse failed on existing session '{task}' ({state} per emdash's DB) "
+                 f"— not spawning a duplicate; retry")
+        readiness.mark_failed(cfg, _note)
+        client.fail_turn(turn_id, _note)
+        return f"failed:{turn_id}"
+
+    if res.get("action") == "collision":
+        choice = dialog.collision_choice(task, res.get("line", ""))
+        logger.info("collision on '%s' (turn=%s): unsent text in prompt — human chose %r",
+                    task, turn_id, choice)
+        client.post_events(turn_id, [{"kind": "status",
+            "payload": {"status": "collision", "task": task, "choice": choice}}])
+        if choice == dialog.NEW:
+            return None                         # leave the prompt untouched; create fresh
+        if choice == dialog.CANCEL:
+            _note = f"collision on session '{task}': cancelled by human; will retry"
+            readiness.mark_ok(cfg)              # not a runner fault — a human deferral
+            client.fail_turn(turn_id, _note)
+            return f"deferred:{turn_id}"
+        # CLEAR & send: kill the leaked text, then send into the same session.
+        try:
+            cdp_control.open_and_send(task, work_prompt, clear_first=True, port=cfg.cdp_port)
+        except cdp_control.CDPError as exc:
+            logger.error("collision clear-and-send failed on '%s': %s", task, str(exc)[:200])
+            _note = f"collision clear-and-send failed on '{task}'; retry"
+            readiness.mark_failed(cfg, _note)
+            client.fail_turn(turn_id, _note)
+            return f"failed:{turn_id}"
+        # fall through to the shared success tail below
+
+    # Delivered — either the empty-line fast path, or a cleared-then-sent collision.
+    logger.info("REUSE  turn=%s agent=%s thread=%s -> existing session '%s' (no new claude session)",
+                turn_id, agent, thread_key, task)
+    client.post_events(turn_id, [{"kind": "status",
+        "payload": {"status": "reused_session", "task": task, "thread_key": thread_key}}])
+    client.record_session(runner_id, turn.get("agent_slug") or "", thread_key,
+                          project=turn.get("project") or "",
+                          workspace=turn.get("workspace_slug") or "", emdash_task_id=task)
+    readiness.mark_ok(cfg)
+    client.finish(turn_id, note=f"delivered to existing session '{task}'")
+    return f"reused:{turn_id}"
 
 
 def execute_turn(cfg, client, runner_id: str, turn: dict) -> str:
@@ -101,45 +184,12 @@ def execute_turn(cfg, client, runner_id: str, turn: dict) -> str:
             client.post_events(turn_id, [{"kind": "status",
                 "payload": {"status": "reuse_task_gone", "task": task, "task_state": state}}])
         else:
-            try:
-                cdp_control.open_and_send(task, work_prompt, port=cfg.cdp_port)
-            except cdp_control.CDPError as exc:
-                if state == "unknown" and "TASK_NOT_FOUND" in str(exc):
-                    # Degraded: emdash's DB was unreadable, so CDP's verdict is all we
-                    # have. Loud, because reuse is running blind until the db path is fixed.
-                    logger.warning("reuse: emdash DB unreadable at %r — trusting CDP's "
-                                   "TASK_NOT_FOUND for '%s' (agent=%s); fix the db path to "
-                                   "make reuse deterministic", cfg.emdash_db, task, agent)
-                    client.post_events(turn_id, [{"kind": "status",
-                        "payload": {"status": "reuse_task_gone", "task": task, "task_state": state}}])
-                else:
-                    # The task EXISTS (sqlite says so) but we couldn't drive it. Creating
-                    # a fresh session here would DUPLICATE the live one and orphan its
-                    # context — the bug that spawned two Hal sessions, and that split
-                    # eva's org-research thread across three cold sessions. Fail the turn
-                    # instead (it retries); never duplicate.
-                    logger.error("reuse FAILED on '%s' which emdash's DB says is %s (agent=%s): "
-                                 "%s — NOT creating a duplicate; failing the turn for retry",
-                                 task, state, agent, str(exc)[:200])
-                    client.post_events(turn_id, [{"kind": "error",
-                        "payload": {"status": "reuse_send_failed", "task": task,
-                                    "task_state": state, "detail": str(exc)[:300]}}])
-                    _note = (f"reuse failed on existing session '{task}' "
-                             f"({state} per emdash's DB) — not spawning a "
-                             f"duplicate; retry")
-                    readiness.mark_failed(cfg, _note)
-                    client.fail_turn(turn_id, _note)
-                    return f"failed:{turn_id}"
-            else:
-                logger.info("REUSE  turn=%s agent=%s thread=%s -> existing session '%s' (no new claude session)",
-                            turn_id, agent, thread_key, task)
-                client.post_events(turn_id, [{"kind": "status",
-                    "payload": {"status": "reused_session", "task": task, "thread_key": thread_key}}])
-                client.record_session(runner_id, agent_slug, thread_key,
-                                      project=project, workspace=workspace, emdash_task_id=task)
-                readiness.mark_ok(cfg)
-                client.finish(turn_id, note=f"delivered to existing session '{task}'")
-                return f"reused:{turn_id}"
+            # Try to deliver into the live session (handles the reuse-glitch and the
+            # human-was-typing collision). A terminal outcome ends the turn here; None
+            # means "route to a fresh session" and falls through to create below.
+            outcome = _deliver_to_existing(cfg, client, runner_id, turn, task, state, work_prompt)
+            if outcome is not None:
+                return outcome
 
     # --- create a fresh session, rehydrating durable context when we have it ---
     prompt = work_prompt

--- a/packages/canopy_runner/tests/test_dialog.py
+++ b/packages/canopy_runner/tests/test_dialog.py
@@ -1,0 +1,62 @@
+"""Native collision dialog — the osascript round-trip is mocked (a real dialog needs a
+GUI session). We assert the argv plumbing and the fail-safe default (New session)."""
+import subprocess
+from types import SimpleNamespace
+
+from canopy_runner import dialog
+
+
+def _fake_run(stdout):
+    captured = {}
+
+    def run(cmd, input, capture_output, text, timeout):
+        captured["cmd"] = cmd
+        captured["script"] = input
+        return SimpleNamespace(stdout=stdout, stderr="", returncode=0)
+
+    return run, captured
+
+
+def test_passes_message_and_timeout_as_argv(monkeypatch):
+    run, captured = _fake_run("Clear & send\n")
+    monkeypatch.setattr(dialog.subprocess, "run", run)
+    choice = dialog.collision_choice("busy-session", "some leaked words", timeout=25)
+    assert choice == dialog.CLEAR
+    # osascript reads the script from stdin ("-") and takes msg + timeout as argv
+    assert captured["cmd"][0] == "osascript" and captured["cmd"][1] == "-"
+    assert captured["cmd"][3] == "25"
+    assert "busy-session" in captured["cmd"][2]      # the message carries the task name
+
+
+def test_each_button_round_trips(monkeypatch):
+    for label in (dialog.CLEAR, dialog.NEW, dialog.CANCEL):
+        run, _ = _fake_run(label + "\n")
+        monkeypatch.setattr(dialog.subprocess, "run", run)
+        assert dialog.collision_choice("t", "x") == label
+
+
+def test_unrecognized_output_falls_back_to_new(monkeypatch):
+    run, _ = _fake_run("gibberish\n")
+    monkeypatch.setattr(dialog.subprocess, "run", run)
+    assert dialog.collision_choice("t", "x") == dialog.NEW
+
+
+def test_no_gui_session_or_missing_osascript_falls_back_to_new(monkeypatch):
+    def boom(*a, **k):
+        raise FileNotFoundError("osascript not found")
+    monkeypatch.setattr(dialog.subprocess, "run", boom)
+    assert dialog.collision_choice("t", "x") == dialog.NEW
+
+
+def test_timeout_falls_back_to_new(monkeypatch):
+    def slow(*a, **k):
+        raise subprocess.TimeoutExpired(cmd="osascript", timeout=40)
+    monkeypatch.setattr(dialog.subprocess, "run", slow)
+    assert dialog.collision_choice("t", "x") == dialog.NEW
+
+
+def test_long_preview_is_truncated(monkeypatch):
+    run, captured = _fake_run(dialog.NEW + "\n")
+    monkeypatch.setattr(dialog.subprocess, "run", run)
+    dialog.collision_choice("t", "x" * 500)
+    assert "…" in captured["cmd"][2]                 # preview clipped, not dumped whole

--- a/packages/canopy_runner/tests/test_execute.py
+++ b/packages/canopy_runner/tests/test_execute.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from canopy_runner import cdp_control, emdash, execute
+from canopy_runner import cdp_control, dialog, emdash, execute
 
 
 def _cfg():
@@ -135,6 +135,67 @@ def test_transient_reuse_send_failure_never_duplicates(monkeypatch):
     assert result == "failed:t-1"
     assert client.failed and "not spawning a duplicate" in client.failed[0][1]
     assert client.recorded == []   # link NOT re-pointed — the original session stays canonical
+
+
+def _collision_then(second_action="sent-cleared"):
+    """A stateful open_and_send: first call returns a collision, the clear_first re-call
+    returns `second_action`. Records the calls so a test can assert the second was a clear."""
+    calls = []
+
+    def send(task, text, clear_first=False, port=9222):
+        calls.append({"task": task, "text": text, "clear_first": clear_first})
+        if not clear_first and len(calls) == 1:
+            return {"ok": True, "action": "collision", "task": task,
+                    "line": "and then we should also che"}
+        return {"ok": True, "action": second_action, "task": task}
+
+    return send, calls
+
+
+def test_collision_clear_and_send_stays_in_the_existing_session(monkeypatch):
+    """Human chose 'Clear & send': the leaked text is cleared and the turn lands in the
+    SAME session (a re-call with clear_first), and the link is recorded — no new session."""
+    send, calls = _collision_then("sent-cleared")
+    monkeypatch.setattr(cdp_control, "open_and_send", send)
+    monkeypatch.setattr(cdp_control, "create_task",
+                        lambda *a, **k: pytest.fail("Clear & send must NOT create a new session"))
+    monkeypatch.setattr(dialog, "collision_choice", lambda task, line, **k: dialog.CLEAR)
+    client = FakeClient({"reuse": True, "emdash_task_id": "busy-session", "summary": ""})
+    result = execute.execute_turn(_cfg(), client, "r-1", _turn(origin_ref={"thread_id": "thr-1"}))
+    assert result == "reused:t-1"
+    assert [c["clear_first"] for c in calls] == [False, True]   # detect, then clear-and-send
+    assert client.recorded and client.recorded[0][2]["emdash_task_id"] == "busy-session"
+
+
+def test_collision_new_session_leaves_prompt_and_creates_fresh(monkeypatch):
+    """Human chose 'New session' (also the timeout default): the existing prompt is left
+    untouched (no clear re-call) and the turn routes to a NEW session."""
+    send, calls = _collision_then()
+    monkeypatch.setattr(cdp_control, "open_and_send", send)
+    created = {}
+    monkeypatch.setattr(cdp_control, "create_task",
+                        lambda project, prompt, task_name="", port=9222: created.update(project=project) or {"task": "fresh-one"})
+    monkeypatch.setattr(dialog, "collision_choice", lambda task, line, **k: dialog.NEW)
+    client = FakeClient({"reuse": True, "emdash_task_id": "busy-session", "summary": "prior ctx"})
+    result = execute.execute_turn(_cfg(), client, "r-1", _turn(origin_ref={"thread_id": "thr-1"}))
+    assert result.startswith("created:t-1:fresh-one")
+    assert [c["clear_first"] for c in calls] == [False]         # detected, never cleared
+    assert created["project"] == "hal"
+
+
+def test_collision_cancel_defers_the_turn_without_touching_anything(monkeypatch):
+    """Human chose 'Cancel': deliver nothing, don't create, requeue for a later tick."""
+    send, calls = _collision_then()
+    monkeypatch.setattr(cdp_control, "open_and_send", send)
+    monkeypatch.setattr(cdp_control, "create_task",
+                        lambda *a, **k: pytest.fail("Cancel must NOT create a session"))
+    monkeypatch.setattr(dialog, "collision_choice", lambda task, line, **k: dialog.CANCEL)
+    client = FakeClient({"reuse": True, "emdash_task_id": "busy-session", "summary": ""})
+    result = execute.execute_turn(_cfg(), client, "r-1", _turn(origin_ref={"thread_id": "thr-1"}))
+    assert result == "deferred:t-1"
+    assert [c["clear_first"] for c in calls] == [False]         # only the detect call
+    assert client.failed and "cancelled by human" in client.failed[0][1]
+    assert client.recorded == []                               # link untouched
 
 
 def test_create_new_thread_rehydrates_from_summary(monkeypatch):


### PR DESCRIPTION
## Problem

When the canopy runner breaks into an existing emdash session to deliver a turn, the human is often mid-typing — usually in **another** session that emdash just switched away from — and their last few keystrokes leak into the target session's prompt. The old path typed the agent's message **char-by-char straight over that leaked text**, scrambling both.

## What changed (all in `packages/canopy_runner`)

- **Atomic delivery.** `keyboard.type` → `keyboard.insertText` (CDP `Input.insertText`) on both the terminal and create-dialog paths — one commit instead of N keystrokes, which narrows the collision window on every send. This is also the "cut & paste instead of typing" efficiency ask.
- **Detect, don't clobber.** `open-send` reads the prompt line first. Empty → fast send, no dialog. Non-empty → returns `{action:"collision", line}` **without** touching it.
- **Ask the human.** On a collision the runner shows a native macOS `osascript` dialog (`com.canopy.runner` is a LaunchAgent in the GUI session, so it renders) with three buttons:
  - **Clear & send** — kill the leaked text (`Ctrl+U` + measured backspaces), send into the same session
  - **New session** — leave the prompt untouched, route to the existing create-fresh path
  - **Cancel** — deliver nothing, requeue the turn
  - **Timeout / no-GUI → New session** (non-destructive default; the human's text is *never* deleted without an explicit Clear)

## Safety / fidelity

- The TUI line-read (`> …` box parse) is heuristic and **fails safe to the fast path** on any ambiguity — no false-positive dialogs.
- Reuse's existing "never duplicate a live session on a glitch" guarantee is preserved, now factored into `_deliver_to_existing`.

## Tests

- 3 new `execute` branches (Clear / New / Cancel) + 6 `dialog` tests. All green.
- Verified live: `osascript - <argv>` plumbing works, and the runner is a LaunchAgent (dialog will render).

## Known follow-ups (deliberately v1 — will tune after dogfooding a real collision)

- TUI line-read heuristic and `Ctrl+U` clearing can only be fully validated against a live collision.
- **New session** repoints the thread's session link to the fresh session; the manual work in the old one stays but is no longer the tracked session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)