### PR TITLE
fix(runner): resume a session stream on re-attach instead of skipping what you missed

### DIFF
--- a/packages/canopy_runner/canopy_runner/main.py
+++ b/packages/canopy_runner/canopy_runner/main.py
@@ -256,6 +256,16 @@ def _maybe_report_sessions(cfg: Config, client: Client, now_fn=time.monotonic) -
         logger.debug("session report failed (non-fatal)", exc_info=True)
 
 
+# Survives a tailer being dropped when you stop watching a session. Without it a
+# re-attach called seek_end() and silently skipped EVERYTHING written while you
+# weren't looking (a phone that closed the chat missed every message until it
+# re-opened), and `seq` restarted at 0 so fresh events reused old message ids and
+# the client deduped them away. Keyed by session id: {"offset": int, "seq": int}.
+# In-memory only — a runner RESTART still resets to seek_end(); the durable
+# recovery for that is "Load full session" (backfill).
+_stream_state: dict[str, dict] = {}
+
+
 def _sync_session_streams(cfg: Config, client: Client) -> None:
     """Tail each session a viewer is watching and post new assistant text up as live
     events. Change-driven off TailReader (only newly-appended bytes), so it stays
@@ -275,17 +285,26 @@ def _sync_session_streams(cfg: Config, client: Client) -> None:
         path = transcript.resolve_transcript(
             s.get("project") or "", s.get("session_key") or "", home=home, claude_home=claude_home
         )
+        remembered = _stream_state.get(sid)
         reader = TailReader(str(path)) if path else None
         if reader is not None:
-            reader.seek_end()  # stream only NEW activity; history is loaded elsewhere
+            if remembered is not None:
+                # RESUME where this session left off, so anything written while the
+                # viewer was away is posted on re-attach rather than skipped.
+                reader.offset = remembered["offset"]
+            else:
+                reader.seek_end()  # first ever attach: don't replay the whole history
         _stream_readers[sid] = {
-            "reader": reader, "seq": 0,
+            "reader": reader, "seq": (remembered or {}).get("seq", 0),
             "session_key": s.get("session_key") or "", "project": s.get("project") or "",
         }
 
     for sid in list(_stream_readers):  # drop tailers for sessions no longer watched
         if sid not in desired:
-            _stream_readers.pop(sid, None)
+            gone = _stream_readers.pop(sid, None)
+            if gone and gone.get("reader") is not None:
+                # Remember where we stopped so re-attaching resumes here.
+                _stream_state[sid] = {"offset": gone["reader"].offset, "seq": gone["seq"]}
 
     for sid, st in _stream_readers.items():
         reader = st["reader"]
@@ -294,7 +313,13 @@ def _sync_session_streams(cfg: Config, client: Client) -> None:
                 st["project"], st["session_key"], home=home, claude_home=claude_home
             )
             if path:
-                reader = TailReader(str(path)); reader.seek_end(); st["reader"] = reader
+                reader = TailReader(str(path))
+                remembered = _stream_state.get(sid)
+                if remembered is not None:
+                    reader.offset = remembered["offset"]
+                else:
+                    reader.seek_end()
+                st["reader"] = reader
             continue
         records = reader.read_new()
         if not records:
@@ -308,6 +333,9 @@ def _sync_session_streams(cfg: Config, client: Client) -> None:
                 client.post_session_stream(cfg.runner_id, sid, events)
             except Exception:  # noqa: BLE001
                 logger.debug("stream post failed (non-fatal)", exc_info=True)
+        # Checkpoint after every read, posted or not, so a detach at any moment
+        # resumes from the right byte with a non-colliding seq.
+        _stream_state[sid] = {"offset": reader.offset, "seq": st["seq"]}
 
 
 def _drain_backfills(cfg: Config, client: Client) -> None:

--- a/packages/canopy_runner/tests/test_session_streaming.py
+++ b/packages/canopy_runner/tests/test_session_streaming.py
@@ -70,3 +70,46 @@ def test_sync_streams_survives_client_error(monkeypatch):
 
     m._sync_session_streams(_Cfg(), _Boom())  # must not raise
     assert m._stream_readers == {}
+
+
+def test_reattach_resumes_instead_of_skipping_what_you_missed(tmp_path, monkeypatch):
+    """The phone-misses-messages bug.
+
+    Detaching dropped the tailer; re-attaching called seek_end() and skipped
+    EVERYTHING written while the viewer was away, and reset seq to 0 so the
+    replayed ids collided with older ones and got deduped away.
+    """
+    m._stream_readers.clear()
+    m._stream_state.clear()
+    p = tmp_path / "echo.jsonl"
+    p.write_text(_asst("old history"))
+    monkeypatch.setattr(m.transcript, "resolve_transcript", lambda _proj, _task, **_k: p)
+
+    watching = [{"session_id": "s1", "session_key": "echo-1", "project": "echo"}]
+    c = _Client(watching)
+
+    m._sync_session_streams(_Cfg(), c)          # attach (skips pre-existing history)
+    with open(p, "a") as f:
+        f.write(_asst("while watching"))
+    m._sync_session_streams(_Cfg(), c)
+    assert [e["payload"]["text"] for _s, ev in c.posted for e in ev] == ["while watching"]
+    first_seq = c.posted[-1][1][-1]["seq"]
+
+    # viewer closes the chat -> tailer dropped
+    c._streams = []
+    m._sync_session_streams(_Cfg(), c)
+    assert "s1" not in m._stream_readers
+
+    # the agent keeps working while nobody is watching
+    with open(p, "a") as f:
+        f.write(_asst("missed while away"))
+
+    # viewer re-opens -> the missed message must arrive, with a NON-colliding seq
+    c._streams = watching
+    m._sync_session_streams(_Cfg(), c)          # re-attach resumes at the saved offset
+    m._sync_session_streams(_Cfg(), c)          # ...and reads the appended bytes
+    texts = [e["payload"]["text"] for _s, ev in c.posted for e in ev]
+    assert "missed while away" in texts, "re-attach skipped what was written while away"
+    seqs = [e["seq"] for _s, ev in c.posted for e in ev]
+    assert len(seqs) == len(set(seqs)), f"seq restarted and collided: {seqs}"
+    assert seqs[-1] > first_seq


### PR DESCRIPTION
## The bug

The phone silently missed messages written while the chat wasn't open.

`_sync_session_streams` **drops** the tailer when a session stops being watched, and on re-attach builds a fresh one:

```python
reader = TailReader(str(path))
reader.seek_end()          # ← skips everything written while you were away
_stream_readers[sid] = {"reader": reader, "seq": 0, ...}   # ← ids restart, get deduped
```

So anything the agent wrote while you weren't looking was **permanently skipped**, and the events that *were* sent after a re-attach reused old message ids (`seq:0`, `seq:1`…) that the client deduped away.

This is why "Test" arrived fine but the messages before it didn't: a chat send is a **turn**, which uses the separate, reliable turn-bridge (`bridged 559 chars from task=supervisor`). The ambient streaming path is the leaky one.

## The fix

Remember `{offset, seq}` per session in `_stream_state`, which **outlives the tailer**:
- re-attach **resumes at the saved byte offset** (`seek_end()` only on the *first* attach, so we still don't replay the whole history);
- `seq` stays **monotonic**, so ids never collide and nothing is deduped away;
- checkpointed after every read, so detaching at any moment resumes correctly.

## I called this wrong earlier

In the Plan 3 whole-branch review I flagged this exact behaviour and dismissed it as *"live-view **cosmetic only** — a reload pulls the real transcript."* It isn't cosmetic; it's the cause of the missing messages.

## Verification

Runner suite **144 passed**, including a new regression that walks the real sequence: attach → message while watching → **detach** → message while away → re-attach → asserts the missed message arrives and that seqs never collide.

**Verified it bites:** reintroducing `seek_end()` + `seq: 0` fails the new test; restoring passes.

## Known limit (documented in the code)

In-memory only — a runner **restart** still resets to `seek_end()`. The durable recovery for that remains "Load full session" (backfill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)