### PR TITLE
fix(ec2-runner): set GOG_KEYRING_PASSWORD — gmail auth was dead fleet-wide

### DIFF
--- a/deploy/ec2-runner/bootstrap_agents.sh
+++ b/deploy/ec2-runner/bootstrap_agents.sh
@@ -254,10 +254,18 @@ bootstrap_one_agent() {
     log "$slug: gmail token not live — importing from op://${vault}/gog-token/credential"
     local tokfile; tokfile="$(mktemp)"
     if op read "op://${vault}/gog-token/credential" >"$tokfile" 2>/dev/null && [[ -s "$tokfile" ]]; then
-      if gog auth tokens import "$tokfile" >/dev/null 2>&1; then
+      # Capture stderr instead of discarding it. Swallowing it here is what hid a
+      # fleet-wide failure for weeks: the `file` keyring backend wants a password
+      # it can only PROMPT for, so on this TTY-less box EVERY import died with
+      # "no TTY available ... set GOG_KEYRING_PASSWORD" and all anyone ever saw
+      # was a bare "import failed".
+      local importerr
+      if importerr="$(gog auth tokens import "$tokfile" 2>&1 >/dev/null)"; then
         ok "$slug: gmail token imported"
       else
-        warn "$slug: gog auth tokens import failed"
+        warn "$slug: gog auth tokens import failed: ${importerr:-(no output)}"
+        [[ -n "${GOG_KEYRING_PASSWORD:-}" ]] || \
+          warn "$slug: GOG_KEYRING_PASSWORD is unset — stage it with ./secrets.sh gog"
       fi
     else
       warn "$slug: op read op://${vault}/gog-token/credential failed — is the item staged for this vault?"

--- a/deploy/ec2-runner/runner.cfn.yaml
+++ b/deploy/ec2-runner/runner.cfn.yaml
@@ -55,6 +55,14 @@ Parameters:
     Type: String
     Default: canopy/cloud-runner/canopy-pat
     Description: Secrets Manager id holding the canopy-web PAT.
+  GogKeyringSecret:
+    Type: String
+    Default: canopy/cloud-runner/gog-keyring-password
+    Description: >
+      Secrets Manager id holding the password for gog's `file` keyring backend
+      (exported as GOG_KEYRING_PASSWORD). Optional — if the secret is absent the
+      runner still boots, but every `gog auth tokens import` fails and the fleet
+      has no Gmail/Drive auth. Stage it with `./secrets.sh gog <file|->`.
   RunnerCodeSecret:
     Type: String
     Default: canopy/cloud-runner/runner-code
@@ -160,7 +168,19 @@ Resources:
                 chown ubuntu:ubuntu /opt/canopy-runner/cloud_runner.py.new
                 chmod 0755 /opt/canopy-runner/cloud_runner.py.new
                 mv /opt/canopy-runner/cloud_runner.py.new /opt/canopy-runner/cloud_runner.py
+                # gog's `file` keyring backend (the only option on a headless box —
+                # there is no OS keychain) encrypts with a password it PROMPTS for.
+                # With no TTY the prompt is impossible, so every `gog auth tokens
+                # import` died with "no TTY available for keyring file backend
+                # password prompt; set GOG_KEYRING_PASSWORD" and the whole fleet had
+                # zero Gmail/Drive auth. It has to live in the runner's own env, not
+                # just bootstrap's: gog needs the password to READ tokens too, so
+                # every agent turn (which inherits this env) needs it as well.
+                # Optional — an absent secret must not wedge the service, so this
+                # tolerates failure and simply leaves gog unusable, as before.
+                GOG_PW=$(secret ${GogKeyringSecret} 2>/dev/null || true)
                 cat > /opt/canopy-runner/runner.env <<ENV
+                GOG_KEYRING_PASSWORD=$GOG_PW
                 CANOPY_BASE_URL=${CanopyBaseUrl}
                 CANOPY_TOKEN=$(secret ${CanopyTokenSecret})
                 CLAUDE_CODE_OAUTH_TOKEN=$(secret ${ClaudeTokenSecret})

--- a/deploy/ec2-runner/secrets.sh
+++ b/deploy/ec2-runner/secrets.sh
@@ -7,6 +7,10 @@
 #   ./secrets.sh op path/to/sa-token.txt         # 1Password service-account token
 #                                                 # (wire.sh stages it into the runner's
 #                                                 # credential bundle for bootstrap_agents.sh)
+#   ./secrets.sh gog path/to/keyring-pw.txt      # password for gog's `file` keyring
+#                                                 # backend; without it every
+#                                                 # `gog auth tokens import` fails on a
+#                                                 # headless box (no TTY for the prompt)
 #   echo -n "<token>" | ./secrets.sh claude -     # or via stdin
 set -euo pipefail
 cd "$(dirname "$0")"
@@ -20,7 +24,8 @@ case "$kind" in
   canopy) SECRET=canopy/cloud-runner/canopy-pat ;;
   claude) SECRET=canopy/cloud-runner/claude-oauth-token ;;
   op)     SECRET=canopy/cloud-runner/op-service-account-token ;;
