### PR TITLE
Supervisor: liveness-aware wrong-branch banner with one-click Retire

### DIFF
--- a/frontend/src/api/harness.ts
+++ b/frontend/src/api/harness.ts
@@ -23,6 +23,15 @@ export async function listRunners(): Promise<RunnerOut[]> {
   return Array.from(unwrap(res, 'listRunners'))
 }
 
+// Retire a runner — permanent (re-pairing mints a fresh row). The supervisor's
+// in-place resolve for a decommissioned runner stuck on a non-main branch.
+export async function retireRunner(runnerId: string): Promise<void> {
+  const { error } = await apiV2.POST('/api/harness/runners/{runner_id}/retire', {
+    params: { path: { runner_id: runnerId } },
+  })
+  if (error) throw new Error(`retireRunner failed: ${JSON.stringify(error)}`)
+}
+
 // Dispatch a turn from the phone composer — to an agent OR a repo.
 //
 // An AGENT turn routes through the flat mount: the server derives the agent's

--- a/frontend/src/components/supervisor/BranchAlerts.test.tsx
+++ b/frontend/src/components/supervisor/BranchAlerts.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+
+import { BranchAlerts } from './BranchAlerts'
+import type { RunnerOut } from '@/api/harness'
+
+const runner = (name: string, code_branch: string, status: string): RunnerOut =>
+  ({ id: name, name, code_branch, status } as unknown as RunnerOut)
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('BranchAlerts', () => {
+  it('renders nothing when every runner is on main', () => {
+    const { container } = render(
+      <BranchAlerts runners={[runner('ok', 'main', 'online')]} retiringId={null} onRetire={() => {}} />,
+    )
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('a heartbeating runner gets the fix-on-machine variant, with no retire button', () => {
+    render(
+      <BranchAlerts runners={[runner('r1', 'feat-x', 'online')]} retiringId={null} onRetire={() => {}} />,
+    )
+    const alert = screen.getByTestId('runner-branch-alert-r1')
+    expect(alert.textContent).toContain('stale / wrong code')
+    expect(alert.textContent).toContain('feat-x')
+    expect(screen.queryByTestId('retire-runner-r1')).toBeNull()
+  })
+
+  it('a dead runner explains the banner can never self-clear and offers Retire', () => {
+    const onRetire = vi.fn()
+    render(
+      <BranchAlerts
+        runners={[runner('jj-mbp-cdp', 'ddd-ui-polish', 'stale')]}
+        retiringId={null}
+        onRetire={onRetire}
+      />,
+    )
+    const alert = screen.getByTestId('runner-branch-alert-jj-mbp-cdp')
+    expect(alert.textContent).toContain('stopped heartbeating')
+    expect(alert.textContent).toContain('never clear on its own')
+    fireEvent.click(screen.getByTestId('retire-runner-jj-mbp-cdp'))
+    expect(onRetire).toHaveBeenCalledTimes(1)
+    expect(onRetire.mock.calls[0][0].name).toBe('jj-mbp-cdp')
+  })
+
+  it('disables the button while that runner is retiring', () => {
+    render(
+      <BranchAlerts
+        runners={[runner('r1', 'feat-x', 'disconnected')]}
+        retiringId="r1"
+        onRetire={() => {}}
+      />,
+    )
+    const btn = screen.getByTestId('retire-runner-r1') as HTMLButtonElement
+    expect(btn.disabled).toBe(true)
+    expect(btn.textContent).toContain('Retiring')
+  })
+})

--- a/frontend/src/components/supervisor/BranchAlerts.tsx
+++ b/frontend/src/components/supervisor/BranchAlerts.tsx
@@ -1,0 +1,72 @@
+import type { JSX } from 'react'
+import type { RunnerOut } from '@/api/harness'
+import { wrongBranchAlerts } from './wrongBranch'
+
+// LOUD alert: a runner on any branch but main is silently running stale/wrong
+// code. Two variants (see wrongBranch.ts): a HEARTBEATING runner is fixed on
+// its machine; a QUIET one can never heartbeat its way off the branch — the
+// shown branch is its last report — so the in-place resolve is Retire.
+export function BranchAlerts({
+  runners,
+  retiringId,
+  onRetire,
+}: {
+  runners: readonly RunnerOut[] | null
+  retiringId: string | null
+  onRetire: (runner: RunnerOut) => void
+}): JSX.Element {
+  return (
+    <>
+      {wrongBranchAlerts(runners).map(({ runner: r, unreachable }) => (
+        <div
+          key={`branch-alert-${r.id}`}
+          role="alert"
+          data-testid={`runner-branch-alert-${r.id}`}
+          className="rounded-lg border-2 border-destructive bg-destructive/15 p-3 text-destructive"
+        >
+          <p className="text-[13px] font-bold uppercase tracking-wide">
+            {unreachable ? '⚠ Offline runner stuck on wrong branch' : '⚠ Runner on wrong branch — stale code'}
+          </p>
+          <p className="mt-1 text-[13px] leading-snug">
+            <span className="font-semibold">{r.name}</span>{' '}
+            {unreachable ? 'last reported branch' : 'is running on branch'}{' '}
+            <span className="rounded bg-destructive/20 px-1 font-mono font-semibold">{r.code_branch}</span>, not{' '}
+            <span className="font-mono">main</span>.{' '}
+            {unreachable ? (
+              <>
+                It has <span className="font-semibold">stopped heartbeating</span>, so this alert can never
+                clear on its own.
+              </>
+            ) : (
+              <>
+                Its turns are executing <span className="font-semibold">stale / wrong code</span> — another
+                process likely checked out a branch in the runner's checkout.
+              </>
+            )}
+          </p>
+          <p className="mt-1.5 break-words text-[12px] leading-snug opacity-90">
+            {unreachable ? 'Bring it back on that machine:' : 'Fix on that machine, then restart the runner:'}
+            <br />
+            <span className="font-mono">git -C ~/emdash-projects/canopy-web checkout main &amp;&amp; git pull</span>
+          </p>
+          {unreachable && (
+            <>
+              <button
+                type="button"
+                data-testid={`retire-runner-${r.id}`}
+                disabled={retiringId === r.id}
+                onClick={() => onRetire(r)}
+                className="mt-2 rounded-md border border-destructive bg-destructive px-2.5 py-1 text-[12px] font-semibold text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50"
+              >
+                {retiringId === r.id ? 'Retiring…' : 'Retire runner'}
+              </button>
+              <p className="mt-1 text-[11px] leading-snug opacity-80">
+                Retiring is permanent for this row and clears the alert; re-pairing later mints a fresh runner.
+              </p>
+            </>
+          )}
+        </div>
+      ))}
+    </>
+  )
+}

--- a/frontend/src/components/supervisor/wrongBranch.test.ts
+++ b/frontend/src/components/supervisor/wrongBranch.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+
+import { wrongBranchAlerts } from './wrongBranch'
+import type { RunnerOut } from '@/api/harness'
+
+// RunnerOut has many fields; the helper only reads code_branch/status.
+const runner = (name: string, code_branch: string, status: string): RunnerOut =>
+  ({ id: name, name, code_branch, status } as unknown as RunnerOut)
+
+describe('wrongBranchAlerts', () => {
+  it('alerts only runners on a non-main, non-empty branch', () => {
+    const rows = [
+      runner('good', 'main', 'online'),
+      runner('cloud', '', 'online'), // no checkout — never alerts
+      runner('bad', 'ddd-ui-polish', 'online'),
+    ]
+    expect(wrongBranchAlerts(rows).map((a) => a.runner.name)).toEqual(['bad'])
+  })
+
+  it('a heartbeating runner is reachable — fix-on-machine, no retire offer', () => {
+    for (const status of ['online', 'degraded']) {
+      const [alert] = wrongBranchAlerts([runner('r', 'feat-x', status)])
+      expect(alert.unreachable).toBe(false)
+    }
+  })
+
+  it('a quiet runner is unreachable — its branch is a LAST report and only retiring clears it', () => {
+    // The 2026-07-25 incident: jj-mbp-cdp died on ddd-ui-polish after its
+    // account logged out; the banner could never clear on its own.
+    for (const status of ['stale', 'disconnected']) {
+      const [alert] = wrongBranchAlerts([runner('r', 'ddd-ui-polish', status)])
+      expect(alert.unreachable).toBe(true)
+    }
+  })
+
+  it('tolerates a null runner list (initial load)', () => {
+    expect(wrongBranchAlerts(null)).toEqual([])
+  })
+})

--- a/frontend/src/components/supervisor/wrongBranch.ts
+++ b/frontend/src/components/supervisor/wrongBranch.ts
@@ -1,0 +1,23 @@
+// The wrong-branch banner's logic, extracted from SupervisorPage so it's
+// unit-testable. A runner heartbeats the git branch of the checkout it imports
+// code from; anything but `main` means its turns execute stale/unreviewed code.
+import type { RunnerOut } from '@/api/harness'
+
+export type BranchAlert = {
+  runner: RunnerOut
+  // A quiet runner (stale/disconnected) can never heartbeat its way off the
+  // wrong branch — the branch shown is just its LAST report, so without action
+  // the banner sits forever (the 2026-07-25 jj-mbp-cdp incident: its macOS
+  // account logged out mid-branch). For those, the in-place resolve is to
+  // retire the runner; a heartbeating one is fixed on its machine instead.
+  unreachable: boolean
+}
+
+export function wrongBranchAlerts(runners: readonly RunnerOut[] | null): BranchAlert[] {
+  return (runners ?? [])
+    .filter((r) => !!r.code_branch && r.code_branch !== 'main')
+    .map((runner) => ({
+      runner,
+      unreachable: runner.status === 'stale' || runner.status === 'disconnected',
+    }))
+}

--- a/frontend/src/pages/SupervisorPage.tsx
+++ b/frontend/src/pages/SupervisorPage.tsx
@@ -2,7 +2,8 @@ import { useCallback, useEffect, useMemo, useState, type JSX } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { listAgents, type AgentOut } from '@/api/agents'
 import { listOpenItems, type ItemOut } from '@/api/items'
-import { listRunners, listUnclaimableTurns, type RunnerOut, type UnclaimableTurn } from '@/api/harness'
+import { listRunners, listUnclaimableTurns, retireRunner, type RunnerOut, type UnclaimableTurn } from '@/api/harness'
+import { BranchAlerts } from '@/components/supervisor/BranchAlerts'
 import { useLiveSupervisor } from '@/hooks/useLiveSupervisor'
 import { RunnerStatus } from '@/components/supervisor/RunnerStatus'
 import { RunnerDetail } from '@/components/supervisor/RunnerDetail'
@@ -80,6 +81,24 @@ export default function SupervisorPage(): JSX.Element {
     load()
     const id = window.setInterval(load, 30_000)
     return () => { cancelled = true; window.clearInterval(id) }
+  }, [])
+
+  // The wrong-branch banner's one-click resolve for a dead runner. Confirmed,
+  // because retiring is permanent for the row (re-pairing mints a fresh one).
+  const [retiring, setRetiring] = useState<string | null>(null)
+  const handleRetire = useCallback(async (r: RunnerOut) => {
+    if (!window.confirm(`Retire ${r.name}? This is permanent for this runner row — re-pairing later creates a new one.`)) return
+    setRetiring(r.id)
+    try {
+      await retireRunner(r.id)
+      // Drop it locally so the banner clears immediately; the 30s re-poll would
+      // otherwise leave a confusing beat where the retired runner lingers.
+      setRunners((prev) => prev?.filter((x) => x.id !== r.id) ?? prev)
+    } catch (err) {
+      setErrs((e) => ({ ...e, runners: err instanceof Error ? err.message : 'Retire failed' }))
+    } finally {
+      setRetiring(null)
+    }
   }, [])
 
   // Re-poll runners so the wrong-branch alert (below) appears/clears without a reload
@@ -170,32 +189,7 @@ export default function SupervisorPage(): JSX.Element {
         </div>
       )}
 
