### PR TITLE
polish(ddd): clear-win UI cleanups across the DDD surface

### DIFF
--- a/frontend/src/components/ddd/DddLeftNav.tsx
+++ b/frontend/src/components/ddd/DddLeftNav.tsx
@@ -320,7 +320,7 @@ export function DddLeftNav({
             const isActive = n.slug === activeSlug
             return (
               <div key={n.slug}>
-                <Link to={`/ddd/${encodeURIComponent(n.slug)}`}>
+                <Link to={`/ddd/${encodeURIComponent(n.slug)}`} title={n.title ?? undefined}>
                   <WorkbenchNavItem active={isActive} count={n.run_count} variant="neutral">
                     {n.slug}
                   </WorkbenchNavItem>

--- a/frontend/src/components/ddd/NarrativeGallery.tsx
+++ b/frontend/src/components/ddd/NarrativeGallery.tsx
@@ -1,0 +1,101 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { listNarratives, type DddNarrativeListItem } from '@/api/ddd'
+
+/** "nutrition-demo" -> "Nutrition Demo". The slug is the stable identity; this
+ *  is just a friendlier headline than the raw kebab-case. */
+function humanize(slug: string): string {
+  return slug.replace(/[-_]+/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
+}
+
+function fmtDate(iso: string | null): string {
+  if (!iso) return ''
+  try {
+    return new Date(iso).toLocaleDateString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    })
+  } catch {
+    return iso
+  }
+}
+
+function NarrativeCard({ n }: { n: DddNarrativeListItem }) {
+  return (
+    <Link
+      to={`/ddd/${encodeURIComponent(n.slug)}`}
+      className="group flex flex-col gap-2 rounded-xl border border-border bg-card p-4 transition-colors hover:border-input"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <h3 className="min-w-0 truncate text-sm font-semibold text-foreground group-hover:text-primary">
+          {humanize(n.slug)}
+        </h3>
+        <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] text-foreground-secondary">
+          {n.run_count} run{n.run_count === 1 ? '' : 's'}
+        </span>
+      </div>
+      <div className="font-mono text-[10px] text-muted-foreground">{n.slug}</div>
+      {n.title && (
+        <p className="line-clamp-2 text-xs leading-relaxed text-foreground-secondary">{n.title}</p>
+      )}
+      <div className="mt-auto flex flex-wrap items-center gap-2 pt-1 text-[11px] text-muted-foreground">
+        {n.phase && (
+          <span className="rounded border border-input bg-muted/60 px-1.5 py-0.5 text-foreground-secondary">
+            {n.phase}
+          </span>
+        )}
+        {n.has_video && <span title="has video">Video</span>}
+        {n.has_deck && <span title="has deck">Deck</span>}
+        <span className="ml-auto">{fmtDate(n.latest_at)}</span>
+      </div>
+    </Link>
+  )
+}
+
+/**
+ * The DDD index main pane: a browsable gallery of every narrative, so the
+ * landing surface shows the work instead of an empty "pick one" void. Clicking a
+ * card opens that narrative's landing (versions + runs). Read-only; the left rail
+ * remains the primary picker, this mirrors it as scannable cards.
+ */
+export function NarrativeGallery() {
+  const [narratives, setNarratives] = useState<DddNarrativeListItem[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    listNarratives({})
+      .then((d) => !cancelled && setNarratives(d))
+      .catch((e) => !cancelled && setError(String(e.message || e)))
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-6 sm:px-8">
+      <header className="mb-5">
+        <h1 className="text-2xl font-semibold text-foreground">Narratives</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Every DDD narrative, newest activity first. Open one to see its versions and runs.
+        </p>
+      </header>
+
+      {error && <div className="text-sm text-destructive/90">Error: {error}</div>}
+      {!narratives && !error && <div className="text-sm text-muted-foreground">Loading…</div>}
+      {narratives && narratives.length === 0 && (
+        <div className="rounded-xl border border-dashed border-border px-4 py-10 text-center text-sm text-muted-foreground">
+          No narratives yet.
+        </div>
+      )}
+      {narratives && narratives.length > 0 && (
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {narratives.map((n) => (
+            <NarrativeCard key={n.slug} n={n} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/ddd/NarrativeLanding.tsx
+++ b/frontend/src/components/ddd/NarrativeLanding.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/api/ddd'
 import { withBase } from '@/lib/basePath'
 import { NarrativeDiff } from './NarrativeDiff'
+import { pairNarrationScenes } from './narrativeScenePairing'
 
 function fmtDate(iso: string | null): string {
   if (!iso) return ''
@@ -149,6 +150,14 @@ function VersionBlock({
   const [open, setOpen] = useState(isCurrent)
   const [busy, setBusy] = useState(false)
   const label = version.version != null ? `v${version.version}` : 'no narrative'
+  // How many scenes this version changed vs the one before it — the thing that
+  // actually distinguishes two versions whose story line (the title) is identical.
+  const changedScenes =
+    previous && previous.narration.length > 0 && version.narration.length > 0
+      ? pairNarrationScenes(previous.narration, version.narration).filter(
+          (p) => p.status !== 'unchanged',
+        ).length
+      : null
 
   async function onDelete(e: React.MouseEvent) {
     e.stopPropagation()
@@ -188,6 +197,11 @@ function VersionBlock({
             </span>
           )}
           <span className="truncate text-sm text-foreground-secondary">{version.title || ''}</span>
+          {changedScenes != null && changedScenes > 0 && (
+            <span className="shrink-0 rounded bg-amber-500/15 px-1.5 py-0.5 text-[10px] text-amber-500">
+              {changedScenes} scene{changedScenes === 1 ? '' : 's'} changed
+            </span>
+          )}
           <span className="ml-auto shrink-0 text-[11px] text-muted-foreground">
             {version.runs.length} run{version.runs.length === 1 ? '' : 's'} ·{' '}
             {fmtDate(version.created_at)}

--- a/frontend/src/components/ddd/RunPackage.tsx
+++ b/frontend/src/components/ddd/RunPackage.tsx
@@ -53,6 +53,14 @@ function roleLabel(role: string | null, kind: string): string {
   }
 }
 
+/** The display form of an artifact URL: its path, without the query string —
+ *  which carries the ?t=<share_token>. The full URL stays the link's href, so
+ *  the token is never rendered as visible text (nor shoulder-surfed from a demo). */
+function displayUrl(url: string): string {
+  const q = url.indexOf('?')
+  return q === -1 ? url : url.slice(0, q)
+}
+
 function fmtDate(iso: string | null): string {
   if (!iso) return ''
   try {
@@ -108,9 +116,10 @@ function OpenLink({ href, label = 'Open' }: { href: string; label?: string }) {
       href={href}
       target="_blank"
       rel="noopener noreferrer"
+      title={href}
       className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-0.5 text-[11px] text-foreground-secondary transition-colors hover:border-input hover:text-primary"
     >
-      <span className="truncate font-mono">{href}</span>
+      <span className="truncate font-mono">{displayUrl(href)}</span>
       <span aria-hidden>↗</span>
       <span className="sr-only">{label}</span>
     </a>
@@ -478,6 +487,7 @@ export function RunPackage({ runId }: { runId: string }) {
               href={a.viewer_url}
               target="_blank"
               rel="noopener noreferrer"
+              title={a.viewer_url}
               className="group flex items-center gap-3 rounded-lg border border-border bg-background/40 px-3 py-1.5 text-xs transition-colors hover:border-input hover:bg-background/70"
             >
               <span className="w-28 shrink-0 text-[10px] font-medium text-foreground-secondary">
@@ -487,9 +497,9 @@ export function RunPackage({ runId }: { runId: string }) {
               <span className="shrink-0 text-muted-foreground">{fmtDate(a.created_at)}</span>
               <span
                 aria-hidden
-                className="shrink-0 font-mono text-[11px] text-muted-foreground transition-colors group-hover:text-primary"
+                className="shrink-0 truncate max-w-[16rem] font-mono text-[11px] text-muted-foreground transition-colors group-hover:text-primary"
               >
-                {a.viewer_url} ↗
+                {displayUrl(a.viewer_url)} ↗
               </span>
             </a>
           ))}

--- a/frontend/src/pages/DddPage.tsx
+++ b/frontend/src/pages/DddPage.tsx
@@ -1,6 +1,7 @@
 import { useParams } from 'react-router-dom'
 import { DddShell } from '@/components/ddd/DddShell'
 import { NarrativeLanding } from '@/components/ddd/NarrativeLanding'
+import { NarrativeGallery } from '@/components/ddd/NarrativeGallery'
 import { RunPackage } from '@/components/ddd/RunPackage'
 
 /**
@@ -21,9 +22,7 @@ export function DddPage() {
       ) : narrative ? (
         <NarrativeLanding key={narrative} slug={narrative} />
       ) : (
-        <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-          Select a narrative to see its runs.
-        </div>
+        <NarrativeGallery />
       )}
     </DddShell>
   )

--- a/frontend/src/pages/DddReleasePage.tsx
+++ b/frontend/src/pages/DddReleasePage.tsx
@@ -81,6 +81,10 @@ function Centered({ children }: { children: React.ReactNode }) {
 function Release({ data }: { data: DddRunRelease }) {
   const shareUrl = useShareUrl(data)
   const products = data.product_links
+  // Only tag scenes with a persona when the walkthrough actually has more than
+  // one — a single-persona demo repeats the same name on every card for no signal.
+  const showPersona =
+    new Set((data.narrative?.narration ?? []).map((n) => n.persona).filter(Boolean)).size > 1
 
   return (
     <div className="min-h-screen bg-background text-foreground">
@@ -140,7 +144,7 @@ function Release({ data }: { data: DddRunRelease }) {
                       {n.title && (
                         <span className="text-[13px] font-medium text-foreground">{n.title}</span>
                       )}
-                      {persona?.name && (
+                      {showPersona && persona?.name && (
                         <span className="text-[11px] text-primary" title={persona.role || ''}>
                           {persona.name}
                         </span>


### PR DESCRIPTION
Five small, additive improvements from a design pass over every DDD page (viewed live as an authenticated member + read the source). These are the **clear wins**; taste-call ideas (video posters, story lede/expand, release "Try it live" grouping) are deliberately held back to iterate on separately.

### Changes
1. **Run package — no more visible share tokens.** `OpenLink` and the Outputs rows rendered artifact `viewer_url`s in full, including `?t=<share_token>`, as body text. Now only the token-free path is shown; the full URL stays the link href (and moves to `title`). Removes a real token-shoulder-surf risk on a shared/demo screen and cuts mono-URL noise.
2. **Narrative landing — versions are distinguishable.** Every version's title is the story's first line, so v4/v3/v2/v1 looked identical. Each version header now shows **"N scenes changed"** vs the previous version (reusing `pairNarrationScenes`), which is the actual delta.
3. **DDD index — gallery instead of a void.** `/w/:ws/ddd` with nothing selected showed an empty right pane with one centered line. It's now a browsable **narrative gallery** (name, slug, phase, run count, last activity) — the landing surface shows the work.
4. **Release page — drop the redundant persona chip** when the walkthrough has a single persona (it was repeating "Priya Sharma" on all 13 scene cards).
5. **Left nav — human title as a hover tooltip** on narrative rows (the rail shows the slug; the tooltip reveals the story title).

### Verification
- `tsc -b` clean; no new eslint findings (the 4 `set-state-in-effect` errors in these files pre-exist on `main`).
- `line-clamp` already used elsewhere (Tailwind v4).
- Frontend-only; no API/schema changes. I'll screenshot the live pages after deploy to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)