-  *) echo "usage: ./secrets.sh {canopy|claude|op} <file|->" >&2; exit 1 ;;
+  gog)    SECRET=canopy/cloud-runner/gog-keyring-password ;;
+  *) echo "usage: ./secrets.sh {canopy|claude|op|gog} <file|->" >&2; exit 1 ;;
 esac
 [[ -n "$src" ]] || { echo "give a file path or - for stdin" >&2; exit 1; }
 


### PR DESCRIPTION
## The bug

Every `gog auth tokens import` on the cloud runner has been failing, for **every agent**, since the box existed. `gog auth list` → *"No tokens stored"*. Gmail/Drive/Sheets/Docs — the substrate most of these agents actually run on — was unavailable to all five.

Running the import with stderr visible gives the whole story:

```
store token: set token: store file keyring item: no TTY available for
keyring file backend password prompt; set GOG_KEYRING_PASSWORD
```

`bootstrap_agents.sh` sets the keyring backend to `file`, which is **correct** — a headless Linux box has no OS keychain. But that backend encrypts with a password it tries to *prompt* for, and there is no TTY.

Nothing was wrong with the tokens: all five are well-formed, and each one's `client` field correctly matches `config.json`'s `account_clients` mapping.

## The fix

Stage the password as `canopy/cloud-runner/gog-keyring-password` (`./secrets.sh gog`) and export it from `canopy-fetch-env` into `runner.env`.

It goes in the **runner's** environment rather than only in bootstrap because gog needs the password to *read* tokens too, not just write them — so every agent turn, which inherits this environment, needs it as well. The fetch tolerates an absent secret, so a box without one still boots and gog simply stays unusable, exactly as today.

## And stop swallowing the error

`>/dev/null 2>&1` on the import is why this went unnoticed for weeks — all anyone ever saw was a bare `WARN: import failed`, with a completely self-describing error thrown away. It now reports the real message, and separately calls out an unset `GOG_KEYRING_PASSWORD`.

## Verified on the box

```
=== import WITH GOG_KEYRING_PASSWORD ===
imported	true
email	hal@dimagi-ai.com
client	canopy
=== tokens now stored ===
hal@dimagi-ai.com	canopy	docs,drive,forms,gmail,sheets	oauth
```

## Note

`canopy-fetch-env` lives in UserData, which cloud-init only runs on an instance's **first** boot — so this needs a stack recycle (`./down.sh && ./up.sh`), not just a restart. Only `cloud_runner.py` is exempt from that gap (it comes from Secrets Manager).

Separately, `ace` still needs `Agent-Ace/gog-oauth-client` staged — it maps to client `ace` and wants `credentials-ace.json`, which doesn't exist on the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)