### PR TITLE
fix(sessions): a DEGRADED runner can still ship a backfill

### DIFF
--- a/apps/canopy_sessions/services.py
+++ b/apps/canopy_sessions/services.py
@@ -111,7 +111,17 @@ def request_backfill(session) -> str:
     if session.messages.exists():
         return "ready"
     binding = RunnerBinding.objects.select_related("runner").filter(session=session).first()
-    if binding is None or binding.runner_id is None or binding.runner.live_status != Runner.ONLINE:
+    # A runner only has to be REACHABLE to ship a transcript — not ready to run
+    # turns. `live_status` returns the self-reported status ONLY while the
+    # heartbeat is fresh (a quiet runner is demoted to STALE/DISCONNECTED), so
+    # ONLINE and DEGRADED are exactly the "still reporting" states.
+    # Gating on ONLINE alone made backfill impossible whenever emdash's CDP port
+    # was down: the runner marks itself DEGRADED and stops CLAIMING, but its poll
+    # loop keeps running and `_drain_backfills` reads the transcript FILE, which
+    # never needed CDP. Found on prod — a degraded runner answered "unavailable"
+    # for history it was perfectly able to ship.
+    reachable = {Runner.ONLINE, Runner.DEGRADED}
+    if binding is None or binding.runner_id is None or binding.runner.live_status not in reachable:
         return "unavailable"
     if not binding.backfill_requested:
         binding.backfill_requested = True

--- a/tests/test_session_backfill.py
+++ b/tests/test_session_backfill.py
@@ -1,3 +1,4 @@
+import datetime as dt
 import pytest
 from django.contrib.auth.models import User
 from django.test import Client
@@ -26,6 +27,49 @@ def _ctx(runner_online=True, has_runner=True):
     RunnerBinding.objects.create(session=s, runner=r, session_key="echo-1")
     c = Client(); c.force_login(user)
     return user, ws, s, r, c
+
+
+def test_backfill_requested_when_runner_is_degraded(monkeypatch):
+    """A DEGRADED runner is still reporting — it just isn't claiming turns.
+
+    Regression (found on prod): emdash's CDP port was unreachable, so the runner
+    self-reported DEGRADED and stopped claiming, but its poll loop kept running
+    and backfill only reads a transcript FILE. Gating on ONLINE made history
+    permanently 'unavailable' for history the runner could ship.
+    """
+    published = []
+    monkeypatch.setattr("apps.realtime.groups.publish", lambda g, m: published.append((g, m)))
+    user = User.objects.create_user("jj", "jj@dimagi.com", "pw")
+    ws = Workspace.objects.create(slug="w1", display_name="W1", created_by=user)
+    WorkspaceMembership.objects.create(user=user, workspace=ws, role=WorkspaceMembership.OWNER)
+    s = Session.objects.create(workspace=ws, created_by=user, origin=Session.ORIGIN_RUNNER, title="t")
+    r = Runner.objects.create(
+        name="laptop", workspace=ws, location=Runner.LOCAL, paired_by=user,
+        status=Runner.DEGRADED, last_heartbeat_at=timezone.now(),  # fresh => live_status == degraded
+    )
+    RunnerBinding.objects.create(session=s, runner=r, session_key="echo-1")
+    c = Client(); c.force_login(user)
+
+    assert r.live_status == Runner.DEGRADED
+    assert c.post(f"/api/canopy-sessions/{s.id}/backfill").json() == {"status": "requested"}
+    assert published, "a degraded (but reachable) runner must still be signalled"
+
+
+def test_backfill_unavailable_when_runner_heartbeat_is_stale():
+    """Stale heartbeat => live_status STALE => genuinely unreachable, so unavailable."""
+    user = User.objects.create_user("jj", "jj@dimagi.com", "pw")
+    ws = Workspace.objects.create(slug="w1", display_name="W1", created_by=user)
+    WorkspaceMembership.objects.create(user=user, workspace=ws, role=WorkspaceMembership.OWNER)
+    s = Session.objects.create(workspace=ws, created_by=user, origin=Session.ORIGIN_RUNNER, title="t")
+    r = Runner.objects.create(
+        name="laptop", workspace=ws, location=Runner.LOCAL, paired_by=user,
+        status=Runner.DEGRADED, last_heartbeat_at=timezone.now() - dt.timedelta(hours=1),
+    )
+    RunnerBinding.objects.create(session=s, runner=r, session_key="echo-1")
+    c = Client(); c.force_login(user)
+
+    assert r.live_status == Runner.STALE
+    assert c.post(f"/api/canopy-sessions/{s.id}/backfill").json() == {"status": "unavailable"}
 
 
 def test_backfill_ready_when_rows_exist():


### PR DESCRIPTION
## What

Found while updating the laptop runner to the Plan 3 code and testing backfill **on prod**.

The runner was healthy and heartbeating (`sessions: true`, fresh `last_heartbeat_at`) but reported `status: degraded` / `"emdash CDP unreachable on :9222 — not claiming"`. `POST /backfill` answered **`unavailable`**.

That's wrong: the runner's CDP preflight gates **only the claim** (*"Inbox + schedule polling still run; only the claim is gated"*), and `_drain_backfills` reads a transcript **file** — it never needed CDP. So the runner could ship the history; the server just refused to ask, and would keep refusing for as long as CDP stayed down (540 ticks and counting on my machine).

## Fix

`request_backfill` gated on `live_status == ONLINE`. But `live_status` returns the self-reported status **only while the heartbeat is fresh** — a quiet runner is demoted to `STALE`/`DISCONNECTED` — so `ONLINE` and `DEGRADED` are exactly the "still reporting" states. Gate on **reachability**, not readiness.

`is_session_running` deliberately keeps its `ONLINE` gate: "running" should mean *actively working*, and a degraded runner isn't.

## Verification

- Backend suite **1076 passed**; ruff clean; no migrations.
- Two new regression tests: a fresh-heartbeat `DEGRADED` runner → `requested` (and is signalled); a stale-heartbeat runner → `unavailable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)