### PR TITLE
feat(chat): origin_key list filter for multi-tenant embedders

### DIFF
--- a/apps/canopy_sessions/api.py
+++ b/apps/canopy_sessions/api.py
@@ -128,6 +128,7 @@ def create_session(request: HttpRequest, payload: SessionCreateIn):
 def list_sessions(
     request: HttpRequest, state: str = "active", limit: int = 200,
     source: str = "", opp_slug: str = "", opp_run_id: str = "",
+    origin_key: str = "",
 ):
     # The ONE unified list (Plan 4): every session the caller can see in their
     # workspaces — their own web sessions UNION any session that has a
@@ -156,8 +157,19 @@ def list_sessions(
     # session list to the sessions it cares about, keyed on the opaque
     # `metadata` bag a session carries (never interpreted elsewhere in this
     # app). Empty string = no filter, so the default call is unaffected.
+    #
+    # `origin_key` is the generic one: an embedder whose own product is
+    # multi-tenant stamps ITS tenant into metadata.origin_key at create time and
+    # filters on it here, so two of its tenants sharing one canopy workspace do
+    # not see each other's sessions in the list. Deliberately opaque — canopy
+    # never parses it. (Note the residual: this scopes the LIST; canopy's own
+    # tenancy still lets any member of the canopy workspace open a session by id.
+    # An embedder that needs hard isolation maps its tenants onto separate canopy
+    # workspaces instead.)
     if source:
         rows = rows.filter(metadata__source=source)
+    if origin_key:
+        rows = rows.filter(metadata__origin_key=origin_key)
     if opp_slug:
         rows = rows.filter(metadata__opp_slug=opp_slug)
     if opp_run_id:

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -10828,6 +10828,7 @@ export interface operations {
                 readonly source?: string;
                 readonly opp_slug?: string;
                 readonly opp_run_id?: string;
+                readonly origin_key?: string;
             };
             readonly header?: never;
             readonly path?: never;

--- a/tests/test_chat_api.py
+++ b/tests/test_chat_api.py
@@ -245,6 +245,30 @@ def test_list_sessions_filters_by_metadata(client, ctx):
     assert len(r.json()) == 3
 
 
+def test_list_sessions_scopes_by_origin_key(client, ctx):
+    """An embedder whose own product is multi-tenant stamps its tenant into
+    metadata.origin_key; filtering on it keeps two of ITS tenants that share one
+    canopy workspace out of each other's lists."""
+    user, ws, _agent = ctx
+    Session.objects.create(
+        workspace=ws, created_by=user,
+        metadata={"source": "ace-web", "origin_key": "ace-web:team-a"},
+    )
+    Session.objects.create(
+        workspace=ws, created_by=user,
+        metadata={"source": "ace-web", "origin_key": "ace-web:team-b"},
+    )
+
+    r = client.get("/api/canopy-sessions/?source=ace-web&origin_key=ace-web:team-a")
+    assert r.status_code == 200, r.content
+    rows = r.json()
+    assert len(rows) == 1
+
+    # Unscoped still sees both — the filter is opt-in, never implicit.
+    r = client.get("/api/canopy-sessions/?source=ace-web")
+    assert len(r.json()) == 2
+
+
 # --- Task 11 fix wave: title vs bound session_key in _out --------------------
 
 


### PR DESCRIPTION
Found by the whole-branch review of ace-web's cutover PR: ace-web is itself multi-tenant (workspaces), but every ace workspace maps onto the single canopy workspace `connect`. Since canopy lists every session in the caller's workspace that has a runner binding, one ace team would see — and could open — another ace team's chats. That is a **new** exposure relative to ace-web's legacy chat, which scoped its list per workspace.

`origin_key` is the generic fix: an embedder stamps its own tenant into `metadata.origin_key` at create time and passes `?origin_key=` when listing. Canopy never parses the value; it sits alongside the existing `source`/`opp_slug`/`opp_run_id` filters and is opt-in, so unscoped callers are unaffected.

Documented residual (in code + PR): this scopes the **list**. Canopy's own tenancy still permits any member of the canopy workspace to open a session by id, so an embedder needing hard isolation must map its tenants onto separate canopy workspaces. ace-web's flag stays off until that trade-off is accepted explicitly.

## Test plan
- `tests/test_chat_api.py::test_list_sessions_scopes_by_origin_key` (new) + existing filter tests
- Full suite green; `generated.ts` regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)