### PR TITLE
fix(chat): offer Load full session on an empty runner-discovered session

### DIFF
--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -11,7 +11,7 @@ import {
   requestBackfill,
   type ChatSessionDetail,
 } from '@/api/chat'
-import { backfillAction, restToKitMessage } from './chatPageLogic'
+import { backfillAction, restToKitMessage, shouldShowLoadFull } from './chatPageLogic'
 
 /** Render assistant/system message text through canopy's shared Markdown (the
  *  same renderer used across every AI-output surface — so it picks up remark-gfm
@@ -155,11 +155,11 @@ export function ChatPage() {
     [],
   )
 
-  const showLoadFull =
-    !hasMoreBefore &&
-    !historyUnavailable &&
-    meta?.origin === 'runner' &&
-    socket.state.messages.length > 0
+  const showLoadFull = shouldShowLoadFull({
+    origin: meta?.origin,
+    hasMoreBefore,
+    historyUnavailable,
+  })
 
   const historySlot = (
     <div className="flex flex-col items-center gap-1 py-2">

--- a/frontend/src/pages/chatPageLogic.test.ts
+++ b/frontend/src/pages/chatPageLogic.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { backfillAction, restToKitMessage } from "./chatPageLogic";
+import {
+  backfillAction,
+  restToKitMessage,
+  shouldShowLoadFull,
+} from "./chatPageLogic";
 import type { ChatSessionDetail } from "@/api/chat";
 
 describe("restToKitMessage", () => {
@@ -54,5 +58,42 @@ describe("backfillAction", () => {
 
   it("degrades an unrecognized status to an immediate reload", () => {
     expect(backfillAction("something-new")).toBe("reload-now");
+  });
+});
+
+describe("shouldShowLoadFull", () => {
+  const base = { hasMoreBefore: false, historyUnavailable: false };
+
+  // REGRESSION (found on prod): a runner-discovered session whose history is
+  // still on the laptop has ZERO server Message rows, so it rendered "Start the
+  // conversation" with no way to pull its transcript. The offer must NOT depend
+  // on messages already being on screen.
+  it("offers Load full for a runner session with no messages yet", () => {
+    expect(shouldShowLoadFull({ ...base, origin: "runner" })).toBe(true);
+  });
+
+  it("does not offer it for a web session", () => {
+    expect(shouldShowLoadFull({ ...base, origin: "web" })).toBe(false);
+  });
+
+  it("defers to Load earlier when the server holds more than the window", () => {
+    expect(
+      shouldShowLoadFull({ ...base, origin: "runner", hasMoreBefore: true }),
+    ).toBe(false);
+  });
+
+  it("stays hidden once history is known unavailable", () => {
+    expect(
+      shouldShowLoadFull({
+        ...base,
+        origin: "runner",
+        historyUnavailable: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("is hidden before the session meta loads (origin null/undefined)", () => {
+    expect(shouldShowLoadFull({ ...base, origin: null })).toBe(false);
+    expect(shouldShowLoadFull({ ...base, origin: undefined })).toBe(false);
   });
 });

--- a/frontend/src/pages/chatPageLogic.ts
+++ b/frontend/src/pages/chatPageLogic.ts
@@ -45,3 +45,28 @@ export function backfillAction(status: string): BackfillAction {
   if (status === "requested") return "reload-after-delay";
   return "reload-now";
 }
+
+/**
+ * Whether to offer "Load full session".
+ *
+ * A local (origin=runner) session's history lives on the runner, not the
+ * server — until a backfill lands the server may hold ZERO `Message` rows. So
+ * the offer must NOT depend on messages already being on screen: an empty
+ * discovered session is precisely the case that needs it (found in prod: an
+ * `origin=runner` session rendered "Start the conversation" with no way to pull
+ * its transcript). Gate only on:
+ *  - `hasMoreBefore` — the server holds more than the loaded window, so
+ *    "Load earlier" is the right control instead;
+ *  - `historyUnavailable` — we already asked and the runner wasn't reachable.
+ * Clicking when the server happens to be complete is a harmless no-op (the
+ * backend answers `ready` and we just reload the same rows).
+ */
+export function shouldShowLoadFull(args: {
+  origin: string | null | undefined;
+  hasMoreBefore: boolean;
+  historyUnavailable: boolean;
+}): boolean {
+  return (
+    args.origin === "runner" && !args.hasMoreBefore && !args.historyUnavailable
+  );
+}


### PR DESCRIPTION
## What

Found while **verifying the unified-sessions work on prod**. Opening a runner-discovered session (e.g. `ace-simple-povgraduate-component-…` from the live laptop runner) rendered an empty transcript — *"Start the conversation"* — with **no way to pull its history**.

Root cause: a local `origin=runner` session's transcript lives on the runner, so the server holds **zero** `Message` rows until a backfill lands. But `showLoadFull` required `socket.state.messages.length > 0`, which suppressed the affordance in exactly the case that needs it.

## Fix

Extract the condition into `chatPageLogic.shouldShowLoadFull` and drop the message-count requirement — gate only on:
- `hasMoreBefore` → the server holds more than the loaded window, so **"Load earlier"** is the right control instead;
- `historyUnavailable` → we already asked and the runner wasn't reachable.

Clicking when the server happens to already be complete is a harmless no-op (backend answers `ready`, we reload the same rows).

## Verification

- vitest **222 passed** (+5 new), including the regression: *"offers Load full for a runner session with no messages yet"* — false under the old condition, true now. Plus web-session, `hasMoreBefore`, `historyUnavailable`, and pre-meta (null origin) cases.
- Frontend build clean; backend suite **1073 passed** (untouched).

## Note

Pulling that history end-to-end also needs the **laptop runner updated** to the Plan 3 code (it polls `/backfills` and ships the transcript). The deployed runner predates that, so backfill will report `requested` until it's updated — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)