### PR TITLE
WS-push live sessions to supervisor (one broadcast, N viewers)

### DIFF
--- a/apps/harness/services.py
+++ b/apps/harness/services.py
@@ -699,6 +699,16 @@ def replace_reported_sessions(runner: Runner, workspace, sessions: list) -> int:
                 None, f"emdash:{s.emdash_task}", runner=runner, project=s.project,
                 workspace=workspace, emdash_task_id=s.emdash_task,
             )
+
+    # Fire AFTER commit so apps/realtime fans the durable rows (never racing the DB)
+    # to the runner-owner's supervisor group — the WS push that makes live emdash
+    # activity reach every connected viewer at once. Local import avoids a cycle.
+    def _fire_reported():
+        from apps.harness.signals import sessions_reported
+
+        sessions_reported.send(sender=Runner, runner=runner)
+
+    transaction.on_commit(_fire_reported)
     return len(deduped)
 
 

--- a/apps/harness/signals.py
+++ b/apps/harness/signals.py
@@ -14,3 +14,9 @@ from django.dispatch import Signal
 # Sent with: sender=Turn, turn=<Turn>, rows=<list[TurnEvent]> (the newly appended
 # rows, in seq order). Fired post-commit.
 turn_events_appended = Signal()
+
+# Sent with: sender=Runner, runner=<Runner> after a runner's session report commits.
+# apps/realtime fans the runner-owner's visible sessions to their supervisor group so
+# the phone reflects live emdash activity instantly (one broadcast, N viewers) instead
+# of every client polling. Post-commit, same reasoning as turn_events_appended.
+sessions_reported = Signal()

--- a/apps/realtime/consumers.py
+++ b/apps/realtime/consumers.py
@@ -133,6 +133,9 @@ class SupervisorConsumer(AsyncJsonWebsocketConsumer):
     async def supervisor_waiting(self, message):
         await self.send_json(message)
 
+    async def supervisor_sessions(self, message):
+        await self.send_json(message)
+
     @database_sync_to_async
     def _snapshot(self, user):
         from .snapshot import supervisor_snapshot

--- a/apps/realtime/signals.py
+++ b/apps/realtime/signals.py
@@ -20,7 +20,7 @@ from django.db.models.signals import post_save
 from django.dispatch import receiver
 
 from apps.harness.models import Runner, Turn
-from apps.harness.signals import turn_events_appended
+from apps.harness.signals import sessions_reported, turn_events_appended
 from apps.push.models import AgentWaitingSnapshot
 from apps.workspaces.services import workspace_member_ids
 
@@ -97,3 +97,24 @@ def _on_waiting_saved(sender, instance: AgentWaitingSnapshot, **kwargs):
             groups.publish(groups.supervisor_user_group(uid), frame)
 
     transaction.on_commit(_fire)
+
+
+@receiver(sessions_reported, dispatch_uid="realtime_sessions_reported")
+def _on_sessions_reported(sender, runner, **kwargs):
+    """A runner reported its open sessions -> push the owner's visible sessions to
+    their supervisor group. One broadcast reaches every device the user has open
+    (phone + desktop + menubar) instead of each polling. Already post-commit (the
+    sender fires inside its own on_commit), so publish directly."""
+    if not runner.paired_by_id:
+        return
+    # Local imports keep this module import-cycle-free and the serialization co-located
+    # with where the GET /sessions endpoint reads the same rows.
+    from apps.harness.schemas import EmdashSessionOut
+    from apps.harness.services import list_visible_sessions
+
+    sessions = list_visible_sessions(runner.paired_by)
+    frame = {
+        "type": "supervisor.sessions",
+        "sessions": [EmdashSessionOut.from_orm(s).model_dump(mode="json") for s in sessions],
+    }
+    groups.publish(groups.supervisor_user_group(runner.paired_by_id), frame)

--- a/frontend/src/api/types.ws.ts
+++ b/frontend/src/api/types.ws.ts
@@ -34,7 +34,15 @@ export interface SupervisorWaitingFrame {
   waiting_count: number
 }
 
+export interface SupervisorSessionsFrame {
+  type: 'supervisor.sessions'
+  // EmdashSessionOut[] — kept loose here to avoid a cross-module type import; the
+  // consumer casts to the OpenSessions shape.
+  sessions: Record<string, unknown>[]
+}
+
 export type SupervisorFrame =
   | SupervisorSnapshotFrame
   | SupervisorRunnerFrame
   | SupervisorWaitingFrame
+  | SupervisorSessionsFrame

