### PR TITLE
feat(agents): DELETE syncs endpoint — remove a mis-filed manager sync

### DIFF
--- a/apps/agents/api.py
+++ b/apps/agents/api.py
@@ -179,6 +179,18 @@ def create_sync(request: HttpRequest, slug: str, payload: AgentSyncIn) -> Status
     return Status(201, AgentSyncOut.model_validate(sync))
 
 
+@router.delete("/{slug}/syncs/{sync_id}/", response={204: None},
+               summary="Delete a sync (wrong period / stray record)",
+               openapi_extra={"x-mcp-expose": True})
+def delete_sync(request: HttpRequest, slug: str, sync_id: int) -> Status:
+    """POST upserts per (period, source), so re-posting only corrects a sync for the
+    SAME window — a sync filed under the wrong period is otherwise unreachable."""
+    agent = _get_agent_or_404(request, slug)
+    if not services.delete_sync(agent, sync_id):
+        raise HttpError(404, f"sync {sync_id} not found for agent '{slug}'")
+    return Status(204, None)
+
+
 # ---- turns (a packaged unit of work + optional transcript link) ----
 @router.get("/{slug}/turns/", response=Page[AgentTurnOut], summary="List the agent's turns",
             openapi_extra={"x-mcp-expose": True})

--- a/apps/agents/services.py
+++ b/apps/agents/services.py
@@ -107,6 +107,17 @@ def list_syncs(agent: Agent, limit: int = 100) -> list[AgentSync]:
     return list(agent.syncs.select_related("agent")[:limit])
 
 
+def delete_sync(agent: Agent, sync_id: int) -> bool:
+    """Delete ONE sync by id, scoped to the agent. True if a row was removed.
+
+    upsert_sync is idempotent per (period_start, period_end, source), so re-posting
+    only ever corrects a sync for the SAME window. A sync posted with the wrong
+    period (or a stray test row) is otherwise unreachable — this is the escape hatch.
+    """
+    deleted, _ = AgentSync.objects.filter(agent=agent, pk=sync_id).delete()
+    return bool(deleted)
+
+
 # ---- turns (a packaged unit of work + optional transcript link) ----
 def upsert_turn(agent: Agent, data) -> AgentTurn:
     """Idempotent per (agent, cli_session_id): one turn per Claude session, so

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -1036,6 +1036,27 @@ export interface paths {
         readonly patch?: never;
         readonly trace?: never;
     };
+    readonly "/api/agents/{slug}/syncs/{sync_id}/": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly get?: never;
+        readonly put?: never;
+        readonly post?: never;
+        /**
+         * Delete a sync (wrong period / stray record)
+         * @description POST upserts per (period, source), so re-posting only corrects a sync for the
+         *     SAME window — a sync filed under the wrong period is otherwise unreachable.
+         */
+        readonly delete: operations["apps_agents_api_delete_sync"];
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
     readonly "/api/agents/{slug}/turns/": {
         readonly parameters: {
             readonly query?: never;
@@ -8360,6 +8381,27 @@ export interface operations {
                 content: {
                     readonly "application/json": components["schemas"]["AgentSyncOut"];
                 };
+            };
+        };
+    };
+    readonly apps_agents_api_delete_sync: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path: {
+                readonly slug: string;
+                readonly sync_id: number;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description No Content */
+            readonly 204: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -46,6 +46,31 @@ def test_sync_is_idempotent_per_period_and_source():
     assert AgentSync.objects.get(agent=agent).self_grades["work"] == "C+"
 
 
+def test_delete_sync_removes_only_the_targeted_row():
+    agent = _agent()
+    other = _agent("eva")
+    payload = SimpleNamespace(
+        period_start=dt.datetime(2026, 6, 3, tzinfo=dt.timezone.utc),
+        period_end=dt.datetime(2026, 6, 17, tzinfo=dt.timezone.utc),
+        title="Sync 1", summary="s", doc_url="https://docs.google.com/document/d/abc/edit",
+        self_grades={}, source="manager-sync",
+    )
+    keep = services.upsert_sync(agent, payload)
+    payload.period_start = dt.datetime(2026, 7, 1, tzinfo=dt.timezone.utc)
+    payload.period_end = dt.datetime(2026, 7, 8, tzinfo=dt.timezone.utc)
+    payload.title = "Wrong period"
+    doomed = services.upsert_sync(agent, payload)
+    theirs = services.upsert_sync(other, payload)
+
+    assert services.delete_sync(agent, doomed.pk) is True
+    assert set(AgentSync.objects.filter(agent=agent).values_list("pk", flat=True)) == {keep.pk}
+    # gone → False (so the API can 404 rather than silently succeed)
+    assert services.delete_sync(agent, doomed.pk) is False
+    # another agent's sync is not reachable through this agent
+    assert services.delete_sync(agent, theirs.pk) is False
+    assert AgentSync.objects.filter(pk=theirs.pk).exists()
+
+
 def _turn(**kw):
     base = dict(cli_session_id="sess-1", title="Turn 1", summary="did stuff",
                 task_ext_ids=["t1"], work_product_urls=[], session_slug="", share_token="",


### PR DESCRIPTION
## Why

`POST /api/agents/{slug}/syncs/` upserts per `(period_start, period_end, source)`, so re-posting only ever corrects a sync for the **same** window. A sync filed under the **wrong period** — or a stray test row — was unreachable: the agent workspace could accumulate records its own owner had no way to remove.

Hit live while running Echo's manager sync: correcting a grade was fine (same period → upsert), but there was no path to remove a record posted under a bad window.

## What

- `services.delete_sync(agent, sync_id) -> bool` — scoped to the agent, so one agent can't delete another's row. Returns `False` on no-match so the API can 404 instead of silently succeeding.
- `DELETE /api/agents/{slug}/syncs/{sync_id}/` — follows the repo's existing `response={204: None}` convention and reuses `_get_agent_or_404`, so a non-member gets the same 404 as a missing agent (no existence leak).
- Test covers targeted delete, idempotent-miss → `False`, and cross-agent isolation.

## Verification

```
pytest tests/test_agents.py tests/test_pagination_limits.py tests/test_agents_turns_api.py
39 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)