### PR TITLE
ci: bound deploy jobs with timeouts (a hung step shouldn't block the deploy queue)

### DIFF
--- a/.github/workflows/deploy-labs.yml
+++ b/.github/workflows/deploy-labs.yml
@@ -35,6 +35,11 @@ on:
         required: false
         default: false
 
+# Deploys are serialized (one at a time, never cancelled mid-flight). That makes a
+# hung job everyone's problem: it holds this lock and every later deploy queues
+# behind it, so the per-job timeout-minutes below are what keep the queue live —
+# GitHub's default is 6 HOURS. Seen in the wild: configure-aws-credentials wedged
+# for ~55min and blocked the queue until it was cancelled by hand.
 concurrency:
   group: deploy-labs-canopy-web
   cancel-in-progress: false
@@ -56,6 +61,7 @@ jobs:
   guard:
     name: Enforce main-only deploys
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Check ref is refs/heads/main
         run: |
@@ -67,6 +73,7 @@ jobs:
   build:
     name: Build & push image
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: guard
     steps:
       - uses: actions/checkout@v5
@@ -124,6 +131,7 @@ jobs:
     name: Deploy to Fargate
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
 


### PR DESCRIPTION
## Why
Deploys are serialized (`concurrency: deploy-labs-canopy-web`, `cancel-in-progress: false`) — correct, but it means a hung job is everyone's problem: it holds the lock and every later deploy queues behind it. No job declared `timeout-minutes`, so GitHub's default applies: **6 hours**.

This is not hypothetical — today a deploy wedged on `configure-aws-credentials` for ~55 minutes (a step that normally takes seconds) and blocked two subsequently-dispatched deploys until it was cancelled by hand. A re-run cleared the same step instantly, so it was a transient wedge, not config.

## What
`timeout-minutes` on all three jobs: guard 5, build 30, deploy 30 (the deploy job's ECS rolling-update wait is the long pole; 30 leaves headroom). Plus a comment above the concurrency block explaining that the timeouts are what keep the serialized queue live.

The same change lands in ace-web, which has the identical serialized-deploy shape and the same missing bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)