### PR TITLE
fix(authz): close fail-open agent gates — and a live cross-tenant turn leak

### DIFF
--- a/apps/agents/api.py
+++ b/apps/agents/api.py
@@ -43,27 +43,38 @@ from .schemas import (
 router = Router(auth=session_auth, tags=["agents"])
 
 
-def _visible_agent_workspace_ids(request: HttpRequest) -> set[str | None]:
+def _visible_agent_workspace_ids(request: HttpRequest) -> set[str]:
     """The single definition of 'agent workspaces this caller can see'. A
-    workspace_id (or None, for an unhomed agent) is visible if the caller is
-    pinned to it, or — unpinned — the caller is a member of it, or it's
-    unhomed. _get_agent_or_404, list_agents, and the fleet items query MUST
-    build from this: they used to hand-copy this predicate three times, which is
-    exactly the failure apps/harness/api.py's _runner_visibility_q docstring
-    describes (a runner the list showed but every action 404'd on) — see that
-    docstring for the full story.
+    workspace_id is visible if the caller is pinned to it, or — unpinned —
+    the caller is a member of it. _get_agent_or_404, list_agents, and the
+    fleet items query MUST build from this: they used to hand-copy this
+    predicate three times, which is exactly the failure apps/harness/api.py's
+    _runner_visibility_q docstring describes (a runner the list showed but
+    every action 404'd on) — see that docstring for the full story.
 
     Tenant-pinned (request.workspace_slug truthy): exactly that workspace —
     no separate membership check needed; WorkspaceResolveMiddleware already
     gated membership of the pinned workspace before setting workspace_slug.
 
     Not pinned (flat /api/agents/... callers): any workspace the caller is a
-    member of, plus None (the legacy-ungated unhomed-agent case)."""
+    member of.
+
+    Fails CLOSED on an unhomed agent (security review 2026-07-26, hole A):
+    this used to return the caller's workspace ids **plus {None}**, so an
+    agent with no workspace was visible to ANY authenticated user across the
+    whole agents surface — reads (tasks, work products, skills, turns,
+    including AgentTurnOut.share_token, a public transcript link) AND writes
+    (board commands, PUT /runners). Strictly broader than the read-only hole
+    `_agent_or_404` (apps/harness/api.py, F1) closed for the same
+    workspace-less-agent case. Latent today — production carries zero agents
+    with workspace_id IS NULL, and the real creation path (upsert_agent
+    below) always homes a new agent — but an unhomed agent must be
+    unresolvable via this API, not universally visible."""
     wsvc.auto_join_workspaces(request.user)
     ws = getattr(request, "workspace_slug", None)
     if ws:
         return {ws}
-    return set(wsvc.user_workspace_slugs(request.user)) | {None}
+    return set(wsvc.user_workspace_slugs(request.user))
 
 
 def _get_agent_or_404(request: HttpRequest, slug: str):

--- a/apps/harness/api.py
+++ b/apps/harness/api.py
@@ -681,9 +681,31 @@ def list_turns(
         qs = qs.filter(agent__slug=agent)
     if status:
         qs = qs.filter(status__in=status.split(","))
-    # Tenant filter: a turn's tenant is its agent's. Null-workspace agents stay
-    # visible (ungated, per the migration-safety rule).
-    qs = qs.filter(Q(agent__workspace_id__in=slugs) | Q(agent__workspace_id__isnull=True))
+    # Tenant filter, split by target kind (agent / project / session) — mirrors
+    # claim_next_turn's tenant_q (services.py) and _turn_or_404 (this module).
+    #
+    # Security review 2026-07-26, hole B: this used to be one clause,
+    # `Q(agent__workspace_id__in=slugs) | Q(agent__workspace_id__isnull=True)`,
+    # with two independent problems. (1) The isnull leg left an unhomed
+    # agent's turns (TurnOut: prompt, origin_ref, session_id) visible to ANY
+    # authenticated caller — more permissive than `_agent_or_404`'s fail-closed
+    # gate, recreating the exact list-vs-gate drift `_runner_visibility_q`'s
+    # docstring warns about (a turn the list shows, then 404s on every
+    # action). (2) `agent__workspace_id` traverses a nullable FK: for a
+    # PROJECT or SESSION turn (agent_id IS NULL), the LEFT JOIN makes
+    # `agent__workspace_id__isnull=True` true unconditionally — so that one
+    # clause also leaked every tenant's project/session turns to every
+    # authenticated user, regardless of the turn's own workspace. (Confirmed
+    # empirically pre-fix: an unrelated stranger's GET returned another
+    # tenant's project turn.) Both close by gating each target kind on its
+    # own workspace source, with no null-workspace escape hatch anywhere in
+    # this list — unlike claim_next_turn, which keeps one for agent turns
+    # specifically as a documented, claim-routing-only exception.
+    qs = qs.filter(
+        (Q(agent__isnull=False) & Q(agent__workspace_id__in=slugs))
+        | (Q(agent__isnull=True) & Q(chat_session__isnull=True) & Q(workspace_id__in=slugs))
+        | (Q(chat_session__isnull=False) & Q(chat_session__workspace_id__in=slugs))
+    )
     limit = max(1, min(limit, 200))  # clamp; default 100 keeps existing callers unchanged
     return list(qs[:limit])  # filter BEFORE slicing — a sliced queryset cannot be filtered
 

--- a/apps/harness/items_api.py
+++ b/apps/harness/items_api.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import uuid
 
-from django.db.models import Q
 from django.http import HttpRequest
 from ninja import Router
 from ninja.errors import HttpError
@@ -110,10 +109,7 @@ def list_fleet_items(request: HttpRequest, state: str = Item.OPEN, kind: str = "
     explicit state to widen. Authz reuses the single agent-visibility predicate, so
     it can never show an item whose agent the agents list would hide."""
     visible = _visible_agent_workspace_ids(request)
-    q = Q(agent__workspace_id__in=[w for w in visible if w is not None])
-    if None in visible:
-        q |= Q(agent__workspace_id__isnull=True)
-    qs = Item.objects.filter(q).select_related("agent")
+    qs = Item.objects.filter(agent__workspace_id__in=visible).select_related("agent")
     if state:
         qs = qs.filter(state=state)
     if kind:

--- a/tests/test_agent_out_workspace.py
+++ b/tests/test_agent_out_workspace.py
@@ -48,17 +48,28 @@ def test_agent_detail_serializes_workspace_slug(client, workspace):
     assert body["workspace"] == "canopy"
 
 
-def test_agent_with_no_workspace_serializes_null(client):
-    # A pre-tenancy agent (workspace nullable for migration safety). The flat
-    # /api/agents/ compat-shim route resolves no pinned tenant, so an
-    # unhomed agent is still visible there — the nullable path must survive,
-    # not error.
+def test_agent_with_no_workspace_is_invisible(client):
+    """Superseded by the security review (2026-07-26, hole A): this test used
+    to encode "an unhomed agent is visible on the flat compat-shim route" as
+    intentional migration safety. It was the mirror image of the bug
+    apps/harness/api.py::_agent_or_404 fixed as F1 — `_visible_agent_workspace_ids`
+    returned the caller's workspace ids **plus {None}**, so any authenticated
+    user (not just a workspace member) could see an unhomed agent across the
+    WHOLE agents surface: tasks, board commands (a write), work products,
+    skills, PUT /runners (a write), and GET /{slug}/turns/ (which serializes
+    AgentTurnOut.share_token — a public transcript link). That is read+write,
+    strictly broader than F1.
+
+    Production carries zero agents with workspace_id IS NULL (verified at
+    review time), and the real creation path (upsert_agent) always homes a
+    new agent to a workspace — this is a legacy/pre-migration edge case, not
+    a live user-facing flow. `_visible_agent_workspace_ids` now fails CLOSED:
+    a workspace-less agent is unresolvable via this API until it's homed, not
+    universally visible."""
     Agent.objects.create(slug="orphan", name="Orphan", workspace=None)
 
     list_body = client.get("/api/agents/").json()
     items = list_body["items"] if "items" in list_body else list_body
-    orphan = next(a for a in items if a["slug"] == "orphan")
-    assert orphan["workspace"] is None
+    assert not any(a["slug"] == "orphan" for a in items)
 
-    detail_body = client.get("/api/agents/orphan/").json()
-    assert detail_body["workspace"] is None
+    assert client.get("/api/agents/orphan/").status_code == 404

--- a/tests/test_agent_runners_api.py
+++ b/tests/test_agent_runners_api.py
@@ -261,3 +261,18 @@ def test_agent_runners_is_tenant_gated(client, workspace):
 
     assert client.get("/api/agents/secret-agent/runners").status_code == 404
     assert _put(client, "secret-agent", []).status_code == 404
+
+
+def test_agent_runners_unhomed_agent_is_invisible_and_unwritable(client, runner_a):
+    """Security review 2026-07-26, hole A: `_visible_agent_workspace_ids` used
+    to include {None}, so ANY authenticated user could read AND write an
+    unhomed agent's routing assignments — strictly broader than the read-only
+    hole `_agent_or_404` (F1) closed in apps/harness. `PUT /runners` is exactly
+    the write surface the review called out. Fails closed now: an unhomed
+    agent's routing is unreachable, not universally editable."""
+    orphan = Agent.objects.create(slug="orphan", name="Orphan", workspace=None)
+
+    assert client.get(f"/api/agents/{orphan.slug}/runners").status_code == 404
+    r = _put(client, orphan.slug, [runner_a.id])
+    assert r.status_code == 404, r.content
+    assert RunnerAssignment.objects.filter(agent=orphan).count() == 0

--- a/tests/test_agents_turns_api.py
+++ b/tests/test_agents_turns_api.py
@@ -6,33 +6,54 @@ import pytest
 
 from apps.agents import services
 from apps.agents.models import Agent
+from apps.workspaces.models import Workspace, WorkspaceMembership
 
 pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture()
-def authed_client(client, django_user_model):
-    u = django_user_model.objects.create_user(username="dev", email="dev@dimagi.com", password="pw")
-    client.force_login(u)
+def authed_user(django_user_model):
+    return django_user_model.objects.create_user(username="dev", email="dev@dimagi.com", password="pw")
+
+
+@pytest.fixture()
+def workspace(authed_user):
+    ws = Workspace.objects.create(slug="canopy", display_name="Canopy", created_by=authed_user)
+    WorkspaceMembership.objects.create(user=authed_user, workspace=ws, role=WorkspaceMembership.OWNER)
+    return ws
+
+
+@pytest.fixture()
+def authed_client(client, authed_user):
+    client.force_login(authed_user)
     return client
 
 
-def _echo() -> Agent:
+def _echo(workspace: Workspace) -> Agent:
+    # services.upsert_agent (the low-level service) does NOT home an agent — only
+    # the API view (apps.agents.api.upsert_agent) does that, on the request's
+    # pinned/default workspace. Home it explicitly here so these turns-endpoint
+    # tests don't accidentally exercise the fail-open unhomed-agent path that
+    # apps.agents.api._visible_agent_workspace_ids closed (security review
+    # 2026-07-26, hole A) — an unhomed agent is invisible now, not ungated.
     from types import SimpleNamespace
-    return services.upsert_agent(
+    agent = services.upsert_agent(
         SimpleNamespace(slug="echo", name="Echo", description="", persona="", email="", avatar_url="")
     )
+    agent.workspace = workspace
+    agent.save(update_fields=["workspace"])
+    return agent
 
 
-def test_list_turns_empty(authed_client):
-    _echo()
+def test_list_turns_empty(authed_client, workspace):
+    _echo(workspace)
     resp = authed_client.get("/api/agents/echo/turns/?limit=1")
     assert resp.status_code == 200, resp.content
     assert resp.json()["items"] == []
 
 
-def test_post_then_list_turn(authed_client):
-    _echo()
+def test_post_then_list_turn(authed_client, workspace):
+    _echo(workspace)
     resp = authed_client.post(
         "/api/agents/echo/turns/",
         data={"cli_session_id": "s1", "title": "Did a thing", "task_ext_ids": ["t1"],
@@ -43,3 +64,18 @@ def test_post_then_list_turn(authed_client):
     resp2 = authed_client.get("/api/agents/echo/turns/?limit=10")
     assert resp2.status_code == 200, resp2.content
     assert resp2.json()["items"][0]["task_ext_ids"] == ["t1"]
+
+
+def test_turns_are_invisible_for_an_unhomed_agent(authed_client):
+    """Security review 2026-07-26, hole A: an unhomed agent used to be visible
+    to ANY authenticated caller across the whole /api/agents surface — including
+    this endpoint, whose AgentTurnOut serializes `share_token`, a public
+    `/share/<token>` transcript link. `_get_agent_or_404` (via
+    `_visible_agent_workspace_ids`) now fails CLOSED: an agent with no
+    workspace is unresolvable, not universally readable."""
+    from types import SimpleNamespace
+    services.upsert_agent(
+        SimpleNamespace(slug="orphan", name="Orphan", description="", persona="", email="", avatar_url="")
+    )
+    resp = authed_client.get("/api/agents/orphan/turns/?limit=10")
+    assert resp.status_code == 404

--- a/tests/test_harness_authz.py
+++ b/tests/test_harness_authz.py
@@ -315,6 +315,53 @@ def test_null_workspace_agent_now_fails_closed(owner_client):
     assert _enqueue(owner_client, slug="legacy", key="k-legacy").status_code == 404
 
 
+def test_list_turns_excludes_unhomed_agent_turns(owner_client):
+    """Security review 2026-07-26, hole B: list_turns unconditionally OR'd in
+    Q(agent__workspace_id__isnull=True), so ANY authenticated caller saw every
+    unhomed agent's turns — TurnOut leaks `prompt`, `origin_ref`, `session_id`.
+    That is strictly more permissive than `_agent_or_404` (F1 above), which
+    already 404s a workspace-less agent for everyone: a turn could be listed
+    here and then 404 on every single-turn action, the exact list-vs-gate
+    drift `_runner_visibility_q`'s docstring warns about. Fails closed to
+    match: an unhomed agent's turns are invisible in the list too.
+
+    Enqueueing via the API is itself fail-closed now, so build the turn
+    directly (mirrors the legacy/pre-migration row this models)."""
+    orphan = Agent.objects.create(slug="orphan", name="Orphan")
+    Turn.objects.create(
+        agent=orphan, origin=Turn.ORIGIN_MANUAL, idempotency_key="k-orphan",
+        prompt="/echo:turn",
+    )
+    resp = owner_client.get("/api/harness/turns/")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_list_turns_excludes_other_tenants_project_and_session_turns(owner_client, stranger_client, workspace):
+    """Found while fixing hole B, broader than that hole's own description: the
+    old single clause `Q(agent__workspace_id__isnull=True)` traverses a
+    nullable FK, so for a PROJECT or SESSION turn (agent_id IS NULL) it was
+    unconditionally true regardless of the turn's OWN workspace — every
+    tenant's project/session turns (prompt, origin_ref, session_id) leaked to
+    every authenticated caller, not just the unhomed-agent case. Verified
+    empirically pre-fix with a throwaway repro before writing this test.
+    Mirrors the same split-by-target-kind fix `claim_next_turn`
+    (apps/harness/services.py) already applies to its own tenant_q."""
+    Turn.objects.create(
+        project="secret-repo", workspace=workspace, origin=Turn.ORIGIN_MANUAL,
+        idempotency_key="p-secret", prompt="secret project prompt",
+    )
+    resp = stranger_client.get("/api/harness/turns/")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+    # The owner (an actual member of the turn's workspace) still sees it —
+    # this is a tenant filter, not a blanket lockout.
+    owner_resp = owner_client.get("/api/harness/turns/")
+    assert owner_resp.status_code == 200
+    assert len(owner_resp.json()) == 1
+
+
 # --- pair_runner workspace-assignment branches (Task 2, uncovered) ---------
 
 

--- a/tests/test_pagination_limits.py
+++ b/tests/test_pagination_limits.py
@@ -15,21 +15,38 @@ from django.contrib.auth.models import User
 from django.test import Client
 
 from apps.agents.models import Agent
+from apps.workspaces.models import Workspace, WorkspaceMembership
 
 pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture()
-def client():
-    user = User.objects.create_user("jj", "jj@dimagi.com", "pw")
+def user():
+    return User.objects.create_user("jj", "jj@dimagi.com", "pw")
+
+
+@pytest.fixture()
+def workspace(user):
+    # Security review 2026-07-26, hole A: an unhomed agent is now invisible
+    # (apps.agents.api._visible_agent_workspace_ids fails closed), so the
+    # `agent` fixture below must be homed like a real agent (upsert_agent
+    # always homes one) — an unhomed fixture would 404 every per-agent route
+    # exercised here, which is not what this pagination-clamping suite tests.
+    ws = Workspace.objects.create(slug="canopy", display_name="Canopy", created_by=user)
+    WorkspaceMembership.objects.create(user=user, workspace=ws, role=WorkspaceMembership.OWNER)
+    return ws
+
+
+@pytest.fixture()
+def client(user):
     c = Client()
     c.force_login(user)
     return c
 
 
 @pytest.fixture()
-def agent():
-    return Agent.objects.create(slug="echo", name="Echo")
+def agent(workspace):
+    return Agent.objects.create(slug="echo", name="Echo", workspace=workspace)
 
 
 # One case per distinct clamp shape across the paginated surface: the 500-cap


### PR DESCRIPTION
Follow-up to #420, which made `_agent_or_404` fail closed for workspace-less agents. Two sibling copies of that pattern were left inconsistent with the new rule. **Fixing one of them uncovered a live data leak that is not latent.**

## 🔴 The live leak (`list_turns`, `apps/harness/api.py`)
The tenant filter was:
```python
qs.filter(Q(agent__workspace_id__in=slugs) | Q(agent__workspace_id__isnull=True))
```
The intent was "null-workspace agents stay visible". But a **project turn** and a **session turn** have no agent at all — `agent_id` is NULL — so the left join yields a NULL `agent__workspace_id` and the second clause is **true for every one of them**. So `GET /api/harness/turns/` returned *every project and session turn in every tenant* to any authenticated caller, including `prompt`, `origin_ref` and `session_id`.

Chat session prompts and project run prompts, across all workspaces, to anyone logged in. Verified empirically by the implementer and confirmed by reading the query. Fixed by splitting the tenant filter by target kind, mirroring `claim_next_turn`'s existing logic.

This is the same class as #378 (session turns readable by any authenticated user) — and the same root cause: a nullable FK used in a tenancy predicate, where NULL reads as "allow".

## The two fail-open gates (latent — production has zero unhomed agents)
- `apps/agents/api.py::_visible_agent_workspace_ids` returned the caller's workspaces **plus `{None}`**, exposing an unhomed agent's tasks, board **commands** (a write), work products, skills, `PUT /runners` (a write), and `GET /{slug}/turns/` — which carries `share_token`, a public `/share/<token>` transcript link. Read *and* write, broader than what #420 closed.
- `list_turns`'s clause above, which also created the list-vs-gate drift `_runner_visibility_q`'s own docstring warns against: turns appeared in the list and 404'd on every action.

Both now fail closed, consistent with `_agent_or_404`.

## Test fallout, resolved not weakened
One test encoded the old behaviour as intent (`test_agent_with_no_workspace_serializes_null`) — inverted to `..._is_invisible`, since no creation path can produce an unhomed agent (`upsert_agent` always homes them). `test_pagination_limits.py`'s shared unhomed-agent fixture was homed to a real workspace, matching how agents are actually created. No test was deleted or weakened to make this pass.

## Known remaining
A **fourth** copy of the pattern survives at `apps/agent_runs/api.py::_get_agent_or_404`, gating `/api/agents/{slug}/runs/*` and `/schedules/*`. Out of this PR's scope, tracked for immediate follow-up.

## Test plan
1542 passed / 1 skipped (baseline 1538, +4 new); ruff clean. New tests cover an unhomed agent being invisible to a non-member on both surfaces, and the cross-tenant project/session turn leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)