### PR TITLE
feat(markdown): render markdown in live chat, insights, and findings

### DIFF
--- a/frontend/src/components/reviews/ProductFindingsReview.tsx
+++ b/frontend/src/components/reviews/ProductFindingsReview.tsx
@@ -24,6 +24,7 @@ import type {
   ProductFindingsResponseJson,
 } from '../../api/reviews'
 import { withBase } from '../../lib/basePath'
+import { Markdown } from '../Markdown'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -279,7 +280,9 @@ const ClusterCard = memo(function ClusterCard({
           <p className="text-[10px] uppercase tracking-wider text-muted-foreground mb-0.5">
             Suggested fix
           </p>
-          <p className="text-sm text-foreground-secondary leading-relaxed">{cluster.suggested_fix}</p>
+          <Markdown className="text-sm text-foreground-secondary leading-relaxed">
+            {cluster.suggested_fix}
+          </Markdown>
         </div>
       )}
 

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -1,36 +1,17 @@
 import { useCallback, useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
-import ReactMarkdown from 'react-markdown'
-import remarkGfm from 'remark-gfm'
 import { ChatPanel, useSessionSocket } from 'canopy-ui/chat'
+import { Markdown } from '@/components/Markdown'
 import { wsUrl } from '@/lib/wsUrl'
 import { getSession, type ChatSessionDetail } from '@/api/chat'
 
-/** Render assistant/system markdown with the same token-based prose styling
- *  used elsewhere in canopy (see ShareoutsPage). Injected into the kit so the
- *  kit itself stays free of react-markdown. */
+/** Render assistant/system message text through canopy's shared Markdown (the
+ *  same renderer used across every AI-output surface — so it picks up remark-gfm
+ *  AND remark-breaks, i.e. single newlines become line breaks instead of
+ *  collapsing). Injected into the kit via its `renderMarkdown` seam so the kit
+ *  itself stays free of react-markdown. */
 function renderMarkdown(text: string) {
-  return (
-    <div
-      className="
-        text-sm leading-relaxed
-        [&_p]:my-1.5 [&_p]:text-inherit
-        [&_ul]:my-1.5 [&_ul]:list-disc [&_ul]:pl-5 [&_ul]:space-y-1
-        [&_ol]:my-1.5 [&_ol]:list-decimal [&_ol]:pl-5 [&_ol]:space-y-1
-        [&_li]:pl-0.5
-        [&_h1]:text-base [&_h1]:font-semibold [&_h1]:mt-2 [&_h1]:mb-1
-        [&_h2]:text-sm [&_h2]:font-semibold [&_h2]:mt-2 [&_h2]:mb-1
-        [&_h3]:text-sm [&_h3]:font-semibold [&_h3]:mt-2 [&_h3]:mb-1
-        [&_strong]:font-semibold
-        [&_a]:text-primary [&_a]:underline [&_a]:underline-offset-2
-        [&_pre]:my-2 [&_pre]:overflow-x-auto [&_pre]:rounded [&_pre]:bg-background [&_pre]:p-2 [&_pre]:text-xs
-        [&_code]:rounded [&_code]:bg-background/60 [&_code]:px-1 [&_code]:py-0.5 [&_code]:text-[0.85em]
-        [&_pre_code]:bg-transparent [&_pre_code]:p-0
-      "
-    >
-      <ReactMarkdown remarkPlugins={[remarkGfm]}>{text}</ReactMarkdown>
-    </div>
-  )
+  return <Markdown className="text-sm leading-relaxed">{text}</Markdown>
 }
 
 /**

--- a/frontend/src/pages/InsightsPage.tsx
+++ b/frontend/src/pages/InsightsPage.tsx
@@ -8,6 +8,7 @@ import {
   parseInsightCategory,
 } from '@/api/insights'
 import { CATEGORY_STYLES, CategoryBadge } from '@/components/InsightChip'
+import { Markdown } from '@/components/Markdown'
 
 const CATEGORIES = [
   { key: 'all', label: 'All' },
@@ -52,7 +53,7 @@ function InsightCard({ insight, onDismiss }: { insight: Insight; onDismiss: (id:
           ✕
         </button>
       </div>
-      <p className="text-sm text-foreground-secondary leading-relaxed mb-2">{body}</p>
+      <Markdown className="text-sm text-foreground-secondary leading-relaxed mb-2">{body}</Markdown>
       <div className="flex items-center gap-2 text-[10px] text-muted-foreground">
         <span>{insight.source}</span>
         <span>·</span>


### PR DESCRIPTION
## What

Continues the markdown-everywhere sweep (after #338 items, #342 turns/syncs). Focus: the **live chat** (the surface the user actually uses on the supervisor Sessions tab).

## The chat fix

The live chat renders through the shared `canopy-ui/chat` kit; the app injects a `renderMarkdown` seam. `ChatPage` was injecting a **local** react-markdown wrapper that used **`remark-gfm` only** — so single newlines in assistant output collapsed and it read as "not rendered properly." This points that seam at the shared `Markdown` component, which adds **`remark-breaks`** (single newline → `<br>`) plus the token-based prose styling, and deletes the duplicated wrapper.

## Also

Two more plain-`<p>` AI-output surfaces now render markdown via the same shared component:
- **Insights feed** (`InsightsPage`) — insight bodies
- **Product findings review** — the AI-authored `suggested_fix`

## Deliberately unchanged
- **User** chat bubbles stay plain (people type literal text, not markdown; matches common chat UX). The kit already only markdown-renders assistant/system messages.
- `ShareoutsPage` and `SystemPage` keep their **bespoke** markdown renderers — those are purpose-built (briefing section labels with dividers; doc-body styling), not generic, so consolidating them would be a visual regression for no functional gain.
- DDD narrative viewer surfaces (story/narration/lede) are still plain — separate prose surfaces, flagged as an optional follow-up batch.

## Verification
- `npm run build` (tsc + vite) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)