### PR TITLE
fix(migrations): reconcile chat→canopy_sessions rename on existing DBs (unblocks labs deploy)

### DIFF
--- a/apps/canopy_sessions/migrations/0001_initial.py
+++ b/apps/canopy_sessions/migrations/0001_initial.py
@@ -10,6 +10,14 @@ class Migration(migrations.Migration):
 
     initial = True
 
+    # This app was renamed from `chat` (PR #350). On a fresh DB these migrations
+    # run directly; on a DB where the old `chat` app was already applied (labs),
+    # `replaces` tells the loader the applied `chat.*` records satisfy these, so
+    # check_consistent_history passes (harness.0013 depends on this migration).
+    # The physical `chat_*` tables are renamed to `canopy_sessions_*` by
+    # 0006_rename_legacy_chat_tables (guarded, so it's a no-op on fresh DBs).
+    replaces = [('chat', '0001_initial')]
+
     dependencies = [
         ('agents', '0010_agenttask_review_agenttask_score'),
         ('harness', '0011_remove_sessionlink_sessionlink_unique_per_project_thread_and_more'),

--- a/apps/canopy_sessions/migrations/0002_draft_sessionparticipant.py
+++ b/apps/canopy_sessions/migrations/0002_draft_sessionparticipant.py
@@ -7,6 +7,9 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
+    # Renamed from `chat` — see 0001_initial for the rename/replaces rationale.
+    replaces = [('chat', '0002_draft_sessionparticipant')]
+
     dependencies = [
         ('canopy_sessions', '0001_initial'),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),

--- a/apps/canopy_sessions/migrations/0003_session_project_and_more.py
+++ b/apps/canopy_sessions/migrations/0003_session_project_and_more.py
@@ -6,6 +6,9 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
+    # Renamed from `chat` — see 0001_initial for the rename/replaces rationale.
+    replaces = [('chat', '0003_session_project_and_more')]
+
     dependencies = [
         ('agents', '0012_agent_runner_preference'),
         ('canopy_sessions', '0002_draft_sessionparticipant'),

--- a/apps/canopy_sessions/migrations/0006_rename_legacy_chat_tables.py
+++ b/apps/canopy_sessions/migrations/0006_rename_legacy_chat_tables.py
@@ -1,0 +1,74 @@
+"""Rename the legacy `chat_*` tables to `canopy_sessions_*`.
+
+Companion to the `replaces` markers on 0001-0003. When the app was renamed from
+`chat` to `canopy_sessions` (PR #350), the default table names changed from
+`chat_<model>` to `canopy_sessions_<model>`, but a DB where the old `chat` app
+was already applied (labs) still has the physical `chat_*` tables. `replaces`
+repairs the migration *history*; this migration repairs the physical *tables*.
+
+Ordering: this runs BEFORE 0004_session_origin (via `run_before`) so that on an
+existing DB the rename happens before 0004 does `ALTER TABLE canopy_sessions_session ADD COLUMN`.
+
+Behavior by backend / DB state (the guard makes it a safe no-op everywhere but labs):
+  - Postgres, existing `chat_*` DB (labs): 0001-0003 were satisfied via `replaces`
+    (never ran), so the `chat_*` tables are present and get renamed here. Postgres
+    foreign keys and id-sequence defaults follow the table rename automatically, so
+    harness_turn.chat_session_id keeps pointing at the (renamed) session table.
+  - Postgres, fresh DB: 0001-0003 already created the `canopy_sessions_*` tables, so
+    no `chat_*` table exists — every rename is skipped.
+  - SQLite (tests): the test DB always replays fresh under the new label, so no
+    `chat_*` table ever exists — skipped. (This is also why we can't emit raw
+    `ALTER TABLE IF EXISTS`: SQLite doesn't support that syntax, so we guard in
+    Python and only touch Postgres.)
+
+Idempotent + non-destructive: renames only when the source exists and the target
+doesn't; the reverse is a no-op (we don't rename back).
+"""
+from django.db import migrations
+
+
+# Legacy default table name -> new default table name. Only the models that
+# existed under the `chat` label (Session, Message, Draft, SessionParticipant)
+# need renaming; RunnerBinding (0005) is new and is created as canopy_sessions_*.
+_RENAMES = [
+    ("chat_session", "canopy_sessions_session"),
+    ("chat_message", "canopy_sessions_message"),
+    ("chat_draft", "canopy_sessions_draft"),
+    ("chat_sessionparticipant", "canopy_sessions_sessionparticipant"),
+]
+
+
+def _rename_legacy_tables(apps, schema_editor):
+    conn = schema_editor.connection
+    # Only a Postgres DB that predates the rename can have `chat_*` tables. Fresh
+    # DBs and the SQLite test DB never do — and SQLite has no `ALTER TABLE IF
+    # EXISTS`, so we must guard in Python rather than in SQL.
+    if conn.vendor != "postgresql":
+        return
+    with conn.cursor() as cursor:
+        existing = set(conn.introspection.table_names(cursor))
+        for old, new in _RENAMES:
+            if old in existing and new not in existing:
+                schema_editor.execute(f'ALTER TABLE "{old}" RENAME TO "{new}"')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("canopy_sessions", "0003_session_project_and_more"),
+    ]
+
+    # Insert this into the graph BEFORE 0004 without editing 0004/0005.
+    run_before = [
+        ("canopy_sessions", "0004_session_origin"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            _rename_legacy_tables,
+            migrations.RunPython.noop,
+            # A pure table rename carries no ORM state change; keeping it elidable
+            # lets a future squash drop it once no `chat_*` DB remains.
+            elidable=True,
+        ),
+    ]


### PR DESCRIPTION
## Why

PR #350 renamed the `chat` app → `canopy_sessions` but was only verified on a **fresh** test DB. On any DB where the old `chat` app was already applied (labs + every prod-shaped DB), `migrate` hard-fails and **blocks all labs deploys**:

```
InconsistentMigrationHistory: harness.0013_turn_chat_session_target is applied
before its dependency canopy_sessions.0001_initial
```

Two things are broken on an existing DB: (1) the applied `chat.0001-0003` records don't satisfy the renamed `canopy_sessions.0001-0003`; (2) the physical tables are still named `chat_*` while the new code expects `canopy_sessions_*`.

This surfaced when the deploy that shipped the `AUTH_ALLOWED_EMAIL_DOMAIN` fix failed at the migration gate. (Labs was never left broken — the migration check runs *before* cutover, so the service stayed on the healthy prior revision.)

## Fix (two parts — `replaces` repairs history, but not the physical tables)

- **`replaces`** on `canopy_sessions` 0001/0002/0003 (1:1 to the old `chat` migrations). On labs the applied `chat.*` records now satisfy them so `check_consistent_history` passes; on a fresh DB they run normally.
- **`0006_rename_legacy_chat_tables`** — vendor-aware `RunPython` that renames `chat_* → canopy_sessions_*` **only on Postgres** and **only when the source table exists** (no-op on fresh Postgres and on the SQLite test DB — SQLite has no `ALTER TABLE IF EXISTS`, which is exactly why the guard is in Python, not SQL). Runs **before** `0004` via `run_before` so `0004`'s `AddField` lands on the renamed table. Postgres FKs + id-sequence defaults follow the rename, so `harness_turn.chat_session_id` keeps pointing at the session table.

## Verification (against real Postgres, not just the sqlite suite)

- **Fresh Postgres:** migrates clean → tables `canopy_sessions_*`, `makemigrations --check` clean.
- **Labs-shaped DB** (reproduced by migrating pre-#350 code, seeding a real `chat_session` row via the old ORM, then migrating forward with this branch): **succeeds** → tables renamed, the seeded row **survives** and is queryable via the new model with `origin` backfilled, `harness_turn` FK → `canopy_sessions_session`, **re-migrate is a no-op**, `makemigrations --check` clean.
- **SQLite test suite:** the `IF EXISTS` breakage is gone — full affected selection **315 passed, 0 errors**.

## After merge

A normal Deploy to Labs will pass the migration gate and roll to a task-def revision that already carries the email allowlist (from #351). No manual DB steps required — the reconciliation is automatic and idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)