### PR TITLE
feat(ddd): link the operator console to each run's shareable summary page

### DIFF
--- a/frontend/src/components/ddd/NarrativeLanding.tsx
+++ b/frontend/src/components/ddd/NarrativeLanding.tsx
@@ -63,6 +63,12 @@ function RunCard({
   const navigate = useNavigate()
   const [busy, setBusy] = useState(false)
   const href = `/ddd/${encodeURIComponent(slug)}/${encodeURIComponent(run.run_id)}`
+  // The clean, shareable RELEASE (summary) page for this run. Offered only when
+  // the run rendered something (video/deck) that the release page can show.
+  const hasSummary = run.has_video || run.has_deck
+  const summaryHref = withBase(
+    `/ddd-release/${encodeURIComponent(slug)}/${encodeURIComponent(run.run_id)}`,
+  )
 
   async function onDelete(e: React.MouseEvent) {
     e.stopPropagation()
@@ -97,6 +103,18 @@ function RunCard({
             <span className="rounded bg-primary/15 px-1.5 py-0.5 text-[9px] text-primary">
               latest
             </span>
+          )}
+          {hasSummary && (
+            <a
+              href={summaryHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={(e) => e.stopPropagation()}
+              title="Open the clean, shareable summary page for this run"
+              className="shrink-0 rounded px-1.5 py-0.5 text-[11px] text-primary transition-colors hover:bg-primary/10"
+            >
+              Summary ↗
+            </a>
           )}
           <DeleteButton label="Delete run" busy={busy} onClick={onDelete} />
         </div>

--- a/frontend/src/components/ddd/RunPackage.tsx
+++ b/frontend/src/components/ddd/RunPackage.tsx
@@ -332,6 +332,17 @@ export function RunPackage({ runId }: { runId: string }) {
     return <div className="p-8 text-sm text-destructive/90">Error: {error}</div>
   if (!run) return <div className="p-8 text-sm text-muted-foreground">Loading run…</div>
 
+  // The clean, shareable RELEASE (summary) page for this run. It resolves for a
+  // member whenever the run has at least one rendered artifact (build_release
+  // picks a primary walkthrough from video/deck/docs) — so only offer the link
+  // when one exists.
+  const hasSummary = Boolean(
+    run.video || run.slides || run.documentation || run.all_artifacts.length > 0,
+  )
+  const summaryHref = withBase(
+    `/ddd-release/${encodeURIComponent(run.narrative_slug)}/${encodeURIComponent(run.run_id)}`,
+  )
+
   return (
     <div className="mx-auto max-w-4xl px-8 py-6">
       <header className="flex flex-wrap items-baseline justify-between gap-2">
@@ -347,6 +358,17 @@ export function RunPackage({ runId }: { runId: string }) {
           </h1>
         </div>
         <div className="flex items-center gap-3 text-xs text-muted-foreground">
+          {hasSummary && (
+            <a
+              href={summaryHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              title="Open the clean, shareable summary page for this run"
+              className="inline-flex items-center gap-1.5 rounded-md border border-primary/30 bg-primary/10 px-3 py-1 text-primary transition-colors hover:bg-primary/20"
+            >
+              View summary page <span aria-hidden>↗</span>
+            </a>
+          )}
           {run.phase && (
             <span className="rounded border border-input bg-muted/60 px-2 py-0.5 text-foreground-secondary">
               {run.phase}


### PR DESCRIPTION
## What

Adds a clear link **to** each run's clean, shareable **summary (release) page** (`/ddd-release/<slug>/<runId>`) from the DDD operator console.

Today the release page links *into* the operator console (`build_url` → "Open the full DDD view →"), but nothing linked *back out* to the summary — so from a narrative or a run you had no way to reach the shareable page. This closes that loop.

- **Run package header** (`/w/:ws/ddd/:narrative/:runId`): a prominent **"View summary page ↗"** button, shown when the run has ≥1 rendered artifact — the exact condition under which `build_release` resolves for a member.
- **Narrative landing run cards** (`/w/:ws/ddd/:narrative`): a per-run **"Summary ↗"** link on each run card, shown when the run has a video or deck. Satisfies "a link to the summary page for that version/run, if it exists" at the run granularity.

## Notes
- Frontend-only, additive. Both existence gates use fields the DDD APIs already return (`all_artifacts`, `has_video`/`has_deck`); no backend change.
- Links open in a new tab (the release page runs outside the app shell). The narrative-card link `stopPropagation`s so it doesn't also trigger the card's navigate-to-console click.
- Prompted by wanting `…/ddd/nutrition-demo` and `…/ddd/nutrition-demo/nutrition-demo-2026-07-23-001` to each surface their summary page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)