### PR TITLE
feat(workspaces): member role management + upgrade-only invite accept

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,7 @@ The tenant that owns agents + runs. `Workspace` + members (owner / editor / view
 - `GET /api/workspaces/{slug}/` — Get a workspace (member-only)
 - `GET /api/workspaces/{slug}/members/` — List members (member-only)
 - `DELETE /api/workspaces/{slug}/members/{user_id}/` — Remove a member (owner-only)
+- `PATCH /api/workspaces/{slug}/members/{user_id}/` — Change a member's role (owner-only; body `{"role": "owner"|"editor"|"viewer"}`). Idempotent; rejects demoting the workspace's last owner (400), same guard `remove_member` uses (`services.is_last_owner`)
 - `POST /api/workspaces/{slug}/invites/` — Invite by email (owner-only)
 - `GET /api/workspaces/{slug}/invites/` — List invites (member-only)
 - `POST /api/workspaces/{slug}/invites/{invite_id}/revoke` — Revoke an invite (owner-only)

--- a/apps/workspaces/api.py
+++ b/apps/workspaces/api.py
@@ -20,6 +20,7 @@ from .schemas import (
     InviteOut,
     InvitePreviewOut,
     MemberOut,
+    MemberRoleUpdateIn,
     WorkspaceCreateIn,
     WorkspaceOut,
 )
@@ -34,6 +35,12 @@ _INVITE_ERROR_STATUS = {
     "revoked": 410,
     "already_accepted": 410,
     "email_mismatch": 403,
+}
+
+# MemberError.code -> HTTP status.
+_MEMBER_ERROR_STATUS = {
+    "not_found": 404,
+    "last_owner": 400,
 }
 
 
@@ -61,6 +68,10 @@ def _require_role(user, slug: str, *allowed: str) -> WorkspaceMembership:
     if m.role not in allowed:
         raise HttpError(403, f"requires one of roles {list(allowed)}")
     return m
+
+
+def _member_out(m: WorkspaceMembership) -> MemberOut:
+    return MemberOut(user_id=m.user_id, email=m.user.email, role=m.role, joined_at=m.joined_at)
 
 
 def _invite_out(inv: WorkspaceInvite) -> InviteOut:
@@ -122,10 +133,7 @@ def list_members(request: HttpRequest, slug: str) -> list[MemberOut]:
         WorkspaceMembership.objects.filter(workspace_id=slug)
         .select_related("user").order_by("joined_at")
     )
