### PR TITLE
feat(ddd): clean, shareable run release page

### DIFF
--- a/apps/common/middleware.py
+++ b/apps/common/middleware.py
@@ -76,6 +76,17 @@ def _is_walkthrough_link(request) -> bool:
     )
 
 
+def _is_ddd_release_link(request) -> bool:
+    # /ddd-release/<slug>/<run_id> (SPA shell) and the read API
+    # (/api/ddd/release/<run_id>/) self-enforce the ?t=<share_token> gate (or a
+    # workspace-member session) inside build_release, so admit anonymous callers
+    # through the middleware. The rest of /ddd/* and /api/ddd/* stay auth'd.
+    path = request.path
+    if path.startswith("/ddd-release/"):
+        return True
+    return request.method == "GET" and path.startswith("/api/ddd/release/")
+
+
 class LoginRequiredMiddleware:
     """Require authentication for every request except the allowlist.
 
@@ -103,6 +114,7 @@ class LoginRequiredMiddleware:
             or _is_walkthrough_link(request)
             or _is_review_link(request.path)
             or _is_share_link(request.path)
+            or _is_ddd_release_link(request)
         ):
             return self.get_response(request)
 

--- a/apps/runs/aggregate.py
+++ b/apps/runs/aggregate.py
@@ -332,6 +332,178 @@ def build_run(run_id: str, workspace_slugs: set[str] | None = None) -> dict | No
 
 
 # ---------------------------------------------------------------------------
+# Clean, shareable run RELEASE page
+#
+# A curated, outside-the-app-shell view of ONE run: title + video + narrative
+# story + the live product URLs the run used. Unlike build_run (the operator
+# console, session-gated), this is reachable anonymously via a ?t=<share_token>
+# link, so its stream URLs must carry each artifact's own token. Access is the
+# same gate the walkthrough viewer uses: a workspace MEMBER, or anyone holding a
+# matching share token for the run's primary (public) artifact.
+# ---------------------------------------------------------------------------
+
+
+def _is_member(w: Walkthrough, request) -> bool:
+    """True iff the caller is a member of the walkthrough's workspace (the
+    non-token half of Walkthrough.readable_by)."""
+    from apps.workspaces import services as wsvc
+
+    if w.workspace_id is None:
+        return bool(request.user.is_authenticated)
+    return w.workspace_id in wsvc.request_workspace_slugs(request)
+
+
+def _tok(base: str, w: Walkthrough) -> str:
+    """Append ?t=<share_token> when the artifact is public + tokened, so an
+    anonymous browser can stream it (each artifact self-checks its OWN token in
+    Walkthrough.readable_by). Members stream tokenlessly via session; the token
+    is harmless for them."""
+    if w.visibility == Walkthrough.VISIBILITY_LINK and w.share_token:
+        sep = "&" if "?" in base else "?"
+        return f"{base}{sep}t={w.share_token}"
+    return base
+
+
+def _release_artifact(w: Walkthrough | None) -> dict | None:
+    if w is None:
+        return None
+    return {
+        "id": w.id,
+        "title": w.title,
+        "kind": w.kind,
+        "role": w.role,
+        "content_url": _tok(f"/walkthrough/{w.id}/content", w),
+        "viewer_url": _tok(f"/walkthrough/{w.id}", w),
+        "duration_sec": w.duration_sec,
+    }
+
+
+def _humanize_slug(slug: str) -> str:
+    return (slug or "").replace("-", " ").replace("_", " ").strip().title()
+
+
+def _lede_from_story(story: str | None, title: str | None) -> str | None:
+    """A one-line hook for the hero: the first sentence of the story that isn't
+    the title line (the story's first line is what _title_from_review returns)."""
+    if not story:
+        return None
+    lines = [ln.strip() for ln in story.splitlines() if ln.strip()]
+    body = [ln for ln in lines if ln != (title or "").strip()]
+    if not body:
+        return None
+    first = body[0]
+    # Trim to the first sentence, capped so the hero stays one line.
+    for end in (". ", "? ", "! "):
+        if end in first:
+            first = first.split(end, 1)[0] + end.strip()
+            break
+    return first[:240]
+
+
+def build_release(run_id: str, request) -> dict | None:
+    """Curated, token-aware package for the clean release page.
+
+    Returns ``None`` (→ 404) when the run doesn't exist OR the caller is neither
+    a workspace member nor holding a valid share token — never leaking existence.
+    NOT workspace-scoped at query time: the share token itself is the capability;
+    the primary artifact's ``readable_by`` gate is the authority.
+    """
+    wts = list(Walkthrough.objects.filter(run_id=run_id).select_related("owner"))
+    revs = list(ReviewRequest.objects.filter(run_id=run_id))
+    if not wts and not revs:
+        return None
+
+    # The primary artifact anchors both the access gate and the shareable token.
+    primary = _pick(
+        wts,
+        lambda w: w.role == Walkthrough.ROLE_HERO_VIDEO,
+        lambda w: w.kind == Walkthrough.KIND_VIDEO,
+        lambda w: w.role == Walkthrough.ROLE_DECK,
+        lambda w: w.role == Walkthrough.ROLE_DOCS,
+        lambda w: True,
+    )
+    if primary is None or not primary.readable_by(request):
+        return None
+
+    is_member = _is_member(primary, request)
+    is_public = bool(
+        primary.visibility == Walkthrough.VISIBILITY_LINK and primary.share_token
+    )
+
+    video = _pick(
+        wts,
+        lambda w: w.role == Walkthrough.ROLE_HERO_VIDEO,
+        lambda w: w.role == Walkthrough.ROLE_CLIP,
+        lambda w: w.kind == Walkthrough.KIND_VIDEO,
+    )
+    documentation = _pick(
+        wts,
+        lambda w: w.role == Walkthrough.ROLE_DOCS,
+        lambda w: w.kind == Walkthrough.KIND_HTML and w.role != Walkthrough.ROLE_DECK,
+    )
+
+    explicit_narrative_slug = next(
+        (w.narrative_slug for w in wts if (w.narrative_slug or "").strip()), None
+    )
+    narrative_slug = explicit_narrative_slug or narrative_slug_from_run_id(run_id)
+
+    stamped = next((w.narrative_review_id for w in wts if w.narrative_review_id), None)
+    narrative_review = None
+    if stamped:
+        narrative_review = ReviewRequest.objects.filter(pk=stamped).first()
+    if narrative_review is None:
+        narrative_review = next((r for r in revs if _is_narrative_version(r)), None)
+    if narrative_review is None:
+        versions = _narrative_versions_for(narrative_slug, None)
+        narrative_review = versions[-1] if versions else None
+    narrative_payload = _narrative_payload(narrative_review)
+
+    title = (narrative_payload or {}).get("title") or _humanize_slug(narrative_slug)
+    lede = _lede_from_story((narrative_payload or {}).get("story"), title)
+
+    # Product URLs the run used (reference) vs sibling artifacts (narrative /
+    # companion). De-duped on url, oldest-first.
+    product_links: list[dict] = []
+    related_links: list[dict] = []
+    seen: set[str] = set()
+    for w in sorted(wts, key=lambda x: x.created_at):
+        for link in w.links or []:
+            if not isinstance(link, dict):
+                continue
+            url = link.get("url", "")
+            if not url or url in seen:
+                continue
+            seen.add(url)
+            entry = {
+                "label": link.get("label", ""),
+                "url": url,
+                "kind": link.get("kind", "reference"),
+            }
+            (product_links if entry["kind"] == "reference" else related_links).append(
+                entry
+            )
+
+    return {
+        "run_id": run_id,
+        "narrative_slug": narrative_slug,
+        "title": title,
+        "lede": lede,
+        "video": _release_artifact(video),
+        "documentation": _release_artifact(documentation),
+        "narrative": narrative_payload,
+        "product_links": product_links,
+        "related_links": related_links,
+        "is_public": is_public,
+        "is_member": is_member,
+        # The shareable handle: the primary artifact's token (only when public).
+        "share_token": primary.share_token if is_public else None,
+        # Internal-only link to the full operator console (flat path redirects
+        # into the member's workspace). The clean page shows it only to members.
+        "build_url": f"/ddd/{narrative_slug}/{run_id}",
+    }
+
+
+# ---------------------------------------------------------------------------
 # Narrative list + detail
 # ---------------------------------------------------------------------------
 
@@ -659,6 +831,15 @@ def set_narrative_visibility(
         for r in _scope(ReviewRequest.objects.all(), workspace_slugs)
         if narrative_of_review(r) == slug
     ]
-    wt_n = Walkthrough.objects.filter(pk__in=wt_pks).update(visibility=visibility)
+    wt_qs = Walkthrough.objects.filter(pk__in=wt_pks)
+    wt_n = wt_qs.update(visibility=visibility)
+    # Flipping a narrative to public (link) must MINT a share token on each
+    # walkthrough, or anonymous ?t= access 404s and there is no shareable link.
+    # The bulk update() above bypasses save(), so re-fetch and ensure a token on
+    # each — mirrors the per-walkthrough PATCH flip-to-public (apps/walkthroughs
+    # /api.py). Reviews stay tokenless by design.
+    if visibility == Walkthrough.VISIBILITY_LINK:
+        for w in wt_qs:
+            w.ensure_share_token()
     rev_n = ReviewRequest.objects.filter(pk__in=rev_pks).update(visibility=visibility)
     return wt_n, rev_n

--- a/apps/runs/api.py
+++ b/apps/runs/api.py
@@ -21,6 +21,7 @@ from .schemas import (
     NarrativeVisibilityIn,
     NarrativeVisibilityOut,
     RunPackageOut,
+    RunReleaseOut,
 )
 
 router = Router(auth=session_auth, tags=["ddd"])
@@ -78,6 +79,25 @@ def get_run(request: HttpRequest, run_id: str) -> RunPackageOut:
     if data is None:
         raise ProblemError(404, "Run not found", type_=TYPE_NOT_FOUND)
     return RunPackageOut.model_validate(data)
+
+
+@router.get(
+    "/release/{run_id}/",
+    response=RunReleaseOut,
+    auth=None,
+    summary="Clean, shareable run release page (public via ?t=<share_token>)",
+)
+def get_run_release(request: HttpRequest, run_id: str) -> RunReleaseOut:
+    """Anonymous-capable: the handler self-enforces access (workspace member OR a
+    matching ``?t=`` share token) inside ``build_release`` — the middleware
+    allowlist only lets the request reach here. Auto-join runs for authed members
+    so their workspace membership resolves, mirroring the console endpoints."""
+    if request.user.is_authenticated:
+        wsvc.auto_join_workspaces(request.user)
+    data = aggregate.build_release(run_id, request)
+    if data is None:
+        raise ProblemError(404, "Run not found", type_=TYPE_NOT_FOUND)
+    return RunReleaseOut.model_validate(data)
 
 
 @router.patch(

--- a/apps/runs/schemas.py
+++ b/apps/runs/schemas.py
@@ -124,6 +124,31 @@ class RunPackageOut(StrictModel):
     all_artifacts: list[RunArtifactRefOut] = []
 
 
+class RunReleaseOut(StrictModel):
+    """Curated, shareable run release page (the clean public-capable surface).
+
+    A trimmed, outsider-legible slice of a run: title + video + narrative story
+    + the live product URLs it used. Artifact URLs are token-appended so an
+    anonymous ?t= viewer can stream them. No phase/gate jargon, no artifact
+    dump, no edit affordances — the operator console (RunPackageOut) keeps those.
+    """
+
+    run_id: str
+    narrative_slug: str
+    title: str | None = None
+    lede: str | None = None
+    video: RunArtifactOut | None = None
+    documentation: RunArtifactOut | None = None
+    narrative: RunNarrativeOut | None = None
+    # Live systems the run used, shown as named buttons.
+    product_links: list[WalkthroughLink] = []
+    related_links: list[WalkthroughLink] = []
+    is_public: bool = False
+    is_member: bool = False
+    share_token: str | None = None
+    build_url: str | None = None
+
+
 class NarrativeVisibilityIn(StrictModel):
     visibility: Literal["private", "link"]
 

--- a/frontend/src/api/ddd.ts
+++ b/frontend/src/api/ddd.ts
@@ -134,6 +134,23 @@ export interface DddRunPackage {
   all_artifacts: DddRunArtifactRef[]
 }
 
+/** The curated, shareable run-release payload (the clean public-capable page). */
+export interface DddRunRelease {
+  run_id: string
+  narrative_slug: string
+  title: string | null
+  lede: string | null
+  video: DddRunArtifact | null
+  documentation: DddRunArtifact | null
+  narrative: DddRunNarrative | null
+  product_links: DddLink[]
+  related_links: DddLink[]
+  is_public: boolean
+  is_member: boolean
+  share_token: string | null
+  build_url: string | null
+}
+
 async function getJson<T>(url: string): Promise<T> {
   const resp = await fetch(apiUrl(url), { credentials: 'same-origin' })
   if (!resp.ok) {
@@ -229,6 +246,17 @@ export function setNarrativeVisibility(
 
 export function getRun(runId: string): Promise<DddRunPackage> {
   return getJson(`/api/ddd/runs/${encodeURIComponent(runId)}/`)
+}
+
+/**
+ * Fetch the clean, shareable release view of a run. Anonymous-capable: pass the
+ * `?t=<share_token>` from the URL so a public viewer (no Dimagi login) is
+ * admitted; members are recognised by their session cookie and `token` is
+ * unnecessary.
+ */
+export function getRelease(runId: string, token?: string | null): Promise<DddRunRelease> {
+  const q = token ? `?t=${encodeURIComponent(token)}` : ''
+  return getJson(`/api/ddd/release/${encodeURIComponent(runId)}/${q}`)
 }
 
 /** Delete a single run: its walkthroughs + reviews (best-effort Drive cleanup). */

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -702,6 +702,29 @@ export interface paths {
         readonly patch?: never;
         readonly trace?: never;
     };
+    readonly "/api/ddd/release/{run_id}/": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        /**
+         * Clean, shareable run release page (public via ?t=<share_token>)
+         * @description Anonymous-capable: the handler self-enforces access (workspace member OR a
+         *     matching ``?t=`` share token) inside ``build_release`` — the middleware
+         *     allowlist only lets the request reach here. Auto-join runs for authed members
+         *     so their workspace membership resolves, mirroring the console endpoints.
+         */
+        readonly get: operations["apps_runs_api_get_run_release"];
+        readonly put?: never;
+        readonly post?: never;
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
     readonly "/api/ddd/narratives/{slug}/visibility/": {
         readonly parameters: {
             readonly query?: never;
@@ -3429,6 +3452,52 @@ export interface components {
              * @default []
              */
             readonly all_artifacts: readonly components["schemas"]["RunArtifactRefOut"][];
+        };
+        /**
+         * RunReleaseOut
+         * @description Curated, shareable run release page (the clean public-capable surface).
+         *
+         *     A trimmed, outsider-legible slice of a run: title + video + narrative story
+         *     + the live product URLs it used. Artifact URLs are token-appended so an
+         *     anonymous ?t= viewer can stream them. No phase/gate jargon, no artifact
+         *     dump, no edit affordances — the operator console (RunPackageOut) keeps those.
+         */
+        readonly RunReleaseOut: {
+            /** Run Id */
+            readonly run_id: string;
+            /** Narrative Slug */
+            readonly narrative_slug: string;
+            /** Title */
+            readonly title?: string | null;
+            /** Lede */
+            readonly lede?: string | null;
+            readonly video?: components["schemas"]["RunArtifactOut"] | null;
+            readonly documentation?: components["schemas"]["RunArtifactOut"] | null;
+            readonly narrative?: components["schemas"]["RunNarrativeOut"] | null;
+            /**
+             * Product Links
+             * @default []
+             */
+            readonly product_links: readonly components["schemas"]["WalkthroughLink"][];
+            /**
+             * Related Links
+             * @default []
+             */
+            readonly related_links: readonly components["schemas"]["WalkthroughLink"][];
+            /**
+             * Is Public
+             * @default false
+             */
+            readonly is_public: boolean;
+            /**
+             * Is Member
+             * @default false
+             */
+            readonly is_member: boolean;
+            /** Share Token */
+            readonly share_token?: string | null;
+            /** Build Url */
+            readonly build_url?: string | null;
         };
         /** NarrativeVisibilityOut */
         readonly NarrativeVisibilityOut: {
@@ -7336,6 +7405,28 @@ export interface operations {
                     readonly [name: string]: unknown;
                 };
                 content?: never;
+            };
+        };
+    };
+    readonly apps_runs_api_get_run_release: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path: {
+                readonly run_id: string;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description OK */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["RunReleaseOut"];
+                };
             };
         };
     };

--- a/frontend/src/components/PublicLayout.tsx
+++ b/frontend/src/components/PublicLayout.tsx
@@ -1,0 +1,16 @@
+import { Outlet } from 'react-router-dom'
+import { ThemeProvider } from '@/theme/ThemeProvider'
+
+/**
+ * Chrome-less layout for public, anonymous-capable pages (the DDD release
+ * surface). Just theme context + an <Outlet/> — deliberately NO TopNav / no
+ * workspace-aware nav, because those fire authed calls that would bounce an
+ * anonymous visitor to login. Mounted OUTSIDE the app shell in the router.
+ */
+export function PublicLayout() {
+  return (
+    <ThemeProvider>
+      <Outlet />
+    </ThemeProvider>
+  )
+}

--- a/frontend/src/pages/DddReleasePage.tsx
+++ b/frontend/src/pages/DddReleasePage.tsx
@@ -1,0 +1,302 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useParams, useSearchParams } from 'react-router-dom'
+import { getRelease, type DddRunRelease, type DddLink } from '@/api/ddd'
+import { withBase } from '@/lib/basePath'
+
+/**
+ * The clean, shareable DDD run RELEASE page — the outsider-legible face of a
+ * run: title + final video + the narrative story + the live product URLs it
+ * used. Deliberately release-only: no phase/gate jargon, no artifact dump, no
+ * edit affordances (those live on the operator console at /w/:ws/ddd/...). Runs
+ * OUTSIDE the app shell (PublicLayout) so a `?t=<share_token>` viewer with no
+ * Dimagi login is served; members additionally see an "open the build view" link.
+ */
+
+type LoadState =
+  | { kind: 'loading' }
+  | { kind: 'ready'; data: DddRunRelease }
+  | { kind: 'not_found' }
+  | { kind: 'error'; message: string }
+
+export default function DddReleasePage() {
+  const { runId } = useParams()
+  const [params] = useSearchParams()
+  const token = params.get('t')
+  const [state, setState] = useState<LoadState>({ kind: 'loading' })
+
+  useEffect(() => {
+    let live = true
+    if (!runId) {
+      setState({ kind: 'not_found' })
+      return
+    }
+    setState({ kind: 'loading' })
+    getRelease(runId, token)
+      .then((data) => live && setState({ kind: 'ready', data }))
+      .catch((e: Error) => {
+        if (!live) return
+        const msg = e.message || ''
+        setState(
+          /not found|404/i.test(msg)
+            ? { kind: 'not_found' }
+            : { kind: 'error', message: msg },
+        )
+      })
+    return () => {
+      live = false
+    }
+  }, [runId, token])
+
+  if (state.kind === 'loading') return <Centered>Loading…</Centered>
+  if (state.kind === 'not_found')
+    return (
+      <Centered>
+        <p className="text-foreground">This demo isn’t available.</p>
+        <p className="mt-1 text-sm text-muted-foreground">
+          The link may be private or the run may have been removed.
+        </p>
+      </Centered>
+    )
+  if (state.kind === 'error')
+    return (
+      <Centered>
+        <p className="text-foreground">Couldn’t load this demo.</p>
+        <p className="mt-1 text-sm text-muted-foreground">{state.message}</p>
+      </Centered>
+    )
+
+  return <Release data={state.data} />
+}
+
+function Centered({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <div className="mx-auto flex min-h-screen max-w-3xl items-center justify-center px-6 text-center">
+        <div>{children}</div>
+      </div>
+    </div>
+  )
+}
+
+function Release({ data }: { data: DddRunRelease }) {
+  const shareUrl = useShareUrl(data)
+  const products = data.product_links
+  const related = data.related_links
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <div className="mx-auto max-w-3xl px-6 py-12 md:py-16">
+        {/* Top bar: quiet wordmark + (members, when public) a copy-share affordance */}
+        <div className="mb-10 flex items-center justify-between">
+          <span className="text-[11px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+            Canopy · Demo
+          </span>
+          {data.is_member && shareUrl && <CopyShare url={shareUrl} />}
+        </div>
+
+        {/* Hero */}
+        <header className="mb-10">
+          <p className="mb-2 text-[11px] font-semibold uppercase tracking-[0.2em] text-primary">
+            Demo walkthrough
+          </p>
+          <h1 className="text-4xl font-semibold leading-tight tracking-tight text-foreground md:text-5xl">
+            {data.title || data.narrative_slug}
+          </h1>
+          {data.lede && (
+            <p className="mt-4 text-lg leading-relaxed text-foreground-secondary">{data.lede}</p>
+          )}
+        </header>
+
+        {/* Final video */}
+        {data.video && (
+          <div className="mb-12 overflow-hidden rounded-2xl border border-border bg-black shadow-sm">
+            <video
+              controls
+              preload="metadata"
+              className="w-full"
+              src={withBase(data.video.content_url)}
+            >
+              <a href={withBase(data.video.viewer_url)}>Watch the demo video</a>
+            </video>
+          </div>
+        )}
+
+        {/* The story */}
+        {data.narrative && (data.narrative.story || data.narrative.narration.length > 0) && (
+          <Section title="The story">
+            {data.narrative.story && (
+              <p className="whitespace-pre-line text-[15px] leading-relaxed text-foreground-secondary">
+                {data.narrative.story}
+              </p>
+            )}
+            {data.narrative.narration.length > 0 && (
+              <ol className="mt-5 flex flex-col gap-2">
+                {data.narrative.narration.map((n, i) => {
+                  const persona = n.persona ? data.narrative?.personas?.[n.persona] : undefined
+                  return (
+                    <li
+                      key={n.id ?? i}
+                      className="rounded-lg border border-border bg-card px-4 py-3"
+                    >
+                      <div className="mb-1 flex items-center gap-2">
+                        <span className="font-mono text-[11px] text-muted-foreground">
+                          {n.scene ?? i + 1}
+                        </span>
+                        {n.title && (
+                          <span className="text-[13px] font-medium text-foreground">{n.title}</span>
+                        )}
+                        {persona?.name && (
+                          <span className="text-[11px] text-primary" title={persona.role || ''}>
+                            {persona.name}
+                          </span>
+                        )}
+                      </div>
+                      <p className="text-[13px] leading-relaxed text-foreground-secondary">
+                        {n.text}
+                      </p>
+                    </li>
+                  )
+                })}
+              </ol>
+            )}
+          </Section>
+        )}
+
+        {/* Try it live — the actual product URLs the demo used */}
+        {products.length > 0 && (
+          <Section title="Try it live" subtitle="the real pages this demo used">
+            <div className="flex flex-col gap-2">
+              {products.map((l) => (
+                <LinkButton key={l.url} link={l} />
+              ))}
+            </div>
+          </Section>
+        )}
+
+        {/* Read more — the written docs page, if one was produced */}
+        {data.documentation && (
+          <Section title="Read more">
+            <a
+              href={withBase(data.documentation.viewer_url)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 rounded-lg border border-border bg-card px-4 py-3 text-[13px] text-foreground transition-colors hover:border-input hover:text-primary"
+            >
+              <span>Open the full write-up</span>
+              <span aria-hidden>↗</span>
+            </a>
+          </Section>
+        )}
+
+        {/* Related material (narrative / companion links) */}
+        {related.length > 0 && (
+          <Section title="Related">
+            <div className="flex flex-col gap-2">
+              {related.map((l) => (
+                <LinkButton key={l.url} link={l} />
+              ))}
+            </div>
+          </Section>
+        )}
+
+        {/* Footer */}
+        <footer className="mt-16 flex items-center justify-between border-t border-border pt-6 text-[11px] text-muted-foreground">
+          <span>
+            Generated by canopy · run <span className="font-mono">{data.run_id}</span>
+          </span>
+          {data.is_member && data.build_url && (
+            <a
+              href={withBase(data.build_url)}
+              className="text-muted-foreground transition-colors hover:text-primary"
+            >
+              Open the full build view →
+            </a>
+          )}
+        </footer>
+      </div>
+    </div>
+  )
+}
+
+function Section({
+  title,
+  subtitle,
+  children,
+}: {
+  title: string
+  subtitle?: string
+  children: React.ReactNode
+}) {
+  return (
+    <section className="mb-12">
+      <div className="mb-4 flex items-baseline gap-2 border-b border-border pb-2">
+        <h2 className="text-[11px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+          {title}
+        </h2>
+        {subtitle && <span className="text-[11px] text-muted-foreground">{subtitle}</span>}
+      </div>
+      {children}
+    </section>
+  )
+}
+
+const KIND_ICON: Record<DddLink['kind'], string> = {
+  reference: '↗',
+  narrative: '📖',
+  companion: '🎞️',
+}
+
+/** A named, verb-labeled destination button — the product URL, not a raw href. */
+function LinkButton({ link }: { link: DddLink }) {
+  return (
+    <a
+      href={link.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="group flex items-center gap-3 rounded-lg border border-border bg-card px-4 py-3 transition-colors hover:border-input hover:bg-muted/40"
+    >
+      <span className="text-[13px] font-medium text-foreground group-hover:text-primary">
+        {link.label || link.url}
+      </span>
+      <span className="flex-1" />
+      <span
+        aria-hidden
+        className="text-[13px] text-muted-foreground transition-colors group-hover:text-primary"
+      >
+        {KIND_ICON[link.kind] ?? '↗'}
+      </span>
+    </a>
+  )
+}
+
+function CopyShare({ url }: { url: string }) {
+  const [copied, setCopied] = useState(false)
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        navigator.clipboard?.writeText(url).then(
+          () => {
+            setCopied(true)
+            setTimeout(() => setCopied(false), 1500)
+          },
+          () => {},
+        )
+      }}
+      className="rounded-md border border-border px-3 py-1 text-[11px] text-foreground-secondary transition-colors hover:border-input hover:text-primary"
+      title="Copy the public share link"
+    >
+      {copied ? 'Copied ✓' : 'Copy share link'}
+    </button>
+  )
+}
+
+/** The absolute, tokened share URL for this release (only when public). */
+function useShareUrl(data: DddRunRelease): string | null {
+  return useMemo(() => {
+    if (!data.is_public || !data.share_token) return null
+    const base = (import.meta.env.BASE_URL || '/').replace(/\/$/, '')
+    const path = `/ddd-release/${data.narrative_slug}/${data.run_id}`
+    return `${window.location.origin}${base}${path}?t=${data.share_token}`
+  }, [data.is_public, data.share_token, data.narrative_slug, data.run_id])
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -20,6 +20,8 @@ import { SessionsPage } from './pages/SessionsPage'
 import { AgentsPage } from './pages/AgentsPage'
 import { AgentWorkspacePage } from './pages/AgentWorkspacePage'
 import SessionSharePage from './pages/SessionSharePage'
+import DddReleasePage from './pages/DddReleasePage'
+import { PublicLayout } from './components/PublicLayout'
 import SupervisorPage from '@/pages/SupervisorPage'
 import ActivityPage from '@/pages/ActivityPage'
 import SchedulesPage from './pages/SchedulesPage'
@@ -199,6 +201,17 @@ export const router = createBrowserRouter(guarded([
   // Canopy"-linking app boundary off a page anonymous visitors can't log
   // into.
   { path: '/share/:token', element: <SessionSharePage />, errorElement: <ShareRouteErrorBoundary /> },
+  // The clean, shareable DDD run RELEASE page — also mounted OUTSIDE AppLayout,
+  // in a chrome-less PublicLayout, so a `?t=<share_token>` viewer with no Dimagi
+  // login is served (the release API self-enforces token-or-member access). New
+  // URL; the operator console at /w/:ws/ddd/:narrative/:runId is untouched.
+  {
+    element: <PublicLayout />,
+    errorElement: <ShareRouteErrorBoundary />,
+    children: [
+      { path: '/ddd-release/:narrative/:runId', element: <DddReleasePage /> },
+    ],
+  },
 ]), {
   // "/" at root, "/canopy" as a labs tenant — keeps every route + <Link> under
   // the deployment's path prefix (from Vite's import.meta.env.BASE_URL).

--- a/tests/test_ddd_release.py
+++ b/tests/test_ddd_release.py
@@ -1,0 +1,133 @@
+"""Clean, shareable DDD run release page (/api/ddd/release/<run_id>/).
+
+Covers the two halves of the share path: the visibility cascade must now MINT a
+share token on flip-to-public, and the release endpoint must be reachable
+anonymously with a matching ?t= token (and 404 without one) while giving members
+the extra internal affordances.
+"""
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import Client, override_settings
+
+from apps.reviews.models import ReviewRequest
+from apps.runs import aggregate
+from apps.walkthroughs.models import Walkthrough
+from apps.workspaces import services as wsvc
+from apps.workspaces.models import Workspace, WorkspaceMembership
+
+RUN_ID = "demo-2026-07-22-001"
+
+
+@pytest.fixture
+def owner(db):
+    u = get_user_model().objects.create_user(
+        username="owner@dimagi.com", email="owner@dimagi.com",
+    )
+    ws = Workspace.objects.create(slug="dimagi", display_name="Dimagi", created_by=u)
+    wsvc.ensure_member(ws, u, WorkspaceMembership.OWNER)
+    return u
+
+
+def _ws():
+    return Workspace.objects.get(slug="dimagi")
+
+
+def _hero(owner, **kw):
+    defaults = dict(
+        title="Hero", kind="video", role=Walkthrough.ROLE_HERO_VIDEO,
+        owner=owner, workspace=_ws(), drive_file_id="hero", drive_folder_id="d",
+        content_type="video/mp4", size_bytes=1, duration_sec=100,
+        run_id=RUN_ID, narrative_slug="demo",
+        links=[{"label": "Program Admin Report", "url": "https://labs/par", "kind": "reference"}],
+    )
+    defaults.update(kw)
+    return Walkthrough.objects.create(**defaults)
+
+
+def _rev(owner, **kw):
+    defaults = dict(
+        run_id=RUN_ID, narrative_slug="demo", workspace=_ws(),
+        gate="narrative-agreement",
+        request_json={"narrative": "The Story Title\nA program manager reads three managers."},
+        owner=owner,
+    )
+    defaults.update(kw)
+    return ReviewRequest.objects.create(**defaults)
+
+
+# --- cascade now mints tokens ------------------------------------------------
+
+def test_cascade_mints_share_tokens_on_public(db, owner):
+    w = _hero(owner, visibility="private")
+    assert not w.share_token
+    aggregate.set_narrative_visibility("demo", "link")
+    w.refresh_from_db()
+    assert w.visibility == "link"
+    assert w.share_token, "flip-to-public must mint a share token"
+
+
+def test_cascade_to_private_leaves_token(db, owner):
+    w = _hero(owner, visibility="private")
+    aggregate.set_narrative_visibility("demo", "link")
+    w.refresh_from_db()
+    tok = w.share_token
+    aggregate.set_narrative_visibility("demo", "private")
+    w.refresh_from_db()
+    assert w.visibility == "private"
+    assert w.share_token == tok, "flip-to-private keeps the token (revive later)"
+
+
+# --- the release endpoint ----------------------------------------------------
+
+@override_settings(REQUIRE_AUTH=True)
+def test_release_anonymous_without_token_404s(db, owner):
+    _hero(owner, visibility="private")
+    _rev(owner)
+    resp = Client().get(f"/api/ddd/release/{RUN_ID}/")
+    assert resp.status_code == 404  # never leaks existence
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_release_anonymous_with_valid_token(db, owner):
+    _hero(owner, visibility="private")
+    _rev(owner)
+    aggregate.set_narrative_visibility("demo", "link")
+    token = Walkthrough.objects.get(run_id=RUN_ID).share_token
+
+    resp = Client().get(f"/api/ddd/release/{RUN_ID}/?t={token}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["run_id"] == RUN_ID
+    assert body["is_public"] is True
+    assert body["is_member"] is False
+    assert body["share_token"] == token
+    # Stream URL carries the artifact's own token so anonymous playback works.
+    assert body["video"]["content_url"] == f"/walkthrough/{Walkthrough.objects.get(run_id=RUN_ID).id}/content?t={token}"
+    # Product URLs surfaced as named links; no operator jargon fields.
+    assert body["product_links"] == [
+        {"label": "Program Admin Report", "url": "https://labs/par", "kind": "reference"}
+    ]
+    assert "phase" not in body and "all_artifacts" not in body
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_release_anonymous_wrong_token_404s(db, owner):
+    _hero(owner, visibility="private")
+    aggregate.set_narrative_visibility("demo", "link")
+    resp = Client().get(f"/api/ddd/release/{RUN_ID}/?t=not-the-token")
+    assert resp.status_code == 404
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_release_member_gets_internal_affordances(db, owner):
+    _hero(owner, visibility="private")  # not public
+    _rev(owner)
+    client = Client(); client.force_login(owner)
+    resp = client.get(f"/api/ddd/release/{RUN_ID}/")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["is_member"] is True
+    assert body["is_public"] is False
+    assert body["build_url"] == f"/ddd/demo/{RUN_ID}"
+    # Private artifact → tokenless stream URL (session auth covers it).
+    assert body["video"]["content_url"].endswith("/content")


### PR DESCRIPTION
A curated, outsider-legible face for a DDD run — **final video + narrative story + the live product URLs it used** — modeled on ace-web's public `OppSummaryPage`. New URL (`/ddd-release/<slug>/<run>`); the operator console at `/w/:ws/ddd/:narrative/:runId` is **untouched** and remains where you edit anything.

## Why
The existing `/ddd/<slug>/<run_id>` package reads as a builder's console (raw `run_id` H1, `external_release · resolved` gate badge, tooling subtitles, a full artifact dump, delete buttons) and is entirely Dimagi-login-gated — no clean page to share, and no external share link.

## What
**Backend**
- `GET /api/ddd/release/{run_id}/` (`auth=None`) — self-enforces access via the primary artifact's existing `readable_by` gate (workspace **member** OR a matching `?t=<share_token>`), returning a **curated** payload with per-artifact **tokenized** stream URLs so an anonymous viewer can play the video/deck.
- **Fix** `set_narrative_visibility`: flip-to-public now **mints** a share token per walkthrough. The bulk `update()` bypassed `save()`, so anonymous `?t=` access 404'd and no shareable link ever existed — the load-bearing gap that made package sharing impossible.
- Login-middleware allowlist for the new page + read API.

**Frontend**
- New public route mounted **outside** the app shell in a chrome-less `PublicLayout` (same pattern as `/share/:token`).
- `DddReleasePage`: hero (title + lede) → final video → **the story** → **Try it live** (product URLs as named buttons) → optional write-up → footer. Members additionally get a copy-share control (when public) + an "open the full build view" link.

## Tests
`tests/test_ddd_release.py` — token-mint cascade + the endpoint's full access matrix (member / anon+valid / anon+wrong / anon+none). Existing visibility suites still pass. No model changes → no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)