### PR TITLE
fix(cloud-runner): survive send errors + reconnect; drills fail on lost turns; gh/op on the box

### DIFF
--- a/apps/harness/services.py
+++ b/apps/harness/services.py
@@ -133,6 +133,15 @@ def sweep_expired_leases() -> int:
         if updated:
             append_events(turn, [{"kind": "status", "payload": {"status": Turn.LOST, "reason": "lease_expired"}}])
             count += 1
+            # A LOST turn is marked via a queryset update, bypassing finish_turn —
+            # so the FAILED-drill hook there never fires and a drill's RunnerDrill
+            # would otherwise strand as pending forever. Mirror that hook here.
+            if turn.origin == Turn.ORIGIN_DRILL:
+                RunnerDrill.objects.filter(
+                    turn=turn, outcome=RunnerDrill.OUTCOME_PENDING
+                ).update(outcome=RunnerDrill.OUTCOME_FAIL,
+                         summary="runner lost the turn (lease expired mid-drill)",
+                         finished_at=now)
     return count
 
 
@@ -1283,7 +1292,7 @@ Verify you can operate end-to-end in THIS environment, then report.
    it proves this environment can reach the control plane):
 
    curl -s -X POST "{report_url}" \\
-     -H "Authorization: Bearer $(cat ~/.claude/canopy/workbench-token 2>/dev/null || echo "$CANOPY_PAT")" \\
+     -H "Authorization: Bearer $(cat ~/.claude/canopy/workbench-token 2>/dev/null || echo "${{CANOPY_TOKEN:-$CANOPY_PAT}}")" \\
      -H "Content-Type: application/json" \\
      -d '{{"outcome": "pass", "summary": "<one-paragraph findings>"}}'
 

--- a/deploy/ec2-runner/cloud_runner.py
+++ b/deploy/ec2-runner/cloud_runner.py
@@ -122,8 +122,13 @@ def run_claude(prompt: str, turn_id: str, emit) -> tuple[bool, str]:
         "--dangerously-skip-permissions",
     ]
     _log(f"exec: claude -p (turn {turn_id[:8]}) in {workdir}")
+    # stderr goes to a file, not PIPE: a chatty claude can fill the 64KB pipe buffer
+    # while we're only reading stdout, deadlocking the process. A file has no such
+    # limit; we tail it for the failure path below.
+    stderr_path = workdir / "stderr.log"
+    stderr_file = stderr_path.open("w")
     proc = subprocess.Popen(
-        cmd, cwd=str(workdir), stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+        cmd, cwd=str(workdir), stdout=subprocess.PIPE, stderr=stderr_file, text=True
     )
     final_text = ""
     ok = True
@@ -160,10 +165,15 @@ def run_claude(prompt: str, turn_id: str, emit) -> tuple[bool, str]:
         if len(batch) >= 10:
             flush()
     proc.wait()
+    stderr_file.close()
     flush()
     if proc.returncode != 0 and not final_text:
         ok = False
-        final_text = (proc.stderr.read() if proc.stderr else "")[:500]
+        try:
+            tail = stderr_path.read_text(errors="replace")
+        except OSError:
+            tail = ""
+        final_text = tail[-500:]
     return ok, final_text
 
 
