### PR TITLE
fix(ddd): curate release-page title + product links

### DIFF
--- a/apps/runs/aggregate.py
+++ b/apps/runs/aggregate.py
@@ -10,6 +10,7 @@ the HTTP layer, and so the Ninja handlers stay thin.
 """
 from __future__ import annotations
 
+import re
 from datetime import datetime
 from typing import Any
 
@@ -382,6 +383,49 @@ def _humanize_slug(slug: str) -> str:
     return (slug or "").replace("-", " ").replace("_", " ").strip().title()
 
 
+def _clean_links(raw: list[dict]) -> list[dict]:
+    """Curate a run's link list into clean, visitable destinations.
+
+    Upstream link capture (the DDD upload harvesting scene targets) can emit
+    junk the release page must not show: an unexpanded ``${var}`` template that
+    never resolved, a bare origin with no path ("App"), a host-less relative
+    URL, and the same page repeated per scene. Drop template leaks + bare
+    origins, absolutize relative URLs against the run's own host, and de-dupe —
+    so "Try it live" is a short list of real pages, not a scene-by-scene dump.
+    """
+    host = ""
+    for link in raw:
+        m = re.match(r"^(https?://[^/]+)", (link.get("url") or "").strip())
+        if m:
+            host = m.group(1)
+            break
+    out: list[dict] = []
+    seen: set[str] = set()
+    for link in raw:
+        if not isinstance(link, dict):
+            continue
+        url = (link.get("url") or "").strip()
+        if not url or "${" in url:  # empty or an unresolved template variable
+            continue
+        if url.startswith("/") and host:  # host-less relative → absolute
+            url = host + url
+        m = re.match(r"^https?://[^/]+(.*)$", url)
+        path = m.group(1) if m else url
+        if path in ("", "/"):  # bare origin, no meaningful destination
+            continue
+        if url in seen:
+            continue
+        seen.add(url)
+        out.append(
+            {
+                "label": link.get("label", ""),
+                "url": url,
+                "kind": link.get("kind", "reference"),
+            }
+        )
+    return out
+
+
 def _lede_from_story(story: str | None, title: str | None) -> str | None:
     """A one-line hook for the hero: the first sentence of the story that isn't
     the title line (the story's first line is what _title_from_review returns)."""
@@ -458,30 +502,32 @@ def build_release(run_id: str, request) -> dict | None:
         narrative_review = versions[-1] if versions else None
     narrative_payload = _narrative_payload(narrative_review)
 
-    title = (narrative_payload or {}).get("title") or _humanize_slug(narrative_slug)
-    lede = _lede_from_story((narrative_payload or {}).get("story"), title)
+    # Title: a short, human headline. The narrative's derived title is the
+    # story's first LINE, which is often a full scene-setting sentence — too
+    # long for an H1. When it is, use the humanized slug and let that long
+    # sentence be the lede instead.
+    story = (narrative_payload or {}).get("story")
+    derived_title = (narrative_payload or {}).get("title")
+    if derived_title and len(derived_title) <= 70:
+        title = derived_title
+        lede = _lede_from_story(story, derived_title)
+    else:
+        title = _humanize_slug(narrative_slug)
+        lede = _lede_from_story(story, None)
 
     # Product URLs the run used (reference) vs sibling artifacts (narrative /
-    # companion). De-duped on url, oldest-first.
-    product_links: list[dict] = []
-    related_links: list[dict] = []
-    seen: set[str] = set()
+    # companion), each curated (template leaks + bare origins dropped, relative
+    # absolutized, de-duped) so the page shows real, visitable destinations.
+    raw_product: list[dict] = []
+    raw_related: list[dict] = []
     for w in sorted(wts, key=lambda x: x.created_at):
         for link in w.links or []:
             if not isinstance(link, dict):
                 continue
-            url = link.get("url", "")
-            if not url or url in seen:
-                continue
-            seen.add(url)
-            entry = {
-                "label": link.get("label", ""),
-                "url": url,
-                "kind": link.get("kind", "reference"),
-            }
-            (product_links if entry["kind"] == "reference" else related_links).append(
-                entry
-            )
+            kind = link.get("kind", "reference")
+            (raw_product if kind == "reference" else raw_related).append(link)
+    product_links = _clean_links(raw_product)
+    related_links = _clean_links(raw_related)
 
     return {
         "run_id": run_id,

--- a/tests/test_ddd_release.py
+++ b/tests/test_ddd_release.py
@@ -118,6 +118,36 @@ def test_release_anonymous_wrong_token_404s(db, owner):
     assert resp.status_code == 404
 
 
+# --- link curation + title -----------------------------------------------
+
+def test_clean_links_drops_junk_and_dedupes():
+    raw = [
+        {"label": "PAR", "url": "https://labs.x/labs/workflow/5003/run/?program_id=1", "kind": "reference"},
+        {"label": "PAR again", "url": "/labs/workflow/5003/run/?program_id=1", "kind": "reference"},  # host-less dup
+        {"label": "template", "url": "https://labs.x${par_url}", "kind": "reference"},  # unresolved var
+        {"label": "App", "url": "https://labs.x", "kind": "reference"},  # bare origin
+        {"label": "App/", "url": "https://labs.x/", "kind": "reference"},  # bare origin w/ slash
+        {"label": "Audit", "url": "https://labs.x/audit/4996/bulk/", "kind": "reference"},
+    ]
+    out = aggregate._clean_links(raw)
+    urls = [l["url"] for l in out]
+    assert urls == [
+        "https://labs.x/labs/workflow/5003/run/?program_id=1",  # first wins; relative dup collapsed
+        "https://labs.x/audit/4996/bulk/",
+    ]  # ${} leak + both bare origins dropped
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_release_title_falls_back_when_story_line_is_long(db, owner):
+    _hero(owner, visibility="private")
+    long_first_line = "Priya runs a nutrition program funded to deliver RUTF across three managers"
+    _rev(owner, request_json={"narrative": f"{long_first_line}\nShe reviews compliance weekly."})
+    client = Client(); client.force_login(owner)
+    body = client.get(f"/api/ddd/release/{RUN_ID}/").json()
+    assert body["title"] == "Demo"  # humanized slug, not the 74-char sentence
+    assert body["lede"] and body["lede"].startswith("Priya runs")  # sentence becomes the lede
+
+
 @override_settings(REQUIRE_AUTH=True)
 def test_release_member_gets_internal_affordances(db, owner):
     _hero(owner, visibility="private")  # not public


### PR DESCRIPTION
Follow-up to #325 (same branch, re-opened). Render-boundary curation so the clean release page reads clean even with messy captured data: humanize an over-long title into the lede, and drop `${var}` template leaks / bare-origin URLs, absolutize host-less relative URLs, and de-dupe the product links. Verified live: the nutrition-demo release page's 'Try it live' collapses from 10 raw entries (incl. a leaked `${par_url}` and a bare-host 'App') to the real deduped pages. Tests added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)