-      {/* LOUD alert: a runner on any branch but main is silently running stale/wrong
-          code (usually another process checked out a branch in its shared checkout). */}
-      {(renderRunners ?? [])
-        .filter((r) => r.code_branch && r.code_branch !== 'main')
-        .map((r) => (
-          <div
-            key={`branch-alert-${r.id}`}
-            role="alert"
-            data-testid={`runner-branch-alert-${r.id}`}
-            className="rounded-lg border-2 border-destructive bg-destructive/15 p-3 text-destructive"
-          >
-            <p className="text-[13px] font-bold uppercase tracking-wide">⚠ Runner on wrong branch — stale code</p>
-            <p className="mt-1 text-[13px] leading-snug">
-              <span className="font-semibold">{r.name}</span> is running on branch{' '}
-              <span className="rounded bg-destructive/20 px-1 font-mono font-semibold">{r.code_branch}</span>, not{' '}
-              <span className="font-mono">main</span>. Its turns are executing{' '}
-              <span className="font-semibold">stale / wrong code</span> — another process likely checked out a
-              branch in the runner's checkout.
-            </p>
-            <p className="mt-1.5 break-words text-[12px] leading-snug opacity-90">
-              Fix on that machine, then restart the runner:
-              <br />
-              <span className="font-mono">git -C ~/emdash-projects/canopy-web checkout main &amp;&amp; git pull</span>
-            </p>
-          </div>
-        ))}
+      <BranchAlerts runners={renderRunners} retiringId={retiring} onRetire={handleRetire} />
 
       <Tabs value={tab} onValueChange={onTab} className="gap-4">
         <TabsList className="w-full">


