### PR TITLE
Chat slice 3 (laptop): real emdash execution — chat replies stream from the running agent

### DIFF
--- a/apps/chat/services.py
+++ b/apps/chat/services.py
@@ -80,8 +80,10 @@ def send_message(*, session: Session, text: str, user, client_id: str = "") -> t
             prompt=text,
             # Continuity: every send in a chat reuses ONE emdash session (the runner's
             # _thread_key reads this), so a conversation is one durable thread rather
-            # than a fresh session per message.
-            origin_ref={"thread_key": str(session.id)},
+            # than a fresh session per message. chat_session_id tells a session-capable
+            # runner to BRIDGE the emdash response back into the ledger (vs the normal
+            # fire-and-continue), so the website streams the reply.
+            origin_ref={"thread_key": str(session.id), "chat_session_id": str(session.id)},
         )
     # RC4 — multiplayer interjection: if a turn is ALREADY running for this session,
     # the human's message is an interjection. Push it down to the runner executing

--- a/apps/chat/services.py
+++ b/apps/chat/services.py
@@ -78,6 +78,10 @@ def send_message(*, session: Session, text: str, user, client_id: str = "") -> t
             origin=Turn.ORIGIN_API,
             idempotency_key=f"chat:{session.id.hex}:{client_id or index}",
             prompt=text,
+            # Continuity: every send in a chat reuses ONE emdash session (the runner's
+            # _thread_key reads this), so a conversation is one durable thread rather
+            # than a fresh session per message.
+            origin_ref={"thread_key": str(session.id)},
         )
     # RC4 — multiplayer interjection: if a turn is ALREADY running for this session,
     # the human's message is an interjection. Push it down to the runner executing

--- a/apps/harness/schemas.py
+++ b/apps/harness/schemas.py
@@ -192,7 +192,12 @@ class TurnOut(Schema):
     def resolve_agent_slug(obj) -> str | None:
         # None for project turns — dereferencing obj.agent unconditionally is
         # what this used to do, and it 500s the moment agent can be NULL.
-        return obj.agent.slug if obj.agent_id else None
+        if obj.agent_id:
+            return obj.agent.slug
+        # A chat SESSION turn targets a Session, not an agent — but you chat WITH an
+        # agent, so surface the session's agent as the emdash target the runner drives.
+        cs = getattr(obj, "chat_session", None)
+        return cs.agent.slug if cs and cs.agent_id else None
 
     @staticmethod
     def resolve_workspace_slug(obj) -> str | None:

