### PR TITLE
fix(sessions): real activity timestamps, render the binding tail, reuse the live session on send + sort toggle

### DIFF
--- a/apps/canopy_sessions/api.py
+++ b/apps/canopy_sessions/api.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import uuid
 
+from django.db.models import Max
+
 from django.http import HttpRequest
 from django.shortcuts import get_object_or_404
 from ninja import Router
@@ -46,6 +48,8 @@ def _out(session: Session) -> dict:
         "title": session.title,
         "status": session.status,
         "created_at": session.created_at,
+        # When it last DID something (binding > newest message > created).
+        "last_activity_at": services.last_activity_at(session, binding),
         # --- liveness (Plan 4): one shape, computed from the binding ---
         "origin": session.origin,
         "running": services.is_session_running(binding),
@@ -63,7 +67,8 @@ def _visible_slugs(request: HttpRequest) -> set[str]:
 
 def _session_or_404(request: HttpRequest, session_id: uuid.UUID) -> Session:
     session = get_object_or_404(
-        Session.objects.select_related("agent", "runner_binding", "runner_binding__runner"),
+        Session.objects.select_related("agent", "runner_binding", "runner_binding__runner")
+        .annotate(_last_msg_at=Max("messages__created_at")),
         pk=session_id,
     )
     if session.workspace_id not in _visible_slugs(request):
@@ -97,18 +102,23 @@ def list_sessions(request: HttpRequest):
     # workspaces — their own web sessions UNION any session that has a
     # RunnerBinding (runner-discovered or live). Deduped, running-first, then
     # newest. Replaces the creator-only list + the harness OpenSessions projection.
-    from django.db.models import Q
+    from django.db.models import Max, Q
 
     slugs = _visible_slugs(request)
     rows = (
         Session.objects.select_related("agent", "runner_binding", "runner_binding__runner")
         .filter(workspace_id__in=slugs)
         .filter(Q(created_by=request.user) | Q(runner_binding__isnull=False))
+        .annotate(_last_msg_at=Max("messages__created_at"))
         .distinct()
         .order_by("-created_at")
     )
     out = [_out(s) for s in rows]
-    out.sort(key=lambda r: (not r["running"], ))  # stable: running first, created-desc within
+    # Running first, then genuinely-most-recent. Sorting by created_at made a
+    # dead repo and a live one interleave arbitrarily (both "created" in the
+    # same report sweep); last_activity_at is the real signal. The client can
+    # re-group by project — this is the default order.
+    out.sort(key=lambda r: (not r["running"], -(r["last_activity_at"].timestamp())))
     return out
 
 
@@ -124,6 +134,13 @@ def get_session(request: HttpRequest, session_id: uuid.UUID, full: bool = False)
     else:
         rows, has_more, oldest = services.tail_messages(session)
     data["messages"] = [MessageOut.from_orm(m) for m in rows]
+    if not data["messages"]:
+        # A local runner session holds NO Message rows until a backfill lands, but
+        # the runner reports a rolling tail we already store on the binding. Render
+        # it so the panel opens with recent context instead of blank; "Load full
+        # session" still pulls the real history, and a live stream layers on top.
+        binding = getattr(session, "runner_binding", None)
+        data["messages"] = services.tail_as_messages(session, binding)
     data["has_more_before"] = has_more
     data["oldest_loaded_turn_index"] = oldest
     return data

--- a/apps/canopy_sessions/schemas.py
+++ b/apps/canopy_sessions/schemas.py
@@ -44,6 +44,10 @@ class SessionOut(Schema):
     title: str
     status: str
     created_at: dt.datetime
+    # When the session last DID something (binding.last_interacted_at > newest
+    # message > created_at). created_at is when canopy first NOTICED a discovered
+    # session, which is identical across a report sweep — useless as an age.
+    last_activity_at: dt.datetime
     # Liveness (Plan 4) — computed from the RunnerBinding; a web session with no
     # binding is origin="web", running=False, runner_name=None.
     origin: str = "web"

