### PR TITLE
fix(ddd): don't let a ${var} link pollute the release-page host

### DIFF
--- a/apps/runs/aggregate.py
+++ b/apps/runs/aggregate.py
@@ -393,9 +393,15 @@ def _clean_links(raw: list[dict]) -> list[dict]:
     origins, absolutize relative URLs against the run's own host, and de-dupe —
     so "Try it live" is a short list of real pages, not a scene-by-scene dump.
     """
+    # Derive the run's host from the first CLEAN absolute url — never a
+    # template-polluted one, or the leaked ${var} would pollute the host and
+    # get prefixed onto every relative link.
     host = ""
     for link in raw:
-        m = re.match(r"^(https?://[^/]+)", (link.get("url") or "").strip())
+        u = (link.get("url") or "").strip()
+        if "${" in u:
+            continue
+        m = re.match(r"^(https?://[^/]+)", u)
         if m:
             host = m.group(1)
             break
@@ -409,6 +415,8 @@ def _clean_links(raw: list[dict]) -> list[dict]:
             continue
         if url.startswith("/") and host:  # host-less relative → absolute
             url = host + url
+        if "${" in url:  # defence: absolutization must never reintroduce a leak
+            continue
         m = re.match(r"^https?://[^/]+(.*)$", url)
         path = m.group(1) if m else url
         if path in ("", "/"):  # bare origin, no meaningful destination

--- a/tests/test_ddd_release.py
+++ b/tests/test_ddd_release.py
@@ -121,10 +121,12 @@ def test_release_anonymous_wrong_token_404s(db, owner):
 # --- link curation + title -----------------------------------------------
 
 def test_clean_links_drops_junk_and_dedupes():
+    # The ${var} link is FIRST so it would pollute host derivation if the helper
+    # naively took the first absolute-looking url (the real nutrition-demo bug).
     raw = [
+        {"label": "template", "url": "https://labs.x${par_url}", "kind": "reference"},  # unresolved var, first
         {"label": "PAR", "url": "https://labs.x/labs/workflow/5003/run/?program_id=1", "kind": "reference"},
         {"label": "PAR again", "url": "/labs/workflow/5003/run/?program_id=1", "kind": "reference"},  # host-less dup
-        {"label": "template", "url": "https://labs.x${par_url}", "kind": "reference"},  # unresolved var
         {"label": "App", "url": "https://labs.x", "kind": "reference"},  # bare origin
         {"label": "App/", "url": "https://labs.x/", "kind": "reference"},  # bare origin w/ slash
         {"label": "Audit", "url": "https://labs.x/audit/4996/bulk/", "kind": "reference"},
@@ -132,9 +134,10 @@ def test_clean_links_drops_junk_and_dedupes():
     out = aggregate._clean_links(raw)
     urls = [l["url"] for l in out]
     assert urls == [
-        "https://labs.x/labs/workflow/5003/run/?program_id=1",  # first wins; relative dup collapsed
+        "https://labs.x/labs/workflow/5003/run/?program_id=1",  # relative dup absolutized to clean host + collapsed
         "https://labs.x/audit/4996/bulk/",
-    ]  # ${} leak + both bare origins dropped
+    ]
+    assert not any("${" in u for u in urls)  # no leak survives, even via absolutization
 
 
 @override_settings(REQUIRE_AUTH=True)


### PR DESCRIPTION
Follow-up to #326. The nutrition-demo run's first reference link is a leaked `https://host${par_url}`; `_clean_links` derived the host from it, so relative links got prefixed with the polluted host and reintroduced the `${}` leak. Fix: skip `${}` urls when deriving the host + re-check after absolutization. Reproducer test added (the `${}` link is first so it exercises host derivation). Verified: the relative PAR link now absolutizes clean and de-dupes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)