### PR TITLE
fix(runner): fresh emdash session per keyless turn — no shared {agent}:main sink

### DIFF
--- a/packages/canopy_runner/canopy_runner/execute.py
+++ b/packages/canopy_runner/canopy_runner/execute.py
@@ -35,8 +35,19 @@ def _target(turn: dict) -> str:
 
 
 def _thread_key(turn: dict) -> str:
+    """The session-continuity key: which emdash session this turn continues.
+
+    An explicit `thread_key`/`thread_id` in the origin_ref means CONTINUE the same
+    session across turns — the phone's persistent per-target thread, a "continue this
+    session" dispatch. With neither, the turn is a self-contained unit of work (a cron
+    fire, a board turn) and must open its OWN fresh session, so we key it on the turn's
+    unique id. The old `{agent}:main` fallback was a shared sink: every keyless turn —
+    all of an agent's cron fires, every board dispatch — resolved to it and reused one
+    ever-growing session (the `{agent}-cron-main-…` task). Continuity is opt-in; keyless
+    is fresh-per-turn."""
     ref = turn.get("origin_ref") or {}
-    return ref.get("thread_key") or ref.get("thread_id") or f"{_target(turn)}:main"
+    explicit = ref.get("thread_key") or ref.get("thread_id")
+    return explicit or f"{_target(turn)}:{turn.get('id') or ''}"
 
 
 def _slug(text: str, n: int = 28) -> str:

--- a/packages/canopy_runner/tests/test_execute.py
+++ b/packages/canopy_runner/tests/test_execute.py
@@ -160,11 +160,36 @@ def test_create_failure_fails_the_turn(monkeypatch):
     assert client.failed and "emdash create failed" in client.failed[0][1]
 
 
-def test_thread_key_defaults_to_agent_main_when_no_ref(monkeypatch):
+def test_keyless_turn_gets_a_fresh_per_turn_key(monkeypatch):
+    """A turn with no explicit thread_key/thread_id is a self-contained unit of work (a
+    cron fire, a board turn). It must NOT collapse onto a shared '{agent}:main' sink —
+    that piled every keyless turn (all of an agent's cron fires, all board dispatches)
+    into one ever-growing session. It keys on the turn's own id, so each opens fresh."""
     monkeypatch.setattr(cdp_control, "create_task", lambda *a, **k: {"task": "x"})
     client = FakeClient({"reuse": False, "new_thread": True, "summary": ""})
-    execute.execute_turn(_cfg(), client, "r-1", _turn(origin_ref={}))
-    assert client.calls[0] == ("resolve", "hal", "hal:main", "", "")
+    execute.execute_turn(_cfg(), client, "r-1", _turn(id="t-1", origin_ref={}))
+    assert client.calls[0] == ("resolve", "hal", "hal:t-1", "", "")
+
+
+def test_two_keyless_turns_get_distinct_keys(monkeypatch):
+    """The core anti-collision property: different keyless turns never share a session."""
+    monkeypatch.setattr(cdp_control, "create_task", lambda *a, **k: {"task": "x"})
+    c1 = FakeClient({"reuse": False, "new_thread": True, "summary": ""})
+    c2 = FakeClient({"reuse": False, "new_thread": True, "summary": ""})
+    execute.execute_turn(_cfg(), c1, "r-1", _turn(id="t-1", origin_ref={}))
+    execute.execute_turn(_cfg(), c2, "r-1", _turn(id="t-2", origin_ref={}))
+    assert c1.calls[0][2] == "hal:t-1" and c2.calls[0][2] == "hal:t-2"
+    assert c1.calls[0][2] != c2.calls[0][2]
+
+
+def test_explicit_thread_key_still_continues_one_session(monkeypatch):
+    """Continuity is opt-in and preserved: an explicit thread_key/thread_id is honored
+    verbatim (the phone's persistent thread, a 'continue this session' dispatch)."""
+    monkeypatch.setattr(cdp_control, "create_task", lambda *a, **k: {"task": "x"})
+    client = FakeClient({"reuse": False, "new_thread": True, "summary": ""})
+    execute.execute_turn(_cfg(), client, "r-1",
+                         _turn(id="t-1", origin_ref={"thread_key": "phone:jj:hal"}))
+    assert client.calls[0] == ("resolve", "hal", "phone:jj:hal", "", "")
 
 
 def test_a_project_turn_drives_the_repo_and_carries_its_tenant(monkeypatch):
