### PR TITLE
supervisor: grouped open sessions (all runners) + start-a-chat

### DIFF
--- a/frontend/src/components/chat/ChatSessionsPanel.tsx
+++ b/frontend/src/components/chat/ChatSessionsPanel.tsx
@@ -24,9 +24,13 @@ import { relativeTime } from '@/components/activity/turnLog'
 export function ChatSessionsPanel({
   agents: agentsProp,
   heading = 'Chats',
+  showList = true,
 }: {
   agents?: AgentOut[]
   heading?: string
+  // When false, render only the "New chat with <agent>" control (no session list) —
+  // supervisor pairs this with the grouped-by-project OpenSessions view instead.
+  showList?: boolean
 }) {
   const navigate = useNavigate()
   const [sessions, setSessions] = useState<ChatSession[]>([])
@@ -42,22 +46,28 @@ export function ChatSessionsPanel({
   useEffect(() => {
     let live = true
     setLoading(true)
-    const jobs: Promise<unknown>[] = [listSessions()]
+    const jobs: Promise<unknown>[] = []
+    if (showList) jobs.push(listSessions())
     if (!agentsProp) jobs.push(listAgents({ limit: 100 }))
     Promise.allSettled(jobs).then((results) => {
       if (!live) return
-      const s = results[0]
-      if (s.status === 'fulfilled') setSessions(s.value as ChatSession[])
-      else setError(s.reason instanceof Error ? s.reason.message : 'failed to load sessions')
-      if (!agentsProp && results[1]?.status === 'fulfilled') {
-        setAgents((results[1].value as { items: AgentOut[] }).items)
+      let idx = 0
+      if (showList) {
+        const s = results[idx++]
+        if (s && s.status === 'fulfilled') setSessions(s.value as ChatSession[])
+        else if (s && s.status === 'rejected')
+          setError(s.reason instanceof Error ? s.reason.message : 'failed to load sessions')
+      }
+      const a = results[idx]
+      if (!agentsProp && a && a.status === 'fulfilled') {
+        setAgents((a.value as { items: AgentOut[] }).items)
       }
       setLoading(false)
     })
     return () => {
       live = false
     }
-  }, [agentsProp])
+  }, [agentsProp, showList])
 
   const agentName = useMemo(() => {
     const by = new Map(agents.map((a) => [a.slug, a.name]))
@@ -102,8 +112,8 @@ export function ChatSessionsPanel({
         </DropdownMenu>
       </div>
 
-      {error && <div className="py-2 text-sm text-destructive">{error}</div>}
-      {loading ? (
+      {showList && error && <div className="py-2 text-sm text-destructive">{error}</div>}
+      {showList && (loading ? (
         <div className="py-6 text-sm text-muted-foreground">Loading sessions…</div>
       ) : sessions.length === 0 ? (
         <div className="flex flex-col items-center justify-center gap-1 py-12 text-center">
@@ -137,7 +147,7 @@ export function ChatSessionsPanel({
             )
           })}
         </ul>
-      )}
+      ))}
     </div>
   )
 }

--- a/frontend/src/pages/SupervisorPage.tsx
+++ b/frontend/src/pages/SupervisorPage.tsx
@@ -9,6 +9,7 @@ import { RunnerDetail } from '@/components/supervisor/RunnerDetail'
 import { AgentKpiCard } from '@/components/supervisor/AgentKpiCard'
 import { ItemInbox } from '@/components/supervisor/ItemInbox'
 import { Composer } from '@/components/supervisor/Composer'
+import { OpenSessions } from '@/components/supervisor/OpenSessions'
 import { ChatSessionsPanel } from '@/components/chat/ChatSessionsPanel'
 import { InstallPrompt } from '@/pwa/InstallPrompt'
 import { PushToggle } from '@/pwa/PushToggle'
@@ -191,10 +192,11 @@ export default function SupervisorPage(): JSX.Element {
           )}
         </TabsContent>
 
-        {/* Sessions — your chats with agents (live, continue from any device);
-            quick dispatch below. */}
+        {/* Sessions — start a chat with an agent, then all open sessions across every
+            runner (laptop + cloud), grouped by project, with the emdash task tag. */}
         <TabsContent value="sessions" className="flex flex-col gap-4">
-          <ChatSessionsPanel agents={agents ?? undefined} heading="Chats" />
+          <ChatSessionsPanel agents={agents ?? undefined} heading="Start a chat" showList={false} />
+          <OpenSessions />
           {agents && agents.length > 0 && <Composer agents={agents} />}
         </TabsContent>
 


### PR DESCRIPTION
Feedback fix: the Sessions tab should show ALL open sessions grouped by project (from any runner, cloud too), with the emdash task tag — not just the chat-app session list. Restores OpenSessions (grouped, cross-runner, matching tags) above the 'New chat with <agent>' control; chat-created sessions appear there too. Frontend-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)