--- a/packages/canopy_runner/canopy_runner/chat_bridge.py
+++ b/packages/canopy_runner/canopy_runner/chat_bridge.py
@@ -1,0 +1,100 @@
+"""Bridge an emdash session's live response back into the harness ledger.
+
+The laptop runner injects a chat prompt into an emdash session and then TAILS that
+session's Claude Code transcript (.jsonl), posting each new assistant TEXT block as
+an `assistant` TurnEvent — which the chat SessionConsumer translates to chat.stream_*
+so the website streams the reply. This is the piece the normal agent/project path
+deliberately omits (there the work just continues in the visible emdash session).
+
+Completion is IDLE-based: emdash/Claude Code write no "turn done" marker to the
+transcript, so we finish when the file stops growing for a few polls AFTER the
+assistant has spoken (or a hard timeout). Pure + injectable (records_fn / sleep) so
+the loop unit-tests without real files or a real clock.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Callable
+
+
+def _assistant_text(content) -> str:
+    """The assistant's spoken output — TEXT blocks only (tool_use blocks are skipped
+    for the v1 bridge; the website shows the reply, not the tool calls)."""
+    if isinstance(content, str):
+        return content.strip()
+    if not isinstance(content, list):
+        return ""
+    parts = [
+        b.get("text", "")
+        for b in content
+        if isinstance(b, dict) and b.get("type") == "text"
+    ]
+    return "".join(parts).strip()
+
+
+def read_records(path) -> list[dict]:
+    """Every JSONL record in the transcript, best-effort (never raises)."""
+    try:
+        text = Path(path).read_text(errors="replace")
+    except OSError:
+        return []
+    out: list[dict] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            out.append(json.loads(line))
+        except ValueError:
+            continue
+    return out
+
+
+def new_assistant_texts(records: list[dict], since: int) -> list[str]:
+    """Assistant TEXT messages in records[since:], oldest->newest, non-empty only."""
+    texts: list[str] = []
+    for rec in records[since:]:
+        if rec.get("type") != "assistant":
+            continue
+        msg = rec.get("message")
+        content = msg.get("content", "") if isinstance(msg, dict) else ""
+        t = _assistant_text(content)
+        if t:
+            texts.append(t)
+    return texts
+
+
+def bridge_response(
+    post_event: Callable[[dict], None],
+    records_fn: Callable[[], list[dict]],
+    *,
+    start_index: int,
+    idle_rounds: int = 6,
+    max_rounds: int = 1200,
+    sleep: Callable[[float], None],
+    poll: float = 0.5,
+) -> str:
+    """Tail the transcript from `start_index`, posting each new assistant TEXT as an
+    `assistant` event via `post_event`. Finish when no new records arrive for
+    `idle_rounds` consecutive polls (after >=1 assistant text), or `max_rounds` hit.
+    Returns the concatenated assistant text (for the turn's finish note)."""
+    seen = start_index
+    got_assistant = False
+    idle = 0
+    collected: list[str] = []
+    for _ in range(max_rounds):
+        records = records_fn()
+        if len(records) > seen:
+            for text in new_assistant_texts(records, seen):
+                post_event({"kind": "assistant", "payload": {"text": text}})
+                collected.append(text)
+                got_assistant = True
+            seen = len(records)
+            idle = 0
+        elif got_assistant:
+            idle += 1
+            if idle >= idle_rounds:
+                break
+        sleep(poll)
+    return "\n\n".join(collected)

--- a/packages/canopy_runner/canopy_runner/execute.py
+++ b/packages/canopy_runner/canopy_runner/execute.py
@@ -21,8 +21,10 @@ from __future__ import annotations
 import datetime as dt
 import logging
 import re
+import time
+from pathlib import Path
 
-from . import cdp_control, dialog, emdash, readiness
+from . import cdp_control, chat_bridge, dialog, emdash, readiness, transcript
 
 logger = logging.getLogger("canopy_runner.execute")
 
@@ -151,9 +153,93 @@ def _deliver_to_existing(cfg, client, runner_id, turn, task, state, work_prompt)
     return f"reused:{turn_id}"
 
 
+def _resolve_transcript_path(target: str, task: str):
+    home = Path.home()
+    return transcript.resolve_transcript(
+        target, task, home=home, claude_home=home / ".claude" / "projects"
+    )
+
+
+def _wait_for_transcript(target: str, task: str, *, timeout: float = 45.0, poll: float = 0.5):
+    """A freshly-created emdash session's transcript .jsonl doesn't exist until Claude
+    Code starts writing. Wait (bounded) for it to appear; reused sessions resolve at once."""
+    deadline = time.monotonic() + timeout
+    path = _resolve_transcript_path(target, task)
+    while path is None and time.monotonic() < deadline:
+        time.sleep(poll)
+        path = _resolve_transcript_path(target, task)
+    return path
+
+
+def execute_chat_turn(cfg, client, runner_id: str, turn: dict) -> str:
+    """A chat SESSION turn: inject the human's message into the session's emdash session,
+    then BRIDGE the assistant reply back into the ledger — unlike agent/project turns,
+    which fire-and-continue in the visible emdash session. The chat SessionConsumer turns
+    the bridged assistant events into chat.stream_* so the website streams the reply."""
+    turn_id = turn["id"]
+    agent_slug = turn.get("agent_slug") or ""
+    project = turn.get("project") or ""
+    workspace = turn.get("workspace_slug") or ""
+    target = agent_slug or project  # the emdash project to drive
+    thread_key = _thread_key(turn)
+    prompt = turn.get("prompt") or ""
+
+    plan = client.resolve_session(
+        runner_id, agent_slug, thread_key, project=project, workspace=workspace
+    )
+    client.start(turn_id)
+
+    task = plan.get("emdash_task_id") if plan.get("reuse") else None
+    if task and emdash.task_state(cfg.emdash_db, task) in ("absent", "archived"):
+        task = None  # the linked emdash session is gone — create a fresh one
+    if task:
+        try:
+            cdp_control.open_and_send(task, prompt, port=cfg.cdp_port)
+        except Exception as exc:  # noqa: BLE001 — any send failure ends the turn
+            logger.error("chat reuse send failed turn=%s task=%s: %s", turn_id, task, exc)
+            client.fail_turn(turn_id, f"chat reuse send failed: {str(exc)[:200]}")
+            return f"failed:{turn_id}"
+        logger.info("chat turn=%s reused emdash task=%s (agent=%s)", turn_id, task, target)
+    else:
+        try:
+            res = cdp_control.create_task(
+                target, prompt, task_name=_task_name(target, turn), port=cfg.cdp_port
+            )
+        except cdp_control.CDPError as exc:
+            logger.error("chat create failed turn=%s agent=%s: %s", turn_id, target, exc)
+            client.fail_turn(turn_id, f"chat create failed: {str(exc)[:200]}")
+            return f"failed:{turn_id}"
+        task = res.get("task") or ""
+        client.record_session(
+            runner_id, agent_slug, thread_key, project=project, workspace=workspace,
+            emdash_task_id=task, summary=None,
+        )
+        logger.info("chat turn=%s created emdash task=%s (agent=%s)", turn_id, task, target)
+
+    path = _wait_for_transcript(target, task)
+    if path is None:
+        logger.warning("chat turn=%s: no transcript for task=%s (agent=%s) — reply not bridged",
+                       turn_id, task, target)
+        client.finish(turn_id, note="chat: transcript not found; reply not bridged")
+        return f"chat:{turn_id}:{task}"
+    start_index = len(chat_bridge.read_records(path))
+    text = chat_bridge.bridge_response(
+        lambda e: client.post_events(turn_id, [e]),
+        lambda: chat_bridge.read_records(path),
+        start_index=start_index, sleep=time.sleep,
+    )
+    client.finish(turn_id, note=f"chat reply bridged ({len(text)} chars)")
+    logger.info("chat turn=%s bridged %d chars from task=%s", turn_id, len(text), task)
+    return f"chat:{turn_id}:{task}"
+
+
 def execute_turn(cfg, client, runner_id: str, turn: dict) -> str:
     """Route one claimed turn to an emdash session (reuse or create). Returns a short
     action string: reused:<id> | created:<id>:<task> | failed:<id>."""
+    # A chat session send is bridged back to the website (its own path); everything
+    # else fires into the visible emdash session and continues there.
+    if (turn.get("origin_ref") or {}).get("chat_session_id"):
+        return execute_chat_turn(cfg, client, runner_id, turn)
     turn_id = turn["id"]
     # `agent` names the emdash project to drive for BOTH turn kinds — an agent's
     # slug or, for a repo turn, the project name. cdp_control takes a project name

--- a/packages/canopy_runner/tests/test_chat_bridge.py
+++ b/packages/canopy_runner/tests/test_chat_bridge.py
@@ -1,0 +1,59 @@
+"""The emdash-response bridge: tail assistant text + idle-based completion."""
+from canopy_runner.chat_bridge import bridge_response, new_assistant_texts
+
+
+def _asst(text):
+    return {"type": "assistant", "message": {"content": [{"type": "text", "text": text}]}}
+
+
+def _user(text):
+    return {"type": "user", "message": {"content": text}}
+
+
+def _tool():
+    return {"type": "assistant", "message": {"content": [{"type": "tool_use", "name": "Bash", "input": {}}]}}
+
+
+def test_new_assistant_texts_after_offset():
+    recs = [_user("hi"), _asst("hello"), _tool(), _asst("done")]
+    assert new_assistant_texts(recs, 0) == ["hello", "done"]
+    assert new_assistant_texts(recs, 2) == ["done"]  # only after the offset
+    assert new_assistant_texts([_tool()], 0) == []   # tool-only -> no text
+
+
+def test_bridge_posts_new_assistant_texts_and_completes_on_idle():
+    states = [
+        [_user("prompt")],                                    # only the injected prompt
+        [_user("prompt"), _asst("thinking")],                 # first assistant chunk
+        [_user("prompt"), _asst("thinking"), _asst("final")],  # second, then stable
+    ]
+    box = {"i": 0}
+
+    def records_fn():
+        i = min(box["i"], len(states) - 1)
+        box["i"] += 1
+        return states[i]
+
+    events = []
+    result = bridge_response(
+        events.append, records_fn, start_index=1,  # skip the injected user prompt
+        idle_rounds=2, max_rounds=50, sleep=lambda _s: None, poll=0,
+    )
+    assert [(e["kind"], e["payload"]["text"]) for e in events] == [
+        ("assistant", "thinking"),
+        ("assistant", "final"),
+    ]
+    assert result == "thinking\n\nfinal"
+
+
+def test_bridge_times_out_without_assistant():
+    def records_fn():
+        return [_user("p")]  # never grows, no assistant ever
+
+    events = []
+    result = bridge_response(
+        events.append, records_fn, start_index=1,
+        idle_rounds=2, max_rounds=5, sleep=lambda _s: None,
+    )
+    assert events == []
+    assert result == ""

--- a/packages/canopy_runner/tests/test_execute_chat.py
+++ b/packages/canopy_runner/tests/test_execute_chat.py
@@ -1,0 +1,87 @@
+"""execute_chat_turn wiring: a chat turn injects into emdash (mocked) and bridges the
+assistant reply that appears in the transcript AFTER injection back into the ledger."""
+import types
+
+from canopy_runner import execute
+
+
+def _asst(text):
+    return {"type": "assistant", "message": {"content": [{"type": "text", "text": text}]}}
+
+
+def _user(text):
+    return {"type": "user", "message": {"content": text}}
+
+
+class _FakeClient:
+    def __init__(self):
+        self.events = []
+        self.finished = None
+        self.failed = None
+
+    def resolve_session(self, *a, **k):
+        return {"reuse": False}  # -> create path
+
+    def start(self, *a, **k):
+        pass
+
+    def record_session(self, *a, **k):
+        pass
+
+    def post_events(self, turn_id, evs):
+        self.events.extend(evs)
+
+    def finish(self, turn_id, note=""):
+        self.finished = note
+
+    def fail_turn(self, turn_id, note):
+        self.failed = note
+
+
+def test_execute_chat_turn_bridges_the_reply(monkeypatch):
+    # emdash transcript GROWS: only the prompt at bridge-start, then the assistant reply.
+    states = [
+        [_user("hello")],
+        [_user("hello"), _asst("Hi there!")],
+        [_user("hello"), _asst("Hi there!")],  # stable -> idle completion
+    ]
+    box = {"i": 0}
+
+    def fake_read(_path):
+        i = min(box["i"], len(states) - 1)
+        box["i"] += 1
+        return states[i]
+
+    monkeypatch.setattr(execute.cdp_control, "create_task", lambda *a, **k: {"task": "echo-1234"})
+    monkeypatch.setattr(execute, "_wait_for_transcript", lambda *a, **k: "/tmp/fake.jsonl")
+    monkeypatch.setattr(execute.chat_bridge, "read_records", fake_read)
+    monkeypatch.setattr(execute.time, "sleep", lambda _s: None)  # instant polls
+
+    cfg = types.SimpleNamespace(cdp_port=9222, emdash_db="/nonexistent")
+    client = _FakeClient()
+    turn = {
+        "id": "t1", "agent_slug": "echo", "project": "", "workspace_slug": "canopy",
+        "prompt": "hello", "origin_ref": {"chat_session_id": "s1", "thread_key": "s1"},
+    }
+
+    res = execute.execute_chat_turn(cfg, client, "runner1", turn)
+
+    assert res.startswith("chat:t1:")
+    assert client.failed is None
+    # the assistant reply was bridged as an assistant TurnEvent
+    assistant_events = [e for e in client.events if e.get("kind") == "assistant"]
+    assert [e["payload"]["text"] for e in assistant_events] == ["Hi there!"]
+    assert "bridged" in (client.finished or "")
+
+
+def test_execute_turn_routes_chat_turns(monkeypatch):
+    called = {}
+
+    def _fake_chat(*a, **k):
+        called["chat"] = True
+        return "chat:x"
+
+    monkeypatch.setattr(execute, "execute_chat_turn", _fake_chat)
+    turn = {"id": "t", "origin_ref": {"chat_session_id": "s"}}
+    assert execute.execute_turn(None, None, "r", turn) == "chat:x"
+    assert called.get("chat") is True

--- a/tests/test_chat_laptop_routing.py
+++ b/tests/test_chat_laptop_routing.py
@@ -27,6 +27,8 @@ def test_send_sets_thread_key_to_session_id():
     u, s, _a = _seed()
     _msg, turn = send_message(session=s, text="hi", user=u)
     assert turn.origin_ref.get("thread_key") == str(s.id)
+    # chat_session_id marks it as a chat turn the runner should bridge back.
+    assert turn.origin_ref.get("chat_session_id") == str(s.id)
 
 
 def test_session_turn_exposes_session_agent_slug():

--- a/tests/test_chat_laptop_routing.py
+++ b/tests/test_chat_laptop_routing.py
@@ -1,0 +1,43 @@
+"""Slice-3 groundwork: a chat session turn carries the continuity thread_key and
+surfaces the session's agent as the emdash target the runner drives."""
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth.models import User
+
+from apps.agents.models import Agent
+from apps.chat import services as chat
+from apps.chat.services import send_message
+from apps.harness.schemas import TurnOut
+from apps.workspaces.models import Workspace, WorkspaceMembership
+
+pytestmark = pytest.mark.django_db
+
+
+def _seed(*, with_agent=True):
+    u = User.objects.create_user("jj", "jj@dimagi.com", "pw")
+    ws = Workspace.objects.create(slug="canopy", display_name="Canopy", created_by=u)
+    WorkspaceMembership.objects.create(user=u, workspace=ws, role=WorkspaceMembership.OWNER)
+    a = Agent.objects.create(slug="echo", name="Echo", workspace=ws, owner=u) if with_agent else None
+    s = chat.create_session(workspace=ws, created_by=u, agent=a)
+    return u, s, a
+
+
+def test_send_sets_thread_key_to_session_id():
+    u, s, _a = _seed()
+    _msg, turn = send_message(session=s, text="hi", user=u)
+    assert turn.origin_ref.get("thread_key") == str(s.id)
+
+
+def test_session_turn_exposes_session_agent_slug():
+    u, s, a = _seed(with_agent=True)
+    _msg, turn = send_message(session=s, text="hi", user=u)
+    out = TurnOut.from_orm(turn)
+    assert out.agent_slug == a.slug
+
+
+def test_agentless_session_turn_has_no_agent_slug():
+    u, s, _a = _seed(with_agent=False)
+    _msg, turn = send_message(session=s, text="hi", user=u)
+    out = TurnOut.from_orm(turn)
+    assert out.agent_slug is None


### PR DESCRIPTION
Makes a chat send run **real work** via the laptop runner + emdash (not the stub), so "continue the work running on your computer, from your phone" shows the actual agent's reply. Live-proven end-to-end.

## The gap this closes
The laptop runner fires a prompt into emdash and finishes — it never streamed the agent's **response** back into the ledger (by design: you watch emdash directly). Chat-on-the-website needs that response, so this adds an emdash→ledger **bridge**.

## Changes
- **Backend routing** (`7e12d1c`): a chat send stamps `origin_ref` with `thread_key` (one durable emdash thread per chat) + `chat_session_id` (marks "bridge this back"); `TurnOut.agent_slug` falls back to the chat session's agent so a session-capable runner has an emdash target. (No OpenAPI shape change.)
- **Bridge primitive** (`0ccce64`): `chat_bridge.py` — tail the emdash session's Claude transcript `.jsonl`, post each new assistant TEXT as an `assistant` TurnEvent, idle-based completion (emdash writes no "done" marker). Pure + injectable; unit-tested.
- **Wiring** (`d2bc9e9`): a chat turn routes to `execute_chat_turn` (resolve/create the emdash session, inject, wait for the transcript, bridge, finish) — **isolated** from the proven agent/project fire-and-continue path. Deterministic wiring + route tests.

## Verification
- Backend + canopy_runner suites green.
- **Live end-to-end** (local backend `CHAT_STUB_EXECUTOR=False` + a session-capable runner + real emdash echo): website "new chat with echo" → send → the runner claimed the chat turn → drove real emdash echo → the agent replied → the reply was bridged into the chat and **rendered on the page** (screenshot verified, zero console errors).

## Operational note
To make the **real laptop daemon** session-capable, add `"sessions": true` to its runner capabilities (a config/re-pair step — no code change). The stub stays the default (`CHAT_STUB_EXECUTOR=True`) until a session-capable runner is intended.

Follow-ons: token-level streaming (append assistant deltas as they appear vs whole-message), tool-call events in the bridge, and the cloud-runner session path (SP2b, always-on cross-device).

🤖 Generated with [Claude Code](https://claude.com/claude-code)