### PR TITLE
Persist a runner session's transcript (durable, restart-proof live view)

### DIFF
--- a/apps/canopy_sessions/migrations/0010_reset_runner_session_messages.py
+++ b/apps/canopy_sessions/migrations/0010_reset_runner_session_messages.py
@@ -1,0 +1,32 @@
+"""Reset runner sessions' Message rows for the transcript-ordinal index space.
+
+From spec 2026-07-24 (persist-runner-session-transcript), an origin=runner
+session's Message.turn_index IS the transcript record ordinal. Rows written
+before that model (send_message user rows, ledger projections, legacy
+backfills) are keyed sequentially from 0 — a different index space. Left in
+place they'd collide with incoming ordinals: get_or_create(session, turn_index)
+would return the OLD row and silently swallow the new message.
+
+Deleting them is safe by the new model's own premise: the laptop transcript is
+the single source of truth for these sessions, so every dropped row is
+re-shippable via catch-up ("everything after last_index") or backfill ("Load
+full"), and the binding tail keeps the recent view meanwhile. Web sessions are
+untouched. Irreversible, and deliberately so — the reverse operation would be
+re-creating rows the transcript already owns.
+"""
+from django.db import migrations
+
+
+def forwards(apps, schema_editor):
+    Message = apps.get_model("canopy_sessions", "Message")
+    Message.objects.filter(session__origin="runner").delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("canopy_sessions", "0009_archive_stale_sessions"),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards, migrations.RunPython.noop),
+    ]

--- a/apps/canopy_sessions/services.py
+++ b/apps/canopy_sessions/services.py
@@ -9,6 +9,7 @@ serializes a conversation, turn_index assignment never races within a session.
 from __future__ import annotations
 
 import datetime as _dt
+import uuid
 from dataclasses import dataclass
 
 from django.conf import settings
@@ -195,12 +196,17 @@ def visible_transcript(session, *, full: bool = False):
 
 
 def request_backfill(session) -> str:
-    """The client asked for full history. 'ready' if already server-full; 'requested'
-    if a live runner is bound (signal it); 'unavailable' otherwise (tail still shows)."""
+    """The client asked for full history. 'ready' if we already hold the START of
+    the transcript (a row at turn_index 0); 'requested' if a live runner is bound
+    (signal it — streamed ordinal rows alone are not the full history); 'unavailable'
+    otherwise (tail still shows)."""
     from apps.canopy_sessions.models import RunnerBinding
     from apps.harness.models import Runner
 
-    if session.messages.exists():
+    first = (
+        session.messages.order_by("turn_index").values_list("turn_index", flat=True).first()
+    )
+    if first == 0:
         return "ready"
     binding = RunnerBinding.objects.select_related("runner").filter(session=session).first()
     # A runner only has to be REACHABLE to ship a transcript — not ready to run
@@ -226,27 +232,48 @@ def request_backfill(session) -> str:
     return "requested"
 
 
-def write_backfill(session, messages) -> int:
-    """Write a runner's shipped transcript as Message rows — ONCE. No-op if the
-    session already has rows (server-full). messages: [{"role","text"}] chronological."""
+def persist_transcript_rows(session, rows) -> int:
+    """THE durable write path for a runner session's transcript. rows:
+    [{"index","role","text"}] chronological.
+
+    `index` is the transcript record ordinal (raw index into the session's
+    .jsonl) — because the stream (forward) and backfill (older) both key on it,
+    they produce the SAME rows by identity and `get_or_create` makes every
+    re-ship (retry, overlap, catch-up) a no-op. index < 0 (an old runner) falls
+    back to sequential server-side assignment. Returns rows actually created."""
+    written = 0
     with transaction.atomic():
         locked = Session.objects.select_for_update().get(pk=session.pk)
-        if Message.objects.filter(session=locked).exists():
-            return 0
-        index = _next_index(locked)
-        written = 0
-        for msg in messages:
-            role = msg.get("role")
+        next_index = None
+        for row in rows:
+            role = row.get("role")
             if role not in _BACKFILL_ROLES:
                 continue
-            Message.objects.create(
-                session=locked, turn_index=index, role=role,
-                content={"text": msg.get("text", ""), "backfill": True},
-                plaintext=str(msg.get("text", "")),
+            text = str(row.get("text", ""))
+            index = row.get("index")
+            index = -1 if index is None else int(index)
+            if index < 0:
+                if next_index is None:
+                    next_index = _next_index(locked)
+                index, next_index = next_index, next_index + 1
+            _, created = Message.objects.get_or_create(
+                session=locked, turn_index=index,
+                defaults={"role": role, "plaintext": text, "content": {"text": text}},
             )
-            index += 1
-            written += 1
+            written += 1 if created else 0
     return written
+
+
+def write_backfill(session, messages) -> int:
+    """Write a runner's shipped full transcript as Message rows. Ordinal-keyed
+    payloads (a current runner) upsert-fill: they add the older rows the live
+    stream never saw and skip anything already persisted. A legacy payload (no
+    ordinals) keeps the old write-once contract — sequential, and only into an
+    empty session. messages: [{"role","text"[,"index"]}] chronological."""
+    ordinal = any(int(m.get("index", -1)) >= 0 for m in messages)
+    if not ordinal and Message.objects.filter(session=session).exists():
+        return 0
+    return persist_transcript_rows(session, messages)
 
 
 def _set_stream_desired(session, desired: bool) -> bool:
@@ -320,7 +347,16 @@ def send_message(*, session: Session, text: str, user, client_id: str = "") -> t
     Without one, the key falls back to the message's session index — best-effort
     only (a genuine retry after the first commit would compute a new index), so a
     nonce is required for true double-submit safety.
+
+    For an origin=runner session the TRANSCRIPT is the sole durable source
+    (spec 2026-07-24): the user's words reach the DB when the runner ships the
+    transcript record they became, keyed on its ordinal. Persisting a second
+    copy here (keyed _next_index) would collide index spaces and duplicate the
+    send, so this path writes no row — the frontend already echoes the message
+    optimistically (draft.committed), and a transient Message keeps the contract.
     """
+    if session.origin == Session.ORIGIN_RUNNER:
+        return _send_runner_message(session=session, text=text, client_id=client_id)
     with transaction.atomic():
         Session.objects.select_for_update().get(pk=session.pk)
         if client_id:
@@ -364,6 +400,38 @@ def send_message(*, session: Session, text: str, user, client_id: str = "") -> t
     # that turn (over its control channel) so the live agent sees it, on top of the
     # new turn that queues behind it. Post-commit + null-safe (a realtime hiccup
     # never breaks the send).
+    _maybe_interject(session, message)
+    return message, turn
+
+
+def _send_runner_message(*, session: Session, text: str, client_id: str = "") -> tuple[Message, Turn]:
+    """The runner-session send path: enqueue the Turn, author NO durable user row.
+
+    The returned Message is transient (never saved): MessageOut serializes it for
+    the REST response and the WS handler broadcasts str(pk) as user_message_id, so
+    both send contracts hold. A synthetic pk keeps those ids unique per send."""
+    content = {"text": text}
+    if client_id:
+        content["client_id"] = client_id
+    message = Message(
+        session=session, turn_index=_next_index(session), role=Message.USER,
+        plaintext=text, content=content,
+    )
+    message.pk = f"transient:{uuid.uuid4().hex}"
+    message.created_at = timezone.now()
+    binding = getattr(session, "runner_binding", None)
+    thread_key = binding.thread_key if (binding and binding.thread_key) else str(session.id)
+    # Without a durable row, _next_index no longer advances between sends, so the
+    # old index fallback would collapse DISTINCT no-nonce sends onto one turn —
+    # fall back to a fresh nonce instead (same dedupe strength as before: only a
+    # real client_id makes a retry idempotent).
+    turn, _created = harness_services.enqueue_turn(
+        session=session,
+        origin=Turn.ORIGIN_API,
+        idempotency_key=f"chat:{session.id.hex}:{client_id or uuid.uuid4().hex}",
+        prompt=text,
+        origin_ref={"thread_key": thread_key, "chat_session_id": str(session.id)},
+    )
     _maybe_interject(session, message)
     return message, turn
 
@@ -412,8 +480,15 @@ def maybe_execute_inline(turn: Turn | None) -> None:
 
 def project_events(turn: Turn, rows) -> int:
     """Materialize a turn's newly-appended assistant/tool events into Message rows.
-    Idempotent per source ledger seq, so a re-delivered signal never doubles a row."""
+    Idempotent per source ledger seq, so a re-delivered signal never doubles a row.
+
+    Runner sessions are excluded: their durable rows come from the transcript
+    (ordinal-keyed, via persist_transcript_rows) — the bridged reply lands in the
+    ledger too, and projecting it as well would persist it twice in a second
+    index space. The ledger frames still stream to the live client unchanged."""
     if not turn.chat_session_id:
+        return 0
+    if turn.chat_session.origin == Session.ORIGIN_RUNNER:
         return 0
     created = 0
     with transaction.atomic():

--- a/apps/harness/api.py
+++ b/apps/harness/api.py
@@ -375,6 +375,8 @@ def list_streams(request: HttpRequest, runner_id: uuid.UUID):
     """The sessions this runner should be tailing live (a viewer is attached). The
     observable half of attach/detach — the runner syncs this each tick and starts/
     stops tailers; the WS runner.stream frame is only a latency optimization."""
+    from django.db.models import Max as _Max
+
     from apps.canopy_sessions.models import RunnerBinding
 
     runner = _runner_or_404(request, runner_id)
@@ -382,34 +384,54 @@ def list_streams(request: HttpRequest, runner_id: uuid.UUID):
         RunnerBinding.objects.select_related("session")
         .filter(runner=runner, stream_desired=True)
         .exclude(session_key="")
+        # The catch-up marker: on attach the runner ships every transcript record
+        # AFTER the server's max persisted turn_index (None = stream-forward only).
+        .annotate(_last_index=_Max("session__messages__turn_index"))
     )
     return {"streams": [
         {"session_id": str(b.session_id), "session_key": b.session_key,
-         "project": b.session.project}
+         "project": b.session.project, "last_index": b._last_index}
         for b in bindings
     ]}
 
 
 @router.post("/runners/{runner_id}/session-stream", response=StreamPostOut)
 def post_session_stream(request: HttpRequest, runner_id: uuid.UUID, payload: SessionStreamIn):
