### PR TITLE
fix(ddd): let anonymous browsers view the release page

### DIFF
--- a/frontend/src/api/client.v2.ts
+++ b/frontend/src/api/client.v2.ts
@@ -71,7 +71,8 @@ function isPublicLinkRoute(): boolean {
   return (
     p.startsWith("/review/") ||
     p.startsWith("/walkthrough/") ||
-    p.startsWith("/share/")
+    p.startsWith("/share/") ||
+    p.startsWith("/ddd-release/")
   );
 }
 

--- a/frontend/src/auth/AuthProvider.tsx
+++ b/frontend/src/auth/AuthProvider.tsx
@@ -24,6 +24,7 @@ function isPublicLinkRoute(): boolean {
     path.startsWith('/review/') ||
     path.startsWith('/walkthrough/') ||
     path.startsWith('/share/') ||
+    path.startsWith('/ddd-release/') ||
     LEGACY_WALKTHROUGH_RE.test(path)
   )
 }


### PR DESCRIPTION
The release API is anonymous-capable and streams fine (verified: 206 video), but in a **browser** an anonymous visitor was bounced to Google OAuth — `AuthProvider` + `client.v2`'s `getMe()` 401 redirect only exempt `/review/`, `/walkthrough/`, `/share/`. Add `/ddd-release/` to both client-side `isPublicLinkRoute()` allowlists (they're documented as kept-in-sync). Caught by loading the live share URL headless — it rendered Google sign-in instead of the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)