### PR TITLE
feat(chat): carry runner_online on the session payload

### DIFF
--- a/apps/canopy_sessions/api.py
+++ b/apps/canopy_sessions/api.py
@@ -41,6 +41,15 @@ from .schemas import (
 router = Router(auth=session_auth, tags=["chat"])
 
 
+def _runner_online(runner) -> bool | None:
+    """Liveness of a session's bound runner, or None when there is no binding."""
+    if runner is None:
+        return None
+    from apps.harness.models import Runner  # lazy: framework->framework import cycle
+
+    return runner.live_status == Runner.ONLINE
+
+
 def _out(session: Session) -> dict:
     binding = getattr(session, "runner_binding", None)  # reverse 1:1 -> None when absent
     runner = binding.runner if (binding and binding.runner_id) else None
@@ -70,6 +79,10 @@ def _out(session: Session) -> dict:
         "running": services.is_session_running(binding),
         "runner_name": runner.name if runner else None,
         "runner_location": runner.location if runner else None,
+        # See SessionOut.runner_online: an embedder's delegated user cannot list
+        # runners, so the session payload is where they learn their bound runner
+        # went away. None when unbound — nothing to be offline.
+        "runner_online": _runner_online(runner),
         "session_key": binding.session_key if binding else "",
     }
 

--- a/apps/canopy_sessions/schemas.py
+++ b/apps/canopy_sessions/schemas.py
@@ -77,6 +77,14 @@ class SessionOut(Schema):
     running: bool = False
     runner_name: str | None = None
     runner_location: str | None = None
+    # Is the bound runner reachable right now? Carried on the session because a
+    # session's own payload is the only place a caller who can see the session is
+    # guaranteed to learn this: GET /api/harness/runners/ is scoped to runners the
+    # caller PAIRED (apps/harness/api.py::_runner_visibility_q), so an embedder's
+    # delegated user sees an empty fleet and could not otherwise tell a stalled
+    # chat ("bound runner offline, turn waiting") from a slow one. None = no
+    # binding, so there is nothing to be offline.
+    runner_online: bool | None = None
     session_key: str = ""
 
 

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -4356,6 +4356,8 @@ export interface components {
             readonly runner_name?: string | null;
             /** Runner Location */
             readonly runner_location?: string | null;
+            /** Runner Online */
+            readonly runner_online?: boolean | null;
             /**
              * Session Key
              * @default
@@ -6863,6 +6865,8 @@ export interface components {
             readonly runner_name?: string | null;
             /** Runner Location */
             readonly runner_location?: string | null;
+            /** Runner Online */
+            readonly runner_online?: boolean | null;
             /**
              * Session Key
              * @default

--- a/tests/test_chat_api.py
+++ b/tests/test_chat_api.py
@@ -351,3 +351,34 @@ def test_stop_with_nothing_to_cancel_returns_false(client):
     r = client.post(f"/api/canopy-sessions/{sid}/stop", content_type="application/json")
     assert r.status_code == 200, r.content
     assert r.json() == {"cancelled": False}
+
+
+# --- runner_online: liveness an embedder's delegated user can actually read ---
+
+
+def test_runner_online_reflects_binding_liveness(client, ctx):
+    """A delegated embedder user cannot list runners (harness scopes that to the
+    pairer), so the session payload must carry its bound runner's liveness —
+    otherwise a stalled chat is indistinguishable from a slow one."""
+    import datetime as dt
+
+    from django.utils import timezone
+
+    user, ws, _agent = ctx
+    session = Session.objects.create(workspace=ws, created_by=user)
+
+    # No binding -> None (nothing to be offline).
+    assert client.get(f"/api/canopy-sessions/{session.id}").json()["runner_online"] is None
+
+    runner = Runner.objects.create(
+        name="r1", kind=Runner.EMDASH, capabilities={"sessions": True},
+        paired_by=user, status=Runner.ONLINE, last_heartbeat_at=timezone.now(),
+    )
+    RunnerBinding.objects.create(session=session, runner=runner, thread_key=str(session.id))
+    assert client.get(f"/api/canopy-sessions/{session.id}").json()["runner_online"] is True
+
+    # Heartbeat older than the online window -> offline.
+    Runner.objects.filter(pk=runner.pk).update(
+        last_heartbeat_at=timezone.now() - dt.timedelta(hours=2)
+    )
+    assert client.get(f"/api/canopy-sessions/{session.id}").json()["runner_online"] is False


### PR DESCRIPTION
Found while verifying ace-web's cutover against production: a delegated embedder user calling `GET /api/harness/runners/` gets **zero rows**, because `_runner_visibility_q` scopes the fleet to runners the caller personally paired. I confirmed this live with a real delegated token.

Consequence for any embedder (ace-web today): the offline-runner banner can never render, so when a session's bound runner goes away — canopy deliberately does not auto-failover a bound session — the chat simply hangs with no explanation.

Fix: put the bound runner's liveness on the session payload, which a caller who can see the session can always read. `None` when there is no binding. No change to runner visibility or to any authorization surface.

## Test plan
- `tests/test_chat_api.py::test_runner_online_reflects_binding_liveness` (new): unbound → None, fresh heartbeat → True, stale heartbeat → False
- Full suite 1249 passed; `generated.ts` regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)