### PR DESCRIPTION
The wrong-branch alert (`SupervisorPage.tsx`) rendered for any listed runner whose last-heartbeated `code_branch != main`, with no liveness distinction. A **dead** runner's final heartbeat therefore kept the banner up forever, with guidance ("fix on that machine, restart the runner") that could never apply — and the only real resolution was a raw `POST /runners/{id}/retire`. Hit for real on 2026-07-25: `jj-mbp-cdp` died on `ddd-ui-polish` when its macOS account logged out.

## What changed

- **Liveness-aware copy** (`components/supervisor/wrongBranch.ts`): a heartbeating runner keeps the existing fix-on-machine guidance; a quiet one (`stale`/`disconnected`) now says the shown branch is its *last report* and the alert **can never clear on its own**.
- **One-click resolve**: dead-runner banners get a confirmed **Retire runner** button (wired to the existing retire endpoint via a new `retireRunner` client). The row drops from local state immediately so the banner clears without waiting for the 30s re-poll; the server excludes retired runners from the list thereafter. Re-pairing later mints a fresh runner, so nothing is unrecoverable.
- Banner extracted from the page into `components/supervisor/BranchAlerts.tsx` with jsdom component tests (variant copy, retire callback, in-flight disable) plus pure-logic tests for the alert predicate. Heartbeating runners deliberately get **no** retire button — retiring a live runner mid-branch would be the wrong fix.

Vitest 261 passed · `tsc -b && vite build` clean. Frontend-only; no API or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)