--- a/frontend/src/components/supervisor/OpenSessions.tsx
+++ b/frontend/src/components/supervisor/OpenSessions.tsx
@@ -226,7 +226,9 @@ function SessionRow({ session }: { session: EmdashSessionOut }): JSX.Element {
   )
 }
 
-export function OpenSessions(): JSX.Element {
+export function OpenSessions(
+  { liveSessions }: { liveSessions?: EmdashSessionOut[] | null } = {},
+): JSX.Element {
   const [sessions, setSessions] = useState<EmdashSessionOut[] | null>(null)
   // Distinct from `sessions === []` (genuinely zero) — a flaky fetch must not
   // collapse into "No open sessions." with no error signal. Mirrors
@@ -252,18 +254,21 @@ export function OpenSessions(): JSX.Element {
         })
     }
     load()
-    // Poll so tails + last-active times stay live. The runner now re-reports the
-    // instant a session's transcript grows (change-driven, ~1 poll tick), so a short
-    // refresh here surfaces live emdash activity — a message you (or the agent) type
-    // directly in emdash shows within a few seconds, not just on a website send.
-    const id = window.setInterval(load, 4_000)
+    // The live path is now the WebSocket push (liveSessions): the runner re-reports
+    // the instant a session's transcript grows, and the server fans it to every
+    // connected device at once — so this poll is just a slow fallback for when the
+    // socket is down. The initial load above gives immediate data before the first push.
+    const id = window.setInterval(load, 20_000)
     return () => {
       cancelled = true
       window.clearInterval(id)
     }
   }, [])
 
