### PR TITLE
feat(chat): let you cancel a turn that is still queued

### DIFF
--- a/frontend/packages/canopy-ui/src/chat/ChatPanel.tsx
+++ b/frontend/packages/canopy-ui/src/chat/ChatPanel.tsx
@@ -14,7 +14,10 @@ export interface ChatPanelProps {
   connected: boolean;
   currentUserId: number;
   onSend: () => void;
-  onStop: (messageId: string) => void;
+  onStop: (messageId: string | null) => void;
+  /** A send is outstanding but no reply has begun — the turn is queued,
+   *  waiting for a runner to claim it. Keeps Stop reachable in that window. */
+  awaitingReply?: boolean;
   onUpdateDraft: (body: string) => void;
   onTakeOver: () => void;
   onDiscard: () => void;
@@ -41,6 +44,7 @@ export function ChatPanel({
   currentUserId,
   onSend,
   onStop,
+  awaitingReply = false,
   onUpdateDraft,
   onTakeOver,
   onDiscard,
@@ -127,7 +131,7 @@ export function ChatPanel({
         connected={connected}
         currentUserId={currentUserId}
         holderIsPresent={holderIsPresent}
-        isStreaming={inFlightMessage != null}
+        isStreaming={inFlightMessage != null || awaitingReply}
         streamingMessageId={inFlightMessage?.id ?? null}
         onUpdate={onUpdateDraft}
         onSend={onSend}

--- a/frontend/packages/canopy-ui/src/chat/SendBox.test.tsx
+++ b/frontend/packages/canopy-ui/src/chat/SendBox.test.tsx
@@ -193,3 +193,55 @@ describe("SendBox — sending is gated on the socket", () => {
     expect(textarea().value).toBe("composed offline");
   });
 });
+
+describe("SendBox — cancelling a queued turn", () => {
+  it("offers stop while a send is outstanding, before any reply exists", () => {
+    // The gap this closes: between send and the first token there is NO
+    // assistant message, so `inFlightMessage` is null and the stop button never
+    // rendered — exactly the window where you most want out, because a queued
+    // turn means no runner has picked it up (offline, or busy with another).
+    // The server has always handled it: chat.stop cancels every non-terminal
+    // turn and ignores message_id.
+    const onStop = vi.fn();
+    render(
+      <SendBox
+        draft={draft()}
+        connected
+        currentUserId={ME}
+        holderIsPresent={false}
+        isStreaming
+        streamingMessageId={null}
+        onUpdate={vi.fn()}
+        onSend={vi.fn()}
+        onStop={onStop}
+        onTakeOver={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /stop/i }));
+
+    expect(onStop).toHaveBeenCalledWith(null);
+  });
+
+  it("passes the message id through once a reply is streaming", () => {
+    const onStop = vi.fn();
+    render(
+      <SendBox
+        draft={draft()}
+        connected
+        currentUserId={ME}
+        holderIsPresent={false}
+        isStreaming
+        streamingMessageId="m1"
+        onUpdate={vi.fn()}
+        onSend={vi.fn()}
+        onStop={onStop}
+        onTakeOver={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /stop/i }));
+
+    expect(onStop).toHaveBeenCalledWith("m1");
+  });
+});

--- a/frontend/packages/canopy-ui/src/chat/SendBox.tsx
+++ b/frontend/packages/canopy-ui/src/chat/SendBox.tsx
@@ -20,7 +20,10 @@ interface Props {
   streamingMessageId: string | null;
   onUpdate: (body: string) => void;
   onSend: () => void;
-  onStop: (messageId: string) => void;
+  /** messageId is null when the turn is still QUEUED — no reply exists yet.
+   *  The server cancels every non-terminal turn regardless, so a null id is
+   *  a valid cancel, not a no-op. */
+  onStop: (messageId: string | null) => void;
   onTakeOver: () => void;
   /** Optional app-supplied banner rendered above the composer (e.g. an
    *  imported-session note). The kit itself has no CLI-auth banners. */
@@ -134,7 +137,9 @@ export function SendBox({
   };
 
   const handleStopClick = () => {
-    if (streamingMessageId != null) onStop(streamingMessageId);
+    // Fires even with no streamingMessageId: while a turn sits QUEUED there is
+    // no assistant message to name, and that is exactly when you want out.
+    onStop(streamingMessageId);
   };
 
   const placeholder = blocked

--- a/frontend/packages/canopy-ui/src/chat/useSessionSocket.ts
+++ b/frontend/packages/canopy-ui/src/chat/useSessionSocket.ts
@@ -37,8 +37,13 @@ export interface UseSessionSocketOptions {
 export interface UseSessionSocketResult {
   state: SessionState;
   connected: boolean;
+  /** A send is outstanding with no reply yet — the turn is QUEUED, waiting for
+   *  a runner. Nothing in `state` can express this (there is no assistant
+   *  message until the first token), and it is what keeps Stop reachable while
+   *  a turn is stuck. */
+  awaitingReply: boolean;
   sendChat: () => void;
-  stopChat: (messageId: string) => void;
+  stopChat: (messageId: string | null) => void;
   updateDraft: (body: string) => void;
   takeOverDraft: () => void;
   discardDraft: () => void;
@@ -54,6 +59,11 @@ export function useSessionSocket({
   const [state, setState] = useState<SessionState>(INITIAL_STATE);
   const [connected, setConnected] = useState(false);
   const [lastError, setLastError] = useState<string | null>(null);
+  // A send has gone out but no reply has begun — i.e. the turn is QUEUED,
+  // waiting for a runner to claim it. There is no assistant message during
+  // this window, so nothing else in the state can express it, and without it
+  // the Stop control is unreachable exactly when the turn is stuck.
+  const [awaitingReply, setAwaitingReply] = useState(false);
 
   const socketRef = useRef<WebSocket | null>(null);
   const stateRef = useRef<SessionState>(INITIAL_STATE);
@@ -91,6 +101,17 @@ export function useSessionSocket({
   }, []);
 
   const applyEvent = useCallback((frame: WsEvent) => {
+    // Any of these means the queued window is over: the reply began, ended,
+    // was cancelled, or the send failed outright.
+    if (
+      frame.event === "chat.stream_start" ||
+      frame.event === "chat.stream_complete" ||
+      frame.event === "chat.stream_error" ||
+      frame.event === "chat.stream_cancelled" ||
+      frame.event === "session.error"
+    ) {
+      setAwaitingReply(false);
+    }
     // Side-effect events: handle BEFORE setState so React strict-mode's
     // double-invocation of the updater doesn't double-fire the effect.
     if (frame.event === "session.title_updated") {
@@ -204,11 +225,16 @@ export function useSessionSocket({
       });
     }
     pendingDraftBodyRef.current = null;
+    setAwaitingReply(true);
     send({ action: "chat.send", data: {} });
   }, [send]);
 
   const stopChat = useCallback(
-    (messageId: string) => {
+    (messageId: string | null) => {
+      // messageId is null when the turn is still queued. The server's
+      // chat.stop cancels every non-terminal turn on the session and only
+      // echoes the id back, so a null one cancels just as effectively.
+      setAwaitingReply(false);
       send({ action: "chat.stop", data: { message_id: messageId } });
     },
     [send],
@@ -294,6 +320,7 @@ export function useSessionSocket({
   return {
     state,
     connected,
+    awaitingReply,
     sendChat,
     stopChat,
     updateDraft,

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -396,6 +396,7 @@ export function ChatPage() {
           currentUserId={socket.state.current_user_id}
           onSend={socket.sendChat}
           onStop={socket.stopChat}
+          awaitingReply={socket.awaitingReply}
           onUpdateDraft={socket.updateDraft}
           onTakeOver={socket.takeOverDraft}
           onDiscard={socket.discardDraft}


### PR DESCRIPTION
You were right that this was implemented but not surfaced. The server side has always worked — `chat.stop` cancels **every non-terminal turn** on the session and only echoes `message_id` back in the broadcast, so it never needed one.

## The gap

Stop rendered only when `inFlightMessage != null`, which is derived from an assistant message with status `streaming` or `pending`. **A queued turn has no assistant message at all** — it appears at the first token.

So between send and first token there was nothing to stop, and that's exactly the window where you want out: a turn sits queued when no runner has claimed it (offline, or busy with another turn), and that can last indefinitely. The one case where cancel matters most was the one case it wasn't offered.

## The fix

`awaitingReply` on the socket hook expresses that window — set on send, cleared by `stream_start` / `stream_complete` / `stream_error` / `stream_cancelled` / `session.error`. It has to be hook state rather than derived from `state`, because the whole point is that no message exists yet.

`onStop` now takes `string | null`, and `SendBox` fires it either way instead of silently doing nothing when there's no id to name — which is what it did before.

## Verification

306 frontend tests pass (2 new covering both paths: null id while queued, real id while streaming), build clean.

Note this touches the exported `ChatPanel` / `useSessionSocket` types (`onStop` widened to accept `null`, new optional `awaitingReply` prop). Widening a callback parameter is backward compatible for consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)