### PR TITLE
ci: fix canopy-ui publish workflow (node 24, pin npm@11)

### DIFF
--- a/.github/workflows/publish-canopy-ui.yml
+++ b/.github/workflows/publish-canopy-ui.yml
@@ -28,11 +28,12 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
-      # Trusted Publishing + provenance need npm >= 11.5.1 (node 20 ships npm 10).
+      # Trusted Publishing + provenance need npm >= 11.5.1. npm@latest is now v12
+      # (requires node >= 22), so pin the major and keep node new enough for it.
       - name: Upgrade npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
       - name: Publish (OIDC, with provenance)
         run: npm publish --access public --provenance
         working-directory: frontend/packages/canopy-ui


### PR DESCRIPTION
The OIDC publish run for `canopy-ui-v0.4.0` failed: `npm install -g npm@latest` now resolves npm@12, which requires node ≥22 while the workflow pinned node 20. Bump to node 24 and pin npm@11 (the floor Trusted Publishing needs) so latest-major drift can't break the publish again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)