### PR TITLE
fix(harness): the unclaimable warning cried wolf on healthy traffic

### DIFF
--- a/apps/harness/schemas.py
+++ b/apps/harness/schemas.py
@@ -34,6 +34,9 @@ class UnclaimableTurnOut(Schema):
     prompt: str
     created_at: dt.datetime
     reason: str
+    # "config" = nothing declares this target (needs a fix); "offline" = something
+    # does, but no runner is reachable right now (usually transient).
+    kind: str = "config"
 
 
 class RunnerCapabilitiesIn(Schema):

--- a/apps/harness/services.py
+++ b/apps/harness/services.py
@@ -184,19 +184,33 @@ def runner_target_q(slugs, projects, session_capable) -> Q:
     return q
 
 
-def unclaimable_queued_turns(user) -> list[dict]:
-    """Queued turns that NO online runner can claim — otherwise a silent stall.
+# A turn is not "stuck" the instant it is enqueued — it is queued for a few seconds
+# on every normal send while a runner polls (5s) or the WS wake fires. And a runner
+# whose heartbeat lapses (>90s) reads STALE, so a flaky laptop network briefly looks
+# like "no runners at all". Both made the warning fire on healthy traffic: a phone
+# chat send was flagged during a DNS blip, then claimed and answered seconds later.
+# Wait longer than a heartbeat window + a claim poll before calling anything stuck.
+UNCLAIMABLE_GRACE = dt.timedelta(seconds=150)
 
-    enqueue_turn happily accepts a turn addressed to an agent/repo nothing
-    declares, and it then sits QUEUED forever with no signal (observed: a
-    project=ace turn sat 12h because every runner declared only canopy-web).
-    Returns [{turn_id, target, prompt, created_at, reason}] for the UI to surface.
+
+def unclaimable_queued_turns(user) -> list[dict]:
+    """Queued turns that look genuinely stuck — otherwise a silent stall.
+
+    enqueue_turn accepts a turn addressed to an agent/repo nothing declares, and it
+    then sits QUEUED forever with no signal (observed: a project=ace turn sat 12h).
+
+    Two DIFFERENT causes, reported differently because they need different actions:
+      * config    — no runner declares this target at all. It will never run.
+      * offline   — a runner does declare it, but none are reachable right now.
+                    Usually transient (network blip, deploy, laptop asleep).
+    Returns [{turn_id, target, prompt, created_at, reason, kind}].
     """
     ws_slugs = wsvc.user_workspace_slugs(user)
     if not ws_slugs:
         return []
+    cutoff = timezone.now() - UNCLAIMABLE_GRACE
     queued = list(
-        Turn.objects.filter(status=Turn.QUEUED)
+        Turn.objects.filter(status=Turn.QUEUED, created_at__lte=cutoff)
         .filter(
             (Q(agent__isnull=False) & (Q(agent__workspace_id__in=ws_slugs) | Q(agent__workspace_id__isnull=True)))
             | (Q(agent__isnull=True) & Q(chat_session__isnull=True) & Q(workspace_id__in=ws_slugs))
@@ -207,32 +221,42 @@ def unclaimable_queued_turns(user) -> list[dict]:
     )
     if not queued:
         return []
-    online = [
-        r for r in Runner.objects.filter(paired_by=user).exclude(status=Runner.RETIRED)
-        if r.live_status in (Runner.ONLINE, Runner.DEGRADED)
-    ]
+    runners = list(Runner.objects.filter(paired_by=user).exclude(status=Runner.RETIRED))
     ids = {t.id for t in queued}
-    claimable: set = set()
-    for r in online:
-        q = runner_target_q(r.agent_slugs(), r.project_names(), r.session_capable())
-        claimable |= set(
-            Turn.objects.filter(pk__in=ids).filter(q).values_list("pk", flat=True)
-        )
+
+    def _covered_by(rs) -> set:
+        out: set = set()
+        for r in rs:
+            q = runner_target_q(r.agent_slugs(), r.project_names(), r.session_capable())
+            out |= set(Turn.objects.filter(pk__in=ids).filter(q).values_list("pk", flat=True))
+        return out
+
+    reachable = [r for r in runners if r.live_status in (Runner.ONLINE, Runner.DEGRADED)]
+    claimable_now = _covered_by(reachable)
+    # Would ANY paired runner take it if it were up? Separates "misconfigured" from
+    # "temporarily unreachable" — the difference between "fix your capabilities" and
+    # "wait, or check the runner".
+    claimable_ever = _covered_by(runners)
+
     out = []
     for t in queued:
-        if t.pk in claimable:
+        if t.pk in claimable_now:
             continue
         if t.chat_session_id:
-            target, reason = "session", "no online runner is session-capable"
+            target, what = "session", "is session-capable"
         elif t.agent_id:
-            target = f"agent {t.agent.slug}"
-            reason = f"no online runner declares the agent '{t.agent.slug}'"
+            target, what = f"agent {t.agent.slug}", f"declares the agent '{t.agent.slug}'"
         else:
-            target = f"project {t.project}"
-            reason = f"no online runner declares the repo '{t.project}'"
+            target, what = f"project {t.project}", f"declares the repo '{t.project}'"
+        if t.pk in claimable_ever:
+            kind = "offline"
+            reason = f"a runner {what}, but none are reachable right now (offline or heartbeat lapsed)"
+        else:
+            kind = "config"
+            reason = f"no runner {what}"
         out.append({
             "turn_id": str(t.pk), "target": target, "prompt": (t.prompt or "")[:120],
-            "created_at": t.created_at, "reason": reason,
+            "created_at": t.created_at, "reason": reason, "kind": kind,
         })
     return out
 

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -6314,6 +6314,11 @@ export interface components {
             readonly created_at: string;
             /** Reason */
             readonly reason: string;
+            /**
+             * Kind
+             * @default config
+             */
+            readonly kind: string;
         };
         /** TurnIn */
         readonly TurnIn: {

--- a/frontend/src/pages/SupervisorPage.tsx
+++ b/frontend/src/pages/SupervisorPage.tsx
@@ -154,7 +154,9 @@ export default function SupervisorPage(): JSX.Element {
           className="rounded-lg border-2 border-warning bg-warning/15 p-3 text-warning"
         >
           <p className="text-[13px] font-bold uppercase tracking-wide">
-            ⚠ {stuck.length} queued turn{stuck.length === 1 ? '' : 's'} no runner can claim
+            {stuck.every((t) => t.kind === 'offline')
+              ? `⚠ ${stuck.length} queued turn${stuck.length === 1 ? '' : 's'} waiting on an unreachable runner`
+              : `⚠ ${stuck.length} queued turn${stuck.length === 1 ? '' : 's'} no runner can claim`}
           </p>
           <ul className="mt-1 space-y-1">
             {stuck.slice(0, 5).map((t) => (
@@ -166,7 +168,9 @@ export default function SupervisorPage(): JSX.Element {
             ))}
           </ul>
           <p className="mt-1.5 text-[12px] leading-snug opacity-90">
-            Declare it on a runner (Runners tab) or cancel the turn — it will not run otherwise.
+            {stuck.every((t) => t.kind === 'offline')
+              ? 'These will run as soon as a runner reconnects — no action needed unless it stays.'
+              : 'Declare it on a runner (Runners tab) or cancel the turn — it will not run otherwise.'}
           </p>
         </div>
       )}

--- a/tests/test_unclaimable_turns.py
+++ b/tests/test_unclaimable_turns.py
@@ -7,6 +7,8 @@ and nothing ever said the turn was unrunnable.
 The detector shares `runner_target_q` with `claim_next_turn`, so "can anyone run
 this?" cannot disagree with what claiming actually does.
 """
