### PR TITLE
items API: dismiss can carry a reason (auditable self-retraction)

### DIFF
--- a/apps/harness/items_api.py
+++ b/apps/harness/items_api.py
@@ -25,7 +25,7 @@ from apps.workspaces import services as wsvc
 
 from . import services
 from .models import Item
-from .schemas import ItemDecideIn, ItemIn, ItemOut
+from .schemas import ItemDecideIn, ItemDismissIn, ItemIn, ItemOut
 
 agent_items_router = Router(auth=session_auth, tags=["items"])
 items_router = Router(auth=session_auth, tags=["items"])
@@ -148,12 +148,14 @@ def decide_item(request: HttpRequest, item_id: uuid.UUID, payload: ItemDecideIn)
 
 
 @items_router.post("/{item_id}/dismiss", response=ItemOut, summary="Dismiss an item")
-def dismiss_item(request: HttpRequest, item_id: uuid.UUID) -> dict:
+def dismiss_item(request: HttpRequest, item_id: uuid.UUID,
+                 payload: ItemDismissIn | None = None) -> dict:
     item = _item_or_404(request, item_id)
     try:
         item = services.dismiss_item(
             item, by=request.user.email or request.user.get_username(),
             decided_by_user=request.user,
+            comment=(payload.comment if payload else ""),
         )
     except services.AlreadyDecidedError as exc:
         # Already decided or dismissed — mirror decide's 409 so a double-click or a

--- a/apps/harness/schemas.py
+++ b/apps/harness/schemas.py
@@ -421,6 +421,14 @@ class ItemDecideIn(Schema):
     comment: str = ""
 
 
+class ItemDismissIn(Schema):
+    # Dismiss carries an optional reason: a PRODUCER retracting its own item raised
+    # in error (e.g. an agent that verified the friction was already fixed) records
+    # WHY, so the board shows "retracted: already shipped" instead of a bare
+    # dismissed row. Optional — an empty-body dismiss stays valid.
+    comment: str = ""
+
+
 # ---- Runner credentials (per-runner, cloud-only; laptop uses emdash) ----
 class RunnerCredentialIn(Schema):
     """Set a cloud runner's credentials. A field left None is unchanged

--- a/apps/harness/services.py
+++ b/apps/harness/services.py
@@ -819,9 +819,10 @@ def decide_item(
     return item, turns
 
 
-def dismiss_item(item: Item, *, by: str, decided_by_user=None) -> Item:
+def dismiss_item(item: Item, *, by: str, decided_by_user=None, comment: str = "") -> Item:
     """Retire an OPEN item without acting — a producer that raised it in error, or
-    a subject that changed under it.
+    a subject that changed under it. `comment` records WHY (e.g. an agent retracting
+    a finding it verified was already shipped), so a dismissed row isn't a mystery.
 
     Only an OPEN item may be dismissed. Dismissing an already-DECIDED item would
     overwrite `decided_by`/`decided_at` — erasing who approved it — while the turns
@@ -835,7 +836,11 @@ def dismiss_item(item: Item, *, by: str, decided_by_user=None) -> Item:
     item.decided_by = by
     item.decided_by_user = decided_by_user if getattr(decided_by_user, "is_authenticated", False) else None
     item.decided_at = timezone.now()
-    item.save(update_fields=["state", "decided_by", "decided_by_user", "decided_at"])
+    fields = ["state", "decided_by", "decided_by_user", "decided_at"]
+    if comment:
+        item.comment = comment
+        fields.append("comment")
+    item.save(update_fields=fields)
     return item
 
 

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -5393,6 +5393,14 @@ export interface components {
              */
             readonly comment: string;
         };
+        /** ItemDismissIn */
+        readonly ItemDismissIn: {
+            /**
+             * Comment
+             * @default
+             */
+            readonly comment: string;
+        };
         /** WorkspaceOut */
         readonly WorkspaceOut: {
             /** Slug */
@@ -8833,7 +8841,11 @@ export interface operations {
             };
             readonly cookie?: never;
         };
