### PR TITLE
live session tail: change-driven reporting so emdash activity reaches the phone

### DIFF
--- a/frontend/src/components/supervisor/OpenSessions.tsx
+++ b/frontend/src/components/supervisor/OpenSessions.tsx
@@ -252,9 +252,11 @@ export function OpenSessions(): JSX.Element {
         })
     }
     load()
-    // Poll so tails + last-active times stay live — this is how a message you send
-    // (and the reply) actually appear in the tail as the runner re-reports (~10s).
-    const id = window.setInterval(load, 10_000)
+    // Poll so tails + last-active times stay live. The runner now re-reports the
+    // instant a session's transcript grows (change-driven, ~1 poll tick), so a short
+    // refresh here surfaces live emdash activity — a message you (or the agent) type
+    // directly in emdash shows within a few seconds, not just on a website send.
+    const id = window.setInterval(load, 4_000)
     return () => {
       cancelled = true
       window.clearInterval(id)

--- a/packages/canopy_runner/canopy_runner/main.py
+++ b/packages/canopy_runner/canopy_runner/main.py
@@ -27,6 +27,7 @@ from pathlib import Path
 
 from . import emdash, transcript
 from .client import Client, ClientError
+from .tail import TailReader
 from .config import Config
 
 logger = logging.getLogger("canopy_runner")
@@ -182,18 +183,64 @@ def _claim_and_execute(cfg: Config, client: Client, paused: set) -> str:
         return f"failed:{turn.get('id')}"
 
 
+# Per-session incremental tail readers, keyed by emdash_task — the byte-offset change
+# signal that makes the phone reflect live emdash activity (see _session_changed).
+_tail_readers: dict[str, "TailReader | None"] = {}
+
+
+def _session_changed(cfg: Config, sessions: list[dict]) -> bool:
+    """True if any SHOWN session's transcript grew, or a new session appeared, since
+    the last check. This is the LIVE signal — cheap (a byte-offset read of only the
+    newly-appended bytes) and it catches assistant streaming too (transcript growth),
+    not just user interaction (which is all last_interacted_at would catch)."""
+    home = Path.home()
+    claude_home = home / ".claude" / "projects"
+    active: set[str] = set()
+    changed = False
+    for s in sessions[: cfg.session_tail_count]:  # only the sessions the phone shows
+        task = s.get("emdash_task")
+        if not task:
+            continue
+        active.add(task)
+        first_sight = task not in _tail_readers
+        tr = _tail_readers.get(task)
+        if tr is None:  # unresolved (new session, or transcript not found yet) — (re)try
+            path = transcript.resolve_transcript(
+                s.get("project") or "", task, home=home, claude_home=claude_home
+            )
+            tr = TailReader(str(path)) if path else None
+            if tr is not None:
+                tr.seek_end()  # stream only NEW activity from here, never the history
+            _tail_readers[task] = tr
+        if first_sight:
+            changed = True  # a session newly appeared
+        elif tr is not None and tr.read_new():
+            changed = True  # its transcript grew
+    for task in list(_tail_readers):  # drop readers for sessions that are gone
+        if task not in active:
+            _tail_readers.pop(task, None)
+    return changed
+
+
 def _maybe_report_sessions(cfg: Config, client: Client, now_fn=time.monotonic) -> None:
-    """Report the open emdash sessions the phone can continue — throttled to
-    session_report_seconds so lowering poll_seconds (for snappy claims) doesn't read
-    up to session_tail_count transcripts every tick. A sqlite read of emdash's DB, not
-    CDP, so it runs even while CDP is down. Best-effort: a read or POST failure must
-    never stop the tick. Reports on the first tick after start (last stamp is 0)."""
+    """Report the open emdash sessions the phone can continue. CHANGE-DRIVEN: reports
+    the instant a shown session's transcript grows (so the phone reflects live emdash
+    activity within a poll tick), plus a heartbeat every session_report_seconds so a
+    freshly-connected phone gets state. The cheap change-check runs every tick; the
+    expensive recent-tail read + POST only on a real change or the heartbeat. A sqlite
+    read of emdash's DB (runs even while CDP is down); best-effort — never stops a tick."""
     global _last_session_report
-    if now_fn() - _last_session_report < cfg.session_report_seconds:
+    try:
+        sessions = emdash.list_open_sessions(cfg.emdash_db)
+    except Exception:  # noqa: BLE001
+        logger.debug("session list failed (non-fatal)", exc_info=True)
+        return
+    changed = _session_changed(cfg, sessions)
+    heartbeat = now_fn() - _last_session_report >= cfg.session_report_seconds
+    if not changed and not heartbeat:
         return
     _last_session_report = now_fn()
     try:
-        sessions = emdash.list_open_sessions(cfg.emdash_db)
         transcript.attach_recent_tail(
             sessions, count=cfg.session_tail_count, limit=cfg.session_tail_limit
         )

--- a/packages/canopy_runner/canopy_runner/tail.py
+++ b/packages/canopy_runner/canopy_runner/tail.py
@@ -1,0 +1,69 @@
+"""Incremental byte-offset reader for an append-only JSONL transcript.
+
+Reads ONLY the newly-appended bytes on each call — O(new data), never re-reading
+the session's history — so it stays cheap no matter how long a session runs. This
+is what the continuous session tailer uses to stream live emdash activity to the
+phone without duplicating (or even re-reading) the durable transcript, which stays
+owned by Claude Code / emdash.
+
+Handles the two real-world hazards of tailing a file another process is writing:
+- a partial trailing line (the writer is mid-append) is buffered, not parsed, and
+  completed on the next read;
+- truncation/rotation (the file shrinks below our offset) resets the offset so we
+  don't read garbage.
+"""
+from __future__ import annotations
+
+import json
+import os
+
+
+class TailReader:
+    """Stateful incremental reader for one transcript path.
+
+    `read_new()` returns the JSON records appended since the last call. `seek_end()`
+    skips the existing history so the first `read_new()` yields only NEW activity
+    (the tailer starts here — the durable history is already visible elsewhere)."""
+
+    def __init__(self, path: str | os.PathLike):
+        self.path = os.fspath(path)
+        self.offset = 0
+        self._partial = b""
+
+    def seek_end(self) -> None:
+        try:
+            self.offset = os.path.getsize(self.path)
+        except OSError:
+            self.offset = 0
+        self._partial = b""
+
+    def read_new(self) -> list[dict]:
+        try:
+            size = os.path.getsize(self.path)
+        except OSError:
+            return []
+        if size < self.offset:  # truncated / rotated — start over
+            self.offset = 0
+            self._partial = b""
+        if size <= self.offset:
+            return []
+        try:
+            with open(self.path, "rb") as f:
+                f.seek(self.offset)
+                chunk = f.read()
+        except OSError:
+            return []
+        self.offset += len(chunk)
+        data = self._partial + chunk
+        lines = data.split(b"\n")
+        self._partial = lines.pop()  # trailing element = incomplete line (or b"")
+        out: list[dict] = []
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                out.append(json.loads(line))
+            except ValueError:
+                continue
+        return out

--- a/packages/canopy_runner/tests/test_main.py
+++ b/packages/canopy_runner/tests/test_main.py
@@ -447,14 +447,17 @@ def test_cdp_recovery_logs_once_and_rearms(monkeypatch, tmp_path, caplog):
 
 
 def test_maybe_report_sessions_throttled(db, tmp_path, monkeypatch):
-    """The session report (up to session_tail_count transcript reads) runs at most
-    every session_report_seconds, even though the claim tick polls far faster."""
+    """When nothing changes, the EXPENSIVE session report (up to session_tail_count
+    transcript reads + POST) runs at most every session_report_seconds — the cheap
+    change-check (list_open_sessions) runs every tick, but the report is heartbeat-only
+    absent a real change. (A transcript that GREW would report immediately — that's the
+    live path, covered in test_session_report_live.)"""
     from canopy_runner import main as m
     from canopy_runner import transcript
     cfg = _cfg(db, tmp_path)  # session_report_seconds defaults to 10
     calls = []
-    monkeypatch.setattr(emdash, "list_open_sessions", lambda p: calls.append(1) or [])
-    monkeypatch.setattr(transcript, "attach_recent_tail", lambda *a, **k: None)
+    monkeypatch.setattr(emdash, "list_open_sessions", lambda p: [])  # no sessions -> no change
+    monkeypatch.setattr(transcript, "attach_recent_tail", lambda *a, **k: calls.append(1))
     m._last_session_report = 0.0
     clock = [1000.0]
     now = lambda: clock[0]

--- a/packages/canopy_runner/tests/test_session_report_live.py
+++ b/packages/canopy_runner/tests/test_session_report_live.py
@@ -1,0 +1,61 @@
+"""Change-driven session reporting: report the instant a shown session's transcript
+grows (live), skip when idle, heartbeat periodically."""
+import json
+
+from canopy_runner import main as m
+
+
+class _Cfg:
+    session_tail_count = 30
+    session_tail_limit = 8
+    session_report_seconds = 10
+    emdash_db = "/nonexistent"
+    runner_id = "r"
+
+
+class _Client:
+    def __init__(self):
+        self.reports = 0
+
+    def report_sessions(self, runner_id, sessions):
+        self.reports += 1
+
+
+def _asst(text):
+    return json.dumps({"type": "assistant", "message": {"content": [{"type": "text", "text": text}]}}) + "\n"
+
+
+def test_reports_on_growth_skips_idle_and_heartbeats(tmp_path, monkeypatch):
+    m._tail_readers.clear()
+    m._last_session_report = 0.0
+    p = tmp_path / "echo.jsonl"
+    p.write_text(_asst("history"))
+    sessions = [{"emdash_task": "echo-1", "project": "echo"}]
+    monkeypatch.setattr(m.emdash, "list_open_sessions", lambda _db: sessions)
+    monkeypatch.setattr(m.transcript, "resolve_transcript", lambda _proj, _task, **_k: p)
+    monkeypatch.setattr(m.transcript, "attach_recent_tail", lambda _s, **_k: None)
+
+    c = _Client()
+    clock = [100.0]
+    now = lambda: clock[0]
+
+    # first sight of the session -> report
+    m._maybe_report_sessions(_Cfg(), c, now_fn=now)
+    assert c.reports == 1
+
+    # no transcript growth, within the heartbeat window -> skip
+    clock[0] = 102.0
+    m._maybe_report_sessions(_Cfg(), c, now_fn=now)
+    assert c.reports == 1
+
+    # the transcript grows (assistant streaming, no user input) -> report LIVE
+    with open(p, "a") as f:
+        f.write(_asst("live reply"))
+    clock[0] = 103.0
+    m._maybe_report_sessions(_Cfg(), c, now_fn=now)
+    assert c.reports == 2
+
+    # idle but the heartbeat window elapsed -> report
+    clock[0] = 120.0
+    m._maybe_report_sessions(_Cfg(), c, now_fn=now)
+    assert c.reports == 3

--- a/packages/canopy_runner/tests/test_tail.py
+++ b/packages/canopy_runner/tests/test_tail.py
@@ -1,0 +1,61 @@
+"""Incremental byte-offset transcript reader — reads only the new tail each call."""
+import json
+
+from canopy_runner.tail import TailReader
+
+
+def _line(d):
+    return json.dumps(d) + "\n"
+
+
+def test_read_new_is_incremental(tmp_path):
+    p = tmp_path / "t.jsonl"
+    p.write_text(_line({"type": "user", "message": {"content": "a"}}))
+    r = TailReader(p)
+    assert [x["type"] for x in r.read_new()] == ["user"]
+    assert r.read_new() == []  # nothing new -> no re-read
+    with open(p, "a") as f:
+        f.write(_line({"type": "assistant", "message": {"content": "b"}}))
+    assert [x["type"] for x in r.read_new()] == ["assistant"]  # only the NEW record
+
+
+def test_partial_trailing_line_is_buffered(tmp_path):
+    p = tmp_path / "t.jsonl"
+    r = TailReader(p)
+    p.write_text('{"type":"user","message"')  # mid-append, no newline
+    assert r.read_new() == []  # incomplete -> not parsed, buffered
+    with open(p, "a") as f:
+        f.write(':{"content":"hi"}}\n')  # completes the line
+    recs = r.read_new()
+    assert recs and recs[0]["type"] == "user"
+
+
+def test_seek_end_skips_history(tmp_path):
+    p = tmp_path / "t.jsonl"
+    p.write_text(_line({"type": "user", "message": {"content": "old"}})
+                 + _line({"type": "assistant", "message": {"content": "old2"}}))
+    r = TailReader(p)
+    r.seek_end()
+    assert r.read_new() == []  # existing history skipped
+    with open(p, "a") as f:
+        f.write(_line({"type": "assistant", "message": {"content": "new"}}))
+    recs = r.read_new()
+    assert recs and recs[0]["message"]["content"] == "new"
+
+
+def test_truncation_resets(tmp_path):
+    p = tmp_path / "t.jsonl"
+    p.write_text(_line({"type": "user", "message": {"content": "a"}})
+                 + _line({"type": "user", "message": {"content": "b"}}))
+    r = TailReader(p)
+    r.read_new()
+    p.write_text(_line({"type": "user", "message": {"content": "fresh"}}))  # smaller -> rotated
+    recs = r.read_new()
+    assert recs and recs[0]["message"]["content"] == "fresh"
+
+
+def test_missing_file_is_safe(tmp_path):
+    r = TailReader(tmp_path / "nope.jsonl")
+    assert r.read_new() == []
+    r.seek_end()
+    assert r.read_new() == []


### PR DESCRIPTION
Makes the grouped sessions view reflect **live emdash activity** — type directly into a session on emdash and it shows on the phone within a few seconds, not only on a website-initiated send.

## How (efficient, addresses the raised concerns)
- **Only the new tail, never the history:** `TailReader` (new) reads only the newly-appended bytes each tick via a byte offset — O(new data), independent of session length. Handles partial trailing lines + truncation. Unit-tested.
- **Change-driven, not busy-polling:** the runner re-reports a session the instant its transcript grows (the TailReader change signal — catches assistant streaming too, not just `last_interacted_at`), plus a heartbeat every `session_report_seconds` so a freshly-connected phone gets state. The cheap change-check runs every tick; the expensive recent-tail read + POST only on a real change or heartbeat.
- **No history duplication / no cleanup burden:** the transcript is owned by Claude Code/emdash (persists with the session, cleaned when it archives); we only read its tail. What we report is the existing bounded recent-messages window — nothing accumulates unbounded on our side.
- Supervisor `OpenSessions` refresh 10s -> 4s to surface the fresher reports.

Follow-up for *instant* (not few-seconds): WS-push the changed session to the supervisor channel instead of the frontend polling — the TailReader already gives the per-message deltas for that.

Runner suite 138 green; frontend 185 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)