### PR TITLE
ci: merge_group trigger + fix the flake that would eject PRs from the queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,12 @@ on:
   push:
     branches: [main]
   pull_request:
+  # Required for the merge queue: GitHub runs the required checks against the
+  # QUEUED merge result (this PR rebased onto the queue head), not the PR branch.
+  # Without this trigger those checks never report, every PR sits in the queue
+  # until it times out, and NOTHING can merge. Must land before the queue is
+  # switched on.
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/frontend/src/components/chat/ChatSessionsPanel.test.tsx
+++ b/frontend/src/components/chat/ChatSessionsPanel.test.tsx
@@ -233,9 +233,12 @@ describe('ChatSessionsPanel — Run on picker', () => {
 
     renderPanel([])
 
-    // Generous timeouts: the menu contents render only after the mocked
-    // listSlugs/listRunners promises resolve, and CI runners have blown the
-    // 1s findBy default here (observed once at 1021ms).
+    // The per-await budgets below are 5s EACH, but vitest's default per-TEST
+    // timeout is also 5s — so the test died at 5s before any of them could be
+    // used, making them decorative. Observed failing at exactly 5006ms on CI
+    // (#391) while passing locally. The test timeout (3rd arg to `it`) is what
+    // actually has to be raised; this matters more under a merge queue, where a
+    // flake ejects the PR from the queue rather than just asking for a re-run.
     fireEvent.click(await screen.findByText('New chat', {}, { timeout: 5000 }))
     fireEvent.click(await screen.findByText('Acme', {}, { timeout: 5000 }))
 
@@ -245,5 +248,5 @@ describe('ChatSessionsPanel — Run on picker', () => {
       () => expect(Array.from(select.options).map((o) => o.textContent)).toEqual(['Auto', '● Alpha']),
       { timeout: 5000 },
     )
-  })
+  }, 20_000)
 })


### PR DESCRIPTION
Prerequisites for the merge queue. **Both must land before it is enabled**, or shipping breaks.

## `merge_group` trigger

The queue runs required checks against the **queued merge result** (your PR rebased onto the queue head), not against the PR branch. Without this trigger those checks never report, every PR sits in the queue until it times out, and **nothing can merge at all**.

Existing concurrency config is already correct for this — `cancel-in-progress` is scoped to `pull_request`, so queue runs won't cancel each other.

## The flake

`ChatSessionsPanel`'s project "Run on" test gives each `findBy`/`waitFor` a 5000ms budget — but **vitest's default per-test timeout is also 5000ms**. The test always died at 5s before any of those budgets could be used, so they were decorative. It failed at exactly `5006ms` on CI in #391 while passing 3/3 locally.

The previous fix raised the *inner* timeouts without raising the *outer* one. Raising the test timeout (3rd arg to `it`) is what actually helps.

Worth fixing now specifically because a merge queue changes what flakiness costs: today a flake asks for a re-run; in a queue it **ejects the PR**.

## Why this is separate from enabling the queue

Sequencing is load-bearing — enabling the queue before this is on `main` would freeze all merges. Once this lands I'll enable the queue and remove the redundant classic branch protection, which is currently overriding the ruleset's `strict: false` and causing the rebase churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)