### PR TITLE
fix(harness): session turns readable by any authenticated user

### DIFF
--- a/apps/harness/api.py
+++ b/apps/harness/api.py
@@ -148,20 +148,34 @@ def _turn_or_404(request: HttpRequest, turn_id: uuid.UUID) -> Turn:
 
     An AGENT turn derives its tenant one hop away, via agent.workspace (spec
     section 8) — it has no workspace FK of its own, because denormalized tenancy
-    drifts. A PROJECT turn has no agent to derive from, so it carries its own
+    drifts. A SESSION turn similarly derives its tenant via chat_session.workspace.
+    A PROJECT turn has no agent/session to derive from, so it carries its own
     workspace FK and is gated on that instead. Same 404-not-403 rule either way:
     non-membership must not leak existence.
     """
-    turn = Turn.objects.select_related("agent", "claimed_by").filter(pk=turn_id).first()
+    turn = (
+        Turn.objects.select_related("agent", "claimed_by", "chat_session")
+        .filter(pk=turn_id)
+        .first()
+    )
     if turn is None:
         raise HttpError(404, "turn not found")
     if turn.agent_id:
         _agent_or_404(request, turn.agent.slug)  # raises 404 on wrong tenant
         return turn
 
-    # Project turn: gate on its own workspace, mirroring _agent_or_404's checks.
+    # Session turn: tenancy derives from the chat session's workspace (a session
+    # turn has agent_id=None AND workspace_id=None, so without this branch both
+    # guards below fall through — any authenticated user could read the transcript).
     wsvc.auto_join_workspaces(request.user)
     ws = getattr(request, "workspace_slug", None)
+    if turn.chat_session_id:
+        slug = turn.chat_session.workspace_id
+        if (ws and slug != ws) or not wsvc.is_member(request.user, slug):
+            raise HttpError(404, "turn not found")
+        return turn
+
+    # Project turn: gate on its own workspace, mirroring _agent_or_404's checks.
     if ws and turn.workspace_id != ws:
         raise HttpError(404, "turn not found")  # wrong tenant
     if turn.workspace_id and not wsvc.is_member(request.user, turn.workspace_id):

--- a/tests/test_harness_session_turn_tenancy.py
+++ b/tests/test_harness_session_turn_tenancy.py
@@ -1,0 +1,56 @@
+"""A chat-session turn must be tenant-gated like agent/project turns: a
+non-member of the session's workspace gets 404 from the turn read routes,
+never the transcript. Regression for the _turn_or_404 fall-through."""
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth.models import User
+from django.test import Client
+
+from apps.canopy_sessions.models import Session
+from apps.harness.models import Turn
+from apps.workspaces.models import Workspace, WorkspaceMembership
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture()
+def owner():
+    return User.objects.create_user("owner", "owner@dimagi.com", "pw")
+
+
+@pytest.fixture()
+def workspace(owner):
+    ws = Workspace.objects.create(slug="canopy", display_name="Canopy", created_by=owner)
+    WorkspaceMembership.objects.create(user=owner, workspace=ws, role=WorkspaceMembership.OWNER)
+    return ws
+
+
+@pytest.fixture()
+def stranger():
+    # email domain outside auto-join so membership stays empty
+    return User.objects.create_user("stranger", "stranger@example.org", "pw")
+
+
+@pytest.fixture()
+def session_turn(workspace, owner):
+    session = Session.objects.create(workspace=workspace, created_by=owner, title="t")
+    return Turn.objects.create(chat_session=session, prompt="hi")
+
+
+def _login(user):
+    c = Client()
+    c.force_login(user)
+    return c
+
+
+def test_member_reads_session_turn(owner, session_turn):
+    c = _login(owner)
+    assert c.get(f"/api/harness/turns/{session_turn.id}").status_code == 200
+    assert c.get(f"/api/harness/turns/{session_turn.id}/events").status_code == 200
+
+
+def test_stranger_gets_404_on_session_turn(stranger, session_turn):
+    c = _login(stranger)
+    assert c.get(f"/api/harness/turns/{session_turn.id}").status_code == 404
+    assert c.get(f"/api/harness/turns/{session_turn.id}/events").status_code == 404


### PR DESCRIPTION
## Summary
- `_turn_or_404` (apps/harness/api.py) had no tenancy branch for chat-session turns: they carry `agent_id=None` and `workspace_id=None`, so both existing guards fell through and **any authenticated user could read any chat turn — including its full transcript via `GET /api/harness/turns/{id}/events`**.
- Adds the session branch (tenant = `chat_session.workspace_id`, mirroring `apps/realtime/groups.py::turn_workspace_slug`), keeps the 404-not-403 no-existence-leak rule, and adds `select_related("chat_session")`.
- Regression tests: member reads 200, stranger 404 on both the turn read and its events.

First PR of the ace-web → canopy chat cutover platform work (spec: `docs/superpowers/specs/2026-07-25-ace-web-canopy-chat-cutover-design.md`, ships separately) — but this is a live vulnerability fix and stands alone.

## Test plan
- `uv run pytest tests/test_harness_session_turn_tenancy.py -v` (new, RED→GREEN)
- Full suite: 1199 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)