@@ -243,7 +253,17 @@ def _ws_request(ws, frame: dict, want_type: str, timeout: float = 120.0):
     waiting on right now). Returns the matched frame, or None on close/timeout."""
     import websocket  # local: only the WS path needs the dep
 
-    ws.send(json.dumps(frame))
+    # ws.settimeout() also governs sends, not just recv. A large event frame (e.g.
+    # drill doctor output) can take longer to write than the short WS_POLL_TIMEOUT
+    # allows; if the socket times out mid-write, OpenSSL has already handed part of
+    # the frame to the kernel and a subsequent SSL_write MUST resend the exact same
+    # buffer or it raises ssl.SSLError BAD_LENGTH — killing the process. Give sends
+    # a generous timeout, then restore the short poll timeout for the recv loop.
+    ws.settimeout(60)
+    try:
+        ws.send(json.dumps(frame))
+    finally:
+        ws.settimeout(WS_POLL_TIMEOUT)
     deadline = time.time() + timeout
     while time.time() < deadline:
         try:
@@ -312,10 +332,10 @@ def run_over_ws(runner_id: str) -> bool:
         def _beat():
             _ws_request(ws, {"action": "heartbeat", "active_turn_ids": []}, "heartbeat.ack", timeout=15)
 
-        _beat()  # register ONLINE immediately (claim_next_turn gates on a fresh heartbeat)
-        last_beat = time.monotonic()
-        _claim_and_run(ws, runner_id)  # drain anything already queued (no wake for those)
         try:
+            _beat()  # register ONLINE immediately (claim_next_turn gates on a fresh heartbeat)
+            last_beat = time.monotonic()
+            _claim_and_run(ws, runner_id)  # drain anything already queued (no wake for those)
             while not _stop:
                 try:
                     raw = ws.recv()

--- a/deploy/ec2-runner/runner.cfn.yaml
+++ b/deploy/ec2-runner/runner.cfn.yaml
@@ -157,9 +157,15 @@ Resources:
                 WantedBy=multi-user.target
           runcmd:
             - [ bash, -c, "curl -fsSL https://deb.nodesource.com/setup_20.x | bash -" ]
-            - [ bash, -c, "DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs unzip python3-websocket" ]
+            - [ bash, -c, "DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs unzip gnupg python3-websocket" ]
             - [ bash, -c, "npm i -g @anthropic-ai/claude-code" ]
             - [ bash, -c, "curl -fsSL https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o /tmp/awscliv2.zip && cd /tmp && unzip -q awscliv2.zip && ./aws/install" ]
+            # gh (GitHub CLI) and op (1Password CLI) — drill doctors flagged both as
+            # missing on the box. Non-fatal (|| true): a transient repo/network hiccup
+            # here shouldn't wedge the whole cloud-init run; the runner still comes up
+            # and a later `canopy-fetch-env`/manual apt-get can retry.
+            - [ bash, -c, "curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o /usr/share/keyrings/githubcli-archive-keyring.gpg && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main' > /etc/apt/sources.list.d/github-cli.list && apt-get update && apt-get install -y gh || true" ]
+            - [ bash, -c, "curl -fsSL https://downloads.1password.com/linux/keys/1password.asc | gpg --dearmor -o /usr/share/keyrings/1password-archive-keyring.gpg && echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/1password-archive-keyring.gpg] https://downloads.1password.com/linux/debian/amd64 stable main' > /etc/apt/sources.list.d/1password.list && mkdir -p /etc/debsig/policies/AC2D62742012EA22 /usr/share/debsig/keyrings/AC2D62742012EA22 && curl -fsSL https://downloads.1password.com/linux/debian/debsig/1password.pol -o /etc/debsig/policies/AC2D62742012EA22/1password.pol && curl -fsSL https://downloads.1password.com/linux/keys/1password.asc | gpg --dearmor -o /usr/share/debsig/keyrings/AC2D62742012EA22/debsig.gpg && apt-get update && apt-get install -y 1password-cli || true" ]
             # Materialize the env + creds once (as root) BEFORE first start, so the
             # unit doesn't fail on a missing EnvironmentFile on boot.
             - [ bash, -c, "/usr/local/bin/canopy-fetch-env" ]

--- a/tests/test_runner_drills.py
+++ b/tests/test_runner_drills.py
@@ -90,6 +90,32 @@ def test_failed_drill_turn_marks_drill_fail(django_user_model):
     assert "claude auth expired" in d.summary
 
 
+def test_lost_drill_turn_marks_drill_fail(django_user_model):
+    # A LOST turn is marked via sweep_expired_leases's queryset update, which
+    # bypasses finish_turn entirely — so the FAILED-drill hook there never
+    # fires on its own. Assert sweep_expired_leases mirrors that hook so a
+    # drill whose runner disappears mid-turn doesn't strand as pending forever.
+    u = django_user_model.objects.create_user(username="o5", password="x")
+    r = Runner.objects.create(name="s5", kind=Runner.EMDASH, capabilities={}, paired_by=u,
+                              last_heartbeat_at=timezone.now(), status=Runner.ONLINE)
+    a = Agent.objects.create(slug="echo5", name="Echo5")
+    RunnerAssignment.objects.create(agent=a, runner=r, rank=0)
+    [d] = services.start_drill(r, [a])
+    turn = Turn.objects.get(origin=Turn.ORIGIN_DRILL)
+    Turn.objects.filter(pk=turn.pk).update(
+        status=Turn.CLAIMED, claimed_by=r,
+        lease_expires_at=timezone.now() - timezone.timedelta(minutes=5),
+    )
+    swept = services.sweep_expired_leases()
+    assert swept == 1
+    turn.refresh_from_db()
+    assert turn.status == Turn.LOST
+    d.refresh_from_db()
+    assert d.outcome == RunnerDrill.OUTCOME_FAIL
+    assert "lost" in d.summary.lower()
+    assert d.finished_at is not None
+
+
 def test_redrill_resets_to_pending(django_user_model):
     u = django_user_model.objects.create_user(username="o", password="x")
     r = Runner.objects.create(name="s", kind=Runner.EMDASH, capabilities={}, paired_by=u,


### PR DESCRIPTION
Production fixes from the first EC2 drill wave (runner crashed 4× with ssl BAD_LENGTH, losing turns):

- `run_over_ws`: initial heartbeat + queued-drain now inside the guarded loop — a send failure reconnects instead of killing the process; `_ws_request` uses a generous send timeout (always restoring the poll timeout) so a partial TLS write of a large event frame can't poison the SSL state.
- `run_claude`: stderr to a file (no more 64KB pipe deadlock risk).
- cloud-init now installs `gh` + `op` (the drills' top environment finding).
- `DRILL_PROMPT` token fallback includes `$CANOPY_TOKEN` (what the EC2 env actually stages).
- Turns swept to LOST now fail their pending `RunnerDrill` instead of stranding it.

Gates: 1198 backend tests green, ruff clean, py_compile + cloud-init YAML parse verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)