### PR TITLE
feat(supervisor): render markdown in live session chat

### DIFF
--- a/frontend/src/components/supervisor/OpenSessions.tsx
+++ b/frontend/src/components/supervisor/OpenSessions.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState, type JSX } from 'react'
 import { listOpenSessions, enqueueTurn, getTurn, type EmdashSessionOut } from '@/api/harness'
 import { normalizeRecentMessages, type RecentMessage } from '@/lib/recentMessages'
 import { relTime, isRunning } from '@/lib/relTime'
+import { Markdown } from '@/components/Markdown'
 
 // The open emdash sessions the runner reported — glance at what each is doing (the
 // recent-message tail), and drop a prompt into a specific one. Continue dispatches a
@@ -35,12 +36,21 @@ function RoleChip({ role }: { role: string }): JSX.Element {
 }
 
 function MessageBubble({ msg }: { msg: RecentMessage }): JSX.Element {
+  // These rows are interactive chat, not a passive tail — render the agent's
+  // messages as markdown (same shared renderer as every other chat surface).
+  // Your own messages stay plain, matching the native chat bubbles.
   return (
     <div className="flex items-start gap-2 rounded-md bg-muted/40 p-2">
       <RoleChip role={msg.role} />
-      <p className="min-w-0 flex-1 whitespace-pre-wrap break-words text-[12px] leading-snug text-foreground-secondary">
-        {msg.text}
-      </p>
+      {msg.role === 'assistant' ? (
+        <Markdown className="min-w-0 flex-1 break-words text-[12px] leading-snug text-foreground-secondary">
+          {msg.text}
+        </Markdown>
+      ) : (
+        <p className="min-w-0 flex-1 whitespace-pre-wrap break-words text-[12px] leading-snug text-foreground-secondary">
+          {msg.text}
+        </p>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## What

The live emdash-session rows in the supervisor **Sessions** tab (`OpenSessions`) are **interactive chat** — you can continue any session inline — not a passive tail. But the agent's messages in the recent-message view rendered as plain text.

Render assistant messages through the shared `Markdown` component (gfm + remark-breaks), matching the native chat surface. Your own messages stay plain (matching native chat bubbles), and the collapsed line-clamped preview stays plain too.

Part of the markdown-everywhere sweep (#338 items, #342 turns/syncs, #343 native chat + insights + findings).

## Note (follow-up, not in this PR)

This surfaces a bigger point: the Sessions tab currently has **two** session-chat surfaces — the native web chat (`ChatPage`) and these live runner sessions (`OpenSessions`) — with two different backends. Per product intent they should be **one** thing: canopy *runner* sessions (local emdash or remote cloud), chattable through a single surface. Tracking that as a design/convergence effort separately.

## Verification
- `npm run build` (tsc + vite) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)