+import datetime as dt
+
 import pytest
 from django.contrib.auth.models import User
 from django.utils import timezone
@@ -32,11 +34,21 @@ def _ctx(*, agents=(), projects=(), sessions=False, online=True):
     return user, ws
 
 
-def _project_turn(ws, project, key="k1"):
-    return services.enqueue_turn(
+def _project_turn(ws, project, key="k1", *, aged=True):
+    t = services.enqueue_turn(
         project=project, workspace=ws, origin=Turn.ORIGIN_API,
         idempotency_key=key, prompt="Go",
     )[0]
+    if aged:
+        _age(t)
+    return t
+
+
+def _age(turn):
+    """Push a turn past UNCLAIMABLE_GRACE — a just-enqueued turn is NOT stuck."""
+    Turn.objects.filter(pk=turn.pk).update(
+        created_at=timezone.now() - services.UNCLAIMABLE_GRACE - dt.timedelta(seconds=5)
+    )
 
 
 def test_flags_a_project_turn_no_runner_declares():
@@ -59,7 +71,7 @@ def test_silent_when_the_runner_declares_the_repo():
 def test_flags_an_agent_turn_no_runner_declares():
     user, ws = _ctx(agents=["ace"], projects=["canopy-web"])
     other = Agent.objects.create(slug="ghost", name="Ghost", workspace=ws)
-    services.enqueue_turn(agent=other, origin=Turn.ORIGIN_API, idempotency_key="k2", prompt="hi")
+    _age(services.enqueue_turn(agent=other, origin=Turn.ORIGIN_API, idempotency_key="k2", prompt="hi")[0])
     rows = services.unclaimable_queued_turns(user)
     assert [r["target"] for r in rows] == ["agent ghost"]
 
@@ -84,7 +96,7 @@ def test_session_turns_need_a_session_capable_runner():
     from apps.canopy_sessions.models import Session
     user, ws = _ctx(agents=["ace"], projects=["canopy-web"], sessions=False)
     s = Session.objects.create(workspace=ws, created_by=user, title="chat")
-    services.enqueue_turn(session=s, origin=Turn.ORIGIN_API, idempotency_key="k3", prompt="hi")
+    _age(services.enqueue_turn(session=s, origin=Turn.ORIGIN_API, idempotency_key="k3", prompt="hi")[0])
     assert [r["target"] for r in services.unclaimable_queued_turns(user)] == ["session"]
 
     Runner.objects.update(capabilities={"agents": [], "projects": [], "sessions": True})
@@ -97,3 +109,36 @@ def test_endpoint_returns_the_rows(client):
     client.force_login(user)
     body = client.get("/api/harness/turns/unclaimable").json()
     assert [r["target"] for r in body] == ["project ace"]
+
+
+# --- false positives that fired on healthy traffic ------------------------
+
+def test_a_just_enqueued_turn_is_not_stuck():
+    """Every normal send is queued for a few seconds while a runner polls.
+
+    Regression: a phone chat send was flagged instantly, then claimed and answered
+    seconds later — the banner cried wolf on healthy traffic.
+    """
+    user, ws = _ctx(agents=["ace"], projects=["canopy-web"])
+    _project_turn(ws, "ace", aged=False)
+    assert services.unclaimable_queued_turns(user) == []
+
+
+def test_a_stale_heartbeat_reports_OFFLINE_not_misconfiguration():
+    """A flaky laptop network (555 DNS failures in 3h) lapses the heartbeat, so the
+    runner reads STALE. That is transient — it must not look like a config error."""
+    user, ws = _ctx(agents=["ace"], projects=["ace"])          # runner DOES declare it
+    Runner.objects.update(last_heartbeat_at=timezone.now() - dt.timedelta(minutes=10))
+    _project_turn(ws, "ace")
+    rows = services.unclaimable_queued_turns(user)
+    assert len(rows) == 1
+    assert rows[0]["kind"] == "offline"
+    assert "none are reachable" in rows[0]["reason"]
+
+
+def test_a_genuinely_undeclared_target_still_reports_CONFIG():
+    user, ws = _ctx(agents=["ace"], projects=["canopy-web"])
+    _project_turn(ws, "ace")
+    rows = services.unclaimable_queued_turns(user)
+    assert rows[0]["kind"] == "config"
+    assert rows[0]["reason"] == "no runner declares the repo 'ace'"


### PR DESCRIPTION
Your phone sent a chat message and the banner immediately claimed no runner could take it. **The turn was fine** — the runner log shows it claimed and answered seconds later:

```
20:07:56  chat turn=36fcf695… reused emdash task=supervisor (agent=canopy-web)
20:08:33  chat turn=36fcf695… bridged 70 chars from task=supervisor
```

Two defects in the warning I shipped an hour earlier:

## 1. No grace period
Every normal send sits `QUEUED` for a few seconds while a runner polls (5s) or the WS wake fires. Flagging a 2-second-old turn means the alarm fires on **healthy traffic**.

Now only turns older than `UNCLAIMABLE_GRACE` (**150s** — comfortably past the 90s heartbeat window plus a claim poll) count as stuck.

## 2. Conflated two very different causes
The laptop logged **555 DNS resolution failures in 3 hours** (plus 3× 502 from my own rolling deploys), so heartbeats lapsed and the runner read `STALE`. The detector reported that as *"no runner declares this"* — a configuration error demanding action — when it was a transient blip that self-heals.

Now split:
- **`kind: "config"`** — nothing declares this target. It will never run; go fix capabilities.
- **`kind: "offline"`** — something *does* declare it, but nothing is reachable right now. Usually transient.

The banner's headline and advice follow the kind ("waiting on an unreachable runner … will run as soon as a runner reconnects" vs "no runner can claim … declare it or cancel").

## Verification

Backend **1101 passed** — 3 new regressions: a just-enqueued turn is not stuck; a stale heartbeat reports `offline` not misconfiguration; a genuinely undeclared target still reports `config`. Two pre-existing tests now age their turns past the grace window, which is itself the fix working. vitest 229, ruff clean, `generated.ts` regenerated.

## Not fixed here (worth your attention)

The **555 DNS failures** are a real laptop-network problem, not a canopy bug — the runner's heartbeats and WS keep dropping (5 reconnects in 3h). Worth looking at separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)