### PR TITLE
feat(harness): warn about queued turns no online runner can claim

### DIFF
--- a/apps/harness/api.py
+++ b/apps/harness/api.py
@@ -23,6 +23,7 @@ from .schemas import (
     BackfillSyncOut,
     BackfillWriteOut,
     EmdashSessionOut,
+    UnclaimableTurnOut,
     HeartbeatIn,
     RecordSessionIn,
     ReportSessionsIn,
@@ -444,6 +445,14 @@ def post_session_backfill(request: HttpRequest, runner_id: uuid.UUID, payload: S
     binding.backfill_requested = False
     binding.save(update_fields=["backfill_requested", "updated_at"])
     return {"written": written}
+
+
+@router.get("/turns/unclaimable", response=list[UnclaimableTurnOut],
+            summary="Queued turns no online runner can claim")
+def list_unclaimable_turns(request: HttpRequest):
+    """A queued turn addressed to an agent/repo nothing declares sits forever with
+    no signal (one sat 12h). Surfacing it turns a silent stall into a warning."""
+    return services.unclaimable_queued_turns(request.user)
 
 
 @router.post("/turns/", response={200: TurnOut, 201: TurnOut})

--- a/apps/harness/schemas.py
+++ b/apps/harness/schemas.py
@@ -27,6 +27,15 @@ class RunnerIn(Schema):
     workspace: str = ""  # tenant slug; defaults to the pairer's default workspace
 
 
+class UnclaimableTurnOut(Schema):
+    """A queued turn no online runner can claim — surfaced so a stall is loud."""
+    turn_id: str
+    target: str
+    prompt: str
+    created_at: dt.datetime
+    reason: str
+
+
 class RunnerCapabilitiesIn(Schema):
     # Wholesale replacement, like the skill catalog — the caller sends the full
     # capabilities it wants (e.g. {"agents": [...], "projects": ["canopy-web"]}).

--- a/apps/harness/services.py
+++ b/apps/harness/services.py
@@ -168,6 +168,75 @@ def _preference_allows(runner: Runner, turn: Turn, now) -> bool:
 EXECUTING = [Turn.CLAIMED, Turn.RUNNING, Turn.NEEDS_HUMAN]
 
 
+def runner_target_q(slugs, projects, session_capable) -> Q:
+    """Which queued turns a runner's declared capabilities can TARGET.
+
+    Shared by claim_next_turn and unclaimable_queued_turns so the "can anyone run
+    this?" warning can never disagree with what claiming actually does — the same
+    class of drift that made REST and the WebSocket show different transcripts.
+    """
+    q = Q(agent__slug__in=slugs) | Q(project__in=projects)
+    if session_capable:
+        # A chat send targets no specific agent/repo — any session-capable runner
+        # in the tenant may take it (this is why continuing on your phone works
+        # regardless of the runner's declared `projects`).
+        q = q | Q(chat_session__isnull=False)
+    return q
+
+
+def unclaimable_queued_turns(user) -> list[dict]:
+    """Queued turns that NO online runner can claim — otherwise a silent stall.
+
+    enqueue_turn happily accepts a turn addressed to an agent/repo nothing
+    declares, and it then sits QUEUED forever with no signal (observed: a
+    project=ace turn sat 12h because every runner declared only canopy-web).
+    Returns [{turn_id, target, prompt, created_at, reason}] for the UI to surface.
+    """
+    ws_slugs = wsvc.user_workspace_slugs(user)
+    if not ws_slugs:
+        return []
+    queued = list(
+        Turn.objects.filter(status=Turn.QUEUED)
+        .filter(
+            (Q(agent__isnull=False) & (Q(agent__workspace_id__in=ws_slugs) | Q(agent__workspace_id__isnull=True)))
+            | (Q(agent__isnull=True) & Q(chat_session__isnull=True) & Q(workspace_id__in=ws_slugs))
+            | (Q(chat_session__isnull=False) & Q(chat_session__workspace_id__in=ws_slugs))
+        )
+        .select_related("agent")
+        .order_by("created_at")
+    )
+    if not queued:
+        return []
+    online = [
+        r for r in Runner.objects.filter(paired_by=user).exclude(status=Runner.RETIRED)
+        if r.live_status in (Runner.ONLINE, Runner.DEGRADED)
+    ]
+    ids = {t.id for t in queued}
+    claimable: set = set()
+    for r in online:
+        q = runner_target_q(r.agent_slugs(), r.project_names(), r.session_capable())
+        claimable |= set(
+            Turn.objects.filter(pk__in=ids).filter(q).values_list("pk", flat=True)
+        )
+    out = []
+    for t in queued:
+        if t.pk in claimable:
+            continue
+        if t.chat_session_id:
+            target, reason = "session", "no online runner is session-capable"
+        elif t.agent_id:
+            target = f"agent {t.agent.slug}"
+            reason = f"no online runner declares the agent '{t.agent.slug}'"
+        else:
+            target = f"project {t.project}"
+            reason = f"no online runner declares the repo '{t.project}'"
+        out.append({
+            "turn_id": str(t.pk), "target": target, "prompt": (t.prompt or "")[:120],
+            "created_at": t.created_at, "reason": reason,
+        })
+    return out
+
+
 def claim_next_turn(runner: Runner, *, lease_seconds: int = DEFAULT_LEASE_SECONDS,
                     exclude_slugs: list[str] | None = None) -> Turn | None:
     if runner.live_status != Runner.ONLINE:
@@ -263,9 +332,7 @@ def claim_next_turn(runner: Runner, *, lease_seconds: int = DEFAULT_LEASE_SECOND
     # Target match: this runner's declared agents/projects, plus every session
     # turn when it is session-capable (a chat send targets no specific agent — any
     # session-capable runner in the tenant may take it).
-    target_q = Q(agent__slug__in=slugs) | Q(project__in=projects)
-    if session_capable:
-        target_q = target_q | Q(chat_session__isnull=False)
+    target_q = runner_target_q(slugs, projects, session_capable)
     candidates = (
         Turn.objects.filter(status=Turn.QUEUED)
         .filter(target_q)

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -2008,6 +2008,27 @@ export interface paths {
         readonly patch?: never;
         readonly trace?: never;
     };
+    readonly "/api/harness/turns/unclaimable": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        /**
+         * Queued turns no online runner can claim
+         * @description A queued turn addressed to an agent/repo nothing declares sits forever with
+         *     no signal (one sat 12h). Surfacing it turns a silent stall into a warning.
+         */
+        readonly get: operations["apps_harness_api_list_unclaimable_turns"];
+        readonly put?: never;
+        readonly post?: never;
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
     readonly "/api/harness/turns/": {
         readonly parameters: {
             readonly query?: never;
@@ -6275,6 +6296,25 @@ export interface components {
              */
             readonly messages: readonly components["schemas"]["BackfillMessageIn"][];
         };
+        /**
+         * UnclaimableTurnOut
+         * @description A queued turn no online runner can claim — surfaced so a stall is loud.
+         */
+        readonly UnclaimableTurnOut: {
+            /** Turn Id */
+            readonly turn_id: string;
+            /** Target */
+            readonly target: string;
+            /** Prompt */
+            readonly prompt: string;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            readonly created_at: string;
+            /** Reason */
+            readonly reason: string;
+        };
         /** TurnIn */
         readonly TurnIn: {
             /**
@@ -9894,6 +9934,26 @@ export interface operations {
                 };
                 content: {
                     readonly "application/json": components["schemas"]["BackfillWriteOut"];
+                };
+            };
+        };
+    };
+    readonly apps_harness_api_list_unclaimable_turns: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description OK */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": readonly components["schemas"]["UnclaimableTurnOut"][];
                 };
             };
         };

--- a/frontend/src/api/harness.ts
+++ b/frontend/src/api/harness.ts
@@ -34,6 +34,15 @@ export async function listRunners(): Promise<RunnerOut[]> {
 // /api/w/{ws}/harness/turns/ (the server gates membership there). No hidden
 // default: the composer chooses the workspace (defaulting its VALUE to dimagi),
 // so repo→workspace ownership stays explicit and survives into cloud/multiplayer.
+export type UnclaimableTurn = components['schemas']['UnclaimableTurnOut']
+
+/** Queued turns no online runner can claim — a silent stall unless surfaced. */
+export async function listUnclaimableTurns(): Promise<UnclaimableTurn[]> {
+  const res = await apiV2.GET('/api/harness/turns/unclaimable')
+  // Array.from for the same Readable<T> reason as listRunners above.
+  return Array.from(unwrap(res, 'listUnclaimableTurns'))
+}
+
 export async function enqueueTurn(input: {
   agentSlug?: string
   project?: string

--- a/frontend/src/pages/SupervisorPage.tsx
+++ b/frontend/src/pages/SupervisorPage.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState, type JSX } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { listAgents, type AgentOut } from '@/api/agents'
 import { listOpenItems, type ItemOut } from '@/api/items'
-import { listRunners, type RunnerOut } from '@/api/harness'
+import { listRunners, listUnclaimableTurns, type RunnerOut, type UnclaimableTurn } from '@/api/harness'
 import { useLiveSupervisor } from '@/hooks/useLiveSupervisor'
 import { RunnerStatus } from '@/components/supervisor/RunnerStatus'
 import { RunnerDetail } from '@/components/supervisor/RunnerDetail'
@@ -74,6 +74,20 @@ export default function SupervisorPage(): JSX.Element {
     }
   }, [])
 
+  // Queued turns nothing online can claim — polled with the runners, since
+  // declaring a repo on a runner is what clears them.
+  const [stuck, setStuck] = useState<UnclaimableTurn[]>([])
+  useEffect(() => {
+    let cancelled = false
+    const load = () =>
+      listUnclaimableTurns()
+        .then((t) => { if (!cancelled) setStuck(t) })
+        .catch(() => { /* non-fatal: the banner is a warning, not a gate */ })
+    load()
+    const id = window.setInterval(load, 30_000)
+    return () => { cancelled = true; window.clearInterval(id) }
+  }, [])
+
   // Re-poll runners so the wrong-branch alert (below) appears/clears without a reload
   // — code_branch rides the REST runner, not the live socket overlay.
   useEffect(() => {
@@ -130,6 +144,32 @@ export default function SupervisorPage(): JSX.Element {
         <h1 className="text-lg font-semibold text-foreground">Supervisor</h1>
         <p className="mt-0.5 text-[12px] text-muted-foreground">Your fleet, and what it needs from you.</p>
       </header>
+
+      {/* LOUD alert: a queued turn addressed to an agent/repo NOTHING online declares
+          sits forever with no signal (one sat 12h). Make the stall visible. */}
+      {stuck.length > 0 && (
+        <div
+          role="alert"
+          data-testid="unclaimable-turns-alert"
+          className="rounded-lg border-2 border-warning bg-warning/15 p-3 text-warning"
+        >
+          <p className="text-[13px] font-bold uppercase tracking-wide">
+            ⚠ {stuck.length} queued turn{stuck.length === 1 ? '' : 's'} no runner can claim
+          </p>
+          <ul className="mt-1 space-y-1">
+            {stuck.slice(0, 5).map((t) => (
+              <li key={t.turn_id} className="text-[13px] leading-snug">
+                <span className="rounded bg-warning/20 px-1 font-mono font-semibold">{t.target}</span>{' '}
+                {t.prompt ? <span className="opacity-90">“{t.prompt}”</span> : null}
+                <span className="block text-[12px] opacity-90">{t.reason}</span>
+              </li>
+            ))}
+          </ul>
+          <p className="mt-1.5 text-[12px] leading-snug opacity-90">
+            Declare it on a runner (Runners tab) or cancel the turn — it will not run otherwise.
+          </p>
+        </div>
+      )}
 
       {/* LOUD alert: a runner on any branch but main is silently running stale/wrong
           code (usually another process checked out a branch in its shared checkout). */}

--- a/tests/test_unclaimable_turns.py
+++ b/tests/test_unclaimable_turns.py
@@ -1,0 +1,99 @@
+"""A queued turn nothing can claim must be LOUD, not silent.
+
+Observed: a `project=ace` turn sat QUEUED for 12 hours because every online
+runner declared `projects: ['canopy-web']`. `enqueue_turn` accepted it happily
+and nothing ever said the turn was unrunnable.
+
+The detector shares `runner_target_q` with `claim_next_turn`, so "can anyone run
+this?" cannot disagree with what claiming actually does.
+"""
+import pytest
+from django.contrib.auth.models import User
+from django.utils import timezone
+
+from apps.agents.models import Agent
+from apps.harness import services
+from apps.harness.models import Runner, Turn
+from apps.workspaces.models import Workspace, WorkspaceMembership
+
+pytestmark = pytest.mark.django_db
+
+
+def _ctx(*, agents=(), projects=(), sessions=False, online=True):
+    user = User.objects.create_user("jj", "jj@dimagi.com", "pw")
+    ws = Workspace.objects.create(slug="w1", display_name="W1", created_by=user)
+    WorkspaceMembership.objects.create(user=user, workspace=ws, role=WorkspaceMembership.OWNER)
+    Runner.objects.create(
+        name="jj-mbp", workspace=ws, location=Runner.LOCAL, paired_by=user, host="jj@mbp",
+        status=Runner.ONLINE if online else Runner.DISCONNECTED,
+        last_heartbeat_at=timezone.now() if online else None,
+        capabilities={"agents": list(agents), "projects": list(projects), "sessions": sessions},
+    )
+    return user, ws
+
+
+def _project_turn(ws, project, key="k1"):
+    return services.enqueue_turn(
+        project=project, workspace=ws, origin=Turn.ORIGIN_API,
+        idempotency_key=key, prompt="Go",
+    )[0]
+
+
+def test_flags_a_project_turn_no_runner_declares():
+    """The exact 12-hour stall."""
+    user, ws = _ctx(agents=["ace"], projects=["canopy-web"])
+    _project_turn(ws, "ace")
+    rows = services.unclaimable_queued_turns(user)
+    assert len(rows) == 1
+    assert rows[0]["target"] == "project ace"
+    assert "declares the repo 'ace'" in rows[0]["reason"]
+    assert rows[0]["prompt"] == "Go"
+
+
+def test_silent_when_the_runner_declares_the_repo():
+    user, ws = _ctx(agents=["ace"], projects=["canopy-web", "ace"])
+    _project_turn(ws, "ace")
+    assert services.unclaimable_queued_turns(user) == []
+
+
+def test_flags_an_agent_turn_no_runner_declares():
+    user, ws = _ctx(agents=["ace"], projects=["canopy-web"])
+    other = Agent.objects.create(slug="ghost", name="Ghost", workspace=ws)
+    services.enqueue_turn(agent=other, origin=Turn.ORIGIN_API, idempotency_key="k2", prompt="hi")
+    rows = services.unclaimable_queued_turns(user)
+    assert [r["target"] for r in rows] == ["agent ghost"]
+
+
+def test_an_offline_runner_does_not_count_as_coverage():
+    """A declared-but-dead runner must not mask the stall."""
+    user, ws = _ctx(agents=["ace"], projects=["ace"], online=False)
+    _project_turn(ws, "ace")
+    rows = services.unclaimable_queued_turns(user)
+    assert [r["target"] for r in rows] == ["project ace"]
+
+
+def test_a_degraded_runner_does_count():
+    """DEGRADED = CDP down, still polling and still able to claim once CDP returns."""
+    user, ws = _ctx(agents=["ace"], projects=["ace"])
+    Runner.objects.update(status=Runner.DEGRADED)
+    _project_turn(ws, "ace")
+    assert services.unclaimable_queued_turns(user) == []
+
+
+def test_session_turns_need_a_session_capable_runner():
+    from apps.canopy_sessions.models import Session
+    user, ws = _ctx(agents=["ace"], projects=["canopy-web"], sessions=False)
+    s = Session.objects.create(workspace=ws, created_by=user, title="chat")
+    services.enqueue_turn(session=s, origin=Turn.ORIGIN_API, idempotency_key="k3", prompt="hi")
+    assert [r["target"] for r in services.unclaimable_queued_turns(user)] == ["session"]
+
+    Runner.objects.update(capabilities={"agents": [], "projects": [], "sessions": True})
+    assert services.unclaimable_queued_turns(user) == []
+
+
+def test_endpoint_returns_the_rows(client):
+    user, ws = _ctx(agents=["ace"], projects=["canopy-web"])
+    _project_turn(ws, "ace")
+    client.force_login(user)
+    body = client.get("/api/harness/turns/unclaimable").json()
+    assert [r["target"] for r in body] == ["project ace"]


### PR DESCRIPTION
## The problem

`enqueue_turn` accepts a turn addressed to an agent/repo that **nothing declares**, and it then sits `QUEUED` **forever with no signal**. A `project=ace` turn sat 12 hours because every runner declared `projects: ['canopy-web']` — `ace` was in the runner's *agents* list but not its *projects* list.

The silence is the actual defect. `CLAUDE.md` already records the same failure shape from a past outage ("4 of 5 agents' turns sat QUEUED forever") — the lesson was never generalised into a guard.

## The fix

- **`runner_target_q(slugs, projects, session_capable)`** extracted so `claim_next_turn` and the new detector share **one** definition of what a runner can target. Reimplementing the match would recreate exactly the REST/WebSocket drift class fixed in #364.
- **`unclaimable_queued_turns(user)`** returns each stuck turn's target + a plain-English reason ("no online runner declares the repo 'ace'").
- **`GET /api/harness/turns/unclaimable`** serves it; `/supervisor` renders a warning banner next to the existing wrong-branch alert.

A **DEGRADED** runner counts as coverage (CDP down still polls, and claims the moment CDP returns); an **offline** one does not, so a dead-but-declared runner can't mask a stall.

## Verification

Backend **1098 passed** — 7 new tests: the exact 12-hour `project=ace` case, silence once the repo is declared, an undeclared agent, offline-doesn't-count, degraded-does-count, session turns needing a session-capable runner, and the endpoint. vitest 229, ruff clean, no migrations, `generated.ts` regenerated.

## Related

Separately (no code change) I refreshed `jj-mbp-cdp`'s capabilities from `projects: ['canopy-web']` to the **10 repos it actually drives** (derived from its own reported sessions), via the existing owner-gated `PATCH /runners/{id}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)