### PR TITLE
fix(deploy): the attachments bucket env var would have rendered away silently

### DIFF
--- a/deploy/aws/canopy-web.cfn.yaml
+++ b/deploy/aws/canopy-web.cfn.yaml
@@ -66,7 +66,13 @@ Resources:
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Properties:
-      BucketName: !Sub labs-jj-canopy-web-attachments-${AWS::AccountId}
+      # Literal, not !Sub: the SAME name is repeated as the container's
+      # CANOPY_ATTACHMENTS_BUCKET env value below, and that one MUST be a plain
+      # string (deploy/aws/render_taskdef.py reads this template outside
+      # CloudFormation and drops any env var whose value is an intrinsic).
+      # Keep the two in sync; render_taskdef's REQUIRED_ENV guard fails the
+      # deploy loudly if the env one ever goes missing.
+      BucketName: labs-jj-canopy-web-attachments-858923557655
       # Nothing in this bucket is ever public. The app streams every byte itself
       # (see apps/canopy_sessions/attachment_storage.py), so there is no reason
       # for anonymous or cross-account access to exist at all.
@@ -239,7 +245,7 @@ Resources:
             # GCP deploy. The matching SA key is the CANOPY_DRIVE_SA_KEY_JSON
             # secret below.
             - { Name: CANOPY_DRIVE_ROOT_FOLDER_ID, Value: 1cUv7wQXOvVwuZ86PdhkxpFcuB4Lm9fPz }
-            - { Name: CANOPY_ATTACHMENTS_BUCKET, Value: !Ref AttachmentsBucket }
+            - { Name: CANOPY_ATTACHMENTS_BUCKET, Value: labs-jj-canopy-web-attachments-858923557655 }
             # Web Push (VAPID). The public key is not a secret — it ships in the
             # JS bundle so the browser can subscribe with it; it is the other
             # half of the VapidPrivateKey secret below and the two must match.

--- a/deploy/aws/render_taskdef.py
+++ b/deploy/aws/render_taskdef.py
@@ -41,7 +41,15 @@ CARRY_ENV = {"AWS_REGION", "PORT"}
 
 # Sanity floor + must-haves for the fail-loud guard.
 MIN_PLAIN_ENV = 6