@@ -186,8 +211,8 @@ def test_a_project_turn_drives_the_repo_and_carries_its_tenant(monkeypatch):
     result = execute.execute_turn(_cfg(), client, "r-1", turn)
 
     assert result == "created:t-9:ct"
-    # resolve keyed on the repo, tagged with project + workspace
-    assert client.calls[0] == ("resolve", "", "canopy-web:main", "canopy-web", "canopy")
+    # resolve keyed on the repo (fresh-per-turn via the turn id), tagged with project + workspace
+    assert client.calls[0] == ("resolve", "", "canopy-web:t-9", "canopy-web", "canopy")
     # the CDP create drove the repo as its emdash project, with the composer's prompt
     assert created == {"project": "canopy-web", "prompt": "fix the header"}
     # the durable link was recorded with the repo's tenant
@@ -199,10 +224,12 @@ def test_a_project_turn_drives_the_repo_and_carries_its_tenant(monkeypatch):
 def test_task_name_is_readable_subject_plus_stamp():
     import datetime as dt
     now = dt.datetime(2026, 7, 14, 15, 32)
-    t = _turn(origin="email", origin_ref={"subject": "Re: Bednet demo!!"})
-    assert execute._task_name("hal", t, now=now) == "hal-re-bednet-demo-main-0714-1532"
+    # keyless turn -> thread key is '{agent}:{turn_id}', so the discriminator comes
+    # from the turn id (last 4 of 'halt1') rather than a shared 'main'.
+    t = _turn(id="t-1", origin="email", origin_ref={"subject": "Re: Bednet demo!!"})
+    assert execute._task_name("hal", t, now=now) == "hal-re-bednet-demo-alt1-0714-1532"
     # no subject -> agent + stamp
-    assert execute._task_name("hal", _turn(origin="manual", origin_ref={}), now=now) == "hal-manual-main-0714-1532"
+    assert execute._task_name("hal", _turn(id="t-1", origin="manual", origin_ref={}), now=now) == "hal-manual-alt1-0714-1532"
 
 
 def test_task_name_distinguishes_threads_with_same_subject():


### PR DESCRIPTION
## Problem

The runner accidentally implemented a **default \"main session\" per agent** instead of opening each new turn in a fresh session. `_thread_key` fell back to `f\"{agent}:main\"` whenever a turn carried no explicit `thread_key`/`thread_id`:

```python
return ref.get(\"thread_key\") or ref.get(\"thread_id\") or f\"{_target(turn)}:main\"
```

So **every keyless turn** — all of an agent's cron fires, every board dispatch, every item dispatch — resolved to that one key and reused a single, ever-growing emdash session (Eva's `eva-cron-main-…` task). That was an accidental sink, not a designed feature, and it contradicted the frontend's own contract (`frontend/src/api/harness.ts`: *\"A thread_key makes the runner REUSE one session… rather than forking a fresh emdash task each time\"*).

## Fix

A keyless turn now keys on its **own unique turn id**, so each opens its own fresh session. Continuity stays **opt-in**: an explicit `thread_key`/`thread_id` (the phone's persistent per-target thread, a \"continue this session\" dispatch) is honored verbatim and still continues one session.

Bonus: keying on the turn id makes a retry of the same failed turn idempotent — it finds its own link and continues rather than duplicating.

## Tests (TDD)

Rewrote the tests that encoded the old `:main` behavior; added anti-collision coverage. RED (4 failing on the `:main` fallback) → GREEN.

- `packages/canopy_runner` suite: **118 passed**
- Django harness/session/mobile-loop suites: **56 passed**

## Notes

- Each keyless turn now writes its own durable `SessionLink` row (`{agent}:{turn_id}`) instead of reusing one. Rows are tiny and nothing depends on a bounded set; a periodic prune of old keyless links would be the place if housekeeping is ever wanted.
- Runner runs from the `~/emdash-projects/canopy-web` main checkout — needs the usual `git pull` + `launchctl kickstart com.canopy.runner` to pick this up after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)