-    return [
-        MemberOut(user_id=m.user_id, email=m.user.email, role=m.role, joined_at=m.joined_at)
-        for m in members
-    ]
+    return [_member_out(m) for m in members]
 
 
 @router.delete("/{slug}/members/{user_id}/", response={204: None},
@@ -136,14 +144,21 @@ def remove_member(request: HttpRequest, slug: str, user_id: int):
         m = WorkspaceMembership.objects.get(workspace_id=slug, user_id=user_id)
     except WorkspaceMembership.DoesNotExist:
         raise HttpError(404, "member not found")
-    if m.role == WorkspaceMembership.OWNER and (
-        WorkspaceMembership.objects.filter(
-            workspace_id=slug, role=WorkspaceMembership.OWNER
-        ).count() == 1
-    ):
+    if services.is_last_owner(m):
         raise HttpError(400, "cannot remove the last owner")
     m.delete()
     return Status(204, None)
+
+
+@router.patch("/{slug}/members/{user_id}/", response=MemberOut,
+              summary="Change a member's role (owner-only)", openapi_extra={"x-mcp-expose": True})
+def set_member_role(request: HttpRequest, slug: str, user_id: int, payload: MemberRoleUpdateIn) -> MemberOut:
+    m = _require_role(request.user, slug, WorkspaceMembership.OWNER)
+    try:
+        updated = services.set_member_role(workspace=m.workspace, user_id=user_id, role=payload.role)
+    except services.MemberError as exc:
+        raise HttpError(_MEMBER_ERROR_STATUS[exc.code], exc.code)
+    return _member_out(updated)
 
 
 # ---- invites ----

--- a/apps/workspaces/api.py
+++ b/apps/workspaces/api.py
@@ -41,6 +41,22 @@ _INVITE_ERROR_STATUS = {
 _MEMBER_ERROR_STATUS = {
     "not_found": 404,
     "last_owner": 400,
+    "invalid_role": 422,
+}
+
+# MemberError.code -> a human-readable message, PER ENDPOINT (the same code
+# reads differently depending on the verb that tripped it — "cannot remove"
+# vs "cannot demote" — so this is deliberately two small dicts, not one
+# shared across both routes). Never surface `exc.code` itself to a user: it's
+# a machine token for the status lookup above, not banner copy.
+_REMOVE_MEMBER_ERROR_MESSAGES = {
+    "not_found": "member not found",
+    "last_owner": "cannot remove the last owner",
+}
+_SET_MEMBER_ROLE_ERROR_MESSAGES = {
+    "not_found": "member not found",
+    "last_owner": "cannot demote the last owner",
+    "invalid_role": "unknown role",
 }
 
 
@@ -139,14 +155,11 @@ def list_members(request: HttpRequest, slug: str) -> list[MemberOut]:
 @router.delete("/{slug}/members/{user_id}/", response={204: None},
                summary="Remove a member (owner-only)", openapi_extra={"x-mcp-expose": True})
 def remove_member(request: HttpRequest, slug: str, user_id: int):
-    _require_role(request.user, slug, WorkspaceMembership.OWNER)
+    m = _require_role(request.user, slug, WorkspaceMembership.OWNER)
     try:
-        m = WorkspaceMembership.objects.get(workspace_id=slug, user_id=user_id)
-    except WorkspaceMembership.DoesNotExist:
-        raise HttpError(404, "member not found")
-    if services.is_last_owner(m):
-        raise HttpError(400, "cannot remove the last owner")
-    m.delete()
+        services.remove_member(workspace=m.workspace, user_id=user_id)
+    except services.MemberError as exc:
+        raise HttpError(_MEMBER_ERROR_STATUS[exc.code], _REMOVE_MEMBER_ERROR_MESSAGES[exc.code])
     return Status(204, None)
 
 
@@ -157,7 +170,7 @@ def set_member_role(request: HttpRequest, slug: str, user_id: int, payload: Memb
     try:
         updated = services.set_member_role(workspace=m.workspace, user_id=user_id, role=payload.role)
     except services.MemberError as exc:
-        raise HttpError(_MEMBER_ERROR_STATUS[exc.code], exc.code)
+        raise HttpError(_MEMBER_ERROR_STATUS[exc.code], _SET_MEMBER_ROLE_ERROR_MESSAGES[exc.code])
     return _member_out(updated)
 
 

--- a/apps/workspaces/models.py
+++ b/apps/workspaces/models.py
@@ -54,6 +54,10 @@ class Workspace(models.Model):
 class WorkspaceMembership(models.Model):
     OWNER, EDITOR, VIEWER = "owner", "editor", "viewer"
     ROLE_CHOICES = [(OWNER, "Owner"), (EDITOR, "Editor"), (VIEWER, "Viewer")]
+    # Total order used to decide "higher" vs "lower" role — the single place
+    # role comparisons live (see `accept_invite`'s upgrade-only semantic and
+    # `services.set_member_role`). Do not scatter role comparisons elsewhere.
+    ROLE_RANK = {VIEWER: 0, EDITOR: 1, OWNER: 2}
 
     workspace = models.ForeignKey(
         Workspace, on_delete=models.CASCADE, related_name="memberships"

--- a/apps/workspaces/models.py
+++ b/apps/workspaces/models.py
@@ -55,8 +55,11 @@ class WorkspaceMembership(models.Model):
     OWNER, EDITOR, VIEWER = "owner", "editor", "viewer"
     ROLE_CHOICES = [(OWNER, "Owner"), (EDITOR, "Editor"), (VIEWER, "Viewer")]
     # Total order used to decide "higher" vs "lower" role — the single place
-    # role comparisons live (see `accept_invite`'s upgrade-only semantic and
-    # `services.set_member_role`). Do not scatter role comparisons elsewhere.
+    # role ORDERING lives (consumed by `accept_invite`'s upgrade-only
+    # semantic, and by `services.set_member_role` as the valid-role check
+    # via `role not in ROLE_RANK`). `is_last_owner`/`set_member_role`'s own
+    # role comparisons are plain `==`/`!=` — ROLE_RANK is only for "which of
+    # two roles outranks the other", not membership/equality checks.
     ROLE_RANK = {VIEWER: 0, EDITOR: 1, OWNER: 2}
 
     workspace = models.ForeignKey(

--- a/apps/workspaces/schemas.py
+++ b/apps/workspaces/schemas.py
@@ -42,6 +42,10 @@ class MemberOut(StrictModel):
     joined_at: dt.datetime
 
 
+class MemberRoleUpdateIn(StrictModel):
+    role: Role
+
+
 class InviteCreateIn(StrictModel):
     # EmailStr rejects a non-email string at the schema boundary, before it
     # ever becomes a matchable admission key for `pending_invite_for_email` /

--- a/apps/workspaces/services.py
+++ b/apps/workspaces/services.py
@@ -11,7 +11,7 @@ import datetime as dt
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.db import IntegrityError
+from django.db import IntegrityError, transaction
 from django.utils import timezone
 
 from .models import Workspace, WorkspaceInvite, WorkspaceMembership, generate_invite_token
@@ -162,10 +162,11 @@ def current_workspace(user, explicit: str | None = None) -> Workspace:
 
 
 class MemberError(Exception):
-    """Raised by `set_member_role` for any reason a role change can't proceed.
+    """Raised by `set_member_role` / `remove_member` for any reason a member
+    mutation can't proceed.
 
-    `.code` is a closed set (`not_found`, `last_owner`) an HTTP layer maps to
-    a status — same shape as `InviteError` below.
+    `.code` is a closed set (`not_found`, `last_owner`, `invalid_role`) an
+    HTTP layer maps to a status — same shape as `InviteError` below.
     """
 
     def __init__(self, code: str):
@@ -175,9 +176,11 @@ class MemberError(Exception):
 
 def is_last_owner(m: WorkspaceMembership) -> bool:
     """True iff `m` is an owner membership and the only owner left in its
-    workspace. Shared by `remove_member` (api.py) and `set_member_role` below
-    so the "can't strand a workspace without an owner" guard lives in exactly
-    one place."""
+    workspace. Shared by `remove_member` and `set_member_role` below so the
+    "can't strand a workspace without an owner" guard lives in exactly one
+    place. Must only be called from inside `_guarded_owner_mutation`'s
+    transaction — see its docstring for why an un-locked call here is a
+    TOCTOU hazard."""
     return m.role == WorkspaceMembership.OWNER and (
         WorkspaceMembership.objects.filter(
             workspace_id=m.workspace_id, role=WorkspaceMembership.OWNER
@@ -186,25 +189,91 @@ def is_last_owner(m: WorkspaceMembership) -> bool:
     )
 
 
+def _guarded_owner_mutation(*, workspace: Workspace, user_id, mutate):
+    """The single choke point for any mutation that can remove a workspace's
+    last owner (a role change OR a removal) — both `set_member_role` and
+    `remove_member` go through this so the "never zero owners" guard has
+    exactly one transaction + lock boundary instead of two independent
+    check-then-act windows.
+
+    TOCTOU this closes: workspace with owners A and B. A demotes/removes B
+    while B (in a truly concurrent request) demotes/removes A. Un-guarded,
+    both read count(owner)==2, both pass `is_last_owner`, both commit — zero
+    owners, workspace permanently unmanageable via the API. Locking every
+    currently-OWNER row of the workspace (`select_for_update`) BEFORE
+    fetching the target row means the second transaction blocks on the
+    first's commit; Postgres then re-evaluates the WHERE clause against the
+    post-commit row versions (EvalPlanQual), so by the time it proceeds the
+    now-demoted-from-owner row no longer matches `role=OWNER` and the count
+    correctly reads 1 — the second mutation is correctly rejected instead of
+    both racing through. (sqlite — this repo's test DB — has no row locking;
+    `has_select_for_update` is False so Django silently drops the FOR UPDATE
+    clause. See test_member_roles.py's TOCTOU tests for what can and can't be
+    proven against that backend.)
+
+    `mutate(m)` does the actual role-change/delete once the target row (and,
+    if it's currently an owner, the lock) is in hand; it may raise
+    `MemberError('last_owner')` itself via `is_last_owner`.
+    """
+    with transaction.atomic():
+        # Lock every currently-OWNER row of this workspace first, before even
+        # fetching the target — this is what makes a concurrent mutation on a
+        # DIFFERENT owner of the same workspace serialize against this one.
+        list(
+            WorkspaceMembership.objects.select_for_update().filter(
+                workspace_id=workspace.pk, role=WorkspaceMembership.OWNER
+            )
+        )
+        try:
+            m = WorkspaceMembership.objects.select_related("user").get(
+                workspace=workspace, user_id=user_id
+            )
+        except WorkspaceMembership.DoesNotExist:
+            raise MemberError("not_found")
+        return mutate(m)
+
+
 def set_member_role(*, workspace: Workspace, user_id, role: str) -> WorkspaceMembership:
     """Change a member's role. Idempotent: setting the role a member already
-    holds succeeds as a no-op. Raises `MemberError('not_found')` if `user_id`
-    isn't a member of `workspace`, or `MemberError('last_owner')` if this
-    would demote the workspace's only remaining owner (mirrors the guard
-    `remove_member` applies when removing the last owner, via `is_last_owner`).
+    holds succeeds as a no-op (and, deliberately, never trips the last-owner
+    guard — see `test_set_member_role_is_idempotent`). Raises
+    `MemberError('invalid_role')` if `role` isn't one `ROLE_RANK` knows (a
+    caller that bypassed the HTTP schema's `Literal`, e.g. a shell/MCP call —
+    `.save()` doesn't enforce Django `choices`, and an unranked role would
+    later KeyError inside `accept_invite`), `MemberError('not_found')` if
+    `user_id` isn't a member of `workspace`, or `MemberError('last_owner')`
+    if this would demote the workspace's only remaining owner. See
+    `_guarded_owner_mutation` for the transaction/lock this runs inside.
     """
-    try:
-        m = WorkspaceMembership.objects.select_related("user").get(
-            workspace=workspace, user_id=user_id
-        )
-    except WorkspaceMembership.DoesNotExist:
-        raise MemberError("not_found")
-    if role != m.role:
+    if role not in WorkspaceMembership.ROLE_RANK:
+        raise MemberError("invalid_role")
+
+    def _mutate(m: WorkspaceMembership) -> WorkspaceMembership:
+        if role != m.role:
+            if is_last_owner(m):
+                raise MemberError("last_owner")
+            m.role = role
+            m.save(update_fields=["role"])
+        return m
+
+    return _guarded_owner_mutation(workspace=workspace, user_id=user_id, mutate=_mutate)
+
+
+def remove_member(*, workspace: Workspace, user_id) -> None:
+    """Remove a member. Raises `MemberError('not_found')` if `user_id` isn't
+    a member of `workspace`, or `MemberError('last_owner')` if this would
+    remove the workspace's only remaining owner. See `_guarded_owner_mutation`
+    for the transaction/lock this runs inside — moved here (out of the API
+    view) so it shares that boundary with `set_member_role` instead of each
+    route running its own independent, unlocked check-then-act.
+    """
+
+    def _mutate(m: WorkspaceMembership) -> None:
         if is_last_owner(m):
             raise MemberError("last_owner")
-        m.role = role
-        m.save(update_fields=["role"])
-    return m
+        m.delete()
+
+    _guarded_owner_mutation(workspace=workspace, user_id=user_id, mutate=_mutate)
 
 
 # ---- invites ----
@@ -233,12 +302,24 @@ def create_invite(
     partial unique constraint treats as live (its condition doesn't consider
     `expires_at`), so an ordinary re-invite after a lapsed 14-day TTL must
     re-arm that same row rather than try to create a sibling and collide with
-    it. Reuse refreshes the row in place: a fresh token, a fresh expiry, and
-    the newly-requested role (unlike reusing a still-pending invite, where
-    the existing role/token/expiry stand as-is). Email is normalized to
-    lowercase. Belt-and-braces: if a genuinely concurrent call still races
-    past the `existing` check, the `.create()` IntegrityError is caught and
-    the winning row is re-fetched and returned instead of raising.
+    it. Reuse re-arms the row in place (fresh token, fresh expiry, the
+    newly-requested role) whenever anything about the request actually
+    changed: the TTL lapsed, OR the requested role differs from what the row
+    already holds. That second case is not cosmetic — it closes a real
+    integrity bug: without it, re-inviting someone at a DIFFERENT role while
+    their first invite is still pending returned the *same* row still
+    carrying the FIRST role (e.g. an owner invites b@ as owner, immediately
+    corrects it to editor — the still-live row kept reading "owner"). The
+    owner then hands out a link that promotes b@ to owner regardless of what
+    the UI most recently showed, and since `accept_invite` is upgrade-only,
+    an already-lower-privileged b@ accepting it is a real, silent promotion —
+    not the harmless no-op it used to be under the old get_or_create accept
+    semantic. A request that changes nothing (same role, still pending) is a
+    true no-op: the token is NOT rotated, so an already-shared link keeps
+    working. Email is normalized to lowercase. Belt-and-braces: if a
+    genuinely concurrent call still races past the `existing` check, the
+    `.create()` IntegrityError is caught and the winning row is re-fetched
+    and returned instead of raising.
     """
     email = (email or "").strip().lower()
     existing = (
@@ -249,7 +330,9 @@ def create_invite(
         .first()
     )
     if existing is not None:
-        if not existing.is_pending():  # never actioned, but its TTL lapsed — re-arm it
+        stale = not existing.is_pending()  # never actioned, but its TTL lapsed
+        role_changed = existing.role != role
+        if stale or role_changed:
             existing.token = generate_invite_token()
             existing.expires_at = timezone.now() + dt.timedelta(days=INVITE_TTL_DAYS)
             existing.role = role

--- a/apps/workspaces/services.py
+++ b/apps/workspaces/services.py
@@ -158,6 +158,55 @@ def current_workspace(user, explicit: str | None = None) -> Workspace:
     return ws
 
 
+# ---- members ----
+
+
+class MemberError(Exception):
+    """Raised by `set_member_role` for any reason a role change can't proceed.
+
+    `.code` is a closed set (`not_found`, `last_owner`) an HTTP layer maps to
+    a status — same shape as `InviteError` below.
+    """
+
+    def __init__(self, code: str):
+        self.code = code
+        super().__init__(code)
+
+
+def is_last_owner(m: WorkspaceMembership) -> bool:
+    """True iff `m` is an owner membership and the only owner left in its
+    workspace. Shared by `remove_member` (api.py) and `set_member_role` below
+    so the "can't strand a workspace without an owner" guard lives in exactly
+    one place."""
+    return m.role == WorkspaceMembership.OWNER and (
+        WorkspaceMembership.objects.filter(
+            workspace_id=m.workspace_id, role=WorkspaceMembership.OWNER
+        ).count()
+        == 1
+    )
+
+
+def set_member_role(*, workspace: Workspace, user_id, role: str) -> WorkspaceMembership:
+    """Change a member's role. Idempotent: setting the role a member already
+    holds succeeds as a no-op. Raises `MemberError('not_found')` if `user_id`
+    isn't a member of `workspace`, or `MemberError('last_owner')` if this
+    would demote the workspace's only remaining owner (mirrors the guard
+    `remove_member` applies when removing the last owner, via `is_last_owner`).
+    """
+    try:
+        m = WorkspaceMembership.objects.select_related("user").get(
+            workspace=workspace, user_id=user_id
+        )
+    except WorkspaceMembership.DoesNotExist:
+        raise MemberError("not_found")
+    if role != m.role:
+        if is_last_owner(m):
+            raise MemberError("last_owner")
+        m.role = role
+        m.save(update_fields=["role"])
+    return m
+
+
 # ---- invites ----
 
 
@@ -225,10 +274,16 @@ def create_invite(
 def accept_invite(*, token: str, user) -> tuple[Workspace, str]:
     """Accept an invite by token on behalf of `user`.
 
-    Returns (workspace, role) — role is the user's resulting membership role,
-    which is their EXISTING role if they were already a member at a different
-    role (get_or_create semantics: acceptance never changes an existing role).
-    Raises InviteError on any invalid state; never mutates on failure.
+    Returns (workspace, role) — role is the user's resulting membership role.
+    UPGRADE-ONLY semantic: if the user is already a member, acceptance moves
+    their role to the HIGHER of their existing role and the invite's role
+    (`WorkspaceMembership.ROLE_RANK`), and never demotes — a stray invite at a
+    lower role than someone already holds must not be able to strip access.
+    Explicit demotion is the owner-only PATCH `/members/{user_id}/`
+    (`set_member_role`), never a side effect of accepting an invite. The
+    invite itself is always consumed (marked accepted) on success, whether or
+    not the role actually changed. Raises InviteError on any invalid state;
+    never mutates on failure.
     """
     try:
         inv = WorkspaceInvite.objects.select_related("workspace").get(token=token)
@@ -242,10 +297,13 @@ def accept_invite(*, token: str, user) -> tuple[Workspace, str]:
         raise InviteError("expired")
     if inv.email and (getattr(user, "email", "") or "").lower() != inv.email.lower():
         raise InviteError("email_mismatch")
-    m, _ = WorkspaceMembership.objects.get_or_create(
+    m, created = WorkspaceMembership.objects.get_or_create(
         workspace=inv.workspace, user=user,
         defaults={"role": inv.role, "invited_by": inv.invited_by},
     )
+    if not created and WorkspaceMembership.ROLE_RANK[inv.role] > WorkspaceMembership.ROLE_RANK[m.role]:
+        m.role = inv.role
+        m.save(update_fields=["role"])
     inv.accepted_at = timezone.now()
     inv.save(update_fields=["accepted_at"])
     return inv.workspace, m.role

--- a/apps/workspaces/tests/test_invites.py
+++ b/apps/workspaces/tests/test_invites.py
@@ -59,6 +59,48 @@ def test_create_invite_reuses_live_pending_invite_for_same_workspace_and_email()
     assert WorkspaceInvite.objects.filter(workspace=ws, email="b@dimagi.com").count() == 1
 
 
+def test_create_invite_reusing_a_still_pending_row_at_a_different_role_updates_role_and_rotates_token():
+    """Regression: an owner invites b@ as owner, immediately realizes the
+    mistake, and re-invites b@ as editor. The prior behavior returned the
+    SAME row still holding role="owner" (only a lapsed/expired row got its
+    role rewritten on reuse) — so the owner would copy a link that still
+    reads "owner", and since accept is now upgrade-only, b (already an
+    editor) accepting it would be silently promoted to owner. A still-live
+    reuse at a genuinely different role must re-arm the row (fresh token,
+    fresh expiry, the newly-requested role) exactly like the lapsed-TTL path
+    does, so the copied link always reflects the LAST-requested role."""
+    owner = _user("a@dimagi.com")
+    ws = _ws(owner)
+    first = create_invite(workspace=ws, email="b@dimagi.com", role="owner", invited_by=owner)
+    old_token = first.token
+
+    second = create_invite(workspace=ws, email="b@dimagi.com", role="editor", invited_by=owner)
+
+    assert second.id == first.id  # still the same row, not a sibling
+    assert second.role == "editor"
+    assert second.token != old_token
+    assert second.is_pending()
+    # the stale (pre-rotation) token no longer resolves to anything live
+    with pytest.raises(InviteError) as exc_info:
+        accept_invite(token=old_token, user=_user("someone-else@dimagi.com"))
+    assert exc_info.value.code == "not_found"
+
+
+def test_create_invite_reusing_a_still_pending_row_at_the_same_role_is_a_true_no_op():
+    """The counterpart to the regression above: re-issuing an invite at the
+    SAME role it already holds must not rotate the token (no reason to
+    invalidate a link nothing about it actually changed)."""
+    owner = _user("a@dimagi.com")
+    ws = _ws(owner)
+    first = create_invite(workspace=ws, email="b@dimagi.com", role="editor", invited_by=owner)
+
+    second = create_invite(workspace=ws, email="b@dimagi.com", role="editor", invited_by=owner)
+
+    assert second.id == first.id
+    assert second.token == first.token
+    assert second.role == "editor"
+
+
 def test_create_invite_after_expiry_reuses_row_with_fresh_token_and_is_pending_again():
     """Regression: an ordinary re-invite after the 14-day TTL lapses (never
     accepted, never revoked) must NOT try to create a sibling row — the

--- a/apps/workspaces/tests/test_invites.py
+++ b/apps/workspaces/tests/test_invites.py
@@ -155,24 +155,60 @@ def test_accept_unknown_token_raises_not_found():
     assert exc_info.value.code == "not_found"
 
 
-def test_accept_when_already_member_at_different_role_keeps_existing_role_but_marks_accepted():
-    """Deliberate semantic: accept is get_or_create on membership. If the invitee
-    somehow already holds a DIFFERENT role in the workspace (e.g. an owner invited
-    to re-join as editor, or a second invite for a role bump landed late), acceptance
-    does NOT change their existing role — but the invite itself is still consumed
-    (marked accepted) so it can't be replayed."""
+def test_accept_when_invited_at_lower_role_than_existing_keeps_existing_role_but_marks_accepted():
+    """Deliberate semantic: accept is UPGRADE-ONLY on membership role (never a
+    demotion). If the invitee already holds a HIGHER role than the invite offers
+    (e.g. an owner invited to re-join as viewer, or a stray lower-role invite
+    landed late), acceptance does NOT change their existing role — but the
+    invite itself is still consumed (marked accepted) so it can't be replayed.
+    Explicit demotion is the owner-only PATCH `/members/{user_id}/`, never a
+    side effect of someone accepting an invite."""
     owner = _user("a@dimagi.com")
     ws = _ws(owner)
     WorkspaceMembership.objects.create(workspace=ws, user=owner, role=WorkspaceMembership.OWNER)
-    # owner already has role "owner" in ws; invite them at a different role ("viewer")
+    # owner already has role "owner" in ws; invite them at a LOWER role ("viewer")
     inv = create_invite(workspace=ws, email="a@dimagi.com", role="viewer", invited_by=owner)
 
     result_ws, role = accept_invite(token=inv.token, user=owner)
 
     assert result_ws == ws
-    # returned role reflects the EXISTING membership role, not the invite's role
+    # returned role reflects the EXISTING (higher) membership role, not the invite's role
     assert role == "owner"
     assert WorkspaceMembership.objects.get(workspace=ws, user=owner).role == "owner"
+    inv.refresh_from_db()
+    assert inv.accepted_at is not None
+
+
+def test_accept_when_invited_at_higher_role_than_existing_upgrades_role():
+    """The upgrade half of the same semantic: an existing viewer invited as
+    editor ends up an editor (upgrade), and the invite is marked accepted."""
+    owner = _user("a@dimagi.com")
+    ws = _ws(owner)
+    viewer = _user("b@dimagi.com")
+    WorkspaceMembership.objects.create(workspace=ws, user=viewer, role=WorkspaceMembership.VIEWER)
+    inv = create_invite(workspace=ws, email="b@dimagi.com", role="editor", invited_by=owner)
+
+    result_ws, role = accept_invite(token=inv.token, user=viewer)
+
+    assert result_ws == ws
+    assert role == "editor"
+    assert WorkspaceMembership.objects.get(workspace=ws, user=viewer).role == "editor"
+    inv.refresh_from_db()
+    assert inv.accepted_at is not None
+
+
+def test_accept_when_invited_at_same_role_as_existing_leaves_role_unchanged():
+    owner = _user("a@dimagi.com")
+    ws = _ws(owner)
+    editor = _user("b@dimagi.com")
+    WorkspaceMembership.objects.create(workspace=ws, user=editor, role=WorkspaceMembership.EDITOR)
+    inv = create_invite(workspace=ws, email="b@dimagi.com", role="editor", invited_by=owner)
+
+    result_ws, role = accept_invite(token=inv.token, user=editor)
+
+    assert result_ws == ws
+    assert role == "editor"
+    assert WorkspaceMembership.objects.get(workspace=ws, user=editor).role == "editor"
     inv.refresh_from_db()
     assert inv.accepted_at is not None
 

--- a/apps/workspaces/tests/test_member_roles.py
+++ b/apps/workspaces/tests/test_member_roles.py
@@ -9,8 +9,10 @@ from __future__ import annotations
 import pytest
 from django.contrib.auth import get_user_model
 
+from django.db.models.query import QuerySet
+
 from apps.workspaces.models import Workspace, WorkspaceMembership
-from apps.workspaces.services import MemberError, is_last_owner, set_member_role
+from apps.workspaces.services import MemberError, is_last_owner, remove_member, set_member_role
 
 pytestmark = pytest.mark.django_db
 User = get_user_model()
@@ -108,3 +110,115 @@ def test_is_last_owner_false_for_a_non_owner():
     viewer = _user("b@dimagi.com")
     m = WorkspaceMembership.objects.create(workspace=ws, user=viewer, role=WorkspaceMembership.VIEWER)
     assert is_last_owner(m) is False
+
+
+def test_set_member_role_rejects_a_role_outside_role_rank():
+    """Defense in depth for a caller that bypasses the Pydantic Literal at the
+    HTTP boundary (shell, management command, MCP tool) — the service itself
+    must not persist a role .save() lets through but ROLE_RANK can't look up
+    (accept_invite's ROLE_RANK[m.role] would otherwise KeyError/500 on the
+    very next invite acceptance for this workspace)."""
+    owner = _user("a@dimagi.com")
+    ws = _ws(owner)
+    with pytest.raises(MemberError) as exc_info:
+        set_member_role(workspace=ws, user_id=owner.id, role="superuser")
+    assert exc_info.value.code == "invalid_role"
+    assert WorkspaceMembership.objects.get(workspace=ws, user=owner).role == WorkspaceMembership.OWNER
+
+
+# ---- remove_member (moved into the service so it shares the same
+# transaction + row-lock boundary as set_member_role — see the TOCTOU tests
+# below) ----
+
+
+def test_remove_member_removes_a_non_owner():
+    owner = _user("a@dimagi.com")
+    ws = _ws(owner)
+    viewer = _user("b@dimagi.com")
+    WorkspaceMembership.objects.create(workspace=ws, user=viewer, role=WorkspaceMembership.VIEWER)
+
+    remove_member(workspace=ws, user_id=viewer.id)
+
+    assert not WorkspaceMembership.objects.filter(workspace=ws, user=viewer).exists()
+
+
+def test_remove_member_raises_not_found_for_non_member():
+    owner = _user("a@dimagi.com")
+    ws = _ws(owner)
+    stranger = _user("z@dimagi.com")
+    with pytest.raises(MemberError) as exc_info:
+        remove_member(workspace=ws, user_id=stranger.id)
+    assert exc_info.value.code == "not_found"
+
+
+def test_remove_member_raises_last_owner_when_removing_the_only_owner():
+    owner = _user("a@dimagi.com")
+    ws = _ws(owner)
+    with pytest.raises(MemberError) as exc_info:
+        remove_member(workspace=ws, user_id=owner.id)
+    assert exc_info.value.code == "last_owner"
+    assert WorkspaceMembership.objects.filter(workspace=ws, user=owner).exists()
+
+
+def test_remove_member_allows_removing_one_of_two_owners():
+    owner = _user("a@dimagi.com")
+    ws = _ws(owner)
+    second_owner = _user("b@dimagi.com")
+    WorkspaceMembership.objects.create(workspace=ws, user=second_owner, role=WorkspaceMembership.OWNER)
+
+    remove_member(workspace=ws, user_id=owner.id)
+
+    assert not WorkspaceMembership.objects.filter(workspace=ws, user=owner).exists()
+
+
+# ---- TOCTOU guard: the last-owner check must take a row lock ----
+#
+# The real hazard (two concurrent requests each observing count(owner)==2
+# before either commits, so BOTH pass the guard and the workspace ends with
+# zero owners) can only be demonstrated against a database that actually
+# enforces row locking under concurrent transactions/connections — this repo's
+# test suite runs on sqlite, which silently no-ops `select_for_update()`
+# (`connection.features.has_select_for_update` is False; Django drops the
+# FOR UPDATE clause instead of erroring — see apps/harness/services.py's
+# `append_events` for the same caveat). These tests are honest about that
+# limit: they assert the code path actually TAKES the lock (a spy on
+# `QuerySet.select_for_update`), not that concurrent transactions serialize.
+# The serialization itself is exercised in production by Postgres.
+
+
+def test_set_member_role_last_owner_guard_takes_a_row_lock(monkeypatch):
+    calls: list[type] = []
+    original = QuerySet.select_for_update
+
+    def spy(self, *args, **kwargs):
+        calls.append(self.model)
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(QuerySet, "select_for_update", spy)
+
+    owner = _user("a@dimagi.com")
+    ws = _ws(owner)
+
+    with pytest.raises(MemberError):
+        set_member_role(workspace=ws, user_id=owner.id, role=WorkspaceMembership.EDITOR)
+
+    assert WorkspaceMembership in calls
+
+
+def test_remove_member_last_owner_guard_takes_a_row_lock(monkeypatch):
+    calls: list[type] = []
+    original = QuerySet.select_for_update
+
+    def spy(self, *args, **kwargs):
+        calls.append(self.model)
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(QuerySet, "select_for_update", spy)
+
+    owner = _user("a@dimagi.com")
+    ws = _ws(owner)
+
+    with pytest.raises(MemberError):
+        remove_member(workspace=ws, user_id=owner.id)
+
+    assert WorkspaceMembership in calls

--- a/apps/workspaces/tests/test_member_roles.py
+++ b/apps/workspaces/tests/test_member_roles.py
@@ -1,0 +1,110 @@
+"""Unit tests for the member-role service layer (`apps/workspaces/services.py`).
+
+These exercise `set_member_role` / `is_last_owner` directly (no HTTP),
+complementing the request-level coverage in `test_members.py` (RBAC + status
+codes), mirroring the split `test_invites.py` already uses for invites.
+"""
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth import get_user_model
+
+from apps.workspaces.models import Workspace, WorkspaceMembership
+from apps.workspaces.services import MemberError, is_last_owner, set_member_role
+
+pytestmark = pytest.mark.django_db
+User = get_user_model()
+
+
+def _user(email):
+    return User.objects.create(username=email, email=email)
+
+
+def _ws(owner, slug="acme"):
+    ws = Workspace.objects.create(slug=slug, display_name=slug.title(), created_by=owner)
+    WorkspaceMembership.objects.create(workspace=ws, user=owner, role=WorkspaceMembership.OWNER)
+    return ws
+
+
+def test_set_member_role_promotes_a_member():
+    owner = _user("a@dimagi.com")
+    ws = _ws(owner)
+    viewer = _user("b@dimagi.com")
+    WorkspaceMembership.objects.create(workspace=ws, user=viewer, role=WorkspaceMembership.VIEWER)
+
+    m = set_member_role(workspace=ws, user_id=viewer.id, role=WorkspaceMembership.EDITOR)
+
+    assert m.role == WorkspaceMembership.EDITOR
+    assert WorkspaceMembership.objects.get(workspace=ws, user=viewer).role == WorkspaceMembership.EDITOR
+
+
+def test_set_member_role_demotes_a_member():
+    owner = _user("a@dimagi.com")
+    ws = _ws(owner)
+    second_owner = _user("b@dimagi.com")
+    WorkspaceMembership.objects.create(workspace=ws, user=second_owner, role=WorkspaceMembership.OWNER)
+
+    m = set_member_role(workspace=ws, user_id=second_owner.id, role=WorkspaceMembership.VIEWER)
+
+    assert m.role == WorkspaceMembership.VIEWER
+
+
+def test_set_member_role_is_idempotent():
+    owner = _user("a@dimagi.com")
+    ws = _ws(owner)
+
+    m = set_member_role(workspace=ws, user_id=owner.id, role=WorkspaceMembership.OWNER)
+
+    assert m.role == WorkspaceMembership.OWNER
+
+
+def test_set_member_role_raises_not_found_for_non_member():
+    owner = _user("a@dimagi.com")
+    ws = _ws(owner)
+    stranger = _user("z@dimagi.com")
+
+    with pytest.raises(MemberError) as exc_info:
+        set_member_role(workspace=ws, user_id=stranger.id, role=WorkspaceMembership.EDITOR)
+    assert exc_info.value.code == "not_found"
+
+
+def test_set_member_role_raises_last_owner_when_demoting_the_only_owner():
+    owner = _user("a@dimagi.com")
+    ws = _ws(owner)
+
+    with pytest.raises(MemberError) as exc_info:
+        set_member_role(workspace=ws, user_id=owner.id, role=WorkspaceMembership.EDITOR)
+    assert exc_info.value.code == "last_owner"
+    assert WorkspaceMembership.objects.get(workspace=ws, user=owner).role == WorkspaceMembership.OWNER
+
+
+def test_set_member_role_allows_demoting_one_of_two_owners():
+    owner = _user("a@dimagi.com")
+    ws = _ws(owner)
+    second_owner = _user("b@dimagi.com")
+    WorkspaceMembership.objects.create(workspace=ws, user=second_owner, role=WorkspaceMembership.OWNER)
+
+    m = set_member_role(workspace=ws, user_id=owner.id, role=WorkspaceMembership.VIEWER)
+
+    assert m.role == WorkspaceMembership.VIEWER
+
+
+def test_is_last_owner_true_only_for_the_sole_owner():
+    owner = _user("a@dimagi.com")
+    ws = _ws(owner)
+    m = WorkspaceMembership.objects.get(workspace=ws, user=owner)
+    assert is_last_owner(m) is True
+
+    second_owner = _user("b@dimagi.com")
+    m2 = WorkspaceMembership.objects.create(workspace=ws, user=second_owner, role=WorkspaceMembership.OWNER)
+    m.refresh_from_db()
+    assert is_last_owner(m) is False
+    assert is_last_owner(m2) is False
+
+
+def test_is_last_owner_false_for_a_non_owner():
+    owner = _user("a@dimagi.com")
+    ws = _ws(owner)
+    viewer = _user("b@dimagi.com")
+    m = WorkspaceMembership.objects.create(workspace=ws, user=viewer, role=WorkspaceMembership.VIEWER)
+    assert is_last_owner(m) is False

--- a/apps/workspaces/tests/test_members.py
+++ b/apps/workspaces/tests/test_members.py
@@ -103,8 +103,10 @@ def test_remove_member_owner_only_and_protects_last_owner():
     assert _client(b).delete(f"/api/workspaces/acme/members/{a.id}/").status_code == 403
     # the owner can remove the editor
     assert _client(a).delete(f"/api/workspaces/acme/members/{b.id}/").status_code == 204
-    # the last owner can't be removed
-    assert _client(a).delete(f"/api/workspaces/acme/members/{a.id}/").status_code == 400
+    # the last owner can't be removed — human-readable message, never the raw code
+    r = _client(a).delete(f"/api/workspaces/acme/members/{a.id}/")
+    assert r.status_code == 400
+    assert r.json()["detail"] == "cannot remove the last owner"
 
 
 def test_set_member_role_owner_only():
@@ -141,6 +143,9 @@ def test_set_member_role_cannot_demote_the_last_owner():
     _ws(a)
     r = _patch(_client(a), f"/api/workspaces/acme/members/{a.id}/", {"role": "editor"})
     assert r.status_code == 400
+    # human-readable, and distinct from the sibling DELETE's message — never
+    # the raw MemberError code ("last_owner") leaking into a user-facing banner
+    assert r.json()["detail"] == "cannot demote the last owner"
     assert WorkspaceMembership.objects.get(workspace_id="acme", user=a).role == "owner"
 
 

--- a/apps/workspaces/tests/test_members.py
+++ b/apps/workspaces/tests/test_members.py
@@ -32,6 +32,10 @@ def _post(c, url, data=None):
     return c.post(url, data=json.dumps(data or {}), content_type="application/json")
 
 
+def _patch(c, url, data=None):
+    return c.patch(url, data=json.dumps(data or {}), content_type="application/json")
+
+
 def _ws(owner, slug="acme"):
     _post(_client(owner), "/api/workspaces/", {"slug": slug, "display_name": slug.title()})
     return slug
@@ -101,3 +105,55 @@ def test_remove_member_owner_only_and_protects_last_owner():
     assert _client(a).delete(f"/api/workspaces/acme/members/{b.id}/").status_code == 204
     # the last owner can't be removed
     assert _client(a).delete(f"/api/workspaces/acme/members/{a.id}/").status_code == 400
+
+
+def test_set_member_role_owner_only():
+    a = _user("a@dimagi.com")
+    _ws(a)
+    inv = _invite(a, "acme", "b@dimagi.com", "editor")
+    b = _user("b@dimagi.com")
+    _post(_client(b), f"/api/workspaces/invites/{inv['token']}/accept")  # b is now an editor
+
+    # a non-member is 404, never 403 (no existence leak)
+    c = _user("c@dimagi.com")
+    assert _patch(_client(c), f"/api/workspaces/acme/members/{b.id}/", {"role": "owner"}).status_code == 404
+
+    # an editor (member, not owner) is 403
+    assert _patch(_client(b), f"/api/workspaces/acme/members/{b.id}/", {"role": "owner"}).status_code == 403
+
+    # the owner can promote the editor
+    r = _patch(_client(a), f"/api/workspaces/acme/members/{b.id}/", {"role": "owner"})
+    assert r.status_code == 200, r.content
+    body = r.json()
+    assert body["role"] == "owner" and body["user_id"] == b.id and body["email"] == "b@dimagi.com"
+    assert WorkspaceMembership.objects.get(workspace_id="acme", user=b).role == "owner"
+
+
+def test_set_member_role_target_not_a_member_is_404():
+    a = _user("a@dimagi.com")
+    _ws(a)
+    ghost_id = 999999
+    assert _patch(_client(a), f"/api/workspaces/acme/members/{ghost_id}/", {"role": "editor"}).status_code == 404
+
+
+def test_set_member_role_cannot_demote_the_last_owner():
+    a = _user("a@dimagi.com")
+    _ws(a)
+    r = _patch(_client(a), f"/api/workspaces/acme/members/{a.id}/", {"role": "editor"})
+    assert r.status_code == 400
+    assert WorkspaceMembership.objects.get(workspace_id="acme", user=a).role == "owner"
+
+
+def test_set_member_role_is_idempotent():
+    a = _user("a@dimagi.com")
+    _ws(a)
+    r = _patch(_client(a), f"/api/workspaces/acme/members/{a.id}/", {"role": "owner"})
+    assert r.status_code == 200, r.content
+    assert r.json()["role"] == "owner"
+
+
+def test_set_member_role_rejects_unknown_role():
+    a = _user("a@dimagi.com")
+    _ws(a)
+    r = _patch(_client(a), f"/api/workspaces/acme/members/{a.id}/", {"role": "superuser"})
+    assert r.status_code == 422

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -1622,7 +1622,8 @@ export interface paths {
         readonly delete: operations["apps_workspaces_api_remove_member"];
         readonly options?: never;
         readonly head?: never;
-        readonly patch?: never;
+        /** Change a member's role (owner-only) */
+        readonly patch: operations["apps_workspaces_api_set_member_role"];
         readonly trace?: never;
     };
     readonly "/api/workspaces/{slug}/invites/": {
@@ -6008,6 +6009,14 @@ export interface components {
              */
             readonly joined_at: string;
         };
+        /** MemberRoleUpdateIn */
+        readonly MemberRoleUpdateIn: {
+            /**
+             * Role
+             * @enum {string}
+             */
+            readonly role: "owner" | "editor" | "viewer";
+        };
         /** InviteOut */
         readonly InviteOut: {
             /** Id */
@@ -9928,6 +9937,33 @@ export interface operations {
                     readonly [name: string]: unknown;
                 };
                 content?: never;
+            };
+        };
+    };
+    readonly apps_workspaces_api_set_member_role: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path: {
+                readonly slug: string;
+                readonly user_id: number;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody: {
+            readonly content: {
+                readonly "application/json": components["schemas"]["MemberRoleUpdateIn"];
+            };
+        };
+        readonly responses: {
+            /** @description OK */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["MemberOut"];
+                };
             };
         };
     };

--- a/frontend/src/api/workspaces.ts
+++ b/frontend/src/api/workspaces.ts
@@ -9,6 +9,7 @@ export type WorkspaceOut = components['schemas']['WorkspaceOut']
 export type MemberOut = components['schemas']['MemberOut']
 export type InviteOut = components['schemas']['InviteOut']
 export type InviteRole = components['schemas']['InviteCreateIn']['role']
+export type MemberRole = components['schemas']['MemberRoleUpdateIn']['role']
 export type InvitePreviewOut = components['schemas']['InvitePreviewOut']
 
 // Every call below needs the HTTP status (404 for non-member, 403 for an
@@ -57,6 +58,17 @@ export async function removeMember(slug: string, userId: number): Promise<void> 
   if (!res.response.ok) {
     throw new WorkspaceApiError(res.response.status, problemMessage(res.error, 'Failed to remove member'))
   }
+}
+
+export async function setMemberRole(slug: string, userId: number, role: MemberRole): Promise<MemberOut> {
+  const res = await apiV2.PATCH('/api/workspaces/{slug}/members/{user_id}/', {
+    params: { path: { slug, user_id: userId } },
+    body: { role },
+  })
+  if (!res.response.ok) {
+    throw new WorkspaceApiError(res.response.status, problemMessage(res.error, 'Failed to change role'))
+  }
+  return res.data as unknown as MemberOut
 }
 
 export async function listInvites(slug: string): Promise<InviteOut[]> {

--- a/frontend/src/pages/WorkspaceMembersPage.test.tsx
+++ b/frontend/src/pages/WorkspaceMembersPage.test.tsx
@@ -11,6 +11,7 @@ import type { MemberOut, InviteOut } from '@/api/workspaces'
 // RunnerAssignments.test.tsx / ChatSessionsPanel.test.tsx.
 const listMembers = vi.fn<(slug: string) => Promise<MemberOut[]>>()
 const removeMember = vi.fn<(slug: string, userId: number) => Promise<void>>()
+const setMemberRole = vi.fn<(slug: string, userId: number, role: string) => Promise<MemberOut>>()
 const listInvites = vi.fn<(slug: string) => Promise<InviteOut[]>>()
 const createInvite = vi.fn<(slug: string, email: string, role: string) => Promise<InviteOut>>()
 const revokeInvite = vi.fn<(slug: string, inviteId: number) => Promise<void>>()
@@ -26,6 +27,7 @@ class FakeWorkspaceApiError extends Error {
 vi.mock('@/api/workspaces', () => ({
   listMembers,
   removeMember,
+  setMemberRole,
   listInvites,
   createInvite,
   revokeInvite,
@@ -189,6 +191,67 @@ describe('WorkspaceMembersPage', () => {
 
     await waitFor(() => expect(removeMember).toHaveBeenCalledWith('acme', 5))
     await waitFor(() => expect(screen.queryByText('leaving@dimagi.com')).toBeNull())
+  })
+
+  it('an owner can change a role via the select, and the row updates', async () => {
+    mockRole = 'owner'
+    listMembers.mockResolvedValue([
+      member({ user_id: 1, email: 'alice@dimagi.com', role: 'owner' }),
+      member({ user_id: 2, email: 'carol@dimagi.com', role: 'viewer' }),
+    ])
+    listInvites.mockResolvedValue([])
+    setMemberRole.mockResolvedValue(member({ user_id: 2, email: 'carol@dimagi.com', role: 'editor' }))
+
+    renderPage()
+    await screen.findByText('carol@dimagi.com')
+
+    const select = screen.getByLabelText(/change role for carol@dimagi.com/i) as HTMLSelectElement
+    fireEvent.change(select, { target: { value: 'editor' } })
+
+    await waitFor(() => expect(setMemberRole).toHaveBeenCalledWith('acme', 2, 'editor'))
+    await waitFor(() => expect((screen.getByLabelText(/change role for carol@dimagi.com/i) as HTMLSelectElement).value).toBe('editor'))
+  })
+
+  it('a non-owner sees static role text, not a select', async () => {
+    mockRole = 'editor'
+    listMembers.mockResolvedValue([member({ user_id: 2, email: 'carol@dimagi.com', role: 'viewer' })])
+    listInvites.mockResolvedValue([])
+
+    renderPage()
+    await screen.findByText('carol@dimagi.com')
+
+    expect(screen.queryByLabelText(/change role for carol@dimagi.com/i)).toBeNull()
+    expect(screen.getByText('viewer')).toBeTruthy()
+  })
+
+  it('the sole owner\'s role select is disabled (cannot self-demote to strand the workspace)', async () => {
+    mockRole = 'owner'
+    listMembers.mockResolvedValue([member({ user_id: 1, email: 'alice@dimagi.com', role: 'owner' })])
+    listInvites.mockResolvedValue([])
+
+    renderPage()
+    await screen.findByText('alice@dimagi.com')
+
+    const select = screen.getByLabelText(/change role for alice@dimagi.com/i) as HTMLSelectElement
+    expect(select.disabled).toBe(true)
+  })
+
+  it('a role-change failure surfaces an error and leaves the row unchanged', async () => {
+    mockRole = 'owner'
+    listMembers.mockResolvedValue([
+      member({ user_id: 1, email: 'alice@dimagi.com', role: 'owner' }),
+      member({ user_id: 2, email: 'carol@dimagi.com', role: 'viewer' }),
+    ])
+    listInvites.mockResolvedValue([])
+    setMemberRole.mockRejectedValue(new FakeWorkspaceApiError(400, 'cannot demote the last owner'))
+
+    renderPage()
+    await screen.findByText('carol@dimagi.com')
+
+    const select = screen.getByLabelText(/change role for carol@dimagi.com/i) as HTMLSelectElement
+    fireEvent.change(select, { target: { value: 'owner' } })
+
+    await waitFor(() => expect(screen.getByText(/cannot demote the last owner/i)).toBeTruthy())
   })
 
   it('redirects to the workspace home on a 404 (non-member)', async () => {

--- a/frontend/src/pages/WorkspaceMembersPage.test.tsx
+++ b/frontend/src/pages/WorkspaceMembersPage.test.tsx
@@ -35,11 +35,24 @@ vi.mock('@/api/workspaces', () => ({
 }))
 
 let mockRole: string | undefined = 'owner'
+const mockRefresh = vi.fn<() => Promise<void>>()
 vi.mock('@/workspace/WorkspaceProvider', () => ({
   useWorkspace: () => ({
     workspaces: mockRole ? [{ slug: 'acme', display_name: 'Acme', role: mockRole }] : [],
     active: 'acme',
     loading: false,
+    refresh: mockRefresh,
+  }),
+}))
+
+// The page needs to know "is the row I just changed MY OWN membership" to
+// decide whether to refresh the (otherwise-stale) cached workspace list —
+// see the self-demotion test below. `alice@dimagi.com` is the default
+// `member()` fixture's email, so it doubles as "the signed-in user" here.
+vi.mock('@/auth/AuthProvider', () => ({
+  useAuth: () => ({
+    status: 'authenticated',
+    user: { email: 'alice@dimagi.com', name: 'Alice', avatar_url: '' },
   }),
 }))
 
@@ -224,7 +237,7 @@ describe('WorkspaceMembersPage', () => {
     expect(screen.getByText('viewer')).toBeTruthy()
   })
 
-  it('the sole owner\'s role select is disabled (cannot self-demote to strand the workspace)', async () => {
+  it('the sole owner\'s role select is disabled with a VISIBLE explanation (not mouse/hover-only)', async () => {
     mockRole = 'owner'
     listMembers.mockResolvedValue([member({ user_id: 1, email: 'alice@dimagi.com', role: 'owner' })])
     listInvites.mockResolvedValue([])
@@ -234,6 +247,51 @@ describe('WorkspaceMembersPage', () => {
 
     const select = screen.getByLabelText(/change role for alice@dimagi.com/i) as HTMLSelectElement
     expect(select.disabled).toBe(true)
+    // A `title` attribute alone is mouse/hover-only — invisible to screen
+    // readers and touch. There must be plain visible text explaining why,
+    // wired to the control via aria-describedby.
+    expect(screen.getByText(/only owner/i)).toBeTruthy()
+    const describedBy = select.getAttribute('aria-describedby')
+    expect(describedBy).toBeTruthy()
+    expect(document.getElementById(describedBy as string)?.textContent).toMatch(/only owner/i)
+  })
+
+  it("refreshes the cached workspace list when the signed-in owner changes their OWN role (avoids a stale isOwner)", async () => {
+    mockRole = 'owner'
+    listMembers.mockResolvedValue([
+      member({ user_id: 1, email: 'alice@dimagi.com', role: 'owner' }),
+      member({ user_id: 2, email: 'bob@dimagi.com', role: 'owner' }),
+    ])
+    listInvites.mockResolvedValue([])
+    setMemberRole.mockResolvedValue(member({ user_id: 1, email: 'alice@dimagi.com', role: 'editor' }))
+
+    renderPage()
+    await screen.findByText('alice@dimagi.com')
+
+    const select = screen.getByLabelText(/change role for alice@dimagi.com/i) as HTMLSelectElement
+    fireEvent.change(select, { target: { value: 'editor' } })
+
+    await waitFor(() => expect(setMemberRole).toHaveBeenCalledWith('acme', 1, 'editor'))
+    await waitFor(() => expect(mockRefresh).toHaveBeenCalled())
+  })
+
+  it("does not refresh the cached workspace list when changing SOMEONE ELSE's role", async () => {
+    mockRole = 'owner'
+    listMembers.mockResolvedValue([
+      member({ user_id: 1, email: 'alice@dimagi.com', role: 'owner' }),
+      member({ user_id: 2, email: 'bob@dimagi.com', role: 'owner' }),
+    ])
+    listInvites.mockResolvedValue([])
+    setMemberRole.mockResolvedValue(member({ user_id: 2, email: 'bob@dimagi.com', role: 'editor' }))
+
+    renderPage()
+    await screen.findByText('bob@dimagi.com')
+
+    const select = screen.getByLabelText(/change role for bob@dimagi.com/i) as HTMLSelectElement
+    fireEvent.change(select, { target: { value: 'editor' } })
+
+    await waitFor(() => expect(setMemberRole).toHaveBeenCalledWith('acme', 2, 'editor'))
+    expect(mockRefresh).not.toHaveBeenCalled()
   })
 
   it('a role-change failure surfaces an error and leaves the row unchanged', async () => {

--- a/frontend/src/pages/WorkspaceMembersPage.tsx
+++ b/frontend/src/pages/WorkspaceMembersPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from 'react-router-dom'
 import { Button, Input, Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from 'canopy-ui/ui'
 import { WorkbenchSubHeader } from 'canopy-ui'
 import { useWorkspace } from '@/workspace/WorkspaceProvider'
+import { useAuth } from '@/auth/AuthProvider'
 import {
   createInvite,
   listInvites,
@@ -38,8 +39,10 @@ function inviteLink(token: string): string {
 export function WorkspaceMembersPage(): JSX.Element | null {
   const { workspace: slug } = useParams()
   const navigate = useNavigate()
-  const { workspaces } = useWorkspace()
+  const { workspaces, refresh: refreshWorkspaces } = useWorkspace()
   const isOwner = workspaces.find((w) => w.slug === slug)?.role === 'owner'
+  const auth = useAuth()
+  const myEmail = auth.status === 'authenticated' ? auth.user.email.toLowerCase() : null
 
   const [members, setMembers] = useState<MemberOut[] | null>(null)
   const [invites, setInvites] = useState<InviteOut[] | null>(null)
@@ -91,6 +94,14 @@ export function WorkspaceMembersPage(): JSX.Element | null {
     try {
       const updated = await setMemberRole(slug, userId, role)
       setMembers((prev) => (prev ?? []).map((m) => (m.user_id === userId ? updated : m)))
+      // The cached workspace list (header switcher, this page's own `isOwner`)
+      // is fetched once and otherwise never invalidated — if I just changed
+      // MY OWN role, refresh it now so `isOwner` reflects reality immediately
+      // instead of continuing to render owner-only controls I can no longer
+      // use until a full page reload (see WorkspaceProvider.refresh's docstring).
+      if (myEmail && updated.email.toLowerCase() === myEmail) {
+        void refreshWorkspaces()
+      }
     } catch (e) {
       setRowError(e instanceof Error ? e.message : 'Failed to change role')
     } finally {
@@ -177,24 +188,34 @@ export function WorkspaceMembersPage(): JSX.Element | null {
                   <TableCell className="whitespace-normal text-foreground">{m.email}</TableCell>
                   <TableCell className="capitalize">
                     {isOwner ? (
-                      <select
-                        aria-label={`Change role for ${m.email}`}
-                        value={m.role}
-                        disabled={isSoleOwner || savingRoleFor === m.user_id}
-                        title={
-                          isSoleOwner
-                            ? 'Every workspace needs at least one owner — promote another member before demoting this one'
-                            : undefined
-                        }
-                        onChange={(e) => void handleRoleChange(m.user_id, e.target.value as MemberRole)}
-                        className="h-8 rounded-lg border border-input bg-input px-2 text-sm text-foreground capitalize disabled:cursor-not-allowed disabled:opacity-50"
-                      >
-                        {ROLES.map((r) => (
-                          <option key={r} value={r} className="capitalize">
-                            {r}
-                          </option>
-                        ))}
-                      </select>
+                      <div className="flex flex-col gap-0.5">
+                        <select
+                          aria-label={`Change role for ${m.email}`}
+                          aria-describedby={isSoleOwner ? `sole-owner-hint-${m.user_id}` : undefined}
+                          value={m.role}
+                          disabled={isSoleOwner || savingRoleFor === m.user_id}
+                          onChange={(e) => void handleRoleChange(m.user_id, e.target.value as MemberRole)}
+                          className="h-8 rounded-lg border border-input bg-input px-2 text-sm text-foreground capitalize disabled:cursor-not-allowed disabled:opacity-50"
+                        >
+                          {ROLES.map((r) => (
+                            <option key={r} value={r} className="capitalize">
+                              {r}
+                            </option>
+                          ))}
+                        </select>
+                        {/* Visible, not just a `title` tooltip — a disabled
+                            <select> isn't focusable, so a hover-only
+                            explanation is invisible to screen readers and
+                            touch. */}
+                        {isSoleOwner && (
+                          <span
+                            id={`sole-owner-hint-${m.user_id}`}
+                            className="text-[11px] normal-case text-muted-foreground"
+                          >
+                            Only owner — promote someone else first
+                          </span>
+                        )}
+                      </div>
                     ) : (
                       m.role
                     )}

--- a/frontend/src/pages/WorkspaceMembersPage.tsx
+++ b/frontend/src/pages/WorkspaceMembersPage.tsx
@@ -9,10 +9,12 @@ import {
   listMembers,
   removeMember,
   revokeInvite,
+  setMemberRole,
   WorkspaceApiError,
   type InviteOut,
   type InviteRole,
   type MemberOut,
+  type MemberRole,
 } from '@/api/workspaces'
 
 const ROLES: InviteRole[] = ['owner', 'editor', 'viewer']
@@ -43,6 +45,7 @@ export function WorkspaceMembersPage(): JSX.Element | null {
   const [invites, setInvites] = useState<InviteOut[] | null>(null)
   const [loadError, setLoadError] = useState<string | null>(null)
   const [rowError, setRowError] = useState<string | null>(null)
+  const [savingRoleFor, setSavingRoleFor] = useState<number | null>(null)
 
   const [email, setEmail] = useState('')
   const [role, setRole] = useState<InviteRole>('editor')
@@ -79,6 +82,21 @@ export function WorkspaceMembersPage(): JSX.Element | null {
   }, [slug, navigate])
 
   const pendingInvites = useMemo(() => (invites ?? []).filter((i) => isInvitePending(i)), [invites])
+  const ownerCount = useMemo(() => (members ?? []).filter((m) => m.role === 'owner').length, [members])
+
+  async function handleRoleChange(userId: number, role: MemberRole) {
+    if (!slug) return
+    setRowError(null)
+    setSavingRoleFor(userId)
+    try {
+      const updated = await setMemberRole(slug, userId, role)
+      setMembers((prev) => (prev ?? []).map((m) => (m.user_id === userId ? updated : m)))
+    } catch (e) {
+      setRowError(e instanceof Error ? e.message : 'Failed to change role')
+    } finally {
+      setSavingRoleFor(null)
+    }
+  }
 
   async function handleRemoveMember(userId: number) {
     if (!slug) return
@@ -152,10 +170,35 @@ export function WorkspaceMembersPage(): JSX.Element | null {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {members.map((m) => (
+              {members.map((m) => {
+                const isSoleOwner = m.role === 'owner' && ownerCount === 1
+                return (
                 <TableRow key={m.user_id}>
                   <TableCell className="whitespace-normal text-foreground">{m.email}</TableCell>
-                  <TableCell className="capitalize">{m.role}</TableCell>
+                  <TableCell className="capitalize">
+                    {isOwner ? (
+                      <select
+                        aria-label={`Change role for ${m.email}`}
+                        value={m.role}
+                        disabled={isSoleOwner || savingRoleFor === m.user_id}
+                        title={
+                          isSoleOwner
+                            ? 'Every workspace needs at least one owner — promote another member before demoting this one'
+                            : undefined
+                        }
+                        onChange={(e) => void handleRoleChange(m.user_id, e.target.value as MemberRole)}
+                        className="h-8 rounded-lg border border-input bg-input px-2 text-sm text-foreground capitalize disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        {ROLES.map((r) => (
+                          <option key={r} value={r} className="capitalize">
+                            {r}
+                          </option>
+                        ))}
+                      </select>
+                    ) : (
+                      m.role
+                    )}
+                  </TableCell>
                   {isOwner && (
                     <TableCell className="text-right">
                       <Button
@@ -170,7 +213,8 @@ export function WorkspaceMembersPage(): JSX.Element | null {
                     </TableCell>
                   )}
                 </TableRow>
-              ))}
+                )
+              })}
             </TableBody>
           </Table>
         )}

--- a/frontend/src/workspace/WorkspaceProvider.tsx
+++ b/frontend/src/workspace/WorkspaceProvider.tsx
@@ -2,7 +2,7 @@
 // :workspace segment (source of truth); this provider fetches the caller's
 // memberships so the header switcher can render and so a bare/legacy route can
 // redirect to a sensible default.
-import { createContext, useContext, useEffect, useState, type ReactNode } from 'react'
+import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from 'react'
 import { listWorkspaces, type WorkspaceOut } from '../api/workspaces'
 import { resolveActiveWorkspace } from './resolveActiveWorkspace'
 
@@ -10,6 +10,15 @@ interface WorkspaceCtx {
   workspaces: WorkspaceOut[]
   active: string | null
   loading: boolean
+  // Re-fetch `workspaces` on demand. The list (incl. each membership's
+  // `role`) is fetched once on mount and otherwise never invalidated — a
+  // page that mutates the CALLER's own role in a workspace (e.g. an owner
+  // demoting themselves on WorkspaceMembersPage) must call this afterward,
+  // or every consumer of this context (header switcher, per-page
+  // isOwner/role checks) keeps rendering the stale pre-mutation role until a
+  // full reload, then gets surprised by a 403 on the very next owner-only
+  // action it still thinks it can take.
+  refresh: () => Promise<void>
 }
 
 const Ctx = createContext<WorkspaceCtx | null>(null)
@@ -23,6 +32,11 @@ export function WorkspaceProvider({
 }) {
   const [workspaces, setWorkspaces] = useState<WorkspaceOut[]>([])
   const [loading, setLoading] = useState(true)
+
+  const refresh = useCallback(async () => {
+    const ws = await listWorkspaces()
+    setWorkspaces(ws)
+  }, [])
 
   useEffect(() => {
     let live = true
@@ -39,7 +53,7 @@ export function WorkspaceProvider({
   }, [])
 
   const active = resolveActiveWorkspace(workspaces, urlSlug)
-  return <Ctx.Provider value={{ workspaces, active, loading }}>{children}</Ctx.Provider>
+  return <Ctx.Provider value={{ workspaces, active, loading, refresh }}>{children}</Ctx.Provider>
 }
 
 export function useWorkspace(): WorkspaceCtx {


### PR DESCRIPTION
Closes the gap left by the invite work: there was **no way to change an existing member's role** — a viewer could only be promoted by removing and re-inviting them — and inviting someone who was *already* a member silently did nothing.

## What's here
- **`PATCH /api/workspaces/{slug}/members/{user_id}/`** — owner-only, 404-not-403 for non-members, idempotent, unknown role 422. Editable role select in `/w/:workspace/members` for owners; static text for everyone else.
- **Upgrade-only accept**: accepting an invite now lands you at the *higher* of your current and invited role (`viewer < editor < owner`), never lower. So an owner inviting an existing viewer as editor does the obvious thing; demotion stays an explicit, guarded, owner-only action rather than something a stray invite can cause.

## Two integrity bugs found in review and fixed
- **A workspace could be stranded with zero owners.** The last-owner guard was check-then-act with no lock, so two owners demoting each other concurrently both saw "there are 2 owners", both passed, and both saved — leaving a workspace nobody could administer, recoverable only via Django admin. Both the PATCH and DELETE paths now share one transactional guard (`select_for_update` on the owner rows, count read inside the transaction), which is what finally moved `remove_member`'s body into the service layer.
- **A stale pending invite could silently promote someone.** `create_invite` reused a live invite *without updating its role*, so an owner who invited `b@` as owner, caught the mistake, and re-invited as editor got back the **same token still carrying owner** — and with upgrade-only accept, `b` would have landed as an owner. Reuse now refreshes the role and rotates the token, so the previously-shared link dies.

Also: user-facing errors are human strings rather than machine codes (a frontend test had been asserting a message the server never sent), service-level role validation so a shell/MCP caller can't persist a bogus role, and the last-owner explanation is now a visible `aria-describedby` hint rather than a mouse-only tooltip.

## Test plan
- 1352 backend passed / 1 skipped; 304 frontend passed; build + ruff clean; no schema drift
- Lock tests are honest spies — they assert the lock is *requested*; sqlite can't prove serialization, and the test module says so rather than implying coverage it doesn't have

🤖 Generated with [Claude Code](https://claude.com/claude-code)