-REQUIRED_ENV = {"DJANGO_SETTINGS_MODULE", "AUTH_ALLOWED_EMAIL_DOMAIN"}
+REQUIRED_ENV = {
+    "DJANGO_SETTINGS_MODULE",
+    "AUTH_ALLOWED_EMAIL_DOMAIN",
+    # Added after nearly shipping it as `!Ref AttachmentsBucket`, which this
+    # script drops silently (intrinsics are not str) — the deploy would have
+    # reported success while every upload 503'd. Listing it here turns that
+    # whole class of mistake into a failed deploy instead of a quiet no-op.
+    "CANOPY_ATTACHMENTS_BUCKET",
+}
 
 # Read-only fields register-task-definition rejects.
 READONLY_FIELDS = (

--- a/tests/test_render_taskdef_env.py
+++ b/tests/test_render_taskdef_env.py
@@ -1,0 +1,90 @@
+"""The deploy renders the container's env FROM the CloudFormation template, and
+silently drops any entry whose value is a CFN intrinsic (`!Ref`, `!Sub`, …)
+because those cannot be resolved outside CloudFormation.
+
+That silence is the hazard: the deploy reports success and the setting is simply
+absent at runtime. It has bitten twice — AUTH_ALLOWED_EMAIL_DOMAIN unset in prod
+while the template said otherwise, and (caught pre-merge)
+CANOPY_ATTACHMENTS_BUCKET written as `!Ref AttachmentsBucket`, which would have
+left every upload 503-ing against a bucket the app could not name.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+TEMPLATE = REPO / "deploy" / "aws" / "canopy-web.cfn.yaml"
+sys.path.insert(0, str(REPO / "deploy" / "aws"))
+
+from render_taskdef import REQUIRED_ENV, template_plain_env  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def plain_env() -> dict[str, str]:
+    return {e["name"]: e["value"] for e in template_plain_env(str(TEMPLATE))}
+
+
+def test_every_required_env_var_survives_rendering(plain_env):
+    """REQUIRED_ENV is the fail-loud list. If a key is there but renders away,
+    the guard only fires at deploy time, in CI, on main."""
+    missing = REQUIRED_ENV - set(plain_env)
+    assert not missing, f"dropped from the rendered task def (intrinsic value?): {sorted(missing)}"
+
+
+def test_the_attachments_bucket_is_a_plain_string(plain_env):
+    value = plain_env.get("CANOPY_ATTACHMENTS_BUCKET")
+    assert isinstance(value, str) and value, "must be a literal, never !Ref/!Sub"
+
+
+def test_the_env_value_matches_the_bucket_the_stack_creates(plain_env):
+    """Two copies of one name — the resource and the env var — because neither
+    can be an intrinsic. Nothing but this test keeps them honest: drift means the
+    app politely reads and writes a bucket that does not exist.
+    """
+    import yaml
+
+    class _Loader(yaml.SafeLoader):
+        pass
+
+    _Loader.add_multi_constructor("!", lambda loader, suffix, node: {"__intrinsic__": True})
+    doc = yaml.load(TEMPLATE.read_text(), Loader=_Loader)
+
+    declared = doc["Resources"]["AttachmentsBucket"]["Properties"]["BucketName"]
+    assert isinstance(declared, str), "BucketName must be a literal too"
+    assert declared == plain_env["CANOPY_ATTACHMENTS_BUCKET"]
+
+
+def test_the_bucket_is_not_publicly_exposed():
+    """Every public-access door shut, ACLs disabled outright, and no Allow
+    statement granting a wildcard principal."""
+    import yaml
+
+    class _Loader(yaml.SafeLoader):
+        pass
+
+    _Loader.add_multi_constructor("!", lambda loader, suffix, node: {"__intrinsic__": True})
+    doc = yaml.load(TEMPLATE.read_text(), Loader=_Loader)
+    bucket = doc["Resources"]["AttachmentsBucket"]["Properties"]
+
+    assert all(bucket["PublicAccessBlockConfiguration"].values()), "all four blocks must be on"
+    # PublicAccessBlock alone does NOT disable ACLs — it only stops them granting
+    # PUBLIC access. BucketOwnerEnforced removes the mechanism entirely.
+    assert bucket["OwnershipControls"]["Rules"][0]["ObjectOwnership"] == "BucketOwnerEnforced"
+    assert bucket["BucketEncryption"], "encryption at rest must be configured"
+
+    statements = doc["Resources"]["AttachmentsBucketPolicy"]["Properties"]["PolicyDocument"]["Statement"]
+    allows = [s for s in statements if s["Effect"] == "Allow"]
+    assert allows, "the task role must still be able to read and write"
+    for s in allows:
+        principal = s["Principal"]
+        assert principal != "*", "an Allow to everyone would make the bucket public"
+        assert isinstance(principal, dict) and "AWS" in principal
+
+    # A Deny with Principal "*" is not a public grant, and is what forces TLS.
+    denies = [s for s in statements if s["Effect"] == "Deny"]
+    assert any(
+        "SecureTransport" in str(s.get("Condition", {})) for s in denies
+    ), "plaintext HTTP must be denied"


### PR DESCRIPTION
Follow-up to #396, found while checking what the deploy would actually do.

## The bug

`render_taskdef.py` builds the container's environment **from the CloudFormation template**, and keeps only entries whose value `isinstance(..., str)`. A CFN intrinsic parses to a dict, so it is **dropped without comment**.

#396 shipped:

```yaml
- { Name: CANOPY_ATTACHMENTS_BUCKET, Value: !Ref AttachmentsBucket }
```

The deploy would have reported success, the setting would never have reached the container, and every upload would have 503'd against a bucket the app could not name. This is the same silence that once left `AUTH_ALLOWED_EMAIL_DOMAIN` unset in prod while the template said otherwise.

## The fix

Make the bucket name a literal in both places it appears — the resource's `BucketName` and the env value — since neither can be an intrinsic. That means two copies of one string, so both are now defended:

- `CANOPY_ATTACHMENTS_BUCKET` joins `REQUIRED_ENV`, turning a dropped value into a **failed deploy** rather than a quiet no-op.
- A test asserts the two copies agree. Drift would mean the app politely reads and writes a bucket that does not exist.

## Security posture is now pinned by tests

Since you asked for the bucket to be locked down, the same file asserts it stays that way — a future edit can't quietly open it:

- all four public-access blocks on
- ACLs disabled via `BucketOwnerEnforced` (a `PublicAccessBlock` alone does **not** disable ACLs, it only stops them granting *public* access)
- encryption at rest present
- no `Allow` statement with a wildcard principal
- plaintext HTTP denied

## ⚠️ This still does not create the bucket

The deploy workflow **never applies CloudFormation** — it builds an image, renders a task definition from the template, migrates, and rolls the service. Nothing runs `aws cloudformation deploy`. So the stack must be updated out of band before attachments can work; until then the app correctly reports "not configured" and 503s, which is the intended fail-loud behaviour rather than a silent half-state.

## Verification

1386 backend tests pass (4 new), ruff clean. Confirmed by rendering the template through the real `template_plain_env`: `CANOPY_ATTACHMENTS_BUCKET = 'labs-jj-canopy-web-attachments-858923557655'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)