### PR TITLE
fix(chat-kit): pin the history slot so Load earlier/full are actually reachable

### DIFF
--- a/frontend/packages/canopy-ui/src/chat/ChatPanel.tsx
+++ b/frontend/packages/canopy-ui/src/chat/ChatPanel.tsx
@@ -107,8 +107,15 @@ export function ChatPanel({
           />
         </div>
       </div>
+      {/* Pinned ABOVE the scroll container, not inside it. The container is
+          auto-scrolled to the bottom (useStickyBottom), so a slot rendered as
+          the first child of the scroll content sits above the visible area —
+          on prod the "Load full session" control on an empty runner-discovered
+          session was in the DOM but scrolled out of view and covered by the
+          header, i.e. unreachable. Pinning keeps "Load earlier"/"Load full"
+          always visible. */}
+      {historySlot}
       <div ref={containerRef} onScroll={onScroll} className="flex-1 overflow-y-auto">
-        {historySlot}
         <MessageList
           messages={state.messages}
           emptyState={emptyState}

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -161,8 +161,12 @@ export function ChatPage() {
     historyUnavailable,
   })
 
-  const historySlot = (
-    <div className="flex flex-col items-center gap-1 py-2">
+  // The slot is PINNED above the transcript, so render nothing at all when
+  // there's nothing to offer — otherwise every session carries an empty strip.
+  const hasHistoryControls = historyUnavailable || hasMoreBefore || showLoadFull
+
+  const historySlot = !hasHistoryControls ? undefined : (
+    <div className="flex flex-col items-center gap-1 border-b border-border py-2">
       {historyUnavailable && (
         <p className="rounded-md border border-warning/30 bg-warning/10 px-3 py-1.5 text-[12px] text-warning">
           Full history unavailable — runner offline. Showing the latest messages.


### PR DESCRIPTION
## What

Follow-up to #357, found by **verifying it on prod**. #357 correctly made "Load full session" *appear* for an empty runner-discovered session — but the control was still unreachable:

- `historySlot` rendered as the **first child of the `overflow-y-auto` scroll container**, which `useStickyBottom` auto-scrolls to the bottom on mount.
- So the slot sat **above the visible area** (slot top `93` vs container top `137`), and `document.elementFromPoint()` at the button's centre hit the **header bar**, not the button.

It was in the DOM, `is_visible: true`, and invisible to a human. Exactly the trap the "render the page, don't curl it" rule exists for — a DOM/text assertion passed while the UI was broken.

## Fix

- Render `historySlot` as a **sibling above** the scroll container, so "Load earlier" / "Load full session" are always visible regardless of scroll position.
- Render **nothing** when there are no controls — a pinned empty wrapper would otherwise put a dead strip above every transcript (a wart that was harmless while it was buried inside the scroll area).

## Verification

- vitest **222 passed**, build clean.
- Post-deploy prod check asserts the stronger property this time: `elementFromPoint` at the button's centre resolves to the button itself, and it sits within the visible region.

🤖 Generated with [Claude Code](https://claude.com/claude-code)