### PR TITLE
feat(items): render markdown in agent Item bodies

### DIFF
--- a/frontend/src/components/Markdown.tsx
+++ b/frontend/src/components/Markdown.tsx
@@ -1,0 +1,48 @@
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import type { JSX } from 'react'
+
+// Shared markdown renderer for agent-authored text (Item bodies, and any other
+// surface that shows model output). One place so the prose styling — semantic
+// tokens only, so it works in both light and dark — never drifts across the app.
+// (react-markdown is already in the eager bundle via SystemPage/ShareoutsPage,
+// so this imports it directly rather than code-splitting.)
+
+// Token-based prose styling. The caller's `className` sets the base text size and
+// color (e.g. `text-[12px] text-foreground-secondary`); block children inherit it.
+// First/last margins are collapsed so a card body sits flush.
+const PROSE = `
+  [&>*:first-child]:mt-0 [&>*:last-child]:mb-0
+  [&_p]:my-1.5
+  [&_ul]:my-1.5 [&_ul]:list-disc [&_ul]:pl-5 [&_ul]:space-y-0.5
+  [&_ol]:my-1.5 [&_ol]:list-decimal [&_ol]:pl-5 [&_ol]:space-y-0.5
+  [&_li]:pl-0.5
+  [&_h1]:text-[1.05em] [&_h1]:font-semibold [&_h1]:text-foreground [&_h1]:mt-2 [&_h1]:mb-1
+  [&_h2]:font-semibold [&_h2]:text-foreground [&_h2]:mt-2 [&_h2]:mb-1
+  [&_h3]:font-semibold [&_h3]:text-foreground [&_h3]:mt-2 [&_h3]:mb-1
+  [&_strong]:font-semibold [&_strong]:text-foreground
+  [&_em]:italic
+  [&_a]:text-primary [&_a]:underline [&_a]:underline-offset-2
+  [&_code]:rounded [&_code]:bg-background [&_code]:px-1 [&_code]:py-0.5 [&_code]:text-primary [&_code]:text-[0.85em]
+  [&_pre]:my-2 [&_pre]:overflow-x-auto [&_pre]:rounded [&_pre]:border [&_pre]:border-border [&_pre]:bg-background [&_pre]:p-2 [&_pre]:text-[0.85em]
+  [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_pre_code]:text-inherit
+  [&_blockquote]:my-1.5 [&_blockquote]:border-l-2 [&_blockquote]:border-border [&_blockquote]:pl-3 [&_blockquote]:text-muted-foreground
+  [&_hr]:my-3 [&_hr]:border-border
+  [&_table]:my-2 [&_table]:block [&_table]:overflow-x-auto [&_table]:text-[0.9em]
+  [&_th]:border [&_th]:border-border [&_th]:px-2 [&_th]:py-1 [&_th]:text-left [&_th]:font-semibold
+  [&_td]:border [&_td]:border-border [&_td]:px-2 [&_td]:py-1
+`
+
+export function Markdown({
+  children,
+  className = '',
+}: {
+  children: string
+  className?: string
+}): JSX.Element {
+  return (
+    <div className={`${PROSE} ${className}`}>
+      <ReactMarkdown remarkPlugins={[remarkGfm]}>{children}</ReactMarkdown>
+    </div>
+  )
+}

--- a/frontend/src/components/items/ItemCard.tsx
+++ b/frontend/src/components/items/ItemCard.tsx
@@ -1,5 +1,6 @@
 import { useState, type JSX } from 'react'
 import { decideItem, dismissItem, type ItemDecision, type ItemOut } from '@/api/items'
+import { Markdown } from '@/components/Markdown'
 
 // One actionable inbox row, shared by both surfaces that render open items: the
 // /supervisor fleet queue and the per-agent rail. Every open Item is decidable in
@@ -55,7 +56,11 @@ export function ItemCard({
     >
       <p className="text-[13px] font-semibold leading-snug text-foreground">{item.title}</p>
       {meta && <p className="mt-1 text-[11px] leading-snug text-muted-foreground">{meta}</p>}
-      {item.body && <p className="mt-1 text-[12px] leading-snug text-foreground-secondary">{item.body}</p>}
+      {item.body && (
+        <Markdown className="mt-1 text-[12px] leading-snug text-foreground-secondary">
+          {item.body}
+        </Markdown>
+      )}
       {error && <p className="mt-1 text-[11px] text-destructive">{error}</p>}
 
       {item.kind === 'question' ? (

--- a/frontend/src/pages/agents/ItemsSection.tsx
+++ b/frontend/src/pages/agents/ItemsSection.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, type JSX } from 'react'
 import { useOutletContext, useSearchParams } from 'react-router-dom'
 import { listItems, decideItem, type ItemOut, type ItemDecision } from '@/api/items'
+import { Markdown } from '@/components/Markdown'
 import type { AgentOutletContext } from '@/pages/AgentWorkspacePage'
 
 // A batch of Items reviewed in one sitting — Ada's fleet audit's home. It belongs
@@ -51,7 +52,9 @@ function ItemCard({
       </div>
 
       {item.body && (
-        <p className="mt-2 text-[13px] leading-snug text-foreground-secondary">{item.body}</p>
+        <Markdown className="mt-2 text-[13px] leading-snug text-foreground-secondary">
+          {item.body}
+        </Markdown>
       )}
 
       {targets.length > 0 && (


### PR DESCRIPTION
## What

AI-authored `Item` bodies were rendered as raw `<p>{item.body}</p>`, so markdown (headings, lists, code, links, emphasis) showed as literal `#`/`*`/backtick syntax on the item surfaces — the ones that show Ada's (and the rest of the fleet's) open items.

## Changes

- **New `frontend/src/components/Markdown.tsx`** — one shared, token-styled markdown renderer (semantic tokens only, so it works in both light and dark). Reuses the already-bundled `react-markdown` + `remark-gfm`. There were three duplicated local wrappers (ChatPage, ShareoutsPage, SystemPage); this becomes the single reusable one to consolidate onto later.
- **Wired into the item body** on all three surfaces that render open items:
  - `components/items/ItemCard.tsx` — the shared row for **`/supervisor`** and the **per-agent Inbox rail**
  - `pages/agents/ItemsSection.tsx` — the **`?batch=` fleet-audit** review surface

Titles stay plain (single-line headlines); the human decision `comment` stays plain (it's a note, not model output).

## Notes

- No bundle-size impact: `react-markdown` was already in the eager bundle via the eagerly-routed `SystemPage`/`ShareoutsPage`, so `Markdown` imports it directly.
- Turn/sync summaries (`components/agents/cards.tsx`) are also plain-text model output but were left out deliberately — they currently rely on `whitespace-pre-wrap` literal newlines, so markdown-izing them needs `remark-breaks` and is a separate decision.

## Verification

- `npm run build` (tsc + vite) passes.
- No existing tests assert on item body text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)