### PR TITLE
fix(sessions): WS snapshot must render the binding tail too

### DIFF
--- a/apps/canopy_sessions/api.py
+++ b/apps/canopy_sessions/api.py
@@ -140,7 +140,9 @@ def get_session(request: HttpRequest, session_id: uuid.UUID, full: bool = False)
         # it so the panel opens with recent context instead of blank; "Load full
         # session" still pulls the real history, and a live stream layers on top.
         binding = getattr(session, "runner_binding", None)
-        data["messages"] = services.tail_as_messages(session, binding)
+        data["messages"] = [
+            MessageOut.from_orm(m) for m in services.tail_as_messages(session, binding)
+        ]
     data["has_more_before"] = has_more
     data["oldest_loaded_turn_index"] = oldest
     return data

--- a/apps/canopy_sessions/consumers.py
+++ b/apps/canopy_sessions/consumers.py
@@ -252,6 +252,14 @@ class SessionConsumer(AsyncJsonWebsocketConsumer):
         # for earlier history is REST (GET /{id}/messages?before=); Plan 4 wires
         # it into the panel. The session.state frame shape is otherwise frozen.
         messages, _has_more, _oldest = chat_services.tail_messages(self.session)
+        if not messages:
+            # A local runner session has NO Message rows until a backfill lands, but
+            # the binding carries a rolling tail. ChatPage's transcript comes from THIS
+            # snapshot (getSession only supplies meta.title), so without this the panel
+            # opened blank on every discovered session. TailMessage quacks like a
+            # Message row, so message_dto below needs no special-casing.
+            binding = getattr(self.session, "runner_binding", None)
+            messages = chat_services.tail_as_messages(self.session, binding)
         return {
             "event": "session.state",
             "data": serializers.session_state_dto(

--- a/apps/canopy_sessions/services.py
+++ b/apps/canopy_sessions/services.py
@@ -9,6 +9,7 @@ serializes a conversation, turn_index assignment never races within a session.
 from __future__ import annotations
 
 import datetime as _dt
+from dataclasses import dataclass
 
 from django.conf import settings
 from django.db import IntegrityError, transaction
@@ -117,8 +118,27 @@ def last_activity_at(session, binding):
     return getattr(session, "_last_msg_at", None) or session.created_at
 
 
-def tail_as_messages(session, binding) -> list[dict]:
-    """A local runner session's reported tail, shaped like MessageOut rows.
+@dataclass(frozen=True)
+class TailMessage:
+    """A binding-tail entry shaped like a `Message` row.
+
+    Quacks like the real model on purpose: the REST path serializes it with
+    `MessageOut.from_orm` and the WebSocket path with `serializers.message_dto`,
+    so BOTH transports render a local session's tail through their normal code
+    with no special-casing. (ChatPage's transcript actually arrives over the WS
+    snapshot — patching only REST left the panel blank.)
+    """
+
+    pk: str
+    turn_index: int
+    role: str
+    plaintext: str
+    content: dict
+    created_at: object
+
+
+def tail_as_messages(session, binding) -> list[TailMessage]:
+    """A local runner session's reported tail, as Message-like rows.
 
     Local sessions hold NO `Message` rows until a backfill lands — the recent
     history lives on `RunnerBinding.tail` (what the retired OpenSessions used to
@@ -141,13 +161,11 @@ def tail_as_messages(session, binding) -> list[dict]:
         if role not in _BACKFILL_ROLES:
             role = Message.ASSISTANT
         text = m.get("text") or ""
-        rows.append({
-            "turn_index": i - n,
-            "role": role,
-            "plaintext": text,
-            "content": {"text": text},
-            "created_at": ts,
-        })
+        idx = i - n
+        rows.append(TailMessage(
+            pk=f"tail:{idx}", turn_index=idx, role=role,
+            plaintext=text, content={"text": text}, created_at=ts,
+        ))
     return rows
 
 

--- a/tests/test_chat_session_consumer.py
+++ b/tests/test_chat_session_consumer.py
@@ -9,6 +9,7 @@ import pytest
 from channels.db import database_sync_to_async
 from channels.testing import WebsocketCommunicator
 from django.contrib.auth.models import AnonymousUser, User
+from django.utils import timezone
 
 from apps.agents.models import Agent
 from apps.canopy_sessions import attach as attach_registry
@@ -244,4 +245,41 @@ async def test_heartbeat_renews_attach_count(monkeypatch):
     import asyncio
     await asyncio.sleep(0.05)
     assert str(session.id) in [str(s) for s in renewed]
+    await comm.disconnect()
+
+
+async def test_snapshot_falls_back_to_the_binding_tail():
+    """A local runner session has NO Message rows — the panel must still open populated.
+
+    Regression (prod): ChatPage's transcript comes from THIS snapshot, not from
+    getSession, so patching only the REST path left every runner-discovered
+    session rendering "Start the conversation" despite the binding holding a tail.
+    """
+    from apps.canopy_sessions.models import RunnerBinding
+    from apps.harness.models import Runner
+
+    owner, _t, session = await database_sync_to_async(_seed)()
+
+    @database_sync_to_async
+    def _bind():
+        ws = session.workspace
+        r = Runner.objects.create(
+            name="jj-mbp", workspace=ws, location=Runner.LOCAL, paired_by=owner,
+            host="jj@mbp", status=Runner.ONLINE, last_heartbeat_at=timezone.now(),
+        )
+        RunnerBinding.objects.create(
+            session=session, runner=r, session_key="ace-demo", thread_key="emdash:ace-demo",
+            host=r.host, last_interacted_at=timezone.now(),
+            tail=[{"role": "user", "text": "q1"}, {"role": "assistant", "text": "a1"}],
+        )
+
+    await _bind()
+    comm = await _connect(session, owner)
+    connected, _ = await comm.connect()
+    assert connected is True
+    snap = await _recv_match(comm, lambda f: f.get("event") == "session.state")
+    msgs = snap["data"]["messages"]
+    assert [m["plaintext"] for m in msgs] == ["q1", "a1"]
+    assert [m["turn_index"] for m in msgs] == [-2, -1]   # never collides with real rows
+    assert [m["id"] for m in msgs] == ["tail:-2", "tail:-1"]
     await comm.disconnect()


### PR DESCRIPTION
Follow-up to #362, caught by re-checking prod in a browser.

#362 made the REST detail endpoint fall back to `RunnerBinding.tail` for a local session with no `Message` rows — and the API genuinely returned 8 messages. But the panel was **still blank**, because **`ChatPage`'s transcript comes from the `session.state` WebSocket snapshot**, not from `getSession` (which only supplies `meta.title`). I'd fixed a path the panel doesn't read for messages.

## Fix

`SessionConsumer._snapshot` now falls back to the same tail. To avoid two shapes, the synthesized row is a `TailMessage` dataclass that **quacks like a `Message`**, so:
- REST serializes it with `MessageOut.from_orm`, and
- the WS serializes it with `serializers.message_dto`,

both through their normal code with zero special-casing. Negative `turn_index` (`-n..-1`) still guarantees it can't collide with a backfill (`0..n`) or a live stream's `seq:` ids.

## Verification

Backend **1085 passed** — including a new WS test asserting the `session.state` snapshot carries the tail (`plaintext` `["q1","a1"]`, `turn_index` `[-2,-1]`, `id` `["tail:-2","tail:-1"]`) for a bound session with no Message rows. vitest 229, ruff clean, no migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)