### PR TITLE
feat(runner): declare websocket-client as `realtime` extra + document install

### DIFF
--- a/packages/canopy_runner/README.md
+++ b/packages/canopy_runner/README.md
@@ -62,6 +62,20 @@ can't, because emdash virtualizes the sidebar).
    launchctl load ~/Library/LaunchAgents/com.canopy.runner.plist
    ```
 
+6. **Enable the realtime wake listener** (recommended). The core loop claims
+   turns on the 5s poll; the `realtime` extra (`pyproject.toml`) adds a WebSocket
+   control channel so the runner also claims on *push* — instant wakes instead of
+   up to a 5s delay. `wake.py` imports `websocket` lazily and degrades to
+   poll-only when it's absent, so this is opt-in — but install it so a provisioned
+   runner isn't silently stuck on polling. Install into the **same interpreter the
+   launchd job uses** (the plist runs `/usr/bin/env python3`):
+   ```bash
+   python3 -m pip install --user --break-system-packages 'websocket-client>=1.8,<2'
+   ```
+   Then `launchctl kickstart -k gui/$(id -u)/com.canopy.runner`. The log should
+   read `wake listener connected: wss://…` rather than `websocket-client not
+   installed — wake listener off, polling only`.
+
 ## Commands
 
 - `run` (default when no subcommand is given) — the main watch loop. `--once`

--- a/packages/canopy_runner/pyproject.toml
+++ b/packages/canopy_runner/pyproject.toml
@@ -12,6 +12,17 @@ dependencies = [
     "canopy-cron",
 ]
 
+[project.optional-dependencies]
+# The runner's core loop is stdlib-only over HTTP and never needs this. The
+# `realtime` extra turns on the WebSocket wake listener (wake.py): the runner
+# holds a live control channel to canopy-web and claims on push instead of only
+# on the 5s poll tick. `wake.py` imports `websocket` LAZILY and falls back to
+# poll-only when it's absent, so this stays an OPT-IN capability, not a hard
+# requirement — but it's installed by default in the one-time setup (see README)
+# so a normally-provisioned runner gets instant wakes rather than silently
+# regressing to polling because nothing ever declared the dep.
+realtime = ["websocket-client>=1.8,<2"]
+
 [tool.uv.sources]
 # In-repo, standalone, installable — same editable path-dep wiring the root
 # pyproject uses for canopy-agent-runs / canopy-cron, resolved relative to this


### PR DESCRIPTION
## Why

The WebSocket wake listener (`wake.py`, from the RC1/RC3 realtime work — #313/#316) was fully built but **dormant on provisioned runners**. It imports `websocket` lazily and degrades to poll-only when the package is absent, and nothing ever *declared* the dependency — so a normally-set-up runner silently claimed on the 5s poll tick instead of on push, with only a log line (`websocket-client not installed — wake listener off, polling only`) to show for it. That's how the live laptop runner ended up on polling.

## What

- **`pyproject.toml`**: declare `websocket-client>=1.8,<2` as an **opt-in extra** (`[project.optional-dependencies] realtime`), not a hard dependency. The core loop stays stdlib-only over HTTP and the poll-only fallback is intentional — this just makes the wake capability declared and reproducible.
- **`README.md`**: add one-time-setup step §6 to install it into the launchd interpreter (`python3 -m pip install --user --break-system-packages 'websocket-client>=1.8,<2'`) and restart, so a provisioned runner gets **instant push-wakes** by default instead of regressing to polling for lack of a declared dep.

Matches the install already applied to the live laptop runner (websocket-client 1.9.0), which now logs `wake listener connected: wss://labs.connect.dimagi.com/canopy/ws/runner/…`.

## Notes

- Kept optional on purpose — the design (`wake.py`, the ec2 `cloud_runner.py`) treats the WS channel as a best-effort accelerator over a working poll fallback.
- Runner suite green (127 passed).
- Follow-up (separate repo): the `canopy:setup` skill in the canopy plugin should mirror README §6 so fully-automated provisioning installs the extra too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)