### PR TITLE
feat(agents): render markdown in turn + sync summaries

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,6 +24,7 @@
         "react-dom": "^19.2.4",
         "react-markdown": "^10.1.0",
         "react-router-dom": "^7.13.2",
+        "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
         "shadcn": "^4.1.1",
         "tailwind-merge": "^3.5.0",
@@ -8824,6 +8825,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-newline-to-break": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-newline-to-break/-/mdast-util-newline-to-break-2.0.0.tgz",
+      "integrity": "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-find-and-replace": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-phrasing": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
@@ -10752,6 +10767,21 @@
       },
       "bin": {
         "regjsparser": "bin/parser"
+      }
+    },
+    "node_modules/remark-breaks": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-4.0.0.tgz",
+      "integrity": "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-newline-to-break": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-gfm": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
     "react-dom": "^19.2.4",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.13.2",
+    "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "shadcn": "^4.1.1",
     "tailwind-merge": "^3.5.0",

--- a/frontend/src/components/Markdown.tsx
+++ b/frontend/src/components/Markdown.tsx
@@ -1,12 +1,18 @@
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import remarkBreaks from 'remark-breaks'
 import type { JSX } from 'react'
 
-// Shared markdown renderer for agent-authored text (Item bodies, and any other
-// surface that shows model output). One place so the prose styling — semantic
-// tokens only, so it works in both light and dark — never drifts across the app.
-// (react-markdown is already in the eager bundle via SystemPage/ShareoutsPage,
-// so this imports it directly rather than code-splitting.)
+// Shared markdown renderer for agent-authored text (Item bodies, turn/sync
+// summaries, and any other surface that shows model output). One place so the
+// prose styling — semantic tokens only, so it works in both light and dark —
+// never drifts across the app. (react-markdown is already in the eager bundle
+// via SystemPage/ShareoutsPage, so this imports it directly rather than
+// code-splitting.)
+//
+// remark-breaks turns single newlines into <br>, so model output authored with
+// bare line breaks (rather than blank-line paragraphs) keeps its intended shape
+// — the behavior the turn/sync summaries previously got from whitespace-pre-wrap.
 
 // Token-based prose styling. The caller's `className` sets the base text size and
 // color (e.g. `text-[12px] text-foreground-secondary`); block children inherit it.
@@ -42,7 +48,7 @@ export function Markdown({
 }): JSX.Element {
   return (
     <div className={`${PROSE} ${className}`}>
-      <ReactMarkdown remarkPlugins={[remarkGfm]}>{children}</ReactMarkdown>
+      <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]}>{children}</ReactMarkdown>
     </div>
   )
 }

--- a/frontend/src/components/agents/cards.tsx
+++ b/frontend/src/components/agents/cards.tsx
@@ -9,6 +9,7 @@ import type {
   AgentTurnOut,
   AgentWorkProductOut,
 } from '@/api/agents'
+import { Markdown } from '@/components/Markdown'
 
 export function formatDate(s: string): string {
   return new Date(s).toLocaleDateString(undefined, {
@@ -79,7 +80,9 @@ export function SyncCard({ sync }: { sync: AgentSyncOut }) {
         <OpenDocChip url={sync.doc_url} label="Open in Google Docs" />
       </div>
       {sync.summary && (
-        <p className="text-[13px] text-muted-foreground leading-relaxed mt-2">{sync.summary}</p>
+        <Markdown className="text-[13px] text-muted-foreground leading-relaxed mt-2">
+          {sync.summary}
+        </Markdown>
       )}
       {grades.length > 0 && (
         <div className="flex flex-wrap gap-1.5 mt-3">
@@ -118,7 +121,9 @@ export function TurnCard({ turn }: { turn: AgentTurnOut }) {
         {shareHref && <OpenDocChip url={shareHref} label="View transcript" />}
       </div>
       {turn.summary && (
-        <p className="text-[13px] text-muted-foreground leading-relaxed mt-2 whitespace-pre-wrap">{turn.summary}</p>
+        <Markdown className="text-[13px] text-muted-foreground leading-relaxed mt-2">
+          {turn.summary}
+        </Markdown>
       )}
       {(turn.task_ext_ids ?? []).length > 0 && (
         <div className="flex flex-wrap items-center gap-1.5 mt-3">


### PR DESCRIPTION
## What

Follow-up to #338. Extends the shared `Markdown` component to the two remaining full-width agent-output surfaces that still rendered model text as plain `<p>`: the **turn** and **sync** summary cards in `components/agents/cards.tsx`.

## Changes

- **`remark-breaks`** added to the shared `Markdown` component so single newlines render as `<br>`. Turn summaries previously relied on `whitespace-pre-wrap` to keep bare line breaks; this preserves that shape while now also rendering headings / lists / code / links / emphasis. Applied at the shared component so **all** agent-output surfaces (Item bodies included) handle line breaks consistently.
- **`SyncCard` + `TurnCard`** summaries now render through `Markdown`; dropped the now-redundant `whitespace-pre-wrap` on the turn summary.

Line-clamped/truncated fields (work-product description, skill description, task notes) are deliberately left plain — markdown block elements fight line-clamp.

## Verification

- `npm run build` (tsc + vite) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)