### PR TITLE
fix(cloud-runner): renew turn leases during execution — long turns no longer swept LOST

### DIFF
--- a/deploy/ec2-runner/README.md
+++ b/deploy/ec2-runner/README.md
@@ -63,6 +63,22 @@ Override with `EXTRA_PARAMS='Key=Val Key=Val' ./up.sh`:
 `InstanceType` (t3.medium), `CanopyBaseUrl`, `RunnerProjects`, `RunnerAgents`,
 `RunnerWorkspace` (dimagi), `RunnerName`. `SshCidr` is set to your IP automatically.
 
+## Updating the runner code
+`up.sh` splices `cloud_runner.py` into the template's UserData as base64, but
+**CloudFormation applies a UserData change to an existing instance as a
+stop/start — it does NOT re-run cloud-init.** cloud-init's `write_files` (and
+everything else in the `#cloud-config` block) only runs on an instance's
+*first* boot. So editing `cloud_runner.py` and running `./up.sh` again updates
+the *template*, but a box that's already up keeps running the old bytes on
+disk until it's replaced — a silent deploy gap, not a redeploy.
+
+Until there's a real re-provisioning mechanism, ship a runner-code change by
+recycling the stack:
+```bash
+./down.sh   # keeps the secrets (no --purge-secrets)
+./up.sh     # fresh instance, fresh cloud-init, new code
+```
+
 ## Notes
 - **Ephemeral by design.** The claude token lives only in Secrets Manager + in
   `/opt/canopy-runner/runner.env` (chmod 600) on the box; `down.sh` removes the box.

--- a/deploy/ec2-runner/cloud_runner.py
+++ b/deploy/ec2-runner/cloud_runner.py
@@ -29,6 +29,7 @@ import signal
 import socket
 import subprocess
 import sys
+import threading
 import time
 import urllib.error
 import urllib.request
@@ -61,6 +62,11 @@ HEARTBEAT_SECONDS = int(os.environ.get("HEARTBEAT_SECONDS", "20"))
 # heartbeat gated on recv() timing out would never fire and the runner would go
 # stale while still connected.
 WS_POLL_TIMEOUT = float(os.environ.get("WS_POLL_TIMEOUT", "3"))
+# How often the lease-renewal thread heartbeats WHILE a turn is executing (both
+# loops block inside run_claude() for the whole turn, so nothing else heartbeats
+# during that window). Must stay comfortably under DEFAULT_LEASE_SECONDS (900s,
+# apps/harness/services.py) or a long turn gets swept LOST mid-execution.
+LEASE_HEARTBEAT_SECONDS = int(os.environ.get("LEASE_HEARTBEAT_SECONDS", "60"))
 STATE_FILE = pathlib.Path(os.environ.get("STATE_FILE", str(pathlib.Path.home() / ".canopy-cloud-runner.json")))
 
 _stop = False