-        readonly requestBody?: never;
+        readonly requestBody?: {
+            readonly content: {
+                readonly "application/json": components["schemas"]["ItemDismissIn"] | null;
+            };
+        };
         readonly responses: {
             /** @description OK */
             readonly 200: {

--- a/tests/test_item_services.py
+++ b/tests/test_item_services.py
@@ -125,6 +125,24 @@ def test_dismiss_never_dispatches_even_with_a_decision_set(ada):
     assert Turn.objects.count() == 0
 
 
+def test_dismiss_records_an_optional_reason(ada):
+    # A producer retracting its own erroneous item records WHY; the reason lands on
+    # the item's comment so the board shows it instead of a bare dismissed row.
+    item = _item(ada)
+    item = services.dismiss_item(item, by="ada@dimagi-ai.com",
+                                 comment="retracted: already shipped in origin/main")
+    assert item.state == Item.DISMISSED
+    assert item.comment == "retracted: already shipped in origin/main"
+
+
+def test_dismiss_reason_is_optional(ada):
+    # Backward-compatible: an empty-body dismiss (no comment) leaves comment untouched.
+    item = _item(ada)
+    item = services.dismiss_item(item, by="jj@dimagi.com")
+    assert item.state == Item.DISMISSED
+    assert item.comment == ""
+
+
 def test_dismiss_refuses_an_already_decided_item(ada):
     # Dismissing a decided-and-dispatched item would erase who approved it while its
     # turns keep running. Dismiss guards on state exactly like decide does.

--- a/tests/test_items_api.py
+++ b/tests/test_items_api.py
@@ -139,6 +139,34 @@ def test_a_bad_dispatch_spec_is_422_and_leaves_the_item_open(client_member, ada)
     assert Turn.objects.count() == 0
 
 
+import json as _json
+
+
+def test_dismiss_persists_an_optional_reason(client_member, ada):
+    # A producer retracting its own item can post a reason; it lands on comment and
+    # is serialized back — so the board can show "why dismissed".
+    _post_batch(client_member)
+    item_id = Item.objects.first().id
+    resp = client_member.post(
+        f"/api/items/{item_id}/dismiss",
+        data=_json.dumps({"comment": "retracted: already shipped"}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["state"] == "dismissed"
+    assert body["comment"] == "retracted: already shipped"
+
+
+def test_dismiss_with_no_body_still_works(client_member, ada):
+    # Backward compat: the no-body dismiss (the pre-existing call shape) still 200s.
+    _post_batch(client_member)
+    item_id = Item.objects.first().id
+    resp = client_member.post(f"/api/items/{item_id}/dismiss", content_type="application/json")
+    assert resp.status_code == 200
+    assert resp.json()["state"] == "dismissed"
+
+
 def test_dismiss_never_dispatches(client_member, ada):
     Agent.objects.create(slug="hal", name="Hal", workspace=ada.workspace)
     _post_batch(client_member)


### PR DESCRIPTION
## Why

While conducting the fleet, Ada posted a findings batch and then verified 4 of them were already fixed. `dismiss` already exists to retire an item "raised in error" (its docstring) — and an agent CAN call it — but it records **no reason**, so the retracted items showed up as bare "dismissed" rows with no explanation.

As agents start both posting *and* retracting their own items, the *why* matters for the audit trail.

## What

- `dismiss` endpoint accepts an optional `{ "comment": "..." }` body (`ItemDismissIn`); the reason lands on `Item.comment` (the existing field `decide` already uses) and serializes back.
- **Backward-compatible**: an empty-body dismiss — the pre-existing call shape — still 200s and leaves `comment` untouched (`payload: ItemDismissIn | None = None`).

## Tests

4 new (25 pass in the two item suites): reason persists via the service and via the API; empty-body dismiss still works at both layers.

## Context

This came out of a fleet-conduct session where an over-eager findings batch had to be retracted. The upstream fix — stopping already-shipped findings from being surfaced at all — is canopy PR #362 (agent-review source-verification gate). This PR just makes the *retraction* clean and auditable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)