### PR TITLE
Harness: pairing a runner requires a resolvable workspace

### DIFF
--- a/apps/harness/api.py
+++ b/apps/harness/api.py
@@ -182,8 +182,25 @@ def pair_runner(request: HttpRequest, payload: RunnerIn):
             raise HttpError(404, f"workspace '{explicit}' not found")
         ws_slug = explicit
     else:
+        # A runner MUST belong to a workspace: a workspace-less one is
+        # half-broken with no signal — heartbeat and claim work (tenancy
+        # derives from paired_by), but every session report 404s, so its
+        # sessions silently never surface (prod incident 2026-07-25: a
+        # multi-workspace pairer made user_default_workspace() None and the
+        # runner paired NULL). Fail loud instead of pairing broken.
         default = wsvc.user_default_workspace(request.user)
-        ws_slug = default.slug if default else None
+        if default is None:
+            n = len(wsvc.user_workspace_slugs(request.user))
+            detail = (
+                "you belong to no workspace" if n == 0
+                else f"you belong to {n} workspaces, so there is no default"
+            )
+            raise HttpError(
+                422,
+                f"a runner must belong to a workspace and {detail} — "
+                "pass `workspace` explicitly",
+            )
+        ws_slug = default.slug
     runner = Runner.objects.create(
         name=payload.name,
         kind=payload.kind,

--- a/tests/test_harness_api.py
+++ b/tests/test_harness_api.py
@@ -10,6 +10,7 @@ from django.utils import timezone
 
 from apps.agents.models import Agent
 from apps.harness.models import HEARTBEAT_ONLINE_WINDOW, Runner, RunnerAssignment
+from apps.workspaces.models import Workspace, WorkspaceMembership
 
 pytestmark = pytest.mark.django_db
 
@@ -17,6 +18,11 @@ pytestmark = pytest.mark.django_db
 @pytest.fixture()
 def client():
     user = User.objects.create_user("jj", "jj@dimagi.com", "pw")
+    # Pairing requires a resolvable workspace tenant (a workspace-less runner
+    # heartbeats fine but 404s every session report — found on prod 2026-07-25),
+    # so the baseline caller has exactly one, like every real auto-joined user.
+    ws = Workspace.objects.create(slug="dimagi", display_name="Dimagi", created_by=user)
+    WorkspaceMembership.objects.create(user=user, workspace=ws, role=WorkspaceMembership.OWNER)
     c = Client()
     c.force_login(user)
     return c
@@ -375,3 +381,46 @@ def test_enqueue_records_the_human_who_launched_the_turn(client, agent):
     assert enq.json()["enqueued_by_email"] == "jj@dimagi.com"
     from apps.harness.models import Turn
     assert Turn.objects.get(idempotency_key="who").enqueued_by.email == "jj@dimagi.com"
+
+
+# --- pairing requires a workspace tenant (2026-07-25 incident) --------------
+# A workspace-less runner is half-broken with no signal: heartbeat and claim
+# work (tenancy derives from paired_by), but POST /runners/{id}/sessions 404s
+# forever, so its sessions silently never appear anywhere.
+
+def _pair_resp(c, **extra):
+    return c.post(
+        "/api/harness/runners/",
+        {"name": "box", "kind": "emdash", "capabilities": {}, **extra},
+        content_type="application/json",
+    )
+
+
+def test_pair_422s_when_the_pairer_belongs_to_no_workspace():
+    u = User.objects.create_user("lonely", "lonely@example.org", "pw")
+    c = Client(); c.force_login(u)
+    resp = _pair_resp(c)
+    assert resp.status_code == 422
+    assert Runner.objects.count() == 0
+
+
+def test_pair_422s_when_the_default_is_ambiguous_without_an_explicit_workspace(client):
+    # A second membership makes user_default_workspace() None — exactly how the
+    # NULL-workspace runner was minted on prod. The error must demand an
+    # explicit workspace rather than silently pairing a broken runner.
+    user = User.objects.get(username="jj")
+    ws2 = Workspace.objects.create(slug="connect", display_name="Connect", created_by=user)
+    WorkspaceMembership.objects.create(user=user, workspace=ws2, role=WorkspaceMembership.OWNER)
+    resp = _pair_resp(client)
+    assert resp.status_code == 422
+    assert Runner.objects.count() == 0
+    # ...and passing it explicitly works.
+    ok = _pair_resp(client, workspace="connect")
+    assert ok.status_code == 201
+    assert ok.json()["workspace"] == "connect"
+
+
+def test_pair_resolves_the_sole_membership_as_the_workspace(client):
+    resp = _pair_resp(client)
+    assert resp.status_code == 201
+    assert resp.json()["workspace"] == "dimagi"

--- a/tests/test_harness_authz.py
+++ b/tests/test_harness_authz.py
@@ -130,13 +130,17 @@ def test_stranger_cannot_claim_victim_turn_via_own_untenanted_runner(
     only precondition claim_next_turn enforces), then claims. This must return 204
     (no work for them) and must NOT mutate the victim's turn — non-mutation is the
     point: a claim that both leaks the prompt/origin_ref AND flips the turn to
-    CLAIMED is a repeatable denial of service against the victim's real runner."""
+    CLAIMED is a repeatable denial of service against the victim's real runner.
+
+    Pairing an untenanted runner via the API now 422s (a workspace is required
+    since the 2026-07-25 incident), but LEGACY null-workspace rows still exist
+    in prod — so mint the row directly and prove the claim path still holds."""
     turn_id = _enqueue(owner_client).json()["id"]
-    rid = stranger_client.post(
-        "/api/harness/runners/",
-        {"name": "attacker-mbp", "kind": "emdash", "capabilities": {"agents": ["echo"]}},
-        content_type="application/json",
-    ).json()["id"]
+    stranger = User.objects.get(username="stranger")
+    rid = Runner.objects.create(
+        name="attacker-mbp", kind="emdash", capabilities={"agents": ["echo"]},
+        paired_by=stranger, workspace=None,
+    ).id
     hb = stranger_client.post(
         f"/api/harness/runners/{rid}/heartbeat",
         {"active_turn_ids": [], "degraded": False, "note": ""},


### PR DESCRIPTION
Closes the root cause of the 2026-07-25 incident: the acedimagi runner paired with `workspace=NULL` because its pairer belongs to multiple workspaces — `user_default_workspace()` returns `None` on ambiguity, and `pair_runner` silently accepted it. The result is a half-broken runner with no signal anywhere: heartbeat/claim work fine (tenancy derives from `paired_by`), but every `POST /runners/{id}/sessions` 404s, so its sessions never appear in the Sessions list. It looked healthy for a day.

**Change:** `pair_runner` now 422s when no workspace resolves — either the pairer belongs to none, or to several with no explicit choice — with a message telling the caller to pass `workspace` explicitly. Explicit pairing and sole-membership defaulting behave exactly as before.

**Deliberately untouched:** legacy NULL-workspace rows (the visibility predicate keeps tolerating them), and `Runner.workspace` stays nullable. The `test_stranger_cannot_claim_victim_turn_via_own_untenanted_runner` exploit test now mints its legacy row via ORM, since the API path to create one is closed — which itself strengthens that posture.

Backend 1201 passed · ruff clean · `makemigrations --check` clean. No schema shape changes (error-path only), so `generated.ts` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)