-    """The runner ships live assistant events for a session it backs; the server fans
-    them to the session group as the same chat.turn_event frames the chat path uses
-    (turn-less -> the consumer derives seq:<n> message ids). Live view only — no
-    Message rows (that is the on-demand backfill, POST /session-backfill)."""
-    from apps.canopy_sessions.models import RunnerBinding
+    """The runner ships live conversational events for a session it backs. For an
+    origin=runner session, events carrying a transcript ordinal are PERSISTED as
+    Message rows first (the transcript is the durable source — spec 2026-07-24),
+    then the assistant frames fan out to the session group as the same
+    chat.turn_event frames the chat path uses (turn-less -> the consumer derives
+    seq:<n> message ids). User events are persisted but never live-pushed — the
+    sender's client already echoed them optimistically."""
+    from apps.canopy_sessions import services as chat_services
+    from apps.canopy_sessions.models import RunnerBinding, Session
     from apps.realtime import groups
 
     runner = _runner_or_404(request, runner_id)
-    if not RunnerBinding.objects.filter(session_id=payload.session_id, runner=runner).exists():
+    binding = (
+        RunnerBinding.objects.select_related("session")
+        .filter(session_id=payload.session_id, runner=runner).first()
+    )
+    if binding is None:
         raise HttpError(404, "session not bound to this runner")
+    if binding.session.origin == Session.ORIGIN_RUNNER:
+        # Ordinal-less events (an old runner) stay live-view-only: persisting
+        # assistant rows without the user side would blank the tail fallback's
+        # human half the moment any row exists.
+        chat_services.persist_transcript_rows(binding.session, [
+            {"index": e.index, "role": e.kind, "text": (e.payload or {}).get("text", "")}
+            for e in payload.events if e.index >= 0
+        ])
     sgroup = groups.session_group(payload.session_id)
     n = 0
     for e in payload.events:
-        groups.publish(sgroup, {
-            "type": "chat.turn_event",
-            "event": {"kind": e.kind, "seq": e.seq, "payload": e.payload},
-            "turn_id": None,
-        })
+        if e.kind != "user":
+            groups.publish(sgroup, {
+                "type": "chat.turn_event",
+                "event": {"kind": e.kind, "seq": e.seq, "payload": e.payload},
+                "turn_id": None,
+            })
         n += 1
     return {"count": n}
 

--- a/apps/harness/schemas.py
+++ b/apps/harness/schemas.py
@@ -407,6 +407,10 @@ class StreamDescriptorOut(Schema):
     session_id: str
     session_key: str
     project: str
+    # The server-side catch-up marker: max persisted turn_index for the session
+    # (None = no rows yet). The runner ships transcript records AFTER this on
+    # attach, so a restart/failover never loses the resume point.
+    last_index: int | None = None
 
 
 class StreamSyncOut(Schema):
@@ -416,6 +420,10 @@ class StreamSyncOut(Schema):
 class LiveEventIn(Schema):
     kind: str
     seq: int
+    # Transcript record ordinal (raw index into the session's .jsonl). -1 = an
+    # old runner that doesn't send ordinals; such events stay live-view-only
+    # (persisting assistant-only rows would kill the tail fallback's user side).
+    index: int = -1
     payload: dict = {}
 
 
@@ -446,6 +454,9 @@ class BackfillSyncOut(Schema):
 class BackfillMessageIn(Schema):
     role: str
     text: str = ""
+    # Transcript record ordinal. -1 = an old runner; the server then keeps the
+    # legacy write-once contract (sequential, only into an empty session).
+    index: int = -1
 
 
 class SessionBackfillIn(Schema):

--- a/docs/superpowers/specs/2026-07-24-persist-runner-session-transcript-design.md
+++ b/docs/superpowers/specs/2026-07-24-persist-runner-session-transcript-design.md
@@ -1,9 +1,12 @@
 # Persist a runner session's transcript (durable, restart-proof live view)
 
