### PR TITLE
refactor(sessions): one transcript policy for REST and the WebSocket (+ parity guard)

### DIFF
--- a/apps/canopy_sessions/api.py
+++ b/apps/canopy_sessions/api.py
@@ -129,20 +129,8 @@ def get_session(request: HttpRequest, session_id: uuid.UUID, full: bool = False)
     # explicit escape hatch. Scroll-back pages via GET /{id}/messages?before=.
     session = _session_or_404(request, session_id)
     data = _out(session)
-    if full:
-        rows, has_more, oldest = services.all_messages(session)
-    else:
-        rows, has_more, oldest = services.tail_messages(session)
+    rows, has_more, oldest = services.visible_transcript(session, full=full)
     data["messages"] = [MessageOut.from_orm(m) for m in rows]
-    if not data["messages"]:
-        # A local runner session holds NO Message rows until a backfill lands, but
-        # the runner reports a rolling tail we already store on the binding. Render
-        # it so the panel opens with recent context instead of blank; "Load full
-        # session" still pulls the real history, and a live stream layers on top.
-        binding = getattr(session, "runner_binding", None)
-        data["messages"] = [
-            MessageOut.from_orm(m) for m in services.tail_as_messages(session, binding)
-        ]
     data["has_more_before"] = has_more
     data["oldest_loaded_turn_index"] = oldest
     return data

--- a/apps/canopy_sessions/consumers.py
+++ b/apps/canopy_sessions/consumers.py
@@ -251,15 +251,10 @@ class SessionConsumer(AsyncJsonWebsocketConsumer):
         # SESSION_TAIL_DEFAULT the REST load uses), never the head. Scroll-back
         # for earlier history is REST (GET /{id}/messages?before=); Plan 4 wires
         # it into the panel. The session.state frame shape is otherwise frozen.