@@ -87,6 +93,35 @@ def _api(method: str, path: str, body: dict | None = None) -> tuple[int, dict | 
     except urllib.error.URLError as exc:
         _log(f"{method} {path} -> URLError {exc.reason}")
         return 0, None
+
+
+def _start_lease_renewal(runner_id: str, turn_id: str) -> threading.Event:
+    """Renew this turn's claim lease for the duration of execution.
+
+    Both `_claim_and_run` (WS) and `run_over_rest`'s turn body block inside
+    `run_claude()` for the entire turn — no heartbeat happens while that call
+    is running, and the idle heartbeats both loops send elsewhere carry
+    `active_turn_ids: []`, which renews nothing (apps/harness/services.py::
+    heartbeat only renews leases for ids in that list). Without this, any
+    turn running longer than DEFAULT_LEASE_SECONDS (900s) gets swept LOST
+    out from under a runner that is still actively working it.
+
+    Runs on its own daemon thread and heartbeats over plain REST via `_api`,
+    which opens a fresh HTTPS connection per call — deliberately, so this is
+    safe to run concurrently with the WS loop's own socket use. The thread
+    must NEVER touch `ws` (send/recv/close): the websocket-client `WebSocket`
+    object is not safe to share across threads, and the caller's loop is
+    already reading/writing it. Caller stops the thread (`.set()`) in a
+    `finally` once the turn ends, whether it succeeded, failed, or raised.
+    """
+    stop = threading.Event()
+
+    def _loop() -> None:
+        while not stop.wait(LEASE_HEARTBEAT_SECONDS):
+            _api("POST", f"/runners/{runner_id}/heartbeat", {"active_turn_ids": [turn_id]})
+
+    threading.Thread(target=_loop, daemon=True, name=f"lease-{turn_id[:8]}").start()
+    return stop
 
 
 def pair_or_load() -> str:
@@ -232,10 +267,14 @@ def run_over_rest(runner_id: str) -> None:
         def emit(events, _tid=turn_id):
             _api("POST", f"/turns/{_tid}/events", {"events": events})
 
+        lease_stop = _start_lease_renewal(runner_id, turn_id)
         try:
-            ok, text = run_claude(turn.get("prompt", ""), turn_id, emit)
-        except Exception as exc:  # never let one turn kill the loop
-            ok, text = False, f"runner error: {exc}"
+            try:
+                ok, text = run_claude(turn.get("prompt", ""), turn_id, emit)
+            except Exception as exc:  # never let one turn kill the loop
+                ok, text = False, f"runner error: {exc}"
+        finally:
+            lease_stop.set()  # turn is over (success/failure/exception) — stop renewing
         finish = "done" if ok else "failed"
         _api("POST", f"/turns/{turn_id}/finish", {"status": finish, "result_note": text[:2000]})
         _log(f"finished turn {turn_id[:8]}: {finish}")
@@ -290,10 +329,17 @@ def _claim_and_run(ws, runner_id: str) -> None:
     def emit(events, _tid=tid):
         _ws_request(ws, {"action": "event", "turn_id": _tid, "events": events}, "event.ack", timeout=60)
 
+    # Lease renewal runs on its own thread over REST (never over `ws` — see
+    # _start_lease_renewal) so the lease survives the whole time run_claude()
+    # blocks this loop.
+    lease_stop = _start_lease_renewal(runner_id, tid)
     try:
-        ok, text = run_claude(turn.get("prompt", ""), tid, emit)
-    except Exception as exc:
-        ok, text = False, f"runner error: {exc}"
+        try:
+            ok, text = run_claude(turn.get("prompt", ""), tid, emit)
+        except Exception as exc:
+            ok, text = False, f"runner error: {exc}"
+    finally:
+        lease_stop.set()  # turn is over (success/failure/exception) — stop renewing
     _ws_request(ws, {"action": "finish", "turn_id": tid,
                      "status": "done" if ok else "failed", "result_note": text[:2000]}, "finish.ack")
     _log(f"finished turn {tid[:8]} (WS): {'done' if ok else 'failed'}")

--- a/deploy/ec2-runner/runner.cfn.yaml
+++ b/deploy/ec2-runner/runner.cfn.yaml
@@ -105,6 +105,15 @@ Resources:
       Tags:
         - { Key: Name, Value: !Ref AWS::StackName }
         - { Key: purpose, Value: canopy-cloud-runner }
+      # DEPLOY GAP: CFN applies a UserData change as a stop/start of the SAME
+      # instance, which does NOT re-run cloud-init (cloud-init only runs its
+      # write_files/runcmd modules on first boot of a given instance id). So
+      # editing cloud_runner.py (or anything else baked in here) and just
+      # redeploying the stack does NOT ship the new code to a running box —
+      # the old bytes stay on disk and the service keeps running them. Until
+      # there's a real re-provisioning mechanism, you MUST recycle the stack
+      # to pick up runner-code changes: `./down.sh && ./up.sh` (see README.md
+      # "Updating the runner code").
       UserData:
         Fn::Base64: !Sub |
           #cloud-config


### PR DESCRIPTION
Confirmed in prod (twice, exact claimed_at+900s sweep signatures): the cloud runner's single-threaded WS loop never heartbeats during turn execution and always sends an empty active-turn list, so any turn longer than the 900s lease is swept LOST while still running.

Fix: a daemon thread posts REST heartbeats with `active_turn_ids=[turn_id]` every 60s for the duration of each turn (REST deliberately — the WS socket isn't thread-safe and stays owned by the main loop), wired into both the WS and REST execution paths, always stopped via finally. Plus docs for the CFN UserData/cloud-init deploy gap (runner-code changes need a stack recycle, not an update).

🤖 Generated with [Claude Code](https://claude.com/claude-code)