-**Status:** designed, not built. Fully worked out; deliberately not crammed into a
-closeout (see "Why this is staged"). Builds on the unified-runner-sessions work
-([[project_unified_runner_sessions]]) and supersedes the in-memory offset fix #368
-as the *durable* answer.
+**Status:** built (issue #373, 2026-07-24). Builds on the unified-runner-sessions
+work ([[project_unified_runner_sessions]]) and supersedes the in-memory offset fix
+#368 as the *durable* answer. Two implementation additions beyond the checklist
+below, both forced by trap 1's "one index space" rule: `project_events` skips
+origin=runner sessions (the bridged reply's durable copy comes from the transcript,
+not the ledger), and migration `canopy_sessions.0010` resets runner sessions'
+pre-ordinal Message rows so legacy sequential keys can't swallow incoming ordinals.
 
 ## Problem
 

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -1955,10 +1955,13 @@ export interface paths {
         readonly put?: never;
         /**
          * Post Session Stream
-         * @description The runner ships live assistant events for a session it backs; the server fans
-         *     them to the session group as the same chat.turn_event frames the chat path uses
-         *     (turn-less -> the consumer derives seq:<n> message ids). Live view only — no
-         *     Message rows (that is the on-demand backfill, POST /session-backfill).
+         * @description The runner ships live conversational events for a session it backs. For an
+         *     origin=runner session, events carrying a transcript ordinal are PERSISTED as
+         *     Message rows first (the transcript is the durable source — spec 2026-07-24),
+         *     then the assistant frames fan out to the session group as the same
+         *     chat.turn_event frames the chat path uses (turn-less -> the consumer derives
+         *     seq:<n> message ids). User events are persisted but never live-pushed — the
+         *     sender's client already echoed them optimistically.
          */
         readonly post: operations["apps_harness_api_post_session_stream"];
         readonly delete?: never;
@@ -6259,6 +6262,8 @@ export interface components {
             readonly session_key: string;
             /** Project */
             readonly project: string;
+            /** Last Index */
+            readonly last_index?: number | null;
         };
         /** StreamSyncOut */
         readonly StreamSyncOut: {
@@ -6279,6 +6284,11 @@ export interface components {
             readonly kind: string;
             /** Seq */
             readonly seq: number;
+            /**
+             * Index
+             * @default -1
+             */
+            readonly index: number;
             /**
              * Payload
              * @default {}
@@ -6331,6 +6341,11 @@ export interface components {
              * @default
              */
             readonly text: string;
+            /**
+             * Index
+             * @default -1
+             */
+            readonly index: number;
         };
         /** SessionBackfillIn */
         readonly SessionBackfillIn: {

--- a/packages/canopy_runner/canopy_runner/chat_bridge.py
+++ b/packages/canopy_runner/canopy_runner/chat_bridge.py
@@ -77,23 +77,31 @@ def _user_text(content) -> str:
     return ""
 
 
-def transcript_messages(records: list[dict]) -> list[dict]:
-    """The full transcript as chronological {"role","text"} rows — user + assistant
-    text only (tool blocks skipped, matching the v1 bridge). Drives on-demand
-    backfill of a local session's history into server Message rows."""
+def conversational_messages(records: list[dict], since: int) -> list[dict]:
+    """Conversational rows after `since`, as chronological {"index","role","text"}.
+
+    `index` is the RAW position in the records list (== the .jsonl line ordinal;
+    read_records reads the whole file, so it's stable and append-only). It is the
+    identity the server keys Message.turn_index on for a runner session, which is
+    what makes the live stream, catch-up, and backfill idempotent against each
+    other. User + assistant text only (tool blocks skipped, matching the v1
+    bridge); non-conversational records advance the index without emitting a row.
+    Pass since=-1 for the full transcript."""
     out: list[dict] = []
-    for rec in records:
+    for i, rec in enumerate(records):
+        if i <= since:
+            continue
         kind = rec.get("type")
         msg = rec.get("message")
         content = msg.get("content", "") if isinstance(msg, dict) else ""
         if kind == "user":
             t = _user_text(content)
             if t:
-                out.append({"role": "user", "text": t})
+                out.append({"index": i, "role": "user", "text": t})
         elif kind == "assistant":
             t = _assistant_text(content)
             if t:
-                out.append({"role": "assistant", "text": t})
+                out.append({"index": i, "role": "assistant", "text": t})
     return out
 
 

--- a/packages/canopy_runner/canopy_runner/main.py
+++ b/packages/canopy_runner/canopy_runner/main.py
@@ -190,8 +190,10 @@ _tail_readers: dict[str, "TailReader | None"] = {}
 # Per-session live-stream tailers, keyed by session_id — active only while a viewer
 # is attached (stream_desired on the server). Distinct from _tail_readers (the idle
 # tail read-model that fills RunnerBinding.tail); this is the live push to attached
-# viewers. Each entry: {"reader": TailReader|None, "seq": int, "session_key": str,
-# "project": str}.
+# viewers. Each entry: {"reader": TailReader|None, "count": int (records consumed ==
+# the next record's ordinal), "session_key": str, "project": str, "last_index":
+# int|None (the server's catch-up marker)}. Deliberately holds NO durable resume
+# state — the server's last_index is the checkpoint (spec 2026-07-24).
 _stream_readers: dict[str, dict] = {}
 
 
@@ -277,20 +279,36 @@ def _maybe_report_sessions(cfg: Config, client: Client, now_fn=time.monotonic) -
         logger.debug("session report failed (non-fatal)", exc_info=True)
 
 
-# Survives a tailer being dropped when you stop watching a session. Without it a
-# re-attach called seek_end() and silently skipped EVERYTHING written while you
-# weren't looking (a phone that closed the chat missed every message until it
-# re-opened), and `seq` restarted at 0 so fresh events reused old message ids and
-# the client deduped them away. Keyed by session id: {"offset": int, "seq": int}.
-# In-memory only — a runner RESTART still resets to seek_end(); the durable
-# recovery for that is "Load full session" (backfill).
-_stream_state: dict[str, dict] = {}
+def _post_stream_rows(cfg: Config, client: Client, sid: str, rows: list[dict]) -> bool:
+    """Ship conversational rows as live events. seq == index (the transcript
+    ordinal): monotonic per session forever, so the WS-derived `seq:<n>` message
+    ids can never collide across detaches, restarts, or failovers."""
+    events = [
+        {"kind": r["role"], "seq": r["index"], "index": r["index"],
+         "payload": {"text": r["text"]}}
+        for r in rows
+    ]
+    try:
+        client.post_session_stream(cfg.runner_id, sid, events)
+        return True
+    except Exception:  # noqa: BLE001
+        logger.debug("stream post failed (non-fatal)", exc_info=True)
+        return False
 
 
 def _sync_session_streams(cfg: Config, client: Client) -> None:
-    """Tail each session a viewer is watching and post new assistant text up as live
-    events. Change-driven off TailReader (only newly-appended bytes), so it stays
-    cheap. Best-effort — a client hiccup never breaks a tick."""
+    """Tail each session a viewer is watching and ship every new conversational
+    record (user + assistant) with its transcript ordinal — the server persists
+    them as the session's durable Message rows and fans the assistant frames out
+    live (spec 2026-07-24).
+
+    The resume point is SERVER-side: the descriptor's `last_index` (max persisted
+    turn_index). On attach we read the transcript once and ship everything after
+    it; steady state stays change-driven off TailReader (only newly-appended
+    bytes). There is deliberately NO local offset checkpoint — a failed post just
+    drops the tailer so the next tick re-attaches from the marker, and a runner
+    restart or account failover recovers identically. Best-effort — a client
+    hiccup never breaks a tick."""
     try:
         streams = client.sync_streams(cfg.runner_id)
     except Exception:  # noqa: BLE001
@@ -300,68 +318,58 @@ def _sync_session_streams(cfg: Config, client: Client) -> None:
     home = Path.home()
     claude_home = home / ".claude" / "projects"
 
-    for sid, s in desired.items():
-        if sid in _stream_readers:
-            continue
-        path = transcript.resolve_transcript(
-            s.get("project") or "", s.get("session_key") or "", home=home, claude_home=claude_home
-        )
-        remembered = _stream_state.get(sid)
-        reader = TailReader(str(path)) if path else None
-        if reader is not None:
-            if remembered is not None:
-                # RESUME where this session left off, so anything written while the
-                # viewer was away is posted on re-attach rather than skipped.
-                reader.offset = remembered["offset"]
-            else:
-                reader.seek_end()  # first ever attach: don't replay the whole history
-        _stream_readers[sid] = {
-            "reader": reader, "seq": (remembered or {}).get("seq", 0),
-            "session_key": s.get("session_key") or "", "project": s.get("project") or "",
-        }
-
     for sid in list(_stream_readers):  # drop tailers for sessions no longer watched
         if sid not in desired:
-            gone = _stream_readers.pop(sid, None)
-            if gone and gone.get("reader") is not None:
-                # Remember where we stopped so re-attaching resumes here.
-                _stream_state[sid] = {"offset": gone["reader"].offset, "seq": gone["seq"]}
+            _stream_readers.pop(sid, None)
+
+    for sid, s in desired.items():
+        st = _stream_readers.setdefault(sid, {
+            "reader": None, "count": 0,
+            "session_key": s.get("session_key") or "", "project": s.get("project") or "",
+        })
+        # Refresh every tick: the marker advances as the server persists our posts.
+        st["last_index"] = s.get("last_index")
 
     for sid, st in _stream_readers.items():
         reader = st["reader"]
-        if reader is None:  # transcript wasn't there yet — retry resolving it
+        if reader is None:
+            # (Re-)attach: read the whole file once, atomically w.r.t. this reader,
+            # and catch up from the server marker. No marker yet -> stream forward
+            # only (history stays the backfill's job).
             path = transcript.resolve_transcript(
                 st["project"], st["session_key"], home=home, claude_home=claude_home
             )
-            if path:
-                reader = TailReader(str(path))
-                remembered = _stream_state.get(sid)
-                if remembered is not None:
-                    reader.offset = remembered["offset"]
-                else:
-                    reader.seek_end()
-                st["reader"] = reader
+            if not path:
+                continue  # transcript wasn't there yet — retry resolving next tick
+            reader = TailReader(str(path))
+            records = reader.read_new()
+            last = st["last_index"]
+            since = len(records) - 1 if last is None else int(last)
+            rows = chat_bridge.conversational_messages(records, since)
+            if rows and not _post_stream_rows(cfg, client, sid, rows):
+                continue  # nothing consumed; re-attach next tick
+            st["reader"], st["count"] = reader, len(records)
             continue
-        records = reader.read_new()
-        if not records:
+        new_records = reader.read_new()
+        if not new_records:
             continue
-        events = []
-        for text in chat_bridge.new_assistant_texts(records, 0):
-            events.append({"kind": "assistant", "seq": st["seq"], "payload": {"text": text}})
-            st["seq"] += 1
-        if events:
-            try:
-                client.post_session_stream(cfg.runner_id, sid, events)
-            except Exception:  # noqa: BLE001
-                logger.debug("stream post failed (non-fatal)", exc_info=True)
-        # Checkpoint after every read, posted or not, so a detach at any moment
-        # resumes from the right byte with a non-colliding seq.
-        _stream_state[sid] = {"offset": reader.offset, "seq": st["seq"]}
+        base = st["count"]
+        rows = [
+            {**r, "index": r["index"] + base}
+            for r in chat_bridge.conversational_messages(new_records, -1)
+        ]
+        if rows and not _post_stream_rows(cfg, client, sid, rows):
+            # Don't advance past unshipped records: reset so the next tick
+            # re-attaches and catches up from the server marker.
+            st["reader"], st["count"] = None, 0
+            continue
+        st["count"] = base + len(new_records)
 
 
 def _drain_backfills(cfg: Config, client: Client) -> None:
-    """Ship full transcript history for each session the server asked to backfill.
-    Best-effort — a missing transcript or a client hiccup is skipped, not fatal."""
+    """Ship full transcript history — with ordinals, so the server upsert-fills the
+    older rows around anything the live stream already persisted. Best-effort — a
+    missing transcript or a client hiccup is skipped, not fatal."""
     try:
         backfills = client.sync_backfills(cfg.runner_id)
     except Exception:  # noqa: BLE001
@@ -376,7 +384,7 @@ def _drain_backfills(cfg: Config, client: Client) -> None:
         )
         if not (sid and path):
             continue  # transcript not resolvable -> leave it; server keeps showing the tail
-        messages = chat_bridge.transcript_messages(chat_bridge.read_records(path))
+        messages = chat_bridge.conversational_messages(chat_bridge.read_records(path), -1)
         try:
             client.post_session_backfill(cfg.runner_id, sid, messages)
         except Exception:  # noqa: BLE001

--- a/packages/canopy_runner/tests/test_chat_bridge.py
+++ b/packages/canopy_runner/tests/test_chat_bridge.py
@@ -1,5 +1,9 @@
 """The emdash-response bridge: tail assistant text + idle-based completion."""
-from canopy_runner.chat_bridge import bridge_response, new_assistant_texts, transcript_messages
+from canopy_runner.chat_bridge import (
+    bridge_response,
+    conversational_messages,
+    new_assistant_texts,
+)
 
 
 def _asst(text):
@@ -59,10 +63,22 @@ def test_bridge_times_out_without_assistant():
     assert result == ""
 
 
-def test_transcript_messages_maps_user_and_assistant():
-    recs = [_user("q1"), _asst("a1"), _tool(), _asst("a2")]
-    assert transcript_messages(recs) == [
-        {"role": "user", "text": "q1"},
-        {"role": "assistant", "text": "a1"},
-        {"role": "assistant", "text": "a2"},  # tool_use block skipped (no text)
+def test_conversational_messages_carry_the_raw_record_ordinal():
+    """The index is the RAW position in the .jsonl — non-conversational records
+    (summaries, tool-only turns) advance it without producing a row, so the
+    ordinal is stable no matter how the transcript is filtered."""
+    recs = [{"type": "summary"}, _user("q1"), _asst("a1"), _tool(), _asst("a2")]
+    assert conversational_messages(recs, -1) == [
+        {"index": 1, "role": "user", "text": "q1"},
+        {"index": 2, "role": "assistant", "text": "a1"},
+        {"index": 4, "role": "assistant", "text": "a2"},  # tool_use record skipped (no text)
     ]
+
+
+def test_conversational_messages_only_after_since():
+    recs = [_user("q1"), _asst("a1"), _user("q2"), _asst("a2")]
+    assert conversational_messages(recs, 1) == [
+        {"index": 2, "role": "user", "text": "q2"},
+        {"index": 3, "role": "assistant", "text": "a2"},
+    ]
+    assert conversational_messages(recs, 3) == []

--- a/packages/canopy_runner/tests/test_session_backfill_runner.py
+++ b/packages/canopy_runner/tests/test_session_backfill_runner.py
@@ -29,9 +29,15 @@ def _user(t):
     return json.dumps({"type": "user", "message": {"content": t}}) + "\n"
 
 
-def test_drains_backfill_and_ships_full_transcript(tmp_path, monkeypatch):
+def _summary():
+    return json.dumps({"type": "summary", "summary": "meta"}) + "\n"
+
+
+def test_drains_backfill_and_ships_full_transcript_with_ordinals(tmp_path, monkeypatch):
+    """Every message carries its RAW record index (the leading summary record shifts
+    them), so the server can key rows on the same ordinals the live stream uses."""
     p = tmp_path / "echo.jsonl"
-    p.write_text(_user("q1") + _asst("a1") + _user("q2") + _asst("a2"))
+    p.write_text(_summary() + _user("q1") + _asst("a1") + _user("q2") + _asst("a2"))
     monkeypatch.setattr(m.transcript, "resolve_transcript", lambda _proj, _task, **_k: p)
 
     c = _Client([{"session_id": "s1", "session_key": "echo-1", "project": "echo"}])
@@ -40,8 +46,8 @@ def test_drains_backfill_and_ships_full_transcript(tmp_path, monkeypatch):
     assert len(c.shipped) == 1
     sid, messages = c.shipped[0]
     assert sid == "s1"
-    assert [(x["role"], x["text"]) for x in messages] == [
-        ("user", "q1"), ("assistant", "a1"), ("user", "q2"), ("assistant", "a2"),
+    assert [(x["index"], x["role"], x["text"]) for x in messages] == [
+        (1, "user", "q1"), (2, "assistant", "a1"), (3, "user", "q2"), (4, "assistant", "a2"),
     ]
 
 

--- a/packages/canopy_runner/tests/test_session_streaming.py
+++ b/packages/canopy_runner/tests/test_session_streaming.py
@@ -1,5 +1,9 @@
-"""Runner live-streaming: tail a desired session's transcript and post new assistant
-text as live events; stop when it's no longer desired. Fake client + tmp transcript."""
+"""Runner live-streaming (spec 2026-07-24): tail a desired session's transcript and
+ship each new conversational record (user + assistant) with its RAW record ordinal.
+The resume point is the SERVER's `last_index` marker on the stream descriptor —
+no in-memory offset state — so a detach, a runner restart, or an account failover
+all catch up the same way: ship everything after the marker. Fake client + tmp
+transcript."""
 import json
 
 from canopy_runner import main as m
@@ -13,11 +17,14 @@ class _Client:
     def __init__(self, streams):
         self._streams = streams
         self.posted = []          # (session_id, events)
+        self.fail_posts = False
 
     def sync_streams(self, runner_id):
         return self._streams
 
     def post_session_stream(self, runner_id, session_id, events):
+        if self.fail_posts:
+            raise RuntimeError("network")
         self.posted.append((session_id, events))
 
 
@@ -25,37 +32,113 @@ def _asst(text):
     return json.dumps({"type": "assistant", "message": {"content": [{"type": "text", "text": text}]}}) + "\n"
 
 
-def test_streams_new_assistant_text_then_stops(tmp_path, monkeypatch):
+def _user(text):
+    return json.dumps({"type": "user", "message": {"content": text}}) + "\n"
+
+
+def _summary():
+    return json.dumps({"type": "summary", "summary": "meta"}) + "\n"
+
+
+def _desc(last_index=None):
+    return {"session_id": "s1", "session_key": "echo-1", "project": "echo",
+            "last_index": last_index}
+
+
+def _events(client):
+    return [e for _sid, ev in client.posted for e in ev]
+
+
+def _setup(tmp_path, monkeypatch, content):
     m._stream_readers.clear()
     p = tmp_path / "echo.jsonl"
-    p.write_text(_asst("old history"))  # pre-existing; seek_end skips it
+    p.write_text(content)
     monkeypatch.setattr(m.transcript, "resolve_transcript", lambda _proj, _task, **_k: p)
+    return p
 
-    streams = [{"session_id": "s1", "session_key": "echo-1", "project": "echo"}]
-    c = _Client(streams)
 
-    # first tick: registers the tailer at end-of-file -> no events yet
-    m._sync_session_streams(_Cfg(), c)
+def test_first_attach_streams_forward_with_raw_ordinals(tmp_path, monkeypatch):
+    """No server marker (last_index=None) => don't replay history; new records ship
+    keyed by their raw position in the file, users included."""
+    p = _setup(tmp_path, monkeypatch, _summary() + _user("old q") + _asst("old a"))
+    c = _Client([_desc()])
+
+    m._sync_session_streams(_Cfg(), c)          # attach: history is not replayed
     assert c.posted == []
 
-    # the session speaks -> next tick posts the new assistant text as a live event
     with open(p, "a") as f:
-        f.write(_asst("live reply"))
+        f.write(_user("live q") + _asst("live a"))   # ordinals 3, 4
     m._sync_session_streams(_Cfg(), c)
-    assert len(c.posted) == 1
-    sid, events = c.posted[0]
-    assert sid == "s1"
-    assert [e["payload"]["text"] for e in events] == ["live reply"]
-    assert events[0]["kind"] == "assistant"
-    assert events[0]["seq"] == 0
+    assert _events(c) == [
+        {"kind": "user", "seq": 3, "index": 3, "payload": {"text": "live q"}},
+        {"kind": "assistant", "seq": 4, "index": 4, "payload": {"text": "live a"}},
+    ]
 
-    # a further reply increments seq monotonically
+
+def test_attach_catches_up_from_the_server_marker(tmp_path, monkeypatch):
+    """The server holds rows through ordinal 1; everything after ships on attach."""
+    _setup(tmp_path, monkeypatch,
+           _user("q1") + _asst("a1") + _user("q2") + _asst("a2"))
+    c = _Client([_desc(last_index=1)])
+    m._sync_session_streams(_Cfg(), c)
+    assert _events(c) == [
+        {"kind": "user", "seq": 2, "index": 2, "payload": {"text": "q2"}},
+        {"kind": "assistant", "seq": 3, "index": 3, "payload": {"text": "a2"}},
+    ]
+
+
+def test_restart_resumes_from_the_server_marker(tmp_path, monkeypatch):
+    """The durable version of the #368 fix: attach → stream → the runner RESTARTS
+    (all in-memory state gone) while the agent keeps writing → on re-attach the
+    server's marker seeds the catch-up, so nothing written while away is lost and
+    no ordinal is ever shipped twice."""
+    p = _setup(tmp_path, monkeypatch, _user("q1") + _asst("a1"))
+    c = _Client([_desc(last_index=None)])
+    m._sync_session_streams(_Cfg(), c)          # attach
     with open(p, "a") as f:
-        f.write(_asst("more"))
+        f.write(_asst("while watching"))        # ordinal 2
     m._sync_session_streams(_Cfg(), c)
-    assert c.posted[-1][1][0]["seq"] == 1
+    assert [e["index"] for e in _events(c)] == [2]
 
-    # no longer desired -> the tailer is dropped, nothing posts
+    # RESTART: every in-memory tailer is gone; the agent worked while we were down.
+    m._stream_readers.clear()
+    with open(p, "a") as f:
+        f.write(_user("missed q") + _asst("missed a"))   # ordinals 3, 4
+    # The server persisted everything shipped so far, so its marker is 2.
+    c._streams = [_desc(last_index=2)]
+    m._sync_session_streams(_Cfg(), c)
+
+    assert [(e["kind"], e["index"], e["payload"]["text"]) for e in _events(c)] == [
+        ("assistant", 2, "while watching"),
+        ("user", 3, "missed q"),
+        ("assistant", 4, "missed a"),
+    ]
+    seqs = [e["seq"] for e in _events(c)]
+    assert len(seqs) == len(set(seqs)), f"ordinal-keyed seqs must never collide: {seqs}"
+
+
+def test_failed_post_is_retried_from_the_marker_next_tick(tmp_path, monkeypatch):
+    """A dropped post must not advance the local cursor past unshipped records —
+    the tailer resets and the next tick re-attaches from the server marker."""
+    p = _setup(tmp_path, monkeypatch, _user("q1"))
+    c = _Client([_desc(last_index=None)])
+    m._sync_session_streams(_Cfg(), c)          # attach at end of history
+    with open(p, "a") as f:
+        f.write(_asst("reply"))                 # ordinal 1
+    c.fail_posts = True
+    m._sync_session_streams(_Cfg(), c)          # post fails silently
+    assert c.posted == []
+    c.fail_posts = False
+    c._streams = [_desc(last_index=0)]          # server still only has ordinal 0
+    m._sync_session_streams(_Cfg(), c)          # re-attach + catch-up
+    assert [(e["index"], e["payload"]["text"]) for e in _events(c)] == [(1, "reply")]
+
+
+def test_detached_session_drops_its_tailer(tmp_path, monkeypatch):
+    _setup(tmp_path, monkeypatch, _asst("old"))
+    c = _Client([_desc()])
+    m._sync_session_streams(_Cfg(), c)
+    assert "s1" in m._stream_readers
     c._streams = []
     m._sync_session_streams(_Cfg(), c)
     assert "s1" not in m._stream_readers
@@ -70,46 +153,3 @@ def test_sync_streams_survives_client_error(monkeypatch):
 
     m._sync_session_streams(_Cfg(), _Boom())  # must not raise
     assert m._stream_readers == {}
-
-
-def test_reattach_resumes_instead_of_skipping_what_you_missed(tmp_path, monkeypatch):
-    """The phone-misses-messages bug.
-
-    Detaching dropped the tailer; re-attaching called seek_end() and skipped
-    EVERYTHING written while the viewer was away, and reset seq to 0 so the
-    replayed ids collided with older ones and got deduped away.
-    """
-    m._stream_readers.clear()
-    m._stream_state.clear()
-    p = tmp_path / "echo.jsonl"
-    p.write_text(_asst("old history"))
-    monkeypatch.setattr(m.transcript, "resolve_transcript", lambda _proj, _task, **_k: p)
-
-    watching = [{"session_id": "s1", "session_key": "echo-1", "project": "echo"}]
-    c = _Client(watching)
-
-    m._sync_session_streams(_Cfg(), c)          # attach (skips pre-existing history)
-    with open(p, "a") as f:
-        f.write(_asst("while watching"))
-    m._sync_session_streams(_Cfg(), c)
-    assert [e["payload"]["text"] for _s, ev in c.posted for e in ev] == ["while watching"]
-    first_seq = c.posted[-1][1][-1]["seq"]
-
-    # viewer closes the chat -> tailer dropped
-    c._streams = []
-    m._sync_session_streams(_Cfg(), c)
-    assert "s1" not in m._stream_readers
-
-    # the agent keeps working while nobody is watching
-    with open(p, "a") as f:
-        f.write(_asst("missed while away"))
-
-    # viewer re-opens -> the missed message must arrive, with a NON-colliding seq
-    c._streams = watching
-    m._sync_session_streams(_Cfg(), c)          # re-attach resumes at the saved offset
-    m._sync_session_streams(_Cfg(), c)          # ...and reads the appended bytes
-    texts = [e["payload"]["text"] for _s, ev in c.posted for e in ev]
-    assert "missed while away" in texts, "re-attach skipped what was written while away"
-    seqs = [e["seq"] for _s, ev in c.posted for e in ev]
-    assert len(seqs) == len(set(seqs)), f"seq restarted and collided: {seqs}"
-    assert seqs[-1] > first_seq

--- a/packages/canopy_runner/uv.lock
+++ b/packages/canopy_runner/uv.lock
@@ -21,8 +21,17 @@ dependencies = [
     { name = "canopy-cron" },
 ]
 
+[package.optional-dependencies]
+realtime = [
+    { name = "websocket-client" },
+]
+
 [package.metadata]
-requires-dist = [{ name = "canopy-cron", editable = "../canopy_cron" }]
+requires-dist = [
+    { name = "canopy-cron", editable = "../canopy_cron" },
+    { name = "websocket-client", marker = "extra == 'realtime'", specifier = ">=1.8,<2" },
+]
+provides-extras = ["realtime"]
 
 [[package]]
 name = "croniter"
@@ -55,4 +64,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
 ]

--- a/tests/test_transcript_persistence.py
+++ b/tests/test_transcript_persistence.py
@@ -1,0 +1,312 @@
+"""Persist a runner session's transcript (durable, restart-proof live view).
+
+Spec: docs/superpowers/specs/2026-07-24-persist-runner-session-transcript-design.md.
+For an origin=runner session the laptop transcript is the single source of truth:
+every Message.turn_index is the transcript record ordinal, so the live stream
+(forward) and backfill (older) are the SAME rows by identity — idempotent
+get_or_create, no collision. Web sessions are unchanged.
+"""
+import pytest
+from channels.db import database_sync_to_async
+from django.contrib.auth.models import User
+from django.test import Client
+from django.utils import timezone
+
+from apps.canopy_sessions import services
+from apps.canopy_sessions.models import Message, RunnerBinding, Session
+from apps.harness.models import Runner, Turn
+from apps.workspaces.models import Workspace, WorkspaceMembership
+
+pytestmark = pytest.mark.django_db
+
+
+def _ctx(*, origin=Session.ORIGIN_RUNNER):
+    user = User.objects.create_user("jj", "jj@dimagi.com", "pw")
+    ws = Workspace.objects.create(slug="w1", display_name="W1", created_by=user)
+    WorkspaceMembership.objects.create(user=user, workspace=ws, role=WorkspaceMembership.OWNER)
+    runner = Runner.objects.create(
+        name="jj-mbp", workspace=ws, location=Runner.LOCAL, paired_by=user,
+        host="jj@mbp", status=Runner.ONLINE, last_heartbeat_at=timezone.now(),
+    )
+    s = Session.objects.create(workspace=ws, origin=origin, created_by=user, title="ace-demo")
+    RunnerBinding.objects.create(
+        session=s, runner=runner, session_key="ace-demo",
+        thread_key="emdash:ace-demo", host=runner.host,
+    )
+    c = Client(); c.force_login(user)
+    return user, ws, runner, s, c
+
+
+def _rows(session):
+    return [(m.turn_index, m.role, m.plaintext) for m in session.messages.order_by("turn_index")]
+
+
+# --- persist_transcript_rows: one idempotent write path -------------------
+
+def test_persist_rows_keys_on_the_transcript_ordinal_idempotently():
+    _u, _w, _r, s, _c = _ctx()
+    rows = [
+        {"index": 5, "role": "user", "text": "q1"},
+        {"index": 7, "role": "assistant", "text": "a1"},
+    ]
+    assert services.persist_transcript_rows(s, rows) == 2
+    # Re-shipping the same records (stream retry, backfill overlap) is a no-op.
+    assert services.persist_transcript_rows(s, rows) == 0
+    assert _rows(s) == [(5, "user", "q1"), (7, "assistant", "a1")]
+
+
+def test_persist_rows_assigns_sequentially_when_no_ordinal():
+    """index=-1 (an old runner) => server assigns the next free index."""
+    _u, _w, _r, s, _c = _ctx()
+    rows = [
+        {"index": -1, "role": "user", "text": "q1"},
+        {"index": -1, "role": "assistant", "text": "a1"},
+    ]
+    assert services.persist_transcript_rows(s, rows) == 2
+    assert _rows(s) == [(0, "user", "q1"), (1, "assistant", "a1")]
+
+
+def test_persist_rows_skips_unknown_roles():
+    _u, _w, _r, s, _c = _ctx()
+    rows = [
+        {"index": 3, "role": "status", "text": "nope"},
+        {"index": 4, "role": "assistant", "text": "a"},
+    ]
+    assert services.persist_transcript_rows(s, rows) == 1
+    assert _rows(s) == [(4, "assistant", "a")]
+
+
+# --- the live stream persists (runner sessions, ordinals only) ------------
+
+def _post_stream(c, runner, session, events):
+    return c.post(
+        f"/api/harness/runners/{runner.id}/session-stream",
+        data={"session_id": str(session.id), "events": events},
+        content_type="application/json",
+    )
+
+
+def test_stream_post_persists_ordinal_rows_and_fans_out_assistant_only(monkeypatch):
+    published = []
+    monkeypatch.setattr("apps.realtime.groups.publish", lambda g, m: published.append((g, m)))
+    _u, _w, runner, s, c = _ctx()
+    body = _post_stream(c, runner, s, [
+        {"kind": "user", "seq": 5, "index": 5, "payload": {"text": "q1"}},
+        {"kind": "assistant", "seq": 7, "index": 7, "payload": {"text": "a1"}},
+    ]).json()
+    assert body == {"count": 2}
+    assert _rows(s) == [(5, "user", "q1"), (7, "assistant", "a1")]
+    # The user's own words are NOT live-pushed (the frontend already echoed them
+    # optimistically); only the assistant frame fans out.
+    kinds = [m["event"]["kind"] for _g, m in published]
+    assert kinds == ["assistant"]
+
+
+def test_stream_post_without_ordinal_does_not_persist(monkeypatch):
+    """An OLD runner (no index) keeps the legacy live-view-only contract: persisting
+    assistant-only rows would kill the tail fallback's human side (trap 2)."""
+    monkeypatch.setattr("apps.realtime.groups.publish", lambda g, m: None)
+    _u, _w, runner, s, c = _ctx()
+    _post_stream(c, runner, s, [{"kind": "assistant", "seq": 0, "payload": {"text": "a"}}])
+    assert s.messages.count() == 0
+
+
+def test_stream_post_never_persists_for_a_web_session(monkeypatch):
+    """A web session's index space belongs to send_message/projection — the
+    transcript stream must not write into it."""
+    monkeypatch.setattr("apps.realtime.groups.publish", lambda g, m: None)
+    _u, _w, runner, s, c = _ctx(origin=Session.ORIGIN_WEB)
+    _post_stream(c, runner, s, [
+        {"kind": "assistant", "seq": 9, "index": 9, "payload": {"text": "a"}},
+    ])
+    assert s.messages.count() == 0
+
+
+# --- catch-up marker: GET /streams carries last_index ----------------------
+
+def test_streams_descriptor_carries_last_index():
+    _u, _w, runner, s, c = _ctx()
+    RunnerBinding.objects.filter(session=s).update(stream_desired=True)
+    body = c.get(f"/api/harness/runners/{runner.id}/streams").json()
+    assert body["streams"][0]["last_index"] is None      # no rows yet
+    Message.objects.create(session=s, turn_index=7, role=Message.ASSISTANT, plaintext="a")
+    body = c.get(f"/api/harness/runners/{runner.id}/streams").json()
+    assert body["streams"][0]["last_index"] == 7
+
+
+# --- backfill: same rows by identity, fills the older gap ------------------
+
+def test_write_backfill_upserts_older_rows_around_streamed_ones():
+    _u, _w, _r, s, _c = _ctx()
+    services.persist_transcript_rows(s, [{"index": 7, "role": "assistant", "text": "a2"}])
+    full = [
+        {"index": 1, "role": "user", "text": "q1"},
+        {"index": 3, "role": "assistant", "text": "a1"},
+        {"index": 5, "role": "user", "text": "q2"},
+        {"index": 7, "role": "assistant", "text": "a2"},
+    ]
+    assert services.write_backfill(s, full) == 3          # 7 already exists
+    assert _rows(s) == [
+        (1, "user", "q1"), (3, "assistant", "a1"), (5, "user", "q2"), (7, "assistant", "a2"),
+    ]
+    assert services.write_backfill(s, full) == 0          # idempotent re-ship
+
+
+def test_write_backfill_without_ordinals_keeps_the_write_once_contract():
+    """An OLD runner ships {role,text} only — sequential, and only into an empty
+    session, exactly as before."""
+    _u, _w, _r, s, _c = _ctx()
+    msgs = [{"role": "user", "text": "q"}, {"role": "assistant", "text": "a"}]
+    assert services.write_backfill(s, msgs) == 2
+    assert services.write_backfill(s, msgs) == 0
+    assert _rows(s) == [(0, "user", "q"), (1, "assistant", "a")]
+
+
+def test_request_backfill_requested_when_rows_lack_the_start(monkeypatch):
+    """Streamed rows alone (ordinals > 0) are not the full history — 'ready' only
+    when the start of the transcript (turn_index 0) is present."""
+    monkeypatch.setattr("apps.realtime.groups.publish", lambda g, m: None)
+    _u, _w, _r, s, c = _ctx()
+    Message.objects.create(session=s, turn_index=3, role=Message.ASSISTANT, plaintext="a")
+    assert c.post(f"/api/canopy-sessions/{s.id}/backfill").json() == {"status": "requested"}
+    Message.objects.create(session=s, turn_index=0, role=Message.USER, plaintext="q")
+    assert c.post(f"/api/canopy-sessions/{s.id}/backfill").json() == {"status": "ready"}
+
+
+# --- send_message: the transcript is the sole durable source ---------------
+
+def test_runner_session_send_writes_no_durable_user_row():
+    user, _w, _r, s, _c = _ctx()
+    msg, turn = services.send_message(session=s, text="hello", user=user, client_id="c1")
+    assert s.messages.count() == 0                        # durable copy = transcript
+    assert turn is not None and turn.status == Turn.QUEUED
+    # The send contract still returns a message the client can render.
+    assert msg.role == Message.USER and msg.plaintext == "hello"
+    assert msg.pk and str(msg.pk) != "None"
+    assert msg.created_at is not None
+
+
+def test_runner_session_send_is_idempotent_per_client_id():
+    user, _w, _r, s, _c = _ctx()
+    _m1, turn1 = services.send_message(session=s, text="hello", user=user, client_id="c1")
+    _m2, turn2 = services.send_message(session=s, text="hello", user=user, client_id="c1")
+    assert turn1.id == turn2.id
+    assert Turn.objects.filter(chat_session=s).count() == 1
+
+
+def test_runner_session_sends_without_client_id_stay_distinct():
+    """The WS path sends no client_id. Without a durable row, _next_index no longer
+    advances between sends — the fallback key must still differ per send."""
+    user, _w, _r, s, _c = _ctx()
+    _m1, turn1 = services.send_message(session=s, text="one", user=user)
+    _m2, turn2 = services.send_message(session=s, text="two", user=user)
+    assert turn1.id != turn2.id
+    assert Turn.objects.filter(chat_session=s).count() == 2
+
+
+def test_web_session_send_still_writes_the_user_row():
+    user, ws, _r, _s, _c = _ctx()
+    s = Session.objects.create(workspace=ws, created_by=user, origin=Session.ORIGIN_WEB, title="w")
+    msg, _turn = services.send_message(session=s, text="hello", user=user, client_id="c1")
+    assert s.messages.count() == 1
+    assert msg.pk == s.messages.get().pk
+
+
+def test_rest_send_returns_a_transient_message_for_runner_sessions():
+    _u, _w, _r, s, c = _ctx()
+    body = c.post(
+        f"/api/canopy-sessions/{s.id}/send",
+        data={"text": "hello", "client_id": "n1"},
+        content_type="application/json",
+    ).json()
+    assert body["message"]["plaintext"] == "hello"
+    assert body["message"]["role"] == "user"
+    assert body["turn_id"]
+    assert s.messages.count() == 0
+
+
+# --- the ledger projection stays out of the transcript's index space -------
+
+def test_project_events_skips_runner_sessions():
+    """A bridged chat reply reaches the DB via the transcript stream (ordinal-keyed);
+    projecting it AGAIN from the TurnEvent ledger would double-persist it."""
+    from apps.harness import services as harness
+
+    user, _w, _r, s, _c = _ctx()
+    turn, _ = harness.enqueue_turn(session=s, origin=Turn.ORIGIN_API,
+                                   idempotency_key="t1", prompt="hi")
+    harness.append_events(turn, [{"kind": "assistant", "payload": {"text": "reply"}}])
+    assert services.project_events(turn, list(turn.events.all())) == 0
+    assert s.messages.count() == 0
+
+
+def test_project_events_still_materializes_web_sessions():
+    from apps.harness import services as harness
+
+    user, ws, _r, _s, _c = _ctx()
+    s = Session.objects.create(workspace=ws, created_by=user, origin=Session.ORIGIN_WEB, title="w")
+    turn, _ = harness.enqueue_turn(session=s, origin=Turn.ORIGIN_API,
+                                   idempotency_key="t2", prompt="hi")
+    harness.append_events(turn, [{"kind": "assistant", "payload": {"text": "reply"}}])
+    assert services.project_events(turn, list(turn.events.all())) == 1
+    assert s.messages.count() == 1
+
+
+# --- the DoD flow: attach → persist → detach → catch-up → parity -----------
+
+async def _ws_messages(session, user):
+    from channels.testing import WebsocketCommunicator
+
+    from apps.canopy_sessions.consumers import SessionConsumer
+
+    comm = WebsocketCommunicator(SessionConsumer.as_asgi(), f"/ws/canopy-sessions/{session.id}/")
+    comm.scope["url_route"] = {"kwargs": {"session_id": str(session.id)}}
+    comm.scope["user"] = user
+    connected, _ = await comm.connect()
+    assert connected is True
+    for _ in range(14):
+        frame = await comm.receive_json_from(timeout=5)
+        if frame.get("event") == "session.state":
+            await comm.disconnect()
+            return frame["data"]["messages"]
+    await comm.disconnect()
+    raise AssertionError("no session.state frame")
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_catch_up_fills_the_gap_and_both_transports_agree(monkeypatch):
+    """Attach → stream persists → detach → the agent keeps writing → re-attach →
+    catch-up ships everything after last_index → REST and the WS snapshot show the
+    same complete, ordered conversation with no dup of the user's own send."""
+    def _flow():
+        user, _w, runner, s, c = _ctx()
+        # Viewer attaches; the runner streams the live exchange with ordinals.
+        assert c.post(f"/api/canopy-sessions/{s.id}/attach").json()["streaming"] is True
+        # The human sends from the phone: optimistic echo only, no durable row.
+        services.send_message(session=s, text="q1", user=user, client_id="n1")
+        _post_stream(c, runner, s, [
+            {"kind": "user", "seq": 5, "index": 5, "payload": {"text": "q1"}},
+            {"kind": "assistant", "seq": 7, "index": 7, "payload": {"text": "a1"}},
+        ])
+        # The runner's catch-up marker is now server-side.
+        RunnerBinding.objects.filter(session=s).update(stream_desired=True)
+        body = c.get(f"/api/harness/runners/{runner.id}/streams").json()
+        assert body["streams"][0]["last_index"] == 7
+        # Viewer detaches; the agent keeps working while nobody watches.
+        c.post(f"/api/canopy-sessions/{s.id}/detach")
+        # Re-attach: the runner ships everything after last_index.
+        c.post(f"/api/canopy-sessions/{s.id}/attach")
+        _post_stream(c, runner, s, [
+            {"kind": "user", "seq": 8, "index": 8, "payload": {"text": "q2"}},
+            {"kind": "assistant", "seq": 9, "index": 9, "payload": {"text": "a2"}},
+        ])
+        rest = c.get(f"/api/canopy-sessions/{s.id}").json()["messages"]
+        return user, s, rest
+
+    monkeypatch.setattr("apps.realtime.groups.publish", lambda g, m: None)
+    user, session, rest = await database_sync_to_async(_flow)()
+    expected = [(5, "q1"), (7, "a1"), (8, "q2"), (9, "a2")]
+    assert [(m["turn_index"], m["plaintext"]) for m in rest] == expected
+    ws_rows = await _ws_messages(session, user)
+    assert [(m["turn_index"], m["plaintext"]) for m in ws_rows] == expected


### PR DESCRIPTION
Closes #373. Implements `docs/superpowers/specs/2026-07-24-persist-runner-session-transcript-design.md` (merged in #372) — the coordinated server + runner + send-path change, built as one PR because no server-only stage is safe (spec traps 1–3).

## The model

For an `origin=runner` session the laptop transcript is the single durable source. Every `Message.turn_index` is the **transcript record ordinal**, so the live stream (forward), attach catch-up, and backfill (older) produce the SAME rows by identity — idempotent `get_or_create(session, turn_index=ordinal)`, no collision, existing ordering + unique constraint untouched. Web sessions unchanged.

- **Stream:** while attached, the runner ships each new conversational record (user + assistant) with its ordinal → the server persists, then fans out only the assistant frames (the sender's client already echoed the user's words optimistically).
- **Catch-up:** `GET /streams` now returns `last_index` (server's max persisted `turn_index`); the runner ships everything after it on attach. The resume marker is server-side, so a detach, runner restart, server-down window, or account failover all recover identically. The in-memory `_stream_state` offset hack from #368 is deleted — superseded.
- **Backfill:** ships the full transcript with ordinals and upsert-fills the older rows around whatever the stream already persisted. `request_backfill` returns `ready` iff a row at `turn_index == 0` exists (we hold the start), else `requested`.
- **send_message:** for `origin=runner`, no durable user row (the transcript is the sole source — trap 1/2); a transient `MessageOut` keeps the REST/WS send contracts, and a nonce fallback keeps no-`client_id` sends from collapsing onto one idempotency key now that `_next_index` doesn't advance.

## Two additions beyond the spec checklist (both forced by trap 1's one-index-space rule)

- **`project_events` skips runner sessions.** `execute_chat_turn` bridges the reply into the TurnEvent ledger too; projecting it as well would persist the same reply twice in a second index space. The ledger frames still stream to the live client unchanged.
- **Migration `canopy_sessions.0010`** deletes runner sessions' pre-ordinal `Message` rows. Legacy sequential keys would otherwise collide with incoming ordinals and `get_or_create` would silently swallow new messages. Safe by the model's own premise: everything dropped is re-shippable from the transcript (catch-up or Load full), and the binding tail covers the interim.

## Backward compatibility (an old runner still works)

`index` defaults to −1 on both wire types. Ordinal-less **stream** events stay live-view-only — persisting assistant-only rows would blank the tail fallback's human side the moment any row exists (trap 2), which would otherwise be a permanent regression for any runner that lags the update, not just a deploy-window one. Ordinal-less **backfills** keep the exact legacy write-once contract.

## Verification

- `tests/test_transcript_parity.py` untouched and green (REST ↔ WS parity).
- New `tests/test_transcript_persistence.py` (18 tests) incl. the DoD flow: attach → stream persists → detach → agent writes while away → re-attach → catch-up fills the gap from `last_index` → REST and WS agree, no dup of the user's own send.
- Runner: rewritten `test_session_streaming.py` proves restart-resume from the server marker with no in-memory state, ordinal-keyed seqs never colliding, and failed posts retrying from the marker.
- Backend 1138 passed · runner 157 passed (`uv run --with pytest pytest`) · vitest 231 passed · `tsc -b && vite build` clean · CI-scoped ruff clean · `makemigrations --check` clean · `generated.ts` regenerated.

## Deploy ordering (after merge)

1. **Deploy to Labs (AWS)** from main (migrations run automatically — 0010 resets runner-session rows).
2. Immediately `git -C ~/emdash-projects/canopy-web pull && launchctl kickstart -k gui/$(id -u)/com.canopy.runner` (both runner accounts).
3. Prod-verify per #373: open a runner-discovered session on the phone, watch it accrue rows, close/reopen, restart the runner — transcript survives all three, both sides present, no dup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)