-        messages, _has_more, _oldest = chat_services.tail_messages(self.session)
-        if not messages:
-            # A local runner session has NO Message rows until a backfill lands, but
-            # the binding carries a rolling tail. ChatPage's transcript comes from THIS
-            # snapshot (getSession only supplies meta.title), so without this the panel
-            # opened blank on every discovered session. TailMessage quacks like a
-            # Message row, so message_dto below needs no special-casing.
-            binding = getattr(self.session, "runner_binding", None)
-            messages = chat_services.tail_as_messages(self.session, binding)
+        # ONE policy for both transports (services.visible_transcript): tail-first,
+        # falling back to the binding tail for a local session with no Message rows.
+        # REST and this snapshot MUST agree — see tests/test_transcript_parity.py.
+        messages, _has_more, _oldest = chat_services.visible_transcript(self.session)
         return {
             "event": "session.state",
             "data": serializers.session_state_dto(

--- a/apps/canopy_sessions/services.py
+++ b/apps/canopy_sessions/services.py
@@ -169,6 +169,27 @@ def tail_as_messages(session, binding) -> list[TailMessage]:
     return rows
 
 
+def visible_transcript(session, *, full: bool = False):
+    """THE answer to "what transcript rows should a client see?" — used by every
+    transport, so REST and the WebSocket can never disagree.
+
+    Both transports previously reimplemented this. When the binding-tail fallback
+    was added to the REST detail endpoint only, `GET` correctly returned 8 rows
+    while the panel — which reads the `session.state` WS snapshot — stayed blank.
+    The shared SESSION_TAIL_DEFAULT constant wasn't enough: the POLICY has to be
+    shared too. `tests/test_transcript_parity.py` asserts the two agree.
+
+    Returns (rows, has_more_before, oldest_loaded_turn_index). Rows are `Message`
+    instances or `TailMessage`s, which serialize identically on both paths.
+    """
+    rows, has_more, oldest = (all_messages if full else tail_messages)(session)
+    if not rows:
+        # No server-side rows yet (a local runner session before backfill) — show
+        # the binding's rolling tail rather than an empty panel.
+        rows = tail_as_messages(session, getattr(session, "runner_binding", None))
+    return rows, has_more, oldest
+
+
 def request_backfill(session) -> str:
     """The client asked for full history. 'ready' if already server-full; 'requested'
     if a live runner is bound (signal it); 'unavailable' otherwise (tail still shows)."""

--- a/tests/test_transcript_parity.py
+++ b/tests/test_transcript_parity.py
@@ -1,0 +1,99 @@
+"""REST and the WebSocket must show the SAME transcript.
+
+The panel reads the `session.state` WS snapshot; `getSession` serves the REST
+detail. When the binding-tail fallback was added to REST only, `GET` returned 8
+rows while the panel rendered "Start the conversation" — a silent divergence
+that every unit test passed through, because each transport was tested against
+itself.
+
+Both now go through `services.visible_transcript`. These tests are the guard:
+they compare the two transports' OUTPUT for the same session, so re-introducing
+a transport-specific code path fails here rather than on prod.
+"""
+import pytest
+from channels.db import database_sync_to_async
+from channels.testing import WebsocketCommunicator
+from django.contrib.auth.models import User
+from django.test import Client
+from django.utils import timezone
+
+from apps.agents.models import Agent
+from apps.canopy_sessions import services as chat
+from apps.canopy_sessions.consumers import SessionConsumer
+from apps.canopy_sessions.models import Message, RunnerBinding
+from apps.harness.models import Runner
+from apps.workspaces.models import Workspace, WorkspaceMembership
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+
+def _seed(*, with_tail: bool, with_rows: bool):
+    owner = User.objects.create_user("jj", "jj@dimagi.com", "pw")
+    ws = Workspace.objects.create(slug="canopy", display_name="Canopy", created_by=owner)
+    WorkspaceMembership.objects.create(user=owner, workspace=ws, role=WorkspaceMembership.OWNER)
+    agent = Agent.objects.create(slug="echo", name="Echo", workspace=ws, owner=owner)
+    session = chat.create_session(workspace=ws, created_by=owner, agent=agent)
+    if with_rows:
+        for i, (role, text) in enumerate([(Message.USER, "real-q"), (Message.ASSISTANT, "real-a")]):
+            Message.objects.create(session=session, turn_index=i, role=role, plaintext=text)
+    if with_tail:
+        r = Runner.objects.create(
+            name="jj-mbp", workspace=ws, location=Runner.LOCAL, paired_by=owner,
+            host="jj@mbp", status=Runner.ONLINE, last_heartbeat_at=timezone.now(),
+        )
+        RunnerBinding.objects.create(
+            session=session, runner=r, session_key="ace-demo", thread_key="emdash:ace-demo",
+            host=r.host, last_interacted_at=timezone.now(),
+            tail=[{"role": "user", "text": "tail-q"}, {"role": "assistant", "text": "tail-a"}],
+        )
+    return owner, session
+
+
+async def _ws_messages(session, user):
+    comm = WebsocketCommunicator(SessionConsumer.as_asgi(), f"/ws/canopy-sessions/{session.id}/")
+    comm.scope["url_route"] = {"kwargs": {"session_id": str(session.id)}}
+    comm.scope["user"] = user
+    connected, _ = await comm.connect()
+    assert connected is True
+    for _ in range(14):
+        frame = await comm.receive_json_from(timeout=5)
+        if frame.get("event") == "session.state":
+            await comm.disconnect()
+            return frame["data"]["messages"]
+    await comm.disconnect()
+    raise AssertionError("no session.state frame")
+
+
+def _rest_messages(owner, session):
+    c = Client(); c.force_login(owner)
+    return c.get(f"/api/canopy-sessions/{session.id}").json()["messages"]
+
+
+def _key(rows):
+    return [(m["turn_index"], m["plaintext"]) for m in rows]
+
+
+@pytest.mark.asyncio
+async def test_parity_when_only_the_binding_tail_exists():
+    """The exact prod divergence: REST served the tail, the WS snapshot did not."""
+    owner, session = await database_sync_to_async(_seed)(with_tail=True, with_rows=False)
+    ws_rows = await _ws_messages(session, owner)
+    rest_rows = await database_sync_to_async(_rest_messages)(owner, session)
+    assert _key(ws_rows) == _key(rest_rows) == [(-2, "tail-q"), (-1, "tail-a")]
+
+
+@pytest.mark.asyncio
+async def test_parity_when_real_rows_exist():
+    """Real rows win on BOTH transports — the tail must not leak in alongside."""
+    owner, session = await database_sync_to_async(_seed)(with_tail=True, with_rows=True)
+    ws_rows = await _ws_messages(session, owner)
+    rest_rows = await database_sync_to_async(_rest_messages)(owner, session)
+    assert _key(ws_rows) == _key(rest_rows) == [(0, "real-q"), (1, "real-a")]
+
+
+@pytest.mark.asyncio
+async def test_parity_for_a_plain_web_session():
+    owner, session = await database_sync_to_async(_seed)(with_tail=False, with_rows=True)
+    ws_rows = await _ws_messages(session, owner)
+    rest_rows = await database_sync_to_async(_rest_messages)(owner, session)
+    assert _key(ws_rows) == _key(rest_rows) == [(0, "real-q"), (1, "real-a")]


### PR DESCRIPTION
Addresses a fair criticism of #362/#363: fixing the binding-tail fallback required touching **two** places, and I demonstrated the hazard by fixing one and shipping the other broken.

## The problem

REST (`get_session`) and the WebSocket (`SessionConsumer._snapshot`) each independently answered *"what transcript rows should a client see?"*. When the tail fallback landed on REST only, `GET` correctly returned 8 rows while the panel — which reads the `session.state` snapshot, not `getSession` — rendered "Start the conversation".

Notably the codebase already had the instinct: Plan 2 made `SESSION_TAIL_DEFAULT` a shared constant *"so the two can't drift"*. It shared the **constant** but not the **policy**.

## The fix

`services.visible_transcript(session, *, full=False)` is now the single source of truth (tail-first → `?full` → binding-tail fallback), called by both transports. Net **-9 lines** of duplicated policy.

## The control

`tests/test_transcript_parity.py` compares the two transports' **output for the same session** — rather than testing each against itself, which is exactly why the divergence slipped through. Three cases: tail-only, real-rows-win, plain web session.

**Verified it actually bites:** reintroducing the old WS-only-`Message`-rows path fails the tail-parity case; restoring passes.

```
with divergence reintroduced → 1 failed, 2 passed
restored                     → 3 passed
```

## Verification

Backend **1088 passed**, vitest 229, ruff clean, no migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)