-  if (sessions === null) return <p className="text-[12px] text-muted-foreground">Loading sessions…</p>
+  // Prefer the live WebSocket push once it has arrived; fall back to the fetched list.
+  const displaySessions = liveSessions ?? sessions
+
+  if (displaySessions === null) return <p className="text-[12px] text-muted-foreground">Loading sessions…</p>
   if (error) {
     return (
       <p
@@ -274,7 +279,7 @@ export function OpenSessions(): JSX.Element {
       </p>
     )
   }
-  if (sessions.length === 0) {
+  if (displaySessions.length === 0) {
     return (
       <p className="text-[12px] text-muted-foreground" data-testid="sessions-empty">
         No open sessions.
@@ -284,7 +289,7 @@ export function OpenSessions(): JSX.Element {
   // Group by project (a header per project), projects alphabetical, sessions within
   // each group left in the server's most-recently-active order.
   const groups = new Map<string, EmdashSessionOut[]>()
-  for (const s of sessions) {
+  for (const s of displaySessions) {
     const key = s.project || '(no project)'
     const arr = groups.get(key)
     if (arr) arr.push(s)

--- a/frontend/src/hooks/useLiveSupervisor.test.ts
+++ b/frontend/src/hooks/useLiveSupervisor.test.ts
@@ -46,4 +46,21 @@ describe('applyFrame', () => {
     expect(next.waiting).toEqual({ echo: 4, ada: 1 })
     expect(next.totalWaiting).toBe(5)
   })
+
+  it('sets sessions from a sessions push and preserves them across a snapshot', () => {
+    const withSessions = applyFrame(EMPTY_SUPERVISOR_STATE, {
+      type: 'supervisor.sessions',
+      sessions: [{ emdash_task: 'echo-1', project: 'echo' }],
+    })
+    expect(withSessions.sessions).toHaveLength(1)
+    // a later snapshot (runners/waiting) must not clobber the live sessions list
+    const afterSnap = applyFrame(withSessions, {
+      type: 'supervisor.snapshot',
+      runners: [],
+      waiting: {},
+      total_waiting: 0,
+    })
+    expect(afterSnap.sessions).toHaveLength(1)
+  })
+
 })

--- a/frontend/src/hooks/useLiveSupervisor.ts
+++ b/frontend/src/hooks/useLiveSupervisor.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 
+import type { EmdashSessionOut } from '@/api/harness'
 import type { SupervisorFrame, SupervisorRunnerLive } from '@/api/types.ws'
 import { wsUrl } from '@/lib/wsUrl'
 
@@ -7,12 +8,16 @@ export interface SupervisorState {
   runners: Record<string, SupervisorRunnerLive>
   waiting: Record<string, number>
   totalWaiting: number
+  // null until the first sessions push arrives — the OpenSessions view uses this
+  // (live, one broadcast to every device) and falls back to its own fetch otherwise.
+  sessions: EmdashSessionOut[] | null
 }
 
 export const EMPTY_SUPERVISOR_STATE: SupervisorState = {
   runners: {},
   waiting: {},
   totalWaiting: 0,
+  sessions: null,
 }
 
 // Pure reducer: a snapshot seeds state; runner/waiting deltas patch it. Exported
@@ -22,7 +27,14 @@ export function applyFrame(state: SupervisorState, frame: SupervisorFrame): Supe
     case 'supervisor.snapshot': {
       const runners: Record<string, SupervisorRunnerLive> = {}
       for (const r of frame.runners) runners[r.id] = r
-      return { runners, waiting: { ...frame.waiting }, totalWaiting: frame.total_waiting }
+      // The snapshot seeds runners/waiting; sessions arrive via their own push, so
+      // preserve whatever we already have (don't clobber a live list on reconnect).
+      return {
+        runners,
+        waiting: { ...frame.waiting },
+        totalWaiting: frame.total_waiting,
+        sessions: state.sessions,
+      }
     }
     case 'supervisor.runner':
       return { ...state, runners: { ...state.runners, [frame.runner.id]: frame.runner } }
@@ -31,6 +43,8 @@ export function applyFrame(state: SupervisorState, frame: SupervisorFrame): Supe
       const totalWaiting = Object.values(waiting).reduce((a, b) => a + b, 0)
       return { ...state, waiting, totalWaiting }
     }
+    case 'supervisor.sessions':
+      return { ...state, sessions: frame.sessions as unknown as EmdashSessionOut[] }
     default:
       return state
   }
@@ -41,6 +55,7 @@ const BACKOFFS_MS = [1000, 2000, 5000, 10000]
 export interface LiveSupervisor {
   runners: SupervisorRunnerLive[]
   waiting: Record<string, number>
+  sessions: EmdashSessionOut[] | null
   connected: boolean
   hasSnapshot: boolean
 }
@@ -94,6 +109,7 @@ export function useLiveSupervisor(): LiveSupervisor {
   return {
     runners: Object.values(state.runners),
     waiting: state.waiting,
+    sessions: state.sessions,
     connected,
     hasSnapshot,
   }

--- a/frontend/src/pages/SupervisorPage.tsx
+++ b/frontend/src/pages/SupervisorPage.tsx
@@ -196,7 +196,7 @@ export default function SupervisorPage(): JSX.Element {
             runner (laptop + cloud), grouped by project, with the emdash task tag. */}
         <TabsContent value="sessions" className="flex flex-col gap-4">
           <ChatSessionsPanel agents={agents ?? undefined} heading="Start a chat" showList={false} />
-          <OpenSessions />
+          <OpenSessions liveSessions={live.sessions} />
           {agents && agents.length > 0 && <Composer agents={agents} />}
         </TabsContent>
 

--- a/tests/test_realtime_fanout.py
+++ b/tests/test_realtime_fanout.py
@@ -98,3 +98,29 @@ def test_waiting_fanout_to_members():
     assert msg["type"] == "supervisor.waiting"
     assert msg["agent"] == agent.slug
     assert msg["waiting_count"] == 3
+
+
+def test_sessions_fanout_to_pairer():
+    """A runner's session report pushes the owner's visible sessions to their
+    supervisor group — the WS broadcast that replaces per-client polling."""
+    from django.utils import timezone
+
+    from apps.harness.schemas import ReportedSessionIn
+
+    user, ws, _agent = _fixtures()
+    runner = Runner.objects.create(
+        name="laptop", kind=Runner.EMDASH, paired_by=user, workspace=ws,
+        status=Runner.ONLINE, last_heartbeat_at=timezone.now(),
+    )
+    layer = get_channel_layer()
+    async_to_sync(layer.group_add)(groups.supervisor_user_group(user.id), "sup-chan")
+
+    services.replace_reported_sessions(
+        runner, ws,
+        [ReportedSessionIn(emdash_task="echo-1", project="echo", status="in_progress",
+                           recent_messages=[{"role": "user", "text": "hi"}])],
+    )
+
+    msg = async_to_sync(layer.receive)("sup-chan")
+    assert msg["type"] == "supervisor.sessions"
+    assert "echo-1" in [s["emdash_task"] for s in msg["sessions"]]


### PR DESCRIPTION
Answers 'isn't WS-push better with multiple viewers' — yes. Replaces per-client polling of the sessions view with a WebSocket broadcast: when a runner reports (change-driven, the instant a transcript grows), the server fans the owner's visible sessions to their supervisor group, so every open device updates at once, instantly, instead of each polling. Uses the proven `turn_events_appended` fan-out pattern (dependency arrow stays realtime->harness). Backend 254 green (+fanout test), frontend 186 green. No daemon change (it already reports change-driven).

🤖 Generated with [Claude Code](https://claude.com/claude-code)