--- a/apps/canopy_sessions/services.py
+++ b/apps/canopy_sessions/services.py
@@ -102,6 +102,55 @@ def is_session_running(binding) -> bool:
 _BACKFILL_ROLES = {Message.USER, Message.ASSISTANT, Message.TOOL_USE, Message.TOOL_RESULT, Message.SYSTEM}
 
 
+def last_activity_at(session, binding):
+    """When this session last DID something — not when its row was created.
+
+    A runner-discovered session's row is created the moment the report sweep first
+    sees it, so `created_at` is "when canopy first noticed you", identical for every
+    session in that sweep. Rendering it made a long-dead repo and a live one both
+    read "4h ago". The real signal is the binding's `last_interacted_at` (the runner
+    reports it every tick); web sessions fall back to their newest message, then to
+    creation. `_last_msg_at` is annotated by the callers so this stays N+1-free.
+    """
+    if binding is not None and binding.last_interacted_at:
+        return binding.last_interacted_at
+    return getattr(session, "_last_msg_at", None) or session.created_at
+
+
+def tail_as_messages(session, binding) -> list[dict]:
+    """A local runner session's reported tail, shaped like MessageOut rows.
+
+    Local sessions hold NO `Message` rows until a backfill lands — the recent
+    history lives on `RunnerBinding.tail` (what the retired OpenSessions used to
+    render). Without this the converged ChatPanel opened blank on every discovered
+    session even though the server had the last N messages in hand.
+
+    turn_index is NEGATIVE (-n..-1): it orders the tail before any real row and can
+    never collide with backfilled rows (which start at 0) or with a live stream's
+    `seq:` ids, so a backfill or a live message layers on cleanly.
+    """
+    if binding is None or not binding.tail:
+        return []
+    ts = binding.last_interacted_at or session.created_at
+    n = len(binding.tail)
+    rows = []
+    for i, m in enumerate(binding.tail):
+        if not isinstance(m, dict):
+            continue
+        role = m.get("role") or Message.ASSISTANT
+        if role not in _BACKFILL_ROLES:
+            role = Message.ASSISTANT
+        text = m.get("text") or ""
+        rows.append({
+            "turn_index": i - n,
+            "role": role,
+            "plaintext": text,
+            "content": {"text": text},
+            "created_at": ts,
+        })
+    return rows
+
+
 def request_backfill(session) -> str:
     """The client asked for full history. 'ready' if already server-full; 'requested'
     if a live runner is bound (signal it); 'unavailable' otherwise (tail still shows)."""
@@ -246,17 +295,26 @@ def send_message(*, session: Session, text: str, user, client_id: str = "") -> t
         message = Message.objects.create(
             session=session, turn_index=index, role=Message.USER, plaintext=text, content=content,
         )
+        # Continuity: every send in a chat reuses ONE emdash session (the runner's
+        # _thread_key reads this), so a conversation is one durable thread rather
+        # than a fresh session per message. chat_session_id tells a session-capable
+        # runner to BRIDGE the emdash response back into the ledger (vs the normal
+        # fire-and-continue), so the website streams the reply.
+        #
+        # A RUNNER-DISCOVERED session already has a binding keyed `emdash:<task>` (the
+        # report sweep wrote it). Sending str(session.id) there matched nothing, so
+        # resolve_session answered new_thread and the runner SPAWNED A FRESH emdash
+        # session instead of typing into the live one you were looking at. Prefer the
+        # binding's existing thread_key; web sessions (no binding yet) keep the
+        # session id, which is what record_session then stores.
+        binding = getattr(session, "runner_binding", None)
+        thread_key = binding.thread_key if (binding and binding.thread_key) else str(session.id)
         turn, _created = harness_services.enqueue_turn(
             session=session,
             origin=Turn.ORIGIN_API,
             idempotency_key=f"chat:{session.id.hex}:{client_id or index}",
             prompt=text,
-            # Continuity: every send in a chat reuses ONE emdash session (the runner's
-            # _thread_key reads this), so a conversation is one durable thread rather
-            # than a fresh session per message. chat_session_id tells a session-capable
-            # runner to BRIDGE the emdash response back into the ledger (vs the normal
-            # fire-and-continue), so the website streams the reply.
-            origin_ref={"thread_key": str(session.id), "chat_session_id": str(session.id)},
+            origin_ref={"thread_key": thread_key, "chat_session_id": str(session.id)},
         )
     # RC4 — multiplayer interjection: if a turn is ALREADY running for this session,
     # the human's message is an interjection. Push it down to the runner executing

--- a/apps/harness/services.py
+++ b/apps/harness/services.py
@@ -723,12 +723,21 @@ def replace_reported_sessions(runner: Runner, workspace, sessions: list) -> int:
                 title=s.emdash_task,
             )
             binding = RunnerBinding(session=session, session_key=s.emdash_task)
-            # thread_key/host are the binding's durable IDENTITY — stamp them
-            # only at creation. An existing binding may already be owned by an
-            # agent/phone thread (record_session), and this report loop must
-            # not steal it: see the docstring above.
             binding.thread_key = f"emdash:{s.emdash_task}"
             binding.host = runner.host
+        else:
+            # thread_key/host are the binding's durable IDENTITY. NEVER overwrite a
+            # non-empty one — an existing binding may be owned by an agent/phone
+            # thread (record_session) and this report loop must not steal it (see
+            # the docstring above). But DO fill an EMPTY one: bindings predating the
+            # SessionLink fold have host="" and can never satisfy
+            # RunnerBinding.reusable_by (which requires runner AND host), so a chat
+            # sent to one spawned a fresh emdash session forever instead of reusing
+            # the live one. Fill-if-empty heals those without clobbering anything.
+            if not binding.thread_key:
+                binding.thread_key = f"emdash:{s.emdash_task}"
+            if not binding.host:
+                binding.host = runner.host
         binding.runner = runner
         binding.status = s.status or ""
         binding.last_interacted_at = _aware(s.last_interacted_at)

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -4107,6 +4107,11 @@ export interface components {
              */
             readonly created_at: string;
             /**
+             * Last Activity At
+             * Format: date-time
+             */
+            readonly last_activity_at: string;
+            /**
              * Origin
              * @default web
              */
@@ -6450,6 +6455,11 @@ export interface components {
              * Format: date-time
              */
             readonly created_at: string;
+            /**
+             * Last Activity At
+             * Format: date-time
+             */
+            readonly last_activity_at: string;
             /**
              * Origin
              * @default web

--- a/frontend/src/components/chat/ChatSessionsPanel.tsx
+++ b/frontend/src/components/chat/ChatSessionsPanel.tsx
@@ -15,6 +15,7 @@ import { listAgents, type AgentOut } from '@/api/agents'
 import { projectsApi, type ProjectSlug } from '@/api/projects'
 import { relativeTime } from '@/components/activity/turnLog'
 import { sessionTargetLabel } from './sessionTargetLabel'
+import { projectHeader, sortSessions, type SessionSort } from './sessionSort'
 
 /**
  * Reusable, CROSS-WORKSPACE chat session surface: a findable list of your chat
@@ -36,6 +37,7 @@ export function ChatSessionsPanel({
   const [agents, setAgents] = useState<AgentOut[]>(agentsProp ?? [])
   const [projects, setProjects] = useState<ProjectSlug[]>([])
   const [loading, setLoading] = useState(true)
+  const [sort, setSort] = useState<SessionSort>('time')
   const [error, setError] = useState<string | null>(null)
   const [creating, setCreating] = useState(false)
 
@@ -146,6 +148,27 @@ export function ChatSessionsPanel({
         </DropdownMenu>
       </div>
 
+      {sessions.length > 1 && (
+        <div className="flex items-center gap-1 pb-2 text-xs">
+          <span className="mr-1 text-muted-foreground">Sort</span>
+          {(['time', 'project'] as const).map((m) => (
+            <button
+              key={m}
+              type="button"
+              onClick={() => setSort(m)}
+              aria-pressed={sort === m}
+              className={
+                sort === m
+                  ? 'rounded-md border border-primary/40 bg-primary/10 px-2 py-0.5 font-medium text-primary'
+                  : 'rounded-md border border-border px-2 py-0.5 text-muted-foreground hover:bg-muted'
+              }
+            >
+              {m === 'time' ? 'Recent' : 'Project'}
+            </button>
+          ))}
+        </div>
+      )}
+
       {error && <div className="py-2 text-sm text-destructive">{error}</div>}
       {loading ? (
         <div className="py-6 text-sm text-muted-foreground">Loading sessions…</div>
@@ -156,10 +179,16 @@ export function ChatSessionsPanel({
         </div>
       ) : (
         <ul className="divide-y divide-border rounded-md border border-border">
-          {sessions.map((s) => {
+          {sortSessions(sessions, sort).map((s, i, rows) => {
             const label = sessionTargetLabel(agentName(s.agent_slug), s.project ?? '')
+            const header = projectHeader(rows, i, sort)
             return (
               <li key={s.id}>
+                {header && (
+                  <div className="bg-muted/40 px-3 py-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                    {header}
+                  </div>
+                )}
                 <Link
                   to={`/w/${s.workspace}/chat/${s.id}`}
                   className="flex items-center justify-between gap-3 px-3 py-2.5 hover:bg-muted"
@@ -181,7 +210,7 @@ export function ChatSessionsPanel({
                         running
                       </span>
                     ) : (
-                      <span className="text-muted-foreground">{relativeTime(s.created_at, now)}</span>
+                      <span className="text-muted-foreground">{relativeTime(s.last_activity_at, now)}</span>
                     )}
                     {s.runner_name && (
                       <span className="text-muted-foreground">

--- a/frontend/src/components/chat/sessionSort.test.ts
+++ b/frontend/src/components/chat/sessionSort.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { projectHeader, sortSessions } from "./sessionSort";
+
+const row = (
+  project: string,
+  last_activity_at: string,
+  running = false,
+  id = `${project}-${last_activity_at}`,
+) => ({ id, project, last_activity_at, running });
+
+const T = {
+  now: "2026-07-23T22:00:00Z",
+  min5: "2026-07-23T21:55:00Z",
+  hr4: "2026-07-23T18:00:00Z",
+  wk1: "2026-07-16T18:00:00Z",
+};
+
+describe("sortSessions — time", () => {
+  it("orders by most recent activity, not creation", () => {
+    const rows = [row("reef", T.wk1), row("canopy-web", T.now), row("ace", T.hr4)];
+    expect(sortSessions(rows, "time").map((r) => r.project)).toEqual([
+      "canopy-web",
+      "ace",
+      "reef",
+    ]);
+  });
+
+  it("does not mutate the input", () => {
+    const rows = [row("b", T.wk1), row("a", T.now)];
+    const before = rows.map((r) => r.project);
+    sortSessions(rows, "time");
+    expect(rows.map((r) => r.project)).toEqual(before);
+  });
+});
+
+describe("sortSessions — project", () => {
+  it("groups by project, then running, then recency within a project", () => {
+    const rows = [
+      row("reef", T.hr4),
+      row("ace", T.wk1),
+      row("ace", T.min5, true), // running -> top of its project
+      row("ace", T.now), // newer, but not running
+    ];
+    const out = sortSessions(rows, "project");
+    expect(out.map((r) => r.project)).toEqual(["ace", "ace", "ace", "reef"]);
+    expect(out[0].running).toBe(true);
+    expect(out[1].last_activity_at).toBe(T.now); // then newest non-running
+    expect(out[2].last_activity_at).toBe(T.wk1);
+  });
+
+  it("sorts web chats (no project) last, not first", () => {
+    const rows = [row("", T.now), row("ace", T.wk1)];
+    expect(sortSessions(rows, "project").map((r) => r.project)).toEqual(["ace", ""]);
+  });
+});
+
+describe("projectHeader", () => {
+  it("labels the first row of each project run and nothing else", () => {
+    const rows = sortSessions(
+      [row("ace", T.now), row("ace", T.hr4), row("reef", T.hr4)],
+      "project",
+    );
+    expect(rows.map((_, i) => projectHeader(rows, i, "project"))).toEqual([
+      "ace",
+      null,
+      "reef",
+    ]);
+  });
+
+  it("never labels in time mode", () => {
+    const rows = [row("ace", T.now), row("reef", T.hr4)];
+    expect(rows.map((_, i) => projectHeader(rows, i, "time"))).toEqual([null, null]);
+  });
+
+  it("labels a blank project readably", () => {
+    const rows = [row("", T.now)];
+    expect(projectHeader(rows, 0, "project")).toBe("No project");
+  });
+});

--- a/frontend/src/components/chat/sessionSort.ts
+++ b/frontend/src/components/chat/sessionSort.ts
@@ -1,0 +1,58 @@
+/**
+ * Display ordering for the unified Sessions list.
+ *
+ * Sorts on `last_activity_at` — when the session last DID something — NOT
+ * `created_at`, which for a runner-discovered session is when the report sweep
+ * first noticed it and is therefore identical across every session in that
+ * sweep (a dead repo and a live one both read "4h ago").
+ */
+export type SessionSort = "time" | "project";
+
+type Sortable = {
+  project?: string | null;
+  running?: boolean;
+  last_activity_at: string;
+};
+
+const activityDesc = (a: Sortable, b: Sortable) =>
+  Date.parse(b.last_activity_at) - Date.parse(a.last_activity_at);
+
+/** Sort a copy; never mutates the input. */
+export function sortSessions<T extends Sortable>(
+  rows: readonly T[],
+  mode: SessionSort,
+): T[] {
+  const copy = [...rows];
+  if (mode === "project") {
+    // Grouped by repo, and inside a repo the liveliest first: running, then
+    // most-recently-active. Blank projects (web chats) sort last, not first.
+    return copy.sort(
+      (a, b) =>
+        projectKey(a).localeCompare(projectKey(b)) ||
+        Number(Boolean(b.running)) - Number(Boolean(a.running)) ||
+        activityDesc(a, b),
+    );
+  }
+  return copy.sort(activityDesc);
+}
+
+/** "" (a web chat) sorts after every named project rather than to the top. */
+function projectKey(s: Sortable): string {
+  return s.project?.trim() ? s.project.trim() : "￿";
+}
+
+/**
+ * The project header to show above a row in project mode, or null when the row
+ * continues the previous project. Lets a flat <ul> render grouped.
+ */
+export function projectHeader(
+  rows: readonly Sortable[],
+  i: number,
+  mode: SessionSort,
+): string | null {
+  if (mode !== "project") return null;
+  const label = rows[i].project?.trim() || "No project";
+  if (i === 0) return label;
+  const prev = rows[i - 1].project?.trim() || "No project";
+  return prev === label ? null : label;
+}

--- a/tests/test_session_activity_and_reuse.py
+++ b/tests/test_session_activity_and_reuse.py
@@ -1,0 +1,143 @@
+"""Regressions found by using the converged Sessions UI on prod (2026-07-23).
+
+Three distinct bugs, all rooted in the API not surfacing what the RunnerBinding
+already held:
+  1. every row rendered `created_at` (when the report sweep first NOTICED the
+     session), so a long-dead repo and a live one both read "4h ago";
+  2. opening a runner-discovered session showed "Start the conversation" even
+     though the binding carried a rolling tail;
+  3. sending into one spawned a FRESH emdash session, because the turn's
+     thread_key was the canopy Session id while the binding is keyed
+     `emdash:<task>`.
+"""
+import datetime as dt
+
+import pytest
+from django.contrib.auth.models import User
+from django.test import Client
+from django.utils import timezone
+
+from apps.canopy_sessions.models import Message, RunnerBinding, Session
+from apps.harness.models import Runner
+from apps.workspaces.models import Workspace, WorkspaceMembership
+
+pytestmark = pytest.mark.django_db
+
+
+def _ctx():
+    user = User.objects.create_user("jj", "jj@dimagi.com", "pw")
+    ws = Workspace.objects.create(slug="w1", display_name="W1", created_by=user)
+    WorkspaceMembership.objects.create(user=user, workspace=ws, role=WorkspaceMembership.OWNER)
+    runner = Runner.objects.create(
+        name="jj-mbp", workspace=ws, location=Runner.LOCAL, paired_by=user,
+        host="jj@mbp", status=Runner.ONLINE, last_heartbeat_at=timezone.now(),
+    )
+    c = Client(); c.force_login(user)
+    return user, ws, runner, c
+
+
+def _discovered(ws, runner, *, key="ace-demo", tail=None, last=None, thread_key=None, host=None):
+    s = Session.objects.create(workspace=ws, origin=Session.ORIGIN_RUNNER, title=key, project="ace")
+    RunnerBinding.objects.create(
+        session=s, runner=runner, session_key=key,
+        thread_key=(f"emdash:{key}" if thread_key is None else thread_key),
+        host=(runner.host if host is None else host),
+        tail=tail or [], last_interacted_at=last,
+    )
+    return s
+
+
+# --- 1. the timestamp bug -------------------------------------------------
+
+def test_last_activity_uses_binding_not_row_creation():
+    """created_at is when canopy first NOTICED it — identical across a sweep."""
+    _u, ws, runner, c = _ctx()
+    recent = timezone.now() - dt.timedelta(minutes=3)
+    stale = timezone.now() - dt.timedelta(days=6)
+    live = _discovered(ws, runner, key="canopy-web", last=recent)
+    dead = _discovered(ws, runner, key="reef", last=stale)
+
+    rows = {r["id"]: r for r in c.get("/api/canopy-sessions/").json()}
+    assert rows[str(live.id)]["last_activity_at"][:16] == recent.isoformat()[:16]
+    assert rows[str(dead.id)]["last_activity_at"][:16] == stale.isoformat()[:16]
+    # the actual symptom: they must NOT report the same age
+    assert rows[str(live.id)]["last_activity_at"] != rows[str(dead.id)]["last_activity_at"]
+
+
+def test_list_sorted_by_real_activity_not_creation():
+    _u, ws, runner, c = _ctx()
+    old = _discovered(ws, runner, key="old", last=timezone.now() - dt.timedelta(days=2))
+    new = _discovered(ws, runner, key="new", last=timezone.now() - dt.timedelta(minutes=1))
+    ids = [r["id"] for r in c.get("/api/canopy-sessions/").json()]
+    assert ids.index(str(new.id)) < ids.index(str(old.id))
+    assert str(old.id) in ids
+
+
+def test_web_session_falls_back_to_newest_message():
+    user, ws, _r, c = _ctx()
+    s = Session.objects.create(workspace=ws, created_by=user, origin=Session.ORIGIN_WEB, title="web")
+    msg_at = timezone.now() - dt.timedelta(minutes=2)
+    m = Message.objects.create(session=s, turn_index=0, role=Message.USER, plaintext="hi")
+    Message.objects.filter(pk=m.pk).update(created_at=msg_at)
+    row = next(r for r in c.get("/api/canopy-sessions/").json() if r["id"] == str(s.id))
+    assert row["last_activity_at"][:16] == msg_at.isoformat()[:16]
+
+
+# --- 2. the blank-panel bug ----------------------------------------------
+
+def test_discovered_session_renders_its_binding_tail():
+    """No Message rows yet — the panel must still open with recent context."""
+    _u, ws, runner, c = _ctx()
+    tail = [{"role": "user", "text": "q1"}, {"role": "assistant", "text": "a1"}]
+    s = _discovered(ws, runner, tail=tail, last=timezone.now())
+    body = c.get(f"/api/canopy-sessions/{s.id}").json()
+    assert [m["plaintext"] for m in body["messages"]] == ["q1", "a1"]
+    # negative indices: order before any real row, never collide with a backfill (0..n)
+    assert [m["turn_index"] for m in body["messages"]] == [-2, -1]
+
+
+def test_real_rows_win_over_the_tail():
+    _u, ws, runner, c = _ctx()
+    s = _discovered(ws, runner, tail=[{"role": "assistant", "text": "stale tail"}])
+    Message.objects.create(session=s, turn_index=0, role=Message.USER, plaintext="real")
+    body = c.get(f"/api/canopy-sessions/{s.id}").json()
+    assert [m["plaintext"] for m in body["messages"]] == ["real"]
+
+
+# --- 3. the "spawned a new session" bug ----------------------------------
+
+def test_send_reuses_the_bindings_thread_key():
+    """Sending str(session.id) matched no binding -> runner spawned a fresh session."""
+    from apps.canopy_sessions import services
+    user, ws, runner, _c = _ctx()
+    s = _discovered(ws, runner, key="ace-demo")
+    _msg, turn = services.send_message(session=s, user=user, text="hello", client_id="c1")
+    assert turn.origin_ref["thread_key"] == "emdash:ace-demo"     # the LIVE session
+    assert turn.origin_ref["chat_session_id"] == str(s.id)        # bridge target unchanged
+
+
+def test_web_session_send_still_keys_on_the_session_id():
+    from apps.canopy_sessions import services
+    user, ws, _r, _c = _ctx()
+    s = Session.objects.create(workspace=ws, created_by=user, origin=Session.ORIGIN_WEB, title="web")
+    _msg, turn = services.send_message(session=s, user=user, text="hello", client_id="c1")
+    assert turn.origin_ref["thread_key"] == str(s.id)
+
+
+# --- report path heals a legacy binding without stealing one --------------
+
+def test_report_fills_empty_identity_but_never_overwrites():
+    from types import SimpleNamespace
+    from apps.harness.services import replace_reported_sessions
+    _u, ws, runner, _c = _ctx()
+    legacy = _discovered(ws, runner, key="legacy", thread_key="", host="")   # pre-fold row
+    owned = _discovered(ws, runner, key="owned", thread_key="phone:jj:echo")
+
+    rep = lambda k: SimpleNamespace(emdash_task=k, project="ace", status="running",
+                                    last_interacted_at=None, recent_messages=[])
+    replace_reported_sessions(runner, ws, [rep("legacy"), rep("owned")])
+
+    healed = RunnerBinding.objects.get(session=legacy)
+    assert healed.thread_key == "emdash:legacy" and healed.host == runner.host  # filled
+    assert healed.reusable_by(runner) is True                                   # now reusable
+    assert RunnerBinding.objects.get(session=owned).thread_key == "phone:jj:echo"  # NOT stolen


### PR DESCRIPTION
Three bugs found by **actually using** the converged Sessions UI on prod, plus the requested sort toggle. All three share one root cause: the API wasn't surfacing what the `RunnerBinding` already held.

## 1. Timestamps were meaningless

Rows rendered `created_at`. For a runner-discovered session that's *when the report sweep first noticed it* — identical for every session in a sweep. So `reef` (not run in a week) and `canopy-web` (live) **both read "4h ago"**.

Expose `last_activity_at` = `binding.last_interacted_at` → newest message → `created_at`, and render/sort on it. (The accurate value was already on the binding — the harness projection has been reporting it correctly all along.)

## 2. Clicking a session showed "Start the conversation"

A local runner session holds **no `Message` rows** until a backfill lands — its recent history lives on `RunnerBinding.tail` (8 messages), which is exactly what the retired `OpenSessions` used to render. `ChatPanel` only renders `Message` rows, so the panel opened blank.

`get_session` now falls back to the tail, with **negative `turn_index`** so it can never collide with a backfill (`0..n`) or a live stream's `seq:` ids — a backfill or live message layers on cleanly.

## 3. Replying spawned a NEW emdash session

`send_message` enqueued the turn with `thread_key = str(session.id)`. But a discovered session's binding is keyed `emdash:<task>`, so `resolve_session` matched nothing, answered `new_thread`, and the runner **started a fresh session instead of typing into the live one you were looking at**.

- Prefer the binding's existing `thread_key` (web sessions, which have no binding yet, keep the session id — that's what `record_session` then stores).
- Also **heal legacy bindings**: the report loop now *fills* an empty `thread_key`/`host` (never overwrites a set one — that anti-clobber rule stays). Rows predating the SessionLink fold have `host=''` and could never satisfy `reusable_by`, so reuse was permanently broken for them.

## 4. Requested: quick sort toggle

**Recent** (activity desc) | **Project** (grouped with headers; running-then-recent within a project). Pure helper in `sessionSort.ts`, 7 unit tests; web chats sort after named projects rather than to the top.

## Verification

Backend **1084 passed** (8 new regression tests covering each bug above), vitest **229 passed** (7 new), ruff clean, no migrations, `generated.ts` regenerated (+10, additive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)