### PR TITLE
feat(cloud-runner): session-capable, transcript-posting, resumable

### DIFF
--- a/deploy/ec2-runner/README.md
+++ b/deploy/ec2-runner/README.md
@@ -7,9 +7,10 @@ output into the `TurnEvent` ledger, and finishes the turn. As of the
 **cloud-agent-bootstrap** milestone it is agent-ready — a real third standby, not
 just a `canopy-web` repo runner — see
 `docs/superpowers/specs/2026-07-25-cloud-agent-bootstrap-design.md`. As of
-**run-convergence PR2** it is also **session-capable**: it also posts the raw
-transcript for every turn and can `--resume` a claude CLI session across turns —
-see "Session-capable, transcript-posting, resumable" below.
+**run-convergence PR2** it also posts the raw transcript for every turn and CAN
+(opt-in, off by default — see below) become session-capable and `--resume` a
+claude CLI session across turns — see "Session-capable, transcript-posting,
+resumable" below.
 
 Everything is declared in **`runner.cfn.yaml`** (CloudFormation, matching
 `deploy/aws/canopy-web.cfn.yaml`): the instance, security group, IAM role, and a
@@ -91,18 +92,29 @@ code" below), it is NOT tied to the stack's cloud-init generation.
 
 ## Session-capable, transcript-posting, resumable (run-convergence PR2)
 
-The runner declares **`capabilities.sessions: true`** by default (env
-`RUNNER_SESSIONS`, "0"/"false"/"no" to opt a specific box out) — this is what makes
-it eligible to claim chat/session-targeted `Turn`s at all (`claim_next_turn` gates
-those on `Runner.session_capable()`, apps/harness/models.py). It is **not yet a
-CloudFormation parameter** (`runner.cfn.yaml` only templates
+The runner CAN declare **`capabilities.sessions: true`**, opt-in via
+**`RUNNER_SESSIONS=1`** (default **OFF**) — this is what makes it eligible to claim
+chat/session-targeted `Turn`s at all (`claim_next_turn` gates those on
+`Runner.session_capable()`, apps/harness/models.py). **Do not turn this on yet.**
+This runner has no durable-record path for a chat session: on labs
+(`CHAT_STUB_EXECUTOR=False`), every session is stamped `transcript_sourced` at
+creation, which means the reduced `TurnEvent`s this runner posts to
+`/turns/{id}/events` never become durable `Message` rows and the user's own line is
+never durably written either — the only durable path is
+`POST /runners/{id}/session-stream` with per-line transcript ordinals, which today
+has exactly one caller, `packages/canopy_runner` (the laptop runner). Flipping
+`sessions` on today means a chat this runner claims streams a perfect-looking live
+reply and then loses the ENTIRE conversation the moment the user reloads the page.
+Flip the default only once that path (`session-stream` + `/streams` + `/backfills`)
+is built here too. It is **not yet a CloudFormation parameter**
+(`runner.cfn.yaml` only templates
 `RUNNER_PROJECTS`/`RUNNER_AGENTS`/`RUNNER_WORKSPACE`/`RUNNER_NAME` into
-`runner.env`); since the default is on, no template change is needed to enable it —
-to disable it on a specific box, add `RUNNER_SESSIONS=0` to `/opt/canopy-runner/runner.env`
-by hand and restart the service. Capabilities are re-synced on every restart
-(`pair_or_load` now `PATCH`es an already-paired runner's capabilities in place, via
-`PATCH /api/harness/runners/{id}`), so flipping the env on an existing box takes
-effect on the next restart without re-pairing (which would otherwise orphan its
+`runner.env`); enabling it today means adding `RUNNER_SESSIONS=1` to
+`/opt/canopy-runner/runner.env` by hand and restarting the service — don't, until
+the durable-record work above ships. Capabilities are re-synced on every restart
+(`pair_or_load` `PATCH`es an already-paired runner's capabilities in place, via
+`PATCH /api/harness/runners/{id}`), so a later flip of the default takes effect on
+the next restart without re-pairing (which would otherwise orphan its
 `RunnerBinding`s).
 
 **Raw transcript, forwarded verbatim.** Every raw `claude -p --output-format
@@ -115,56 +127,80 @@ purpose. Batching is **by bytes, not line count** — the server caps a single
 request at 1 MiB of line bytes (`TRANSCRIPT_APPEND_MAX_BYTES` in
 `apps/harness/api.py`) and 422s over it, since a single large tool result can
 exceed a naive per-N-lines batch — `cloud_runner.py` flushes at 512 KiB
-(`TRANSCRIPT_FLUSH_BYTES`) or every 10s (`TRANSCRIPT_FLUSH_SECONDS`), whichever
-comes first, well under the server's cap, and always flushes whatever remains at
-the end of the turn. Every batch carries a unique `batch_id` scoped to
-`(turn, attempt, seq)` so a resume-fallback retry (see below) can never collide
-with — and silently no-op-drop — an earlier attempt's batch. A transcript POST
-failure is logged and swallowed: **it never fails the turn.**
+(`TRANSCRIPT_FLUSH_BYTES`) or **every 10s on a dedicated background thread**
+(`TRANSCRIPT_FLUSH_SECONDS`), whichever comes first, well under the server's cap.
+The background thread is what makes the time trigger actually periodic — the byte
+trigger alone only runs when a NEW line arrives, so a long-quiet stdout (a
+multi-minute tool call) would otherwise hold buffered lines in memory indefinitely.
+A single line too large to ever fit the server's cap is replaced with a synthetic
+`canopy_runner_line_dropped` marker (never silently dropped with no trace). Every
+batch carries a unique `batch_id` scoped to `(turn, attempt, seq)` so a
+resume-fallback retry (see below) can never collide with — and silently no-op-drop
+— an earlier attempt's batch, and a transient POST failure (5xx/timeout) retries a
+few times with that SAME id before giving up on just that slice; the server's
+`truncated` response flag is honored (further posting for that turn stops once the
+server has stopped storing it). A transcript failure is logged and swallowed:
+**it never fails the turn**, and buffered-but-unflushed content is still flushed
+in a `finally` even if the read loop itself raises (e.g. a dropped WS `emit`).
 
-**Real `--resume` continuity.** A session turn's CLI session id is captured from
-the first stream-json line that carries one (normally `system`/`init`, which fires
-before any other output) and round-tripped through the EXISTING
-resolve-session/record-session RPCs (`POST /api/harness/runners/{id}/resolve-session`
-/ `record-session`) so a later turn on the same canopy `Session` can pass it back as
-`--resume <id>` instead of cold-starting. Concretely: `_session_resume_plan` asks
-resolve-session for a reusable handle before running claude; `_record_session_resume`
-reports the fresh (or reused) session id back after the turn. This reuses
-`RunnerBinding.session_key` — documented as "engine-agnostic ... was emdash_task" —
-rather than the newer `Session.cli_session_id` column
-(`apps/canopy_sessions/models.py`), which the docstring says is unwired for exactly
-this purpose but which nothing in `apps/harness/services.py` actually persists yet
-(`record_session`'s `session_id` param is accepted for wire-compat and currently
-discarded). `cloud_runner.py` sends BOTH fields on every record-session call, so
-wiring that column server-side later needs zero runner-side changes. Reuse is
-additionally gated on a stable `RUNNER_HOST` value (new env var, defaults to
-`RUNNER_NAME`) sent on every heartbeat/pairing call — `RunnerBinding.reusable_by`
-requires the runner id AND host to match the ones that recorded the binding, so a
-brand-new EC2 instance (a new `RUNNER_HOST`, since `RUNNER_NAME` defaults from the
-hostname) correctly cannot "resume" a session it never actually ran, and falls back
-to a fresh spawn instead.
+**Real `--resume` continuity, with a stable per-session working directory.**
+A session turn's CLI session id is captured from the first stream-json line that
+carries one (normally `system`/`init`, which fires before any other output) and
+round-tripped through the EXISTING resolve-session/record-session RPCs
+(`POST /api/harness/runners/{id}/resolve-session` / `record-session`) so a later
+turn on the same canopy `Session` can pass it back as `--resume <id>` instead of
+cold-starting. Concretely: `_session_resume_plan` asks resolve-session for a
+reusable handle before running claude; `_record_session_resume` reports the fresh
+(or reused) session id back after the turn. This reuses `RunnerBinding.session_key`
+— documented as "engine-agnostic ... was emdash_task" — rather than a
+`Session.cli_session_id`-style column (no such field exists anywhere in the
+codebase despite the originating plan naming one — confirmed by grep; see
+`_session_resume_plan`'s docstring). `cloud_runner.py` also sends a `session_id`
+field on every record-session call (currently a documented no-op server-side), so
+wiring a real column for this later needs zero runner-side changes. Reuse is
+additionally gated on a stable `RUNNER_HOST` value (defaults to `RUNNER_NAME`) sent
+on every heartbeat/pairing call — `RunnerBinding.reusable_by` requires the runner id
+AND host to match the ones that recorded the binding, so a brand-new EC2 instance
+correctly cannot "resume" a session it never actually ran.
 
-If `--resume <id>` yields **nothing** — the CLI exits non-zero having emitted no
-stream-json lines at all, its behavior when the resume target no longer exists —
-`run_claude` retries **once** as a fresh spawn (no `--resume`), mirroring the
-reuse-then-fall-back-to-create pattern `packages/canopy_runner/execute.py` already
-uses for emdash sessions. A failure that happens AFTER real output was produced
-under a resumed session is treated as a genuine task failure and is never retried
-(retrying would silently duplicate work under a new session).
+Critically, **every turn on the same canopy Session runs in the SAME working
+directory** (`WORK_DIR/sessions/<chat_session_id>`, keyed on the canopy Session id,
+never the turn id) — Claude Code resolves a `--resume` target by a cwd-derived
+project directory (`~/.claude/projects/<cwd with '/','.' -> '-'>/<session-id>.jsonl`),
+so a session id captured under one cwd is invisible under a different one. Before
+ever invoking `--resume`, `_resume_target_exists` checks that file actually exists
+under the turn's cwd — the cheap local equivalent of
+`packages/canopy_runner/execute.py`'s verify-before-reuse (it reads emdash's DB
+before driving a task; this reads the filesystem before resuming a transcript) — and
+drops straight to a fresh spawn if it doesn't, rather than ever invoking a doomed
+`--resume`. As a second-layer safety net, if the file existed but the CLI still
+yields NOTHING (exits non-zero having emitted no stream-json lines at all), `run_claude`
+retries **once** as a fresh spawn (no `--resume`). A failure that happens AFTER real
+output was produced under a resumed session is treated as a genuine task failure and
+is never retried (retrying would silently duplicate work under a new session).
 
 **What was and was not verified.** There is no live cloud runner instance running
 today (the EC2 stack is down), so none of this has been exercised against a real
 `claude` binary or a real canopy-web deployment. What IS covered, by unit tests
 under `deploy/ec2-runner/tests/` (mocking `subprocess.Popen` and the runner's own
 `_api` helper — see the test file for exactly what's stubbed): capability
-env-gating and the pair-time `PATCH`-in-place sync; byte-bounded transcript
-batching (`_chunk_transcript_lines`); `--resume` argv construction; the
-resolve-session/record-session request shapes (including the agentless-and-
-projectless-session degrade-to-fresh-spawn case); and `run_claude`'s session-id
-capture, transcript forwarding, and the resume-fails-then-falls-back-to-fresh-spawn
-behavior (and that a genuine post-resume failure does NOT retry). Not verified:
-the real `claude -p --output-format stream-json` event shape (the `system`/`init`
-event carrying `session_id` is documented CLI behavior, not something captured
+env-gating (default OFF) and the pair-time `PATCH`-in-place sync; byte-bounded
+transcript batching including the oversized-line marker and driving `run_claude`'s
+own byte-threshold flush (not just the pure helper); the periodic background flush
+actually firing during a simulated multi-second-quiet stdout; transcript POST retry
++ truncation handling; `--resume` argv construction; the resume-target
+filesystem-existence gate (including the stable-per-session-cwd behavior itself —
+two different turn ids on the same chat_session_id resolve to the same directory);
+the resolve-session/record-session request shapes (including the
+agentless-and-projectless-session degrade-to-fresh-spawn case, with a
+non-vacuous-pass assertion that `_api` was actually called); `run_claude`'s
+session-id capture, transcript forwarding, the resume-fails-then-falls-back
+behavior (and that a genuine post-resume failure does NOT retry); and that a
+mid-loop exception (e.g. a broken `emit`) still flushes buffered transcript/events
+in the `finally` rather than dropping them. Not verified: the real
+`claude -p --output-format stream-json` event shape (the `system`/`init` event
+carrying `session_id`, and Claude Code's cwd-encoding convention for
+`~/.claude/projects/`, are both documented CLI behavior, not something captured
 from a live run here), real network behavior against `apps/harness`'s actual
 endpoints, and end-to-end resume against a real, previously-`--resume`d Claude
 session.

--- a/deploy/ec2-runner/README.md
+++ b/deploy/ec2-runner/README.md
@@ -6,7 +6,10 @@ capabilities, runs `claude -p` on the turn's prompt, streams the assistant/tool
 output into the `TurnEvent` ledger, and finishes the turn. As of the
 **cloud-agent-bootstrap** milestone it is agent-ready — a real third standby, not
 just a `canopy-web` repo runner — see
-`docs/superpowers/specs/2026-07-25-cloud-agent-bootstrap-design.md`.
+`docs/superpowers/specs/2026-07-25-cloud-agent-bootstrap-design.md`. As of
+**run-convergence PR2** it is also **session-capable**: it also posts the raw
+transcript for every turn and can `--resume` a claude CLI session across turns —
+see "Session-capable, transcript-posting, resumable" below.
 
 Everything is declared in **`runner.cfn.yaml`** (CloudFormation, matching
 `deploy/aws/canopy-web.cfn.yaml`): the instance, security group, IAM role, and a
@@ -85,6 +88,86 @@ reached yet, keep the original `WORK_DIR` scratch-dir behavior.
 `systemctl restart canopy-runner` on the box (or just wait for the next restart) —
 unlike `cloud_runner.py` itself (baked into UserData; see "Updating the runner
 code" below), it is NOT tied to the stack's cloud-init generation.
+
+## Session-capable, transcript-posting, resumable (run-convergence PR2)
+
+The runner declares **`capabilities.sessions: true`** by default (env
+`RUNNER_SESSIONS`, "0"/"false"/"no" to opt a specific box out) — this is what makes
+it eligible to claim chat/session-targeted `Turn`s at all (`claim_next_turn` gates
+those on `Runner.session_capable()`, apps/harness/models.py). It is **not yet a
+CloudFormation parameter** (`runner.cfn.yaml` only templates
+`RUNNER_PROJECTS`/`RUNNER_AGENTS`/`RUNNER_WORKSPACE`/`RUNNER_NAME` into
+`runner.env`); since the default is on, no template change is needed to enable it —
+to disable it on a specific box, add `RUNNER_SESSIONS=0` to `/opt/canopy-runner/runner.env`
+by hand and restart the service. Capabilities are re-synced on every restart
+(`pair_or_load` now `PATCH`es an already-paired runner's capabilities in place, via
+`PATCH /api/harness/runners/{id}`), so flipping the env on an existing box takes
+effect on the next restart without re-pairing (which would otherwise orphan its
+`RunnerBinding`s).
+
+**Raw transcript, forwarded verbatim.** Every raw `claude -p --output-format
+stream-json` line — whether or not it parses as JSON — is ALSO forwarded to
+`POST /api/harness/turns/{id}/transcript`, in addition to the reduced
+`assistant`/`tool_start`/`tool_end` `TurnEvent`s already streamed for the live UI.
+This is the durable, re-derivable artifact cost/structure aggregators read from
+(apps/harness's `TurnTranscript` model); the ledger stays a live, lossy stream on
+purpose. Batching is **by bytes, not line count** — the server caps a single
+request at 1 MiB of line bytes (`TRANSCRIPT_APPEND_MAX_BYTES` in
+`apps/harness/api.py`) and 422s over it, since a single large tool result can
+exceed a naive per-N-lines batch — `cloud_runner.py` flushes at 512 KiB
+(`TRANSCRIPT_FLUSH_BYTES`) or every 10s (`TRANSCRIPT_FLUSH_SECONDS`), whichever
+comes first, well under the server's cap, and always flushes whatever remains at
+the end of the turn. Every batch carries a unique `batch_id` scoped to
+`(turn, attempt, seq)` so a resume-fallback retry (see below) can never collide
+with — and silently no-op-drop — an earlier attempt's batch. A transcript POST
+failure is logged and swallowed: **it never fails the turn.**
+
+**Real `--resume` continuity.** A session turn's CLI session id is captured from
+the first stream-json line that carries one (normally `system`/`init`, which fires
+before any other output) and round-tripped through the EXISTING
+resolve-session/record-session RPCs (`POST /api/harness/runners/{id}/resolve-session`
+/ `record-session`) so a later turn on the same canopy `Session` can pass it back as
+`--resume <id>` instead of cold-starting. Concretely: `_session_resume_plan` asks
+resolve-session for a reusable handle before running claude; `_record_session_resume`
+reports the fresh (or reused) session id back after the turn. This reuses
+`RunnerBinding.session_key` — documented as "engine-agnostic ... was emdash_task" —
+rather than the newer `Session.cli_session_id` column
+(`apps/canopy_sessions/models.py`), which the docstring says is unwired for exactly
+this purpose but which nothing in `apps/harness/services.py` actually persists yet
+(`record_session`'s `session_id` param is accepted for wire-compat and currently
+discarded). `cloud_runner.py` sends BOTH fields on every record-session call, so
+wiring that column server-side later needs zero runner-side changes. Reuse is
+additionally gated on a stable `RUNNER_HOST` value (new env var, defaults to
+`RUNNER_NAME`) sent on every heartbeat/pairing call — `RunnerBinding.reusable_by`
+requires the runner id AND host to match the ones that recorded the binding, so a
+brand-new EC2 instance (a new `RUNNER_HOST`, since `RUNNER_NAME` defaults from the
+hostname) correctly cannot "resume" a session it never actually ran, and falls back
+to a fresh spawn instead.
+
+If `--resume <id>` yields **nothing** — the CLI exits non-zero having emitted no
+stream-json lines at all, its behavior when the resume target no longer exists —
+`run_claude` retries **once** as a fresh spawn (no `--resume`), mirroring the
+reuse-then-fall-back-to-create pattern `packages/canopy_runner/execute.py` already
+uses for emdash sessions. A failure that happens AFTER real output was produced
+under a resumed session is treated as a genuine task failure and is never retried
+(retrying would silently duplicate work under a new session).
+
+**What was and was not verified.** There is no live cloud runner instance running
+today (the EC2 stack is down), so none of this has been exercised against a real
+`claude` binary or a real canopy-web deployment. What IS covered, by unit tests
+under `deploy/ec2-runner/tests/` (mocking `subprocess.Popen` and the runner's own
+`_api` helper — see the test file for exactly what's stubbed): capability
+env-gating and the pair-time `PATCH`-in-place sync; byte-bounded transcript
+batching (`_chunk_transcript_lines`); `--resume` argv construction; the
+resolve-session/record-session request shapes (including the agentless-and-
+projectless-session degrade-to-fresh-spawn case); and `run_claude`'s session-id
+capture, transcript forwarding, and the resume-fails-then-falls-back-to-fresh-spawn
+behavior (and that a genuine post-resume failure does NOT retry). Not verified:
+the real `claude -p --output-format stream-json` event shape (the `system`/`init`
+event carrying `session_id` is documented CLI behavior, not something captured
+from a live run here), real network behavior against `apps/harness`'s actual
+endpoints, and end-to-end resume against a real, previously-`--resume`d Claude
+session.
 
 ## Per-agent canopy-web PAT (TODO — not yet provisioned)
 

--- a/deploy/ec2-runner/cloud_runner.py
+++ b/deploy/ec2-runner/cloud_runner.py
@@ -479,9 +479,22 @@ def run_claude(prompt: str, turn_id: str, emit, cwd: pathlib.Path | None = None,
     # POST in the opposite order if the earlier one is slower (e.g. retrying
     # a 500), corrupting the transcript's byte ordering. Acquired for the
     # whole of one flush_transcript() call (swap included), so at most one
-    # flush is ever "in flight" — this is where the backpressure N2 flags
-    # actually still exists (flush vs. flush), which is fine: it only ever
-    # blocks ANOTHER FLUSH, never the read loop's line-by-line appending.
+    # flush is ever "in flight".
+    #
+    # Documented residual (measured, review N2 round 2): this fixes the
+    # COMMON case — a turn that stays under TRANSCRIPT_FLUSH_BYTES is never
+    # stalled by a slow/failing canopy-web, because the periodic thread is
+    # the only thing ever waiting on a POST and the read loop's per-line
+    # append only ever touches the fast `transcript_lock`. But if a turn
+    # CROSSES the byte trigger WHILE the periodic thread's flush is already
+    # mid-POST, the read loop's OWN inline `flush_transcript()` call (below)
+    # blocks acquiring `transcript_post_lock` for that entire POST (up to
+    # ~182s across retries) before it can even swap its new content out —
+    # i.e. the read loop genuinely stalls in that narrower case, not just
+    # "another flush". Bounded and rarer than the pre-fix behavior (which
+    # stalled on EVERY line, not just a threshold-crossing one), and
+    # correctness (never posting out of order) is worth that residual — but
+    # it is a real stall on the read loop, not merely a flush-vs-flush one.
     transcript_post_lock = threading.Lock()
     transcript_flush_stop = threading.Event()
 
@@ -556,6 +569,15 @@ def run_claude(prompt: str, turn_id: str, emit, cwd: pathlib.Path | None = None,
                 transcript_buf.append(line)
                 transcript_bytes += len(line.encode("utf-8"))
                 should_flush = transcript_bytes >= TRANSCRIPT_FLUSH_BYTES
+            # `flush_transcript()` is called AFTER the `with` block exits, on
+            # purpose: this is the one line the whole deadlock-freedom
+            # argument rests on. flush_transcript() itself acquires
+            # transcript_post_lock THEN transcript_lock (L2 -> L1) — calling
+            # it while still holding transcript_lock here would attempt the
+            # inverse order (L1 already held, then try to take L2 inside),
+            # which is exactly the shape of an AB/BA deadlock the moment two
+            # threads do it in opposite orders. Releasing L1 first keeps
+            # every acquisition in this file on the single L2 -> L1 order.
             if should_flush:
                 flush_transcript()
             try:
@@ -588,38 +610,42 @@ def run_claude(prompt: str, turn_id: str, emit, cwd: pathlib.Path | None = None,
         # no try/finally at all, so an exception mid-loop — e.g. the WS `emit`
         # breaking on a dropped socket — dropped every buffered line/event).
         transcript_flush_stop.set()
-        # KILL (AND CLOSE STDOUT) BEFORE REAPING — unconditionally, regardless
-        # of whether the loop reached EOF (review N1). On a mid-loop exception
-        # `claude` can still be RUNNING with its stdout pipe no longer drained;
-        # once the 64KB pipe buffer fills, the child blocks on write and a
-        # bare `proc.wait()` NEVER RETURNS. That doesn't just fail this turn —
-        # it means run_claude() itself never returns, so the caller's own
+        # CLOSE STDOUT BEFORE REAPING, unconditionally, regardless of whether
+        # the loop reached EOF (review N1). On a mid-loop exception `claude`
+        # can still be RUNNING with its stdout pipe no longer drained; once
+        # the 64KB pipe buffer fills, the child blocks on write and a bare
+        # `proc.wait()` NEVER RETURNS. That doesn't just fail this turn — it
+        # means run_claude() itself never returns, so the caller's own
         # `finally: lease_stop.set()` never runs, the lease-renewal thread
         # keeps heartbeating this turn EXECUTING forever, and
         # one_executing_turn_per_agent wedges the whole agent permanently
         # (the exact "wedged-but-heartbeating runner" pathology CLAUDE.md
-        # documents) — worse than the turn simply failing.
+        # documents) — worse than the turn simply failing. Closing the read
+        # end delivers EPIPE/SIGPIPE to a child still blocked writing, which
+        # is what actually unblocks it — kill() alone would not (a blocked
+        # write doesn't unblock just because the process received SIGKILL any
+        # sooner than it would have anyway; closing the pipe is what matters).
         #
-        # Closing stdout first unblocks any pending write (the read end going
-        # away delivers SIGPIPE/EPIPE to the writer); kill() on a process that
-        # already exited cleanly (the ordinary happy path, where the loop
-        # already reached EOF) is a harmless no-op signal to a reapable
-        # zombie — Python's Popen doesn't guard against re-signaling because
-        # nothing here has called wait()/poll() yet to know it's dead.
+        # KILL ONLY IF A BOUNDED WAIT TIMES OUT (review N4) — never
+        # unconditionally. `claude` finishing normally often does a little
+        # work AFTER its last stream-json line (whatever it takes to close
+        # out its own `~/.claude/projects/<enc>/<id>.jsonl` transcript — the
+        # very file this PR's `--resume`/I1/C2 depend on); an unconditional
+        # SIGKILL the instant stdout EOFs was measured to hit that window and
+        # both flip a clean turn's outcome to `ok=False` AND risk truncating
+        # that transcript file. `Popen.kill()` on an already-exited process is
+        # in fact safe on its own terms (`send_signal` polls `self.poll()`
+        # first and no-ops on a dead process, Python 3.9+/bpo-38630) — but
+        # "safe to call" was never the point; calling it on a process that
+        # was about to exit cleanly, before giving it the chance to, is the
+        # bug. Wait first; escalate only on a genuine timeout.
         try:
             proc.stdout.close()  # type: ignore[union-attr]
-        except Exception:  # noqa: BLE001 — best-effort; still try to kill below
-            pass
-        try:
-            proc.kill()
         except Exception:  # noqa: BLE001 — best-effort; still try to wait below
             pass
-        # The wait itself is ALSO bounded — never unconditional — because a
-        # kill() can still leave a zombie the OS is slow to reap, and this
-        # runner must never block on that either.
         try:
             proc.wait(timeout=PROC_REAP_TIMEOUT_SECONDS)
-        except Exception:  # noqa: BLE001 — subprocess.TimeoutExpired or worse
+        except Exception:  # noqa: BLE001 — subprocess.TimeoutExpired or worse: escalate
             try:
                 proc.kill()
                 proc.wait(timeout=PROC_REAP_TIMEOUT_SECONDS)

--- a/deploy/ec2-runner/cloud_runner.py
+++ b/deploy/ec2-runner/cloud_runner.py
@@ -6,15 +6,19 @@ drives a GUI over CDP, which is wrong for a headless box. This pairs a cloud run
 claims harness Turns, runs `claude -p` (stream-json) on the turn's prompt, streams
 the assistant/tool output into the TurnEvent ledger, and finishes the turn.
 
-SESSION-CAPABLE (RC/run-convergence PR2): this runner declares `capabilities.sessions`
-(RUNNER_SESSIONS, default on) so it is eligible to claim chat/session-targeted Turns —
-see Runner.session_capable() in apps/harness/models.py. Every raw stream-json line the
-CLI emits is ALSO forwarded verbatim to POST /turns/{id}/transcript (batched by bytes;
-see deploy/ec2-runner/README.md), in addition to the reduced TurnEvents. And a session
-turn's CLI session id is captured from the stream and round-tripped through the
-existing resolve-session/record-session RPCs so a later turn on the same canopy
-Session can `--resume` it instead of cold-starting — see _session_resume_plan /
-_record_session_resume below for exactly which field carries that id and why.
+SESSION-CAPABLE, OPT-IN (RC/run-convergence PR2): this runner CAN declare
+`capabilities.sessions` (RUNNER_SESSIONS=1; default OFF) to become eligible to claim
+chat/session-targeted Turns — see Runner.session_capable() in apps/harness/models.py.
+It is off by default because this runner has no durable-record path for a chat
+session yet (see the RUNNER_SESSIONS comment at its declaration for the full trace);
+turning it on today means a real conversation's history can be silently lost. Every
+raw stream-json line the CLI emits is ALSO forwarded verbatim to
+POST /turns/{id}/transcript (batched by bytes; see deploy/ec2-runner/README.md), in
+addition to the reduced TurnEvents. And a session turn's CLI session id is captured
+from the stream and round-tripped through the existing resolve-session/record-session
+RPCs so a later turn on the same canopy Session can `--resume` it instead of
+cold-starting — see _session_resume_plan / _record_session_resume below for exactly
+which field carries that id and why.
 
 Config comes from the environment (see deploy/ec2-runner/README.md):
   CANOPY_BASE_URL   e.g. https://labs.connect.dimagi.com/canopy
@@ -22,8 +26,8 @@ Config comes from the environment (see deploy/ec2-runner/README.md):
   RUNNER_NAME       display name (default: this hostname)
   RUNNER_PROJECTS   comma-separated repo names this runner may drive (e.g. canopy-web)
   RUNNER_AGENTS     comma-separated agent slugs this runner may drive (e.g. echo,ada)
-  RUNNER_SESSIONS   whether this runner claims chat/session turns (default: on; "0"/
-                     "false"/"no" to disable)
+  RUNNER_SESSIONS   whether this runner claims chat/session turns (default: OFF —
+                     opt-in; see the RUNNER_SESSIONS declaration for why)
   RUNNER_HOST       stable identity for session-reuse gating (default: RUNNER_NAME).
                      Analogous to emdash's per-macOS-account host, but for a headless
                      box it just needs to be STABLE across process restarts on the
@@ -85,12 +89,23 @@ if _csv("RUNNER_PROJECTS"):
     RUNNER_CAPS["projects"] = _csv("RUNNER_PROJECTS")
 if _csv("RUNNER_AGENTS"):
     RUNNER_CAPS["agents"] = _csv("RUNNER_AGENTS")
-# Default ON: this runner kind (headless, `claude -p` subprocess) is exactly the
-# session-capable executor SP2b anticipated (apps/canopy_sessions/models.py's
-# Session.cli_session_id docstring: "continuity for the real subprocess runner").
-# Opt out per-box with RUNNER_SESSIONS=0 if a particular instance should stay
-# agent/project-only.
-RUNNER_SESSIONS = _bool_env("RUNNER_SESSIONS", True)
+# Default OFF (opt-in, RUNNER_SESSIONS=1): this runner has no durable-record path
+# for a chat session yet. On labs (CHAT_STUB_EXECUTOR=False) every session is
+# stamped transcript_sourced at creation (apps/canopy_sessions/services.py
+# create_session), which means the reduced TurnEvents this runner posts to
+# /turns/{id}/events NEVER become durable Message rows (project_events short-
+# circuits to 0 for such a session) and the user's own line is never durably
+# written either (_send_transcript_sourced_message deliberately authors none).
+# The only durable path is POST /runners/{id}/session-stream with per-line
+# transcript ordinals -> services.persist_transcript_rows, which today has
+# exactly one caller: packages/canopy_runner/canopy_runner/client.py (the
+# laptop runner). Until THIS runner implements that same call (plus honoring
+# /runners/{id}/streams + /backfills), declaring sessions:true would make it
+# eligible to claim a real chat turn, stream a perfect-looking live reply, and
+# then silently lose the entire conversation the moment the user reloads the
+# page — worse than not claiming it at all. Flip this default only once
+# persist_transcript_rows (via session-stream/streams/backfills) is wired here.
+RUNNER_SESSIONS = _bool_env("RUNNER_SESSIONS", False)
 if RUNNER_SESSIONS:
     RUNNER_CAPS["sessions"] = True
 RUNNER_WORKSPACE = os.environ.get("RUNNER_WORKSPACE", "")
@@ -165,14 +180,33 @@ def _chunk_transcript_lines(
     """Split raw JSONL lines into batches whose UTF-8-encoded total stays at or
     under `max_bytes` — the server enforces a hard per-request byte cap, not a
     line count, so a single giant tool-result line would blow past a count-based
-    batch. A single line that itself exceeds `max_bytes` still ships alone rather
-    than being dropped (the server's own 100MB per-turn ceiling, not this client,
-    is the backstop for that pathological case)."""
+    batch.
+
+    A single line that itself exceeds `max_bytes` can never fit even alone: the
+    server 422s the WHOLE request when total_bytes > its cap
+    (apps/harness/api.py), before `append_transcript`'s separate 100MB per-turn
+    ceiling is ever consulted — that ceiling is a different mechanism and is not
+    a backstop for this case. Shipping it "alone" would still fail, silently
+    dropping the line with no record. Instead it is replaced with a synthetic
+    `canopy_runner_line_dropped` marker line, so a cost/structure aggregator
+    reading the transcript can at least SEE the gap instead of it vanishing."""
     batches: list[list[str]] = []
     current: list[str] = []
     current_bytes = 0
     for line in lines:
         n = len(line.encode("utf-8"))
+        if n > max_bytes:
+            if current:
+                batches.append(current)
+                current = []
+                current_bytes = 0
+            marker = json.dumps({
+                "type": "canopy_runner_line_dropped",
+                "reason": "line exceeds the per-request transcript byte cap",
+                "bytes": n,
+            })
+            batches.append([marker])
+            continue
         if current and current_bytes + n > max_bytes:
             batches.append(current)
             current = []
@@ -300,28 +334,59 @@ def _agent_env(slug: str | None) -> dict:
     return env
 
 
-def _post_transcript_batch(turn_id: str, attempt_id: str, seq: int, lines: list[str]) -> None:
-    """Ship one already-byte-bounded batch. Best-effort: per the transcript
-    contract (deploy/ec2-runner/README.md), a transcript failure must never fail
-    the turn, so every error is logged and swallowed here, never raised.
+# Bounded retry for a transient transcript-POST failure (5xx/timeout/URLError).
+# Small and short: this runs INLINE in the turn's own execution path (see
+# run_claude's flush_transcript), so it must not itself become the thing that
+# stalls a live turn for a long time.
+TRANSCRIPT_POST_RETRIES = 3
+TRANSCRIPT_POST_RETRY_SLEEP_SECONDS = 1.0
 
-    `batch_id` is scoped to (turn, attempt, seq) rather than just (turn, seq): a
-    resume-fallback retry (see `run_claude`) re-invokes this whole function with
-    seq restarting at 1, and reusing a bare `f"{turn_id}:{seq}"` id would collide
-    with the FIRST (failed-resume) attempt's batch 1 — the server's dedup treats
-    a repeated batch_id as a lost-ack retry and silently no-ops it, which would
-    drop the fresh attempt's transcript rather than the intended duplicate."""
+
+def _post_transcript_batch(turn_id: str, attempt_id: str, seq: int, lines: list[str]) -> bool:
+    """Ship one already-byte-bounded batch, retrying a transient failure a few
+    times with the SAME `batch_id` (never fabricating a new one per attempt —
+    that would defeat the server's last-batch dedup, apps/harness/services.py,
+    which is exactly what makes a same-id retry safe rather than a duplicate).
+
+    Returns False iff the SERVER reports this turn's transcript as `truncated`
+    (its per-turn size ceiling latched) — the caller should stop posting for
+    the rest of THIS turn, since every further byte would be silently dropped
+    server-side anyway. Returns True in every other case, including after
+    exhausting retries on a genuinely failing batch: per the transcript
+    contract (deploy/ec2-runner/README.md), a transcript failure must never
+    fail the TURN, so a batch that never lands is logged and abandoned rather
+    than raised, but posting continues for whatever comes next.
+
+    `batch_id` is scoped to (turn, attempt, seq) rather than just (turn, seq):
+    a resume-fallback retry (see `run_claude`) re-invokes this whole function
+    with seq restarting at 1, and reusing a bare `f"{turn_id}:{seq}"` id would
+    collide with the FIRST (failed-resume) attempt's batch 1 — the server's
+    dedup treats a repeated batch_id as a lost-ack retry and silently no-ops
+    it, which would drop the fresh attempt's transcript rather than the
+    intended duplicate."""
     if not lines:
-        return
+        return True
     batch_id = f"{turn_id}:{attempt_id}:{seq}"
-    try:
-        status, _ = _api(
-            "POST", f"/turns/{turn_id}/transcript", {"lines": lines, "batch_id": batch_id}
-        )
-        if status != 200:
-            _log(f"transcript POST turn={turn_id[:8]} batch={seq} -> {status}")
-    except Exception as exc:  # noqa: BLE001 — a transcript hiccup must never fail the turn
-        _log(f"transcript POST turn={turn_id[:8]} batch={seq} raised: {exc}")
+    body = {"lines": lines, "batch_id": batch_id}
+    for attempt in range(1, TRANSCRIPT_POST_RETRIES + 1):
+        try:
+            status, payload = _api("POST", f"/turns/{turn_id}/transcript", body)
+        except Exception as exc:  # noqa: BLE001 — a transcript hiccup must never fail the turn
+            status, payload = 0, None
+            _log(f"transcript POST turn={turn_id[:8]} batch={seq} attempt={attempt} raised: {exc}")
+        if status == 200:
+            if payload and payload.get("truncated"):
+                _log(f"transcript POST turn={turn_id[:8]}: server reports truncated; "
+                     "no further posts for this turn")
+                return False
+            return True
+        if attempt < TRANSCRIPT_POST_RETRIES:
+            _log(f"transcript POST turn={turn_id[:8]} batch={seq} -> {status}; "
+                 f"retry {attempt}/{TRANSCRIPT_POST_RETRIES}")
+            time.sleep(TRANSCRIPT_POST_RETRY_SLEEP_SECONDS)
+    _log(f"transcript POST turn={turn_id[:8]} batch={seq} failed after "
+         f"{TRANSCRIPT_POST_RETRIES} attempts; this slice is lost, continuing")
+    return True
 
 
 def run_claude(prompt: str, turn_id: str, emit, cwd: pathlib.Path | None = None,
@@ -349,23 +414,35 @@ def run_claude(prompt: str, turn_id: str, emit, cwd: pathlib.Path | None = None,
     the caller round-trips it through record-session so a LATER turn on the same
     canopy Session can pass it back as `resume_session_id` here.
 
-    `resume_session_id`, if given, is passed as `--resume <id>`. If that yields
-    NOTHING — the process exits non-zero having emitted no stream-json lines at
-    all, the CLI's behavior when a resume target no longer exists — this retries
-    ONCE as a fresh spawn (`_resume_retried` guards against looping), mirroring
-    the reuse-then-fall-back-to-create pattern packages/canopy_runner/execute.py
-    already uses for emdash sessions: never assume continuity works, always have
-    a cold-start fallback.
+    `resume_session_id`, if given, is verified FIRST against the local
+    filesystem (`_resume_target_exists` — Claude Code resolves `--resume` by
+    cwd-derived project dir, so a session captured under a different cwd is
+    invisible here regardless of the id) and dropped to a fresh spawn
+    immediately if that fails, rather than ever invoking a doomed `--resume`.
+    As a second-layer safety net — if the file existed but the CLI still
+    yields NOTHING (exits non-zero having emitted no stream-json lines at
+    all) — this retries ONCE as a fresh spawn (`_resume_retried` guards
+    against looping), mirroring the reuse-then-fall-back-to-create pattern
+    packages/canopy_runner/execute.py already uses for emdash sessions: never
+    assume continuity works, always have a cold-start fallback.
     """
     workdir = cwd if cwd is not None else pathlib.Path(WORK_DIR) / turn_id[:8]
     workdir.mkdir(parents=True, exist_ok=True)
+    if resume_session_id and not _resume_target_exists(workdir, resume_session_id):
+        _log(f"resume target {resume_session_id!r} not found under {workdir} "
+             f"(turn {turn_id[:8]}); treating as a fresh spawn")
+        resume_session_id = None
     cmd = _claude_cmd(prompt, resume_session_id)
     _log(f"exec: claude -p (turn {turn_id[:8]}) in {workdir}"
          + (f" --resume {resume_session_id}" if resume_session_id else ""))
     # stderr goes to a file, not PIPE: a chatty claude can fill the 64KB pipe buffer
     # while we're only reading stdout, deadlocking the process. A file has no such
     # limit; we tail it for the failure path below.
-    stderr_path = workdir / "stderr.log"
+    # A resume-fallback retry (_resume_retried=True) writes to a DIFFERENT file
+    # than the original attempt, so a failed --resume's stderr — the only
+    # evidence of why it failed — survives the fresh-spawn retry instead of
+    # being truncated by its `.open("w")` (review finding M2).
+    stderr_path = workdir / ("stderr.resume-retry.log" if _resume_retried else "stderr.log")
     stderr_file = stderr_path.open("w")
     proc = subprocess.Popen(
         cmd, cwd=str(workdir), stdout=subprocess.PIPE, stderr=stderr_file, text=True,
@@ -380,7 +457,11 @@ def run_claude(prompt: str, turn_id: str, emit, cwd: pathlib.Path | None = None,
     transcript_buf: list[str] = []
     transcript_bytes = 0
     transcript_seq = 0
-    last_transcript_flush = time.monotonic()
+    transcript_stopped = False  # latched True once the server reports `truncated`
+    # Guards transcript_buf/transcript_bytes/transcript_seq/transcript_stopped,
+    # which the main read loop AND the periodic flush thread below both touch.
+    transcript_lock = threading.Lock()
+    transcript_flush_stop = threading.Event()
 
     def flush():
         nonlocal batch
@@ -389,63 +470,117 @@ def run_claude(prompt: str, turn_id: str, emit, cwd: pathlib.Path | None = None,
             batch = []
 
     def flush_transcript():
-        nonlocal transcript_buf, transcript_bytes, transcript_seq, last_transcript_flush
-        for chunk in _chunk_transcript_lines(transcript_buf):
-            transcript_seq += 1
-            _post_transcript_batch(turn_id, attempt_id, transcript_seq, chunk)
-        transcript_buf = []
-        transcript_bytes = 0
-        last_transcript_flush = time.monotonic()
+        # Swap-and-clear happens under the lock (short critical section); the
+        # actual chunking + network POSTs run with the lock HELD too (simpler
+        # and race-free, at the cost of some backpressure on a concurrent
+        # appender — the same tradeoff `emit()` already carries elsewhere in
+        # this file). `nonlocal` writes inside a `with` block are fine: the
+        # lock only serializes callers, it doesn't scope the names.
+        nonlocal transcript_buf, transcript_bytes, transcript_seq, transcript_stopped
+        with transcript_lock:
+            if not transcript_buf or transcript_stopped:
+                transcript_buf = []
+                transcript_bytes = 0
+                return
+            pending = transcript_buf
+            transcript_buf = []
+            transcript_bytes = 0
+            for chunk in _chunk_transcript_lines(pending):
+                transcript_seq += 1
+                if not _post_transcript_batch(turn_id, attempt_id, transcript_seq, chunk):
+                    transcript_stopped = True
+                    break
 
-    for line in proc.stdout:  # type: ignore[union-attr]
-        line = line.strip()
-        if not line:
-            continue
-        lines_seen += 1
-        transcript_buf.append(line)
-        transcript_bytes += len(line.encode("utf-8"))
-        if (transcript_bytes >= TRANSCRIPT_FLUSH_BYTES
-                or time.monotonic() - last_transcript_flush >= TRANSCRIPT_FLUSH_SECONDS):
+    def _periodic_flush() -> None:
+        # The byte-size flush trigger below only runs when a NEW line arrives,
+        # so a long-quiet stdout (a multi-minute tool call — CLAUDE.md's own
+        # worked example is 296s) would otherwise hold buffered lines in RAM
+        # indefinitely, lost to any crash/SIGTERM/instance-stop in the
+        # meantime (review finding I2). This thread is what makes
+        # TRANSCRIPT_FLUSH_SECONDS actually periodic rather than "on the next
+        # line after N seconds".
+        while not transcript_flush_stop.wait(TRANSCRIPT_FLUSH_SECONDS):
             flush_transcript()
+
+    flusher = threading.Thread(
+        target=_periodic_flush, daemon=True, name=f"transcript-flush-{turn_id[:8]}",
+    )
+    flusher.start()
+
+    loop_error: Exception | None = None
+    try:
+        for line in proc.stdout:  # type: ignore[union-attr]
+            line = line.strip()
+            if not line:
+                continue
+            lines_seen += 1
+            should_flush = False
+            with transcript_lock:
+                transcript_buf.append(line)
+                transcript_bytes += len(line.encode("utf-8"))
+                should_flush = transcript_bytes >= TRANSCRIPT_FLUSH_BYTES
+            if should_flush:
+                flush_transcript()
+            try:
+                evt = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if evt.get("session_id"):
+                cli_session_id = evt["session_id"]
+            etype = evt.get("type")
+            if etype == "assistant":
+                for block in (evt.get("message", {}).get("content") or []):
+                    if block.get("type") == "text" and block.get("text"):
+                        batch.append({"kind": "assistant", "payload": {"text": block["text"]}})
+                    elif block.get("type") == "tool_use":
+                        batch.append({"kind": "tool_start", "payload": {"name": block.get("name", "")}})
+            elif etype == "user":
+                for block in (evt.get("message", {}).get("content") or []):
+                    if block.get("type") == "tool_result":
+                        batch.append({"kind": "tool_end", "payload": {}})
+            elif etype == "result":
+                final_text = evt.get("result", "") or ""
+                ok = not evt.get("is_error", False)
+            if len(batch) >= 10:
+                flush()
+    except Exception as exc:  # noqa: BLE001 — must not lose buffered events/transcript
+        loop_error = exc
+    finally:
+        # Everything here runs whether the loop finished cleanly, raised, or
+        # the process is still alive (review finding I3: the ORIGINAL code had
+        # no try/finally at all, so an exception mid-loop — e.g. the WS `emit`
+        # breaking on a dropped socket — dropped every buffered line/event).
+        transcript_flush_stop.set()
         try:
-            evt = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        if evt.get("session_id"):
-            cli_session_id = evt["session_id"]
-        etype = evt.get("type")
-        if etype == "assistant":
-            for block in (evt.get("message", {}).get("content") or []):
-                if block.get("type") == "text" and block.get("text"):
-                    batch.append({"kind": "assistant", "payload": {"text": block["text"]}})
-                elif block.get("type") == "tool_use":
-                    batch.append({"kind": "tool_start", "payload": {"name": block.get("name", "")}})
-        elif etype == "user":
-            for block in (evt.get("message", {}).get("content") or []):
-                if block.get("type") == "tool_result":
-                    batch.append({"kind": "tool_end", "payload": {}})
-        elif etype == "result":
-            final_text = evt.get("result", "") or ""
-            ok = not evt.get("is_error", False)
-        if len(batch) >= 10:
-            flush()
-    proc.wait()
-    stderr_file.close()
-    flush()
-    flush_transcript()
-    if proc.returncode != 0 and not final_text:
+            proc.wait()
+        except Exception:  # noqa: BLE001 — best-effort reap; loop_error already captured
+            pass
+        stderr_file.close()
+        try:
+            flush()  # calls the caller-supplied `emit` — can itself raise (e.g. a dead WS)
+        except Exception as exc:  # noqa: BLE001 — cleanup must not lose flush_transcript below
+            if loop_error is None:
+                loop_error = exc
+        flush_transcript()  # never raises — _post_transcript_batch swallows everything
+    if loop_error is not None:
+        ok = False
+        final_text = final_text or f"runner error while streaming claude output: {loop_error}"
+    elif proc.returncode != 0 and not final_text:
         ok = False
         try:
             tail = stderr_path.read_text(errors="replace")
         except OSError:
             tail = ""
         final_text = tail[-500:]
-    if resume_session_id and not _resume_retried and lines_seen == 0 and proc.returncode != 0:
-        # The CLI emitted NOTHING at all before exiting — the resume target is
-        # gone (expired/evicted), not a genuine task failure. Fall back to a
-        # fresh spawn rather than surfacing a cold "resume failed" as the turn's
-        # result. A failure AFTER real output happened is a genuine task failure
-        # and must not retry (that would silently duplicate work/tokens).
+    if (resume_session_id and not _resume_retried and lines_seen == 0
+            and loop_error is None and proc.returncode != 0):
+        # The CLI emitted NOTHING at all before exiting even though the
+        # transcript file existed at start (already verified above) — some
+        # other resume failure (a corrupt/incompatible file, a CLI version
+        # mismatch). Fall back to a fresh spawn rather than surfacing a cold
+        # "resume failed" as the turn's result. A failure AFTER real output
+        # happened is a genuine task failure and must not retry (that would
+        # silently duplicate work/tokens).
         _log(f"resume of session {resume_session_id!r} yielded nothing "
              f"(turn {turn_id[:8]}); falling back to a fresh spawn")
         return run_claude(prompt, turn_id, emit, cwd=cwd, agent_slug=agent_slug,
@@ -467,6 +602,16 @@ def _stage_github_token(token: str) -> None:
         _log(f"warn: could not stage github token: {exc}")
 
 
+def _chat_session_id(turn: dict) -> str:
+    """The canopy Session id (origin_ref.chat_session_id) for a SESSION-targeted
+    turn, or "" for an agent/project turn. This is the one identity that is
+    INVARIANT for the life of a conversation — unlike `thread_key` (see
+    `_session_thread_key`), which can take other forms (e.g. "emdash:<task>" for
+    a runner-discovered binding) — so it is what `_turn_cwd` keys a session's
+    on-disk workdir on, not the turn id and not the thread key."""
+    return (turn.get("origin_ref") or {}).get("chat_session_id") or ""
+
+
 def _turn_agent_slug(turn: dict) -> str:
     """The agent this turn runs AS, or "" — the single place that decision is made.
 
@@ -477,9 +622,19 @@ def _turn_agent_slug(turn: dict) -> str:
     `_agent_env` (whose credentials to load) so the two can never disagree about
     what counts as an agent turn.
     """
-    if (turn.get("origin_ref") or {}).get("chat_session_id"):
+    if _chat_session_id(turn):
         return ""
     return turn.get("agent_slug") or ""
+
+
+def _safe_session_dirname(session_id: str) -> str:
+    """A filesystem-safe basename for a session workdir. `session_id` is normally
+    a canopy Session UUID (server-controlled at creation, but a turn payload is
+    still data off the wire) — this never trusts it enough to join onto a path
+    unsanitized, mirroring packages/canopy_runner/canopy_runner/execute.py's
+    `_safe_name` for the same reason."""
+    cleaned = "".join(c if (c.isalnum() or c in "._-") else "-" for c in session_id).strip(".-")
+    return cleaned[:80] or "unknown-session"
 
 
 def _turn_cwd(turn: dict, turn_id: str) -> pathlib.Path:
@@ -488,21 +643,26 @@ def _turn_cwd(turn: dict, turn_id: str) -> pathlib.Path:
     bootstrapped clone under AGENT_ROOT (bootstrap_agents.sh, run once per
     service start — see bootstrap_agent_fleet) runs IN that clone, freshly
     `git pull`ed here at claim, so it sees the agent's real repo — config,
-    skills, state — not an empty scratch dir. Everything else (project turns,
-    session turns, or an agent bootstrap hasn't reached yet) keeps the original
-    scratch-dir behavior. Best-effort: a pull failure logs and still uses the
-    clone as-is (stale beats absent).
+    skills, state — not an empty scratch dir. Best-effort: a pull failure logs
+    and still uses the clone as-is (stale beats absent).
 
-    Session turns are excluded explicitly: TurnOut surfaces agent_slug for an
-    agent-backed chat session too, but a session turn's "prompt" is one message
-    in an ongoing conversation, not "go work in this repo" — scratch-dir is the
-    right default whether or not the session happens to have an agent identity.
-    (This runner now DOES declare capabilities.sessions and executes session
-    turns directly via `claude -p --resume` — see run_claude/_session_resume_plan
-    — so this is live, not merely anticipatory.)"""
-    # A chat turn surfaces agent_slug (you chat WITH an agent) but carries its
-    # session id in origin_ref — that, not a top-level field, is the session
-    # signal on TurnOut. A live chat is bridged, never run from a checkout.
+    A SESSION turn gets a STABLE per-canopy-Session directory
+    (WORK_DIR/sessions/<chat_session_id>), checked BEFORE the agent-clone branch
+    and never the turn-id scratch dir: Claude Code resolves a `--resume` target
+    by the cwd-derived project directory
+    (~/.claude/projects/<cwd with '/','.' -> '-'>/<session-id>.jsonl), so a
+    session id captured under one cwd is invisible under a different one. Every
+    turn on the same conversation MUST share one cwd or `--resume` can never
+    resolve — keying on the turn id (the pre-fix behavior) handed every turn on
+    a session its own directory and made resume permanently unresolvable.
+    A brand-new-per-turn scratch dir remains correct for project/agent turns
+    (each is its own unit of work), just not for a session's ongoing thread.
+
+    Everything else (project turns, or an agent bootstrap hasn't reached yet)
+    keeps the original scratch-dir behavior."""
+    session_id = _chat_session_id(turn)
+    if session_id:
+        return pathlib.Path(WORK_DIR) / "sessions" / _safe_session_dirname(session_id)
     slug = _turn_agent_slug(turn)
     if slug:
         agent_dir = pathlib.Path(AGENT_ROOT) / slug
@@ -606,15 +766,45 @@ def fetch_and_stage_credential(runner_id: str) -> bool:
 
 # ── session continuity (resolve-session / record-session round-trip) ───────
 def _session_thread_key(turn: dict) -> str:
-    """The chat_session id for a SESSION-targeted turn, or "" for an agent/project
-    turn. apps/canopy_sessions/services.py always stamps BOTH `thread_key` and
-    `chat_session_id` together on a chat send's origin_ref — `chat_session_id`'s
-    presence is the reliable "this is a session turn" signal (mirrors
-    `_turn_agent_slug` above); `thread_key` is what resolve/record-session key on."""
+    """The key resolve-session/record-session use for a SESSION-targeted turn, or
+    "" for an agent/project turn. apps/canopy_sessions/services.py always stamps
+    BOTH `thread_key` and `chat_session_id` together on a chat send's origin_ref;
+    `thread_key` is what the RPCs key on (it can be "emdash:<task>" for a
+    runner-discovered binding, unlike `_chat_session_id`, which is always the
+    canopy Session's own id — that's what `_turn_cwd` keys the workdir on)."""
     ref = turn.get("origin_ref") or {}
-    if not ref.get("chat_session_id"):
+    session_id = _chat_session_id(turn)
+    if not session_id:
         return ""
-    return ref.get("thread_key") or ref["chat_session_id"]
+    return ref.get("thread_key") or session_id
+
+
+# Claude Code resolves a `--resume <id>` target by cwd, not by id alone: the
+# transcript lives at ~/.claude/projects/<cwd with '/','.' -> '-'>/<id>.jsonl.
+# Mirrors packages/canopy_runner/canopy_runner/transcript.py's
+# `encode_project_dir` (duplicated, not imported: that package pulls in
+# non-stdlib deps and this runner is deliberately stdlib-only).
+CLAUDE_PROJECTS_HOME = pathlib.Path.home() / ".claude" / "projects"
+
+
+def _encode_project_dir(cwd: pathlib.Path) -> str:
+    return str(cwd).replace("/", "-").replace(".", "-")
+
+
+def _resume_target_exists(cwd: pathlib.Path, session_id: str) -> bool:
+    """Whether claude actually has a transcript to `--resume` for (cwd, session_id)
+    — the cheap, local equivalent of packages/canopy_runner/execute.py's
+    verify-before-reuse (it reads emdash's DB to confirm a task exists before
+    driving it; this reads the filesystem to confirm a transcript exists before
+    resuming it). Never guesses: a missing file, or any OSError while checking,
+    is treated as "not resumable" so the caller falls back to a fresh spawn
+    instead of a doomed `--resume` invocation."""
+    if not session_id:
+        return False
+    try:
+        return (CLAUDE_PROJECTS_HOME / _encode_project_dir(cwd) / f"{session_id}.jsonl").is_file()
+    except OSError:
+        return False
 
 
 def _session_resume_plan(runner_id: str, turn: dict) -> str:
@@ -626,10 +816,11 @@ def _session_resume_plan(runner_id: str, turn: dict) -> str:
     Reuses the existing resolve-session RPC (apps/harness/api.py) rather than a
     new endpoint — `RunnerBinding.session_key` is documented as "engine-agnostic
     ... was emdash_task", so a raw claude CLI session id is exactly the kind of
-    handle it was generalized to carry. `Session.cli_session_id` (the column
-    SP2b's docstring names for this) stays unwired by this PR — see the PR2
-    report for why that's a deliberate, small, separately-tracked gap rather
-    than blocking this on a schema/service change.
+    handle it was generalized to carry. The originating plan for this work named
+    a `canopy_sessions.Session.cli_session_id` column for this purpose — no such
+    field or docstring exists anywhere in the codebase (confirmed by grep before
+    writing this), so this deliberately reuses the field that DOES exist and is
+    fully wired end to end, rather than adding a new column/service change.
 
     An agentless AND projectless session (legal per the Session model, but not
     something resolve-session's tenant gate accepts today) degrades silently to
@@ -664,10 +855,11 @@ def _record_session_resume(runner_id: str, turn: dict, cli_session_id: str) -> N
 
     Sends BOTH `emdash_task_id` (what's actually read back today, via
     RunnerBinding.session_key) and `session_id` (the wire-compat field already
-    threaded through RecordSessionIn -> services.record_session, currently a
-    documented no-op) — the moment the server wires that param through to
-    `Session.cli_session_id`, this call starts populating it with zero runner-
-    side changes.
+    threaded through RecordSessionIn -> services.record_session, currently
+    accepted and silently discarded there) — if a `Session`-level column for
+    this is ever added and wired server-side, this call starts populating it
+    with zero runner-side changes; see `_session_resume_plan`'s docstring for
+    why no such column exists today despite the originating plan naming one.
     """
     thread_key = _session_thread_key(turn)
     if not thread_key or not cli_session_id:

--- a/deploy/ec2-runner/cloud_runner.py
+++ b/deploy/ec2-runner/cloud_runner.py
@@ -6,12 +6,29 @@ drives a GUI over CDP, which is wrong for a headless box. This pairs a cloud run
 claims harness Turns, runs `claude -p` (stream-json) on the turn's prompt, streams
 the assistant/tool output into the TurnEvent ledger, and finishes the turn.
 
+SESSION-CAPABLE (RC/run-convergence PR2): this runner declares `capabilities.sessions`
+(RUNNER_SESSIONS, default on) so it is eligible to claim chat/session-targeted Turns —
+see Runner.session_capable() in apps/harness/models.py. Every raw stream-json line the
+CLI emits is ALSO forwarded verbatim to POST /turns/{id}/transcript (batched by bytes;
+see deploy/ec2-runner/README.md), in addition to the reduced TurnEvents. And a session
+turn's CLI session id is captured from the stream and round-tripped through the
+existing resolve-session/record-session RPCs so a later turn on the same canopy
+Session can `--resume` it instead of cold-starting — see _session_resume_plan /
+_record_session_resume below for exactly which field carries that id and why.
+
 Config comes from the environment (see deploy/ec2-runner/README.md):
   CANOPY_BASE_URL   e.g. https://labs.connect.dimagi.com/canopy
   CANOPY_TOKEN      a canopy-web Personal Access Token (Bearer)
   RUNNER_NAME       display name (default: this hostname)
   RUNNER_PROJECTS   comma-separated repo names this runner may drive (e.g. canopy-web)
   RUNNER_AGENTS     comma-separated agent slugs this runner may drive (e.g. echo,ada)
+  RUNNER_SESSIONS   whether this runner claims chat/session turns (default: on; "0"/
+                     "false"/"no" to disable)
+  RUNNER_HOST       stable identity for session-reuse gating (default: RUNNER_NAME).
+                     Analogous to emdash's per-macOS-account host, but for a headless
+                     box it just needs to be STABLE across process restarts on the
+                     SAME instance — a new EC2 instance getting a new value is the
+                     correct behavior (see _session_resume_plan).
   RUNNER_WORKSPACE  optional workspace slug (defaults to the token's default)
   CLAUDE_BIN        path to the claude binary (default: claude)
   WORK_DIR          scratch dir for project/session turns and clone-less agents
@@ -40,6 +57,7 @@ import threading
 import time
 import urllib.error
 import urllib.request
+import uuid
 
 BASE_URL = os.environ.get("CANOPY_BASE_URL", "").rstrip("/")
 TOKEN = os.environ.get("CANOPY_TOKEN", "")
@@ -50,14 +68,38 @@ def _csv(name: str) -> list[str]:
     return [x.strip() for x in (os.environ.get(name, "") or "").split(",") if x.strip()]
 
 
+def _bool_env(name: str, default: bool) -> bool:
+    """A tri-state env flag: unset -> `default`; anything else -> its truthiness,
+    with the obvious falsy spellings ("0"/"false"/"no"/"") honored regardless of
+    case. Same env-var-only philosophy as _csv (no JSON in the env file)."""
+    val = os.environ.get(name)
+    if val is None:
+        return default
+    return val.strip().lower() not in ("0", "false", "no", "")
+
+
 # Capabilities as plain comma-separated env vars — no JSON in the env file, which
 # bash `source` and systemd EnvironmentFile both mangle (they strip the quotes).
-RUNNER_CAPS: dict[str, list[str]] = {}
+RUNNER_CAPS: dict[str, object] = {}
 if _csv("RUNNER_PROJECTS"):
     RUNNER_CAPS["projects"] = _csv("RUNNER_PROJECTS")
 if _csv("RUNNER_AGENTS"):
     RUNNER_CAPS["agents"] = _csv("RUNNER_AGENTS")
+# Default ON: this runner kind (headless, `claude -p` subprocess) is exactly the
+# session-capable executor SP2b anticipated (apps/canopy_sessions/models.py's
+# Session.cli_session_id docstring: "continuity for the real subprocess runner").
+# Opt out per-box with RUNNER_SESSIONS=0 if a particular instance should stay
+# agent/project-only.
+RUNNER_SESSIONS = _bool_env("RUNNER_SESSIONS", True)
+if RUNNER_SESSIONS:
+    RUNNER_CAPS["sessions"] = True
 RUNNER_WORKSPACE = os.environ.get("RUNNER_WORKSPACE", "")
+# A stable identity for THIS process/instance, load-bearing for session-reuse
+# gating (RunnerBinding.reusable_by requires host to match — see
+# _session_resume_plan). Unlike emdash's per-macOS-account host, a headless box
+# has no account concept; RUNNER_NAME (which defaults to the hostname) is a fine
+# stand-in as long as it is stable across restarts of the SAME instance.
+RUNNER_HOST = os.environ.get("RUNNER_HOST") or RUNNER_NAME
 CLAUDE_BIN = os.environ.get("CLAUDE_BIN", "claude")
 WORK_DIR = os.environ.get("WORK_DIR", "/tmp/canopy-runner-work")
 # Agent-fleet bootstrap (deploy/ec2-runner/bootstrap_agents.sh) — see
@@ -80,6 +122,16 @@ WS_POLL_TIMEOUT = float(os.environ.get("WS_POLL_TIMEOUT", "3"))
 # apps/harness/services.py) or a long turn gets swept LOST mid-execution.
 LEASE_HEARTBEAT_SECONDS = int(os.environ.get("LEASE_HEARTBEAT_SECONDS", "60"))
 STATE_FILE = pathlib.Path(os.environ.get("STATE_FILE", str(pathlib.Path.home() / ".canopy-cloud-runner.json")))
+
+# The server caps a single POST /turns/{id}/transcript body at 1 MiB of line bytes
+# (apps/harness/api.py::TRANSCRIPT_APPEND_MAX_BYTES) and 422s over it — batch well
+# under that so this runner never has to handle (or silently drop on) that error.
+TRANSCRIPT_APPEND_MAX_BYTES = 900 * 1024
+# Flush the accumulated raw-line buffer once it reaches this many bytes...
+TRANSCRIPT_FLUSH_BYTES = 512 * 1024
+# ...or this many seconds have passed since the last flush, whichever comes first —
+# a quiet turn (waiting on a long tool call) must not sit on unflushed lines forever.
+TRANSCRIPT_FLUSH_SECONDS = 10.0
 
 _stop = False
 
@@ -107,6 +159,44 @@ def _api(method: str, path: str, body: dict | None = None) -> tuple[int, dict | 
         return 0, None
 
 
+def _chunk_transcript_lines(
+    lines: list[str], max_bytes: int = TRANSCRIPT_APPEND_MAX_BYTES
+) -> list[list[str]]:
+    """Split raw JSONL lines into batches whose UTF-8-encoded total stays at or
+    under `max_bytes` — the server enforces a hard per-request byte cap, not a
+    line count, so a single giant tool-result line would blow past a count-based
+    batch. A single line that itself exceeds `max_bytes` still ships alone rather
+    than being dropped (the server's own 100MB per-turn ceiling, not this client,
+    is the backstop for that pathological case)."""
+    batches: list[list[str]] = []
+    current: list[str] = []
+    current_bytes = 0
+    for line in lines:
+        n = len(line.encode("utf-8"))
+        if current and current_bytes + n > max_bytes:
+            batches.append(current)
+            current = []
+            current_bytes = 0
+        current.append(line)
+        current_bytes += n
+    if current:
+        batches.append(current)
+    return batches
+
+
+def _claude_cmd(prompt: str, resume_session_id: str | None = None) -> list[str]:
+    """The `claude -p` argv for one invocation. Split out from `run_claude` so the
+    `--resume` wiring is unit-testable without touching subprocess."""
+    cmd = [
+        CLAUDE_BIN, "-p", prompt,
+        "--output-format", "stream-json", "--verbose",
+        "--dangerously-skip-permissions",
+    ]
+    if resume_session_id:
+        cmd += ["--resume", resume_session_id]
+    return cmd
+
+
 def _start_lease_renewal(runner_id: str, turn_id: str) -> threading.Event:
     """Renew this turn's claim lease for the duration of execution.
 
@@ -130,7 +220,8 @@ def _start_lease_renewal(runner_id: str, turn_id: str) -> threading.Event:
 
     def _loop() -> None:
         while not stop.wait(LEASE_HEARTBEAT_SECONDS):
-            _api("POST", f"/runners/{runner_id}/heartbeat", {"active_turn_ids": [turn_id]})
+            _api("POST", f"/runners/{runner_id}/heartbeat",
+                 {"active_turn_ids": [turn_id], "host": RUNNER_HOST})
 
     threading.Thread(target=_loop, daemon=True, name=f"lease-{turn_id[:8]}").start()
     return stop
@@ -141,11 +232,19 @@ def pair_or_load() -> str:
         rid = json.loads(STATE_FILE.read_text()).get("runner_id")
         if rid:
             # Confirm it still exists (a heartbeat 404 means it was retired).
-            status, _ = _api("POST", f"/runners/{rid}/heartbeat", {"active_turn_ids": []})
+            status, _ = _api("POST", f"/runners/{rid}/heartbeat",
+                              {"active_turn_ids": [], "host": RUNNER_HOST})
             if status == 200:
                 _log(f"reusing runner {rid}")
+                # Capabilities were historically fixed at pairing time; re-pairing
+                # to pick up a changed env var (e.g. RUNNER_SESSIONS flipped on for
+                # a box paired before this feature existed) would mint a NEW runner
+                # id and orphan this one's RunnerBindings. PATCH in place instead
+                # (apps/harness/api.py::update_runner_capabilities) so a redeploy
+                # with a new env always reflects the CURRENT declared capabilities.
+                _api("PATCH", f"/runners/{rid}", {"capabilities": RUNNER_CAPS})
                 return rid
-    body = {"name": RUNNER_NAME, "kind": "cloud", "capabilities": RUNNER_CAPS}
+    body = {"name": RUNNER_NAME, "kind": "cloud", "capabilities": RUNNER_CAPS, "host": RUNNER_HOST}
     if RUNNER_WORKSPACE:
         body["workspace"] = RUNNER_WORKSPACE
     status, payload = _api("POST", "/runners/", body)
@@ -201,23 +300,68 @@ def _agent_env(slug: str | None) -> dict:
     return env
 
 
+def _post_transcript_batch(turn_id: str, attempt_id: str, seq: int, lines: list[str]) -> None:
+    """Ship one already-byte-bounded batch. Best-effort: per the transcript
+    contract (deploy/ec2-runner/README.md), a transcript failure must never fail
+    the turn, so every error is logged and swallowed here, never raised.
+
+    `batch_id` is scoped to (turn, attempt, seq) rather than just (turn, seq): a
+    resume-fallback retry (see `run_claude`) re-invokes this whole function with
+    seq restarting at 1, and reusing a bare `f"{turn_id}:{seq}"` id would collide
+    with the FIRST (failed-resume) attempt's batch 1 — the server's dedup treats
+    a repeated batch_id as a lost-ack retry and silently no-ops it, which would
+    drop the fresh attempt's transcript rather than the intended duplicate."""
+    if not lines:
+        return
+    batch_id = f"{turn_id}:{attempt_id}:{seq}"
+    try:
+        status, _ = _api(
+            "POST", f"/turns/{turn_id}/transcript", {"lines": lines, "batch_id": batch_id}
+        )
+        if status != 200:
+            _log(f"transcript POST turn={turn_id[:8]} batch={seq} -> {status}")
+    except Exception as exc:  # noqa: BLE001 — a transcript hiccup must never fail the turn
+        _log(f"transcript POST turn={turn_id[:8]} batch={seq} raised: {exc}")
+
+
 def run_claude(prompt: str, turn_id: str, emit, cwd: pathlib.Path | None = None,
-               agent_slug: str | None = None) -> tuple[bool, str]:
+               agent_slug: str | None = None, resume_session_id: str | None = None,
+               _resume_retried: bool = False) -> tuple[bool, str, str]:
     """Run `claude -p` on the prompt, streaming stream-json events via `emit`
-    (a callable taking a list of event dicts — WS or REST). Returns (ok, final_text).
+    (a callable taking a list of event dicts — WS or REST). Returns
+    (ok, final_text, cli_session_id).
 
     `cwd` lets the caller run this IN an agent's real clone (see `_turn_cwd`)
     instead of a throwaway scratch dir; None keeps the original scratch-dir
     behavior (project/session turns, or an agent with no bootstrapped clone).
-    `agent_slug` layers that agent's provisioned env on top (see `_agent_env`)."""
+    `agent_slug` layers that agent's provisioned env on top (see `_agent_env`).
+
+    Every raw stream-json line the CLI emits — regardless of whether it parses —
+    is ALSO forwarded verbatim to POST /turns/{id}/transcript, batched by bytes
+    (never held entirely in memory) and flushed periodically and at the end; see
+    `_post_transcript_batch` / TRANSCRIPT_FLUSH_*. This is IN ADDITION to the
+    reduced TurnEvents `emit` carries for the live UI — the transcript is the
+    durable, re-derivable artifact (cost/structure), the ledger stays the live
+    stream (docs/superpowers/specs/2026-07-26-run-execution-convergence-design.md).
+
+    `cli_session_id` is the CLI's own session id, captured from the first event
+    that carries one (normally `system`/`init`, fired before any other output) —
+    the caller round-trips it through record-session so a LATER turn on the same
+    canopy Session can pass it back as `resume_session_id` here.
+
+    `resume_session_id`, if given, is passed as `--resume <id>`. If that yields
+    NOTHING — the process exits non-zero having emitted no stream-json lines at
+    all, the CLI's behavior when a resume target no longer exists — this retries
+    ONCE as a fresh spawn (`_resume_retried` guards against looping), mirroring
+    the reuse-then-fall-back-to-create pattern packages/canopy_runner/execute.py
+    already uses for emdash sessions: never assume continuity works, always have
+    a cold-start fallback.
+    """
     workdir = cwd if cwd is not None else pathlib.Path(WORK_DIR) / turn_id[:8]
     workdir.mkdir(parents=True, exist_ok=True)
-    cmd = [
-        CLAUDE_BIN, "-p", prompt,
-        "--output-format", "stream-json", "--verbose",
-        "--dangerously-skip-permissions",
-    ]
-    _log(f"exec: claude -p (turn {turn_id[:8]}) in {workdir}")
+    cmd = _claude_cmd(prompt, resume_session_id)
+    _log(f"exec: claude -p (turn {turn_id[:8]}) in {workdir}"
+         + (f" --resume {resume_session_id}" if resume_session_id else ""))
     # stderr goes to a file, not PIPE: a chatty claude can fill the 64KB pipe buffer
     # while we're only reading stdout, deadlocking the process. A file has no such
     # limit; we tail it for the failure path below.
@@ -228,8 +372,15 @@ def run_claude(prompt: str, turn_id: str, emit, cwd: pathlib.Path | None = None,
         env=_agent_env(agent_slug),
     )
     final_text = ""
+    cli_session_id = ""
     ok = True
+    lines_seen = 0
     batch: list[dict] = []
+    attempt_id = uuid.uuid4().hex[:8]
+    transcript_buf: list[str] = []
+    transcript_bytes = 0
+    transcript_seq = 0
+    last_transcript_flush = time.monotonic()
 
     def flush():
         nonlocal batch
@@ -237,14 +388,31 @@ def run_claude(prompt: str, turn_id: str, emit, cwd: pathlib.Path | None = None,
             emit(batch)
             batch = []
 
+    def flush_transcript():
+        nonlocal transcript_buf, transcript_bytes, transcript_seq, last_transcript_flush
+        for chunk in _chunk_transcript_lines(transcript_buf):
+            transcript_seq += 1
+            _post_transcript_batch(turn_id, attempt_id, transcript_seq, chunk)
+        transcript_buf = []
+        transcript_bytes = 0
+        last_transcript_flush = time.monotonic()
+
     for line in proc.stdout:  # type: ignore[union-attr]
         line = line.strip()
         if not line:
             continue
+        lines_seen += 1
+        transcript_buf.append(line)
+        transcript_bytes += len(line.encode("utf-8"))
+        if (transcript_bytes >= TRANSCRIPT_FLUSH_BYTES
+                or time.monotonic() - last_transcript_flush >= TRANSCRIPT_FLUSH_SECONDS):
+            flush_transcript()
         try:
             evt = json.loads(line)
         except json.JSONDecodeError:
             continue
+        if evt.get("session_id"):
+            cli_session_id = evt["session_id"]
         etype = evt.get("type")
         if etype == "assistant":
             for block in (evt.get("message", {}).get("content") or []):
@@ -264,6 +432,7 @@ def run_claude(prompt: str, turn_id: str, emit, cwd: pathlib.Path | None = None,
     proc.wait()
     stderr_file.close()
     flush()
+    flush_transcript()
     if proc.returncode != 0 and not final_text:
         ok = False
         try:
@@ -271,7 +440,17 @@ def run_claude(prompt: str, turn_id: str, emit, cwd: pathlib.Path | None = None,
         except OSError:
             tail = ""
         final_text = tail[-500:]
-    return ok, final_text
+    if resume_session_id and not _resume_retried and lines_seen == 0 and proc.returncode != 0:
+        # The CLI emitted NOTHING at all before exiting — the resume target is
+        # gone (expired/evicted), not a genuine task failure. Fall back to a
+        # fresh spawn rather than surfacing a cold "resume failed" as the turn's
+        # result. A failure AFTER real output happened is a genuine task failure
+        # and must not retry (that would silently duplicate work/tokens).
+        _log(f"resume of session {resume_session_id!r} yielded nothing "
+             f"(turn {turn_id[:8]}); falling back to a fresh spawn")
+        return run_claude(prompt, turn_id, emit, cwd=cwd, agent_slug=agent_slug,
+                           resume_session_id=None, _resume_retried=True)
+    return ok, final_text, cli_session_id
 
 
 def _stage_github_token(token: str) -> None:
@@ -315,10 +494,12 @@ def _turn_cwd(turn: dict, turn_id: str) -> pathlib.Path:
     clone as-is (stale beats absent).
 
     Session turns are excluded explicitly: TurnOut surfaces agent_slug for an
-    agent-backed chat session too, but a live chat session is bridged, not run
-    from a repo checkout — so a chat turn must keep scratch-dir behavior even
-    once cloud sessions ship (this runner does not declare capabilities.sessions
-    today, so it is inert now, but the guard makes the intent explicit)."""
+    agent-backed chat session too, but a session turn's "prompt" is one message
+    in an ongoing conversation, not "go work in this repo" — scratch-dir is the
+    right default whether or not the session happens to have an agent identity.
+    (This runner now DOES declare capabilities.sessions and executes session
+    turns directly via `claude -p --resume` — see run_claude/_session_resume_plan
+    — so this is live, not merely anticipatory.)"""
     # A chat turn surfaces agent_slug (you chat WITH an agent) but carries its
     # session id in origin_ref — that, not a top-level field, is the session
     # signal on TurnOut. A live chat is bridged, never run from a checkout.
@@ -423,19 +604,111 @@ def fetch_and_stage_credential(runner_id: str) -> bool:
     return False
 
 
+# ── session continuity (resolve-session / record-session round-trip) ───────
+def _session_thread_key(turn: dict) -> str:
+    """The chat_session id for a SESSION-targeted turn, or "" for an agent/project
+    turn. apps/canopy_sessions/services.py always stamps BOTH `thread_key` and
+    `chat_session_id` together on a chat send's origin_ref — `chat_session_id`'s
+    presence is the reliable "this is a session turn" signal (mirrors
+    `_turn_agent_slug` above); `thread_key` is what resolve/record-session key on."""
+    ref = turn.get("origin_ref") or {}
+    if not ref.get("chat_session_id"):
+        return ""
+    return ref.get("thread_key") or ref["chat_session_id"]
+
+
+def _session_resume_plan(runner_id: str, turn: dict) -> str:
+    """Ask the server whether a PRIOR turn on this same canopy Session left a CLI
+    session id this runner can `--resume`. Returns that id, or "" for a fresh
+    spawn (brand new thread, a different runner/host owns the hint, or the turn
+    is not a session turn at all).
+
+    Reuses the existing resolve-session RPC (apps/harness/api.py) rather than a
+    new endpoint — `RunnerBinding.session_key` is documented as "engine-agnostic
+    ... was emdash_task", so a raw claude CLI session id is exactly the kind of
+    handle it was generalized to carry. `Session.cli_session_id` (the column
+    SP2b's docstring names for this) stays unwired by this PR — see the PR2
+    report for why that's a deliberate, small, separately-tracked gap rather
+    than blocking this on a schema/service change.
+
+    An agentless AND projectless session (legal per the Session model, but not
+    something resolve-session's tenant gate accepts today) degrades silently to
+    fresh-per-turn here rather than failing the turn.
+    """
+    thread_key = _session_thread_key(turn)
+    if not thread_key:
+        return ""
+    agent_slug = turn.get("agent_slug") or ""
+    project = turn.get("project") or ""
+    if not agent_slug and not project:
+        return ""
+    body: dict = {"thread_key": thread_key}
+    if project:
+        body["project"] = project
+        body["workspace"] = turn.get("workspace_slug") or ""
+    else:
+        body["agent_slug"] = agent_slug
+    status, plan = _api("POST", f"/runners/{runner_id}/resolve-session", body)
+    if status != 200 or not plan:
+        return ""
+    if plan.get("reuse") and plan.get("emdash_task_id"):
+        return plan["emdash_task_id"]
+    return ""
+
+
+def _record_session_resume(runner_id: str, turn: dict, cli_session_id: str) -> None:
+    """Persist this turn's real CLI session id as the thread's engine handle, so
+    a LATER turn on the same canopy Session can `--resume` it (see
+    `_session_resume_plan`). Best-effort: a failure here only degrades the NEXT
+    turn to a fresh spawn, never this one — logged, never raised.
+
+    Sends BOTH `emdash_task_id` (what's actually read back today, via
+    RunnerBinding.session_key) and `session_id` (the wire-compat field already
+    threaded through RecordSessionIn -> services.record_session, currently a
+    documented no-op) — the moment the server wires that param through to
+    `Session.cli_session_id`, this call starts populating it with zero runner-
+    side changes.
+    """
+    thread_key = _session_thread_key(turn)
+    if not thread_key or not cli_session_id:
+        return
+    agent_slug = turn.get("agent_slug") or ""
+    project = turn.get("project") or ""
+    if not agent_slug and not project:
+        return
+    body: dict = {
+        "thread_key": thread_key,
+        "emdash_task_id": cli_session_id,
+        "session_id": cli_session_id,
+    }
+    if project:
+        body["project"] = project
+        body["workspace"] = turn.get("workspace_slug") or ""
+    else:
+        body["agent_slug"] = agent_slug
+    try:
+        status, _ = _api("POST", f"/runners/{runner_id}/record-session", body)
+        if status != 200:
+            _log(f"record-session turn={str(turn.get('id', ''))[:8]} -> {status}")
+    except Exception as exc:  # noqa: BLE001 — never let this fail the turn
+        _log(f"record-session turn={str(turn.get('id', ''))[:8]} raised: {exc}")
+
+
 # ── REST fallback loop (poll) ───────────────────────────────────────────────
 def run_over_rest(runner_id: str) -> None:
     _log(f"polling {BASE_URL} every {POLL_SECONDS}s (REST fallback)")
     while not _stop:
-        _api("POST", f"/runners/{runner_id}/heartbeat", {"active_turn_ids": []})
+        _api("POST", f"/runners/{runner_id}/heartbeat", {"active_turn_ids": [], "host": RUNNER_HOST})
         status, turn = _api("POST", f"/runners/{runner_id}/claim")
         if status != 200 or not turn:
             time.sleep(POLL_SECONDS)
             continue
         turn_id = turn["id"]
         _log(f"claimed turn {turn_id[:8]} target={turn.get('target')} (REST)")
-        _api("POST", f"/turns/{turn_id}/start", {"session_id": f"cloud-{turn_id[:8]}"})
-        _api("POST", f"/runners/{runner_id}/heartbeat", {"active_turn_ids": [turn_id]})
+        resume_id = _session_resume_plan(runner_id, turn)
+        _api("POST", f"/turns/{turn_id}/start",
+             {"session_id": resume_id or f"cloud-{turn_id[:8]}"})
+        _api("POST", f"/runners/{runner_id}/heartbeat", {"active_turn_ids": [turn_id], "host": RUNNER_HOST})
         cwd = _turn_cwd(turn, turn_id)
 
         def emit(events, _tid=turn_id):
@@ -444,12 +717,16 @@ def run_over_rest(runner_id: str) -> None:
         lease_stop = _start_lease_renewal(runner_id, turn_id)
         try:
             try:
-                ok, text = run_claude(turn.get("prompt", ""), turn_id, emit, cwd=cwd,
-                                  agent_slug=_turn_agent_slug(turn))
+                ok, text, cli_session_id = run_claude(
+                    turn.get("prompt", ""), turn_id, emit, cwd=cwd,
+                    agent_slug=_turn_agent_slug(turn), resume_session_id=resume_id or None,
+                )
             except Exception as exc:  # never let one turn kill the loop
-                ok, text = False, f"runner error: {exc}"
+                ok, text, cli_session_id = False, f"runner error: {exc}", ""
         finally:
             lease_stop.set()  # turn is over (success/failure/exception) — stop renewing
+        if cli_session_id:
+            _record_session_resume(runner_id, turn, cli_session_id)
         finish = "done" if ok else "failed"
         _api("POST", f"/turns/{turn_id}/finish", {"status": finish, "result_note": text[:2000]})
         _log(f"finished turn {turn_id[:8]}: {finish}")
@@ -504,7 +781,9 @@ def _claim_and_run_once(ws, runner_id: str) -> bool:
         return False
     tid = turn["id"]
     _log(f"claimed turn {tid[:8]} target={turn.get('target')} (WS)")
-    _ws_request(ws, {"action": "start", "turn_id": tid, "session_id": f"cloud-{tid[:8]}"}, "start.ack")
+    resume_id = _session_resume_plan(runner_id, turn)
+    _ws_request(ws, {"action": "start", "turn_id": tid,
+                     "session_id": resume_id or f"cloud-{tid[:8]}"}, "start.ack")
     cwd = _turn_cwd(turn, tid)
 
     def emit(events, _tid=tid):
@@ -516,12 +795,16 @@ def _claim_and_run_once(ws, runner_id: str) -> bool:
     lease_stop = _start_lease_renewal(runner_id, tid)
     try:
         try:
-            ok, text = run_claude(turn.get("prompt", ""), tid, emit, cwd=cwd,
-                                  agent_slug=_turn_agent_slug(turn))
+            ok, text, cli_session_id = run_claude(
+                turn.get("prompt", ""), tid, emit, cwd=cwd,
+                agent_slug=_turn_agent_slug(turn), resume_session_id=resume_id or None,
+            )
         except Exception as exc:
-            ok, text = False, f"runner error: {exc}"
+            ok, text, cli_session_id = False, f"runner error: {exc}", ""
     finally:
         lease_stop.set()  # turn is over (success/failure/exception) — stop renewing
+    if cli_session_id:
+        _record_session_resume(runner_id, turn, cli_session_id)
     _ws_request(ws, {"action": "finish", "turn_id": tid,
                      "status": "done" if ok else "failed", "result_note": text[:2000]}, "finish.ack")
     _log(f"finished turn {tid[:8]} (WS): {'done' if ok else 'failed'}")

--- a/deploy/ec2-runner/cloud_runner.py
+++ b/deploy/ec2-runner/cloud_runner.py
@@ -138,6 +138,12 @@ WS_POLL_TIMEOUT = float(os.environ.get("WS_POLL_TIMEOUT", "3"))
 LEASE_HEARTBEAT_SECONDS = int(os.environ.get("LEASE_HEARTBEAT_SECONDS", "60"))
 STATE_FILE = pathlib.Path(os.environ.get("STATE_FILE", str(pathlib.Path.home() / ".canopy-cloud-runner.json")))
 
+# Bound on reaping the claude subprocess in run_claude's cleanup (review N1) —
+# a bare, untimed proc.wait() can hang the RUNNER forever if the child is still
+# alive with an undrained stdout pipe (a mid-loop exception leaves exactly that
+# state). Always kill/close before waiting, and never wait unboundedly.
+PROC_REAP_TIMEOUT_SECONDS = 15.0
+
 # The server caps a single POST /turns/{id}/transcript body at 1 MiB of line bytes
 # (apps/harness/api.py::TRANSCRIPT_APPEND_MAX_BYTES) and 422s over it — batch well
 # under that so this runner never has to handle (or silently drop on) that error.
@@ -458,38 +464,69 @@ def run_claude(prompt: str, turn_id: str, emit, cwd: pathlib.Path | None = None,
     transcript_bytes = 0
     transcript_seq = 0
     transcript_stopped = False  # latched True once the server reports `truncated`
-    # Guards transcript_buf/transcript_bytes/transcript_seq/transcript_stopped,
-    # which the main read loop AND the periodic flush thread below both touch.
+    # Guards transcript_buf/transcript_bytes/transcript_seq/transcript_stopped —
+    # held only for FAST, non-blocking mutations (list swap, int increment).
+    # Never held across network I/O (review N2): the read loop's per-line
+    # append takes this lock on every single line, so if it also covered the
+    # POST it would stall stdout-draining for as long as canopy-web is slow —
+    # the same full-pipe-stall failure mode N1 fixes, just caused by a slow
+    # server instead of a raised exception.
     transcript_lock = threading.Lock()
+    # Separate lock serializing actual POSTING order across the two producers
+    # (the read loop's own byte-triggered flush, and the periodic thread
+    # below) — held ACROSS the network call, unlike transcript_lock. Without
+    # this, two concurrent flushes could swap out their content in order but
+    # POST in the opposite order if the earlier one is slower (e.g. retrying
+    # a 500), corrupting the transcript's byte ordering. Acquired for the
+    # whole of one flush_transcript() call (swap included), so at most one
+    # flush is ever "in flight" — this is where the backpressure N2 flags
+    # actually still exists (flush vs. flush), which is fine: it only ever
+    # blocks ANOTHER FLUSH, never the read loop's line-by-line appending.
+    transcript_post_lock = threading.Lock()
     transcript_flush_stop = threading.Event()
 
     def flush():
+        # Swap BEFORE calling emit (same pattern as flush_transcript's swap-
+        # before-post): if `emit` raises, `batch` must already be empty, or
+        # the `finally` block's own `flush()` call (see below) would re-emit
+        # the identical batch a second time — a duplicate-events bug this
+        # test suite caught while building a genuine mid-loop-exception case
+        # for N1 (a raising `emit` left `batch` non-empty under the old
+        # emit-then-clear order).
         nonlocal batch
-        if batch:
-            emit(batch)
-            batch = []
+        if not batch:
+            return
+        pending = batch
+        batch = []
+        emit(pending)
 
     def flush_transcript():
-        # Swap-and-clear happens under the lock (short critical section); the
-        # actual chunking + network POSTs run with the lock HELD too (simpler
-        # and race-free, at the cost of some backpressure on a concurrent
-        # appender — the same tradeoff `emit()` already carries elsewhere in
-        # this file). `nonlocal` writes inside a `with` block are fine: the
-        # lock only serializes callers, it doesn't scope the names.
+        # transcript_post_lock is held for the WHOLE call (swap through the
+        # last POST) so at most one flush is ever in flight and posts land in
+        # swap order — but transcript_lock (the one the read loop's per-line
+        # append also needs) is only ever held for the swap itself and for
+        # each seq allocation, never across `_post_transcript_batch`'s network
+        # call (review N2 — see the lock declarations above for why).
         nonlocal transcript_buf, transcript_bytes, transcript_seq, transcript_stopped
-        with transcript_lock:
-            if not transcript_buf or transcript_stopped:
+        with transcript_post_lock:
+            with transcript_lock:
+                if not transcript_buf or transcript_stopped:
+                    transcript_buf = []
+                    transcript_bytes = 0
+                    return
+                pending = transcript_buf
                 transcript_buf = []
                 transcript_bytes = 0
-                return
-            pending = transcript_buf
-            transcript_buf = []
-            transcript_bytes = 0
             for chunk in _chunk_transcript_lines(pending):
-                transcript_seq += 1
-                if not _post_transcript_batch(turn_id, attempt_id, transcript_seq, chunk):
-                    transcript_stopped = True
-                    break
+                with transcript_lock:
+                    if transcript_stopped:
+                        return
+                    transcript_seq += 1
+                    seq = transcript_seq
+                if not _post_transcript_batch(turn_id, attempt_id, seq, chunk):
+                    with transcript_lock:
+                        transcript_stopped = True
+                    return
 
     def _periodic_flush() -> None:
         # The byte-size flush trigger below only runs when a NEW line arrives,
@@ -551,10 +588,45 @@ def run_claude(prompt: str, turn_id: str, emit, cwd: pathlib.Path | None = None,
         # no try/finally at all, so an exception mid-loop — e.g. the WS `emit`
         # breaking on a dropped socket — dropped every buffered line/event).
         transcript_flush_stop.set()
+        # KILL (AND CLOSE STDOUT) BEFORE REAPING — unconditionally, regardless
+        # of whether the loop reached EOF (review N1). On a mid-loop exception
+        # `claude` can still be RUNNING with its stdout pipe no longer drained;
+        # once the 64KB pipe buffer fills, the child blocks on write and a
+        # bare `proc.wait()` NEVER RETURNS. That doesn't just fail this turn —
+        # it means run_claude() itself never returns, so the caller's own
+        # `finally: lease_stop.set()` never runs, the lease-renewal thread
+        # keeps heartbeating this turn EXECUTING forever, and
+        # one_executing_turn_per_agent wedges the whole agent permanently
+        # (the exact "wedged-but-heartbeating runner" pathology CLAUDE.md
+        # documents) — worse than the turn simply failing.
+        #
+        # Closing stdout first unblocks any pending write (the read end going
+        # away delivers SIGPIPE/EPIPE to the writer); kill() on a process that
+        # already exited cleanly (the ordinary happy path, where the loop
+        # already reached EOF) is a harmless no-op signal to a reapable
+        # zombie — Python's Popen doesn't guard against re-signaling because
+        # nothing here has called wait()/poll() yet to know it's dead.
         try:
-            proc.wait()
-        except Exception:  # noqa: BLE001 — best-effort reap; loop_error already captured
+            proc.stdout.close()  # type: ignore[union-attr]
+        except Exception:  # noqa: BLE001 — best-effort; still try to kill below
             pass
+        try:
+            proc.kill()
+        except Exception:  # noqa: BLE001 — best-effort; still try to wait below
+            pass
+        # The wait itself is ALSO bounded — never unconditional — because a
+        # kill() can still leave a zombie the OS is slow to reap, and this
+        # runner must never block on that either.
+        try:
+            proc.wait(timeout=PROC_REAP_TIMEOUT_SECONDS)
+        except Exception:  # noqa: BLE001 — subprocess.TimeoutExpired or worse
+            try:
+                proc.kill()
+                proc.wait(timeout=PROC_REAP_TIMEOUT_SECONDS)
+            except Exception:  # noqa: BLE001 — truly never block cleanup on this
+                _log(f"warn: turn {turn_id[:8]}: could not reap the claude "
+                     "subprocess (pid may be leaked) — continuing rather than "
+                     "blocking the runner")
         stderr_file.close()
         try:
             flush()  # calls the caller-supplied `emit` — can itself raise (e.g. a dead WS)

--- a/deploy/ec2-runner/tests/conftest.py
+++ b/deploy/ec2-runner/tests/conftest.py
@@ -1,0 +1,42 @@
+"""Loads deploy/ec2-runner/cloud_runner.py by path.
+
+cloud_runner.py is deliberately stdlib-only and lives under a hyphenated
+directory (`ec2-runner`), which is not a valid Python package name — it can
+never be `import`ed as `deploy.ec2_runner.cloud_runner`. Loading it via
+importlib.util by its file path sidesteps that entirely and needs no
+packaging changes to the runner itself.
+"""
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+
+import pytest
+
+_MODULE_PATH = pathlib.Path(__file__).resolve().parent.parent / "cloud_runner.py"
+
+
+def _load_cloud_runner():
+    spec = importlib.util.spec_from_file_location("cloud_runner", _MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["cloud_runner"] = module
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+@pytest.fixture
+def load_cloud_runner():
+    """A callable, so a test can set env vars (via monkeypatch) BEFORE the
+    module-level RUNNER_CAPS/RUNNER_SESSIONS/etc. reads happen at import time."""
+    return _load_cloud_runner
+
+
+@pytest.fixture
+def cloud_runner(load_cloud_runner):
+    """A freshly (re)loaded module per test with whatever env is ambient at
+    fixture-setup time — cheap, and guarantees no test can leak module-level
+    state (RUNNER_CAPS, _stop, ...) into another. Tests that care about
+    specific env values should use `load_cloud_runner` directly instead, so
+    they can set env before loading."""
+    return load_cloud_runner()

--- a/deploy/ec2-runner/tests/test_cloud_runner.py
+++ b/deploy/ec2-runner/tests/test_cloud_runner.py
@@ -6,6 +6,10 @@ against (see the PR2 report for what this suite does and does not cover).
 """
 from __future__ import annotations
 
+import json
+import threading
+import time
+
 ENV_KEYS = (
     "RUNNER_SESSIONS", "RUNNER_HOST", "RUNNER_NAME", "RUNNER_PROJECTS",
     "RUNNER_AGENTS", "RUNNER_WORKSPACE",
@@ -36,19 +40,22 @@ def test_bool_env_truthy_spellings(cloud_runner, monkeypatch):
         assert cloud_runner._bool_env("X_FLAG", False) is True, spelling
 
 
-def test_sessions_capability_default_on(load_cloud_runner, monkeypatch):
+def test_sessions_capability_default_off(load_cloud_runner, monkeypatch):
+    """Opt-in, not opt-out: this runner has no durable-record path for a chat
+    session yet (review C1), so claiming session turns must not happen unless
+    an operator deliberately turns it on."""
     _clean_env(monkeypatch)
-    mod = load_cloud_runner()
-    assert mod.RUNNER_SESSIONS is True
-    assert mod.RUNNER_CAPS.get("sessions") is True
-
-
-def test_sessions_capability_opt_out(load_cloud_runner, monkeypatch):
-    _clean_env(monkeypatch)
-    monkeypatch.setenv("RUNNER_SESSIONS", "0")
     mod = load_cloud_runner()
     assert mod.RUNNER_SESSIONS is False
     assert "sessions" not in mod.RUNNER_CAPS
+
+
+def test_sessions_capability_opt_in(load_cloud_runner, monkeypatch):
+    _clean_env(monkeypatch)
+    monkeypatch.setenv("RUNNER_SESSIONS", "1")
+    mod = load_cloud_runner()
+    assert mod.RUNNER_SESSIONS is True
+    assert mod.RUNNER_CAPS.get("sessions") is True
 
 
 def test_runner_host_defaults_to_runner_name(load_cloud_runner, monkeypatch):
@@ -110,10 +117,31 @@ def test_chunk_transcript_lines_stays_under_cap(cloud_runner):
         assert sum(len(line.encode("utf-8")) for line in batch) <= 50 or len(batch) == 1
 
 
-def test_chunk_transcript_lines_oversized_single_line_ships_alone(cloud_runner):
+def test_chunk_transcript_lines_oversized_single_line_becomes_marker(cloud_runner):
+    """An oversized line can never fit even alone (the server 422s the whole
+    request over its byte cap before the 100MB per-turn ceiling is ever
+    consulted) — it must not be shipped verbatim, and must not vanish either
+    (review I4)."""
     huge = "x" * 1000
     batches = cloud_runner._chunk_transcript_lines(["a", huge, "b"], max_bytes=10)
-    assert batches == [["a"], [huge], ["b"]]
+    assert batches[0] == ["a"]
+    assert batches[-1] == ["b"]
+    assert len(batches) == 3
+    marker = json.loads(batches[1][0])
+    assert marker["type"] == "canopy_runner_line_dropped"
+    assert marker["bytes"] == 1000
+    # The marker itself must fit comfortably under the cap, or it would just
+    # recreate the same problem.
+    assert len(batches[1][0].encode("utf-8")) <= 200
+
+
+def test_chunk_transcript_lines_oversized_line_does_not_merge_with_neighbors(cloud_runner):
+    huge = "y" * 500
+    batches = cloud_runner._chunk_transcript_lines(["a", "b", huge, "c", "d"], max_bytes=10)
+    # "a","b" batch together; the marker stands alone; "c","d" batch together.
+    assert batches[0] == ["a", "b"]
+    assert json.loads(batches[1][0])["type"] == "canopy_runner_line_dropped"
+    assert batches[2] == ["c", "d"]
 
 
 # ── --resume argv ────────────────────────────────────────────────────────────
@@ -127,6 +155,76 @@ def test_claude_cmd_without_resume(cloud_runner):
 def test_claude_cmd_with_resume(cloud_runner):
     cmd = cloud_runner._claude_cmd("hello", "sess-123")
     assert cmd[-2:] == ["--resume", "sess-123"]
+
+
+# ── resume-target existence check (review C2 / I1) ──────────────────────────
+
+def _stage_resume_target(cloud_runner, monkeypatch, tmp_path, cwd, session_id):
+    """Make it look like claude has a real transcript for (cwd, session_id) —
+    the exact convention `_resume_target_exists` reads
+    (~/.claude/projects/<encoded-cwd>/<session-id>.jsonl)."""
+    projects_home = tmp_path / "claude-projects-home"
+    monkeypatch.setattr(cloud_runner, "CLAUDE_PROJECTS_HOME", projects_home)
+    proj_dir = projects_home / cloud_runner._encode_project_dir(cwd)
+    proj_dir.mkdir(parents=True, exist_ok=True)
+    (proj_dir / f"{session_id}.jsonl").write_text("")
+    return projects_home
+
+
+def test_resume_target_exists_false_when_no_file(cloud_runner, monkeypatch, tmp_path):
+    monkeypatch.setattr(cloud_runner, "CLAUDE_PROJECTS_HOME", tmp_path / "nope")
+    assert cloud_runner._resume_target_exists(tmp_path / "work", "some-session") is False
+
+
+def test_resume_target_exists_true_when_staged(cloud_runner, monkeypatch, tmp_path):
+    cwd = tmp_path / "work"
+    _stage_resume_target(cloud_runner, monkeypatch, tmp_path, cwd, "some-session")
+    assert cloud_runner._resume_target_exists(cwd, "some-session") is True
+
+
+def test_resume_target_exists_false_for_empty_session_id(cloud_runner, tmp_path):
+    assert cloud_runner._resume_target_exists(tmp_path, "") is False
+
+
+# ── stable per-session workdir (review C2) ──────────────────────────────────
+
+def test_turn_cwd_session_turn_is_stable_across_turn_ids(cloud_runner):
+    """The whole point of the fix: two DIFFERENT turns on the SAME canopy
+    Session must resolve to the SAME cwd, or --resume can never find its
+    target (Claude Code resolves a session by cwd-derived project dir)."""
+    turn_a = {"origin_ref": {"chat_session_id": "sess-fixed-1"}}
+    turn_b = {"origin_ref": {"chat_session_id": "sess-fixed-1"}}
+    cwd_a = cloud_runner._turn_cwd(turn_a, "turn-id-aaaaaaaa")
+    cwd_b = cloud_runner._turn_cwd(turn_b, "turn-id-bbbbbbbb")
+    assert cwd_a == cwd_b
+
+
+def test_turn_cwd_different_sessions_get_different_dirs(cloud_runner):
+    turn_a = {"origin_ref": {"chat_session_id": "sess-1"}}
+    turn_b = {"origin_ref": {"chat_session_id": "sess-2"}}
+    assert (cloud_runner._turn_cwd(turn_a, "t1")
+            != cloud_runner._turn_cwd(turn_b, "t2"))
+
+
+def test_turn_cwd_session_turn_ignores_agent_slug(cloud_runner):
+    """A session turn can carry agent_slug too (you chat WITH an agent), but it
+    must still get the stable session dir, not the agent's clone — a session
+    turn is one message in an ongoing conversation, not "go work in this repo"."""
+    turn = {"agent_slug": "ace", "origin_ref": {"chat_session_id": "sess-99"}}
+    cwd = cloud_runner._turn_cwd(turn, "t1")
+    assert "sessions" in cwd.parts
+    assert "sess-99" in cwd.parts
+
+
+def test_turn_cwd_non_session_agent_turn_unaffected(cloud_runner, tmp_path, monkeypatch):
+    """A non-session agent turn with no bootstrapped clone (no AGENT_ROOT/<slug>/
+    .git) keeps the pre-existing turn-id-keyed scratch-dir behavior — the C2
+    fix only changes behavior for SESSION turns."""
+    monkeypatch.setattr(cloud_runner, "AGENT_ROOT", str(tmp_path))  # no .git -> falls through
+    turn = {"agent_slug": "ace", "origin_ref": {}}
+    cwd = cloud_runner._turn_cwd(turn, "turn-id-12345678")
+    assert cwd == cloud_runner.pathlib.Path(cloud_runner.WORK_DIR) / "turn-id-12345678"[:8]
+    assert "sessions" not in cwd.parts
 
 
 # ── session continuity plumbing ──────────────────────────────────────────────
@@ -191,13 +289,20 @@ def test_session_resume_plan_no_reuse_returns_empty(cloud_runner, monkeypatch):
 
 
 def test_session_resume_plan_project_turn_sends_workspace(cloud_runner, monkeypatch):
+    called = []
+
     def fake_api(method, path, body=None):
+        called.append((method, path, body))
         assert body == {"thread_key": "thread-abc", "project": "canopy-web", "workspace": "acme"}
         return 200, {"reuse": False, "emdash_task_id": ""}
 
     monkeypatch.setattr(cloud_runner, "_api", fake_api)
     turn = _session_turn(agent_slug="", project="canopy-web")
     cloud_runner._session_resume_plan("runner-1", turn)
+    # Vacuous-pass guard (review): if _session_resume_plan stopped calling _api
+    # entirely, the assertions inside fake_api would never run and this test
+    # would pass for the wrong reason.
+    assert called, "_session_resume_plan never called _api"
 
 
 def test_record_session_resume_sends_both_fields(cloud_runner, monkeypatch):
@@ -233,10 +338,44 @@ def test_record_session_resume_never_raises_on_transport_failure(cloud_runner, m
     cloud_runner._record_session_resume("runner-1", _session_turn(), "cli-sess-9")
 
 
+# ── transcript POST retry / truncation (review I5) ──────────────────────────
+
+def test_post_transcript_batch_retries_then_succeeds(cloud_runner, monkeypatch):
+    attempts = []
+
+    def flaky_api(method, path, body=None):
+        attempts.append(body["batch_id"])
+        if len(attempts) < 3:
+            return 500, None
+        return 200, {"truncated": False}
+
+    monkeypatch.setattr(cloud_runner, "_api", flaky_api)
+    monkeypatch.setattr(cloud_runner.time, "sleep", lambda *_a: None)  # don't slow the test down
+    ok = cloud_runner._post_transcript_batch("turn-1", "att1", 1, ["line-a"])
+    assert ok is True
+    assert len(attempts) == 3
+    # Same batch_id on every retry — a fabricated new id per attempt would
+    # defeat the server's dedup and is exactly what the docstring warns against.
+    assert len(set(attempts)) == 1
+
+
+def test_post_transcript_batch_gives_up_after_max_retries_without_raising(cloud_runner, monkeypatch):
+    monkeypatch.setattr(cloud_runner, "_api", lambda *a, **k: (500, None))
+    monkeypatch.setattr(cloud_runner.time, "sleep", lambda *_a: None)
+    # Must not raise, and must return True (keep trying future batches) even
+    # though THIS batch never landed.
+    assert cloud_runner._post_transcript_batch("turn-1", "att1", 1, ["line-a"]) is True
+
+
+def test_post_transcript_batch_stops_on_truncated(cloud_runner, monkeypatch):
+    monkeypatch.setattr(cloud_runner, "_api", lambda *a, **k: (200, {"truncated": True}))
+    assert cloud_runner._post_transcript_batch("turn-1", "att1", 1, ["line-a"]) is False
+
+
 # ── run_claude: transcript forwarding + session-id capture + resume fallback ─
 
 class _FakeProc:
-    def __init__(self, lines: list[str], returncode: int = 0):
+    def __init__(self, lines, returncode: int = 0):
         self.stdout = iter(lines)
         self.returncode = returncode
 
@@ -245,7 +384,6 @@ class _FakeProc:
 
 
 def _stream_json_lines(session_id: str, text: str) -> list[str]:
-    import json
     return [
         json.dumps({"type": "system", "subtype": "init", "session_id": session_id}) + "\n",
         json.dumps({
@@ -282,9 +420,18 @@ def test_run_claude_captures_session_id_and_forwards_transcript(cloud_runner, mo
     # Every raw line shipped verbatim, in order, across however many batches.
     shipped = [line for call in transcript_calls for line in call["lines"]]
     assert shipped == [line.strip() for line in lines]
-    # Distinct batch_ids (no accidental collisions/dedup-by-accident).
-    batch_ids = [call["batch_id"] for call in transcript_calls]
-    assert len(batch_ids) == len(set(batch_ids))
+    # batch_id is `{turn_id}:{attempt_id}:{seq}` — STABLE attempt id across
+    # every batch of this one attempt, with strictly increasing seq. A bare
+    # uuid4() per POST (the exact regression this guards against — it would
+    # destroy the server's retry-dedup) would fail the "same attempt id"
+    # assertion below even though a naive distinctness check could not
+    # tell it apart from the real thing.
+    parsed = [call["batch_id"].split(":") for call in transcript_calls]
+    assert all(p[0] == "turn-abc12345" for p in parsed)
+    attempt_ids = {p[1] for p in parsed}
+    assert len(attempt_ids) == 1, "attempt id must be stable across all batches of one attempt"
+    seqs = [int(p[2]) for p in parsed]
+    assert seqs == sorted(seqs) == list(range(1, len(seqs) + 1))
     assert any(e["kind"] == "assistant" for e in events)
 
 
@@ -303,9 +450,37 @@ def test_run_claude_transcript_failure_does_not_fail_turn(cloud_runner, monkeypa
     assert cli_session_id == "sess-2"
 
 
+def test_run_claude_no_resume_target_never_invokes_resume(cloud_runner, monkeypatch, tmp_path):
+    """No staged transcript for the given (cwd, session_id) -> claude is never
+    even invoked with --resume; it goes straight to a fresh spawn in ONE
+    subprocess call, not a wasted resume-then-fallback round trip."""
+    monkeypatch.setattr(cloud_runner, "CLAUDE_PROJECTS_HOME", tmp_path / "nothing-here")
+    fresh_lines = _stream_json_lines("brand-new", "fresh")
+    popen_calls = []
+
+    def fake_popen(cmd, **_kwargs):
+        popen_calls.append(cmd)
+        return _FakeProc(fresh_lines, returncode=0)
+
+    monkeypatch.setattr(cloud_runner.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(cloud_runner, "_api", lambda *a, **k: (200, {}))
+
+    ok, text, cli_session_id = cloud_runner.run_claude(
+        "hi", "turn-noresume", lambda batch: None, cwd=tmp_path / "work",
+        resume_session_id="never-existed",
+    )
+    assert len(popen_calls) == 1
+    assert "--resume" not in popen_calls[0]
+    assert ok is True
+    assert cli_session_id == "brand-new"
+
+
 def test_run_claude_resume_fallback_to_fresh_spawn(cloud_runner, monkeypatch, tmp_path):
-    """A --resume attempt that yields NOTHING (no lines, non-zero exit) retries
-    once as a fresh spawn, dropping --resume from argv the second time."""
+    """A staged (existing) --resume target that STILL yields NOTHING (no
+    lines, non-zero exit) retries once as a fresh spawn, dropping --resume
+    from argv the second time."""
+    cwd = tmp_path / "work"
+    _stage_resume_target(cloud_runner, monkeypatch, tmp_path, cwd, "stale-session-id")
     fresh_lines = _stream_json_lines("brand-new-session", "fresh reply")
     popen_calls: list[list[str]] = []
 
@@ -319,7 +494,7 @@ def test_run_claude_resume_fallback_to_fresh_spawn(cloud_runner, monkeypatch, tm
     monkeypatch.setattr(cloud_runner, "_api", lambda *a, **k: (200, {}))
 
     ok, text, cli_session_id = cloud_runner.run_claude(
-        "hi", "turn-resume", lambda batch: None, cwd=tmp_path,
+        "hi", "turn-resume", lambda batch: None, cwd=cwd,
         resume_session_id="stale-session-id",
     )
 
@@ -333,7 +508,8 @@ def test_run_claude_resume_fallback_to_fresh_spawn(cloud_runner, monkeypatch, tm
 def test_run_claude_genuine_failure_after_output_does_not_retry(cloud_runner, monkeypatch, tmp_path):
     """A resumed session that DID produce output before failing must not be
     silently retried fresh — that would duplicate work under a new session."""
-    import json
+    cwd = tmp_path / "work"
+    _stage_resume_target(cloud_runner, monkeypatch, tmp_path, cwd, "stale-session-id")
     lines = [
         json.dumps({"type": "system", "subtype": "init", "session_id": "resumed-1"}) + "\n",
         json.dumps({"type": "result", "session_id": "resumed-1", "result": "", "is_error": True}) + "\n",
@@ -348,10 +524,130 @@ def test_run_claude_genuine_failure_after_output_does_not_retry(cloud_runner, mo
     monkeypatch.setattr(cloud_runner, "_api", lambda *a, **k: (200, {}))
 
     ok, text, cli_session_id = cloud_runner.run_claude(
-        "hi", "turn-genuine-fail", lambda batch: None, cwd=tmp_path,
+        "hi", "turn-genuine-fail", lambda batch: None, cwd=cwd,
         resume_session_id="stale-session-id",
     )
 
     assert len(popen_calls) == 1  # no fallback retry
     assert ok is False
     assert cli_session_id == "resumed-1"
+
+
+def test_run_claude_production_batching_crosses_flush_threshold(cloud_runner, monkeypatch, tmp_path):
+    """Drives run_claude's OWN byte-threshold flush logic (not just the pure
+    _chunk_transcript_lines helper) — review coverage gap: feed enough bytes
+    to cross TRANSCRIPT_FLUSH_BYTES twice mid-stream and assert more than one
+    transcript POST happened, with the full content preserved across them."""
+    monkeypatch.setattr(cloud_runner, "TRANSCRIPT_FLUSH_BYTES", 200)
+    monkeypatch.setattr(cloud_runner, "TRANSCRIPT_FLUSH_SECONDS", 999)  # isolate the byte trigger
+    big_text = "z" * 100
+    lines = []
+    for i in range(6):
+        lines.append(json.dumps({
+            "type": "assistant", "session_id": "sess-batch",
+            "message": {"content": [{"type": "text", "text": f"{big_text}-{i}"}]},
+        }) + "\n")
+    lines.append(json.dumps({"type": "result", "session_id": "sess-batch", "result": "done", "is_error": False}) + "\n")
+
+    monkeypatch.setattr(cloud_runner.subprocess, "Popen", lambda *a, **k: _FakeProc(lines))
+    transcript_calls = []
+
+    def fake_api(method, path, body=None):
+        if path.endswith("/transcript"):
+            transcript_calls.append(body)
+            return 200, {}
+        raise AssertionError(f"unexpected call {method} {path}")
+
+    monkeypatch.setattr(cloud_runner, "_api", fake_api)
+    ok, _text, _sid = cloud_runner.run_claude(
+        "hi", "turn-batching", lambda batch: None, cwd=tmp_path,
+    )
+    assert ok is True
+    assert len(transcript_calls) > 1, "expected the byte threshold to trigger more than one flush"
+    shipped = [line for call in transcript_calls for line in call["lines"]]
+    assert shipped == [line.strip() for line in lines]
+
+
+def test_run_claude_periodic_flush_fires_during_a_quiet_stdout(cloud_runner, monkeypatch, tmp_path):
+    """review I2: the byte/size flush only runs when a NEW line arrives, so a
+    long-quiet stdout (a multi-minute tool call) must not sit on unflushed
+    lines until the process exits. Uses a short TRANSCRIPT_FLUSH_SECONDS and a
+    slow-yielding fake stdout so the background flush thread gets a real
+    chance to fire mid-turn."""
+    monkeypatch.setattr(cloud_runner, "TRANSCRIPT_FLUSH_SECONDS", 0.05)
+    monkeypatch.setattr(cloud_runner, "TRANSCRIPT_FLUSH_BYTES", 10 ** 9)  # isolate the timer trigger
+
+    first_line = json.dumps({"type": "system", "subtype": "init", "session_id": "sess-slow"}) + "\n"
+    second_line = json.dumps(
+        {"type": "result", "session_id": "sess-slow", "result": "done", "is_error": False}
+    ) + "\n"
+
+    class _SlowFakeProc:
+        def __init__(self):
+            self.returncode = 0
+
+        @property
+        def stdout(self):
+            yield first_line
+            time.sleep(0.3)  # generous vs. the 0.05s flush interval above
+            yield second_line
+
+        def wait(self):
+            return self.returncode
+
+    monkeypatch.setattr(cloud_runner.subprocess, "Popen", lambda *a, **k: _SlowFakeProc())
+    transcript_calls = []
+    lock = threading.Lock()
+
+    def fake_api(method, path, body=None):
+        if path.endswith("/transcript"):
+            with lock:
+                transcript_calls.append(body)
+            return 200, {}
+        raise AssertionError(f"unexpected call {method} {path}")
+
+    monkeypatch.setattr(cloud_runner, "_api", fake_api)
+    ok, _text, _sid = cloud_runner.run_claude(
+        "hi", "turn-slow", lambda batch: None, cwd=tmp_path,
+    )
+    assert ok is True
+    # The first line must have been flushed by the PERIODIC thread while the
+    # loop was still blocked waiting for the second line — i.e. more than one
+    # POST happened, not just the single final flush.
+    assert len(transcript_calls) >= 2
+
+
+def test_run_claude_finally_flushes_on_mid_loop_exception(cloud_runner, monkeypatch, tmp_path):
+    """review I3: an exception mid-loop (e.g. a broken WS emit) must not drop
+    buffered transcript lines — the finally block must still flush them, and
+    a cli_session_id already captured must still be returned."""
+    lines = [
+        json.dumps({"type": "system", "subtype": "init", "session_id": "sess-crash"}) + "\n",
+        json.dumps({
+            "type": "assistant", "session_id": "sess-crash",
+            "message": {"content": [{"type": "tool_use", "name": "Bash"}]},
+        }) + "\n",
+    ]
+    monkeypatch.setattr(cloud_runner.subprocess, "Popen", lambda *a, **k: _FakeProc(lines, returncode=0))
+
+    transcript_calls = []
+
+    def fake_api(method, path, body=None):
+        if path.endswith("/transcript"):
+            transcript_calls.append(body)
+            return 200, {}
+        raise AssertionError(f"unexpected call {method} {path}")
+
+    monkeypatch.setattr(cloud_runner, "_api", fake_api)
+
+    def crashing_emit(_batch):
+        raise RuntimeError("socket dropped")
+
+    ok, text, cli_session_id = cloud_runner.run_claude(
+        "hi", "turn-crash", crashing_emit, cwd=tmp_path,
+    )
+    assert ok is False
+    assert "socket dropped" in text
+    assert cli_session_id == "sess-crash"  # captured before the crash, not lost
+    shipped = [line for call in transcript_calls for line in call["lines"]]
+    assert shipped == [line.strip() for line in lines]  # nothing buffered was dropped

--- a/deploy/ec2-runner/tests/test_cloud_runner.py
+++ b/deploy/ec2-runner/tests/test_cloud_runner.py
@@ -1,0 +1,357 @@
+"""Unit tests for deploy/ec2-runner/cloud_runner.py.
+
+Everything here is pure-python or mocks subprocess.Popen / the runner's own
+`_api` helper — there is no live canopy-web and no live EC2 box to test
+against (see the PR2 report for what this suite does and does not cover).
+"""
+from __future__ import annotations
+
+ENV_KEYS = (
+    "RUNNER_SESSIONS", "RUNNER_HOST", "RUNNER_NAME", "RUNNER_PROJECTS",
+    "RUNNER_AGENTS", "RUNNER_WORKSPACE",
+)
+
+
+def _clean_env(monkeypatch):
+    for key in ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+
+# ── capability declaration ──────────────────────────────────────────────────
+
+def test_bool_env_default_when_unset(cloud_runner):
+    assert cloud_runner._bool_env("NOPE_NOT_SET", True) is True
+    assert cloud_runner._bool_env("NOPE_NOT_SET", False) is False
+
+
+def test_bool_env_falsy_spellings(cloud_runner, monkeypatch):
+    for spelling in ("0", "false", "False", "FALSE", "no", "No", ""):
+        monkeypatch.setenv("X_FLAG", spelling)
+        assert cloud_runner._bool_env("X_FLAG", True) is False, spelling
+
+
+def test_bool_env_truthy_spellings(cloud_runner, monkeypatch):
+    for spelling in ("1", "true", "yes", "anything"):
+        monkeypatch.setenv("X_FLAG", spelling)
+        assert cloud_runner._bool_env("X_FLAG", False) is True, spelling
+
+
+def test_sessions_capability_default_on(load_cloud_runner, monkeypatch):
+    _clean_env(monkeypatch)
+    mod = load_cloud_runner()
+    assert mod.RUNNER_SESSIONS is True
+    assert mod.RUNNER_CAPS.get("sessions") is True
+
+
+def test_sessions_capability_opt_out(load_cloud_runner, monkeypatch):
+    _clean_env(monkeypatch)
+    monkeypatch.setenv("RUNNER_SESSIONS", "0")
+    mod = load_cloud_runner()
+    assert mod.RUNNER_SESSIONS is False
+    assert "sessions" not in mod.RUNNER_CAPS
+
+
+def test_runner_host_defaults_to_runner_name(load_cloud_runner, monkeypatch):
+    _clean_env(monkeypatch)
+    monkeypatch.setenv("RUNNER_NAME", "cloud-box-7")
+    mod = load_cloud_runner()
+    assert mod.RUNNER_HOST == "cloud-box-7"
+
+
+def test_runner_host_explicit_override(load_cloud_runner, monkeypatch):
+    _clean_env(monkeypatch)
+    monkeypatch.setenv("RUNNER_NAME", "cloud-box-7")
+    monkeypatch.setenv("RUNNER_HOST", "pinned-host")
+    mod = load_cloud_runner()
+    assert mod.RUNNER_HOST == "pinned-host"
+
+
+# ── capability sync on reuse (pair_or_load) ─────────────────────────────────
+
+def test_pair_or_load_reuse_syncs_capabilities(cloud_runner, monkeypatch, tmp_path):
+    state_file = tmp_path / "state.json"
+    state_file.write_text('{"runner_id": "existing-rid"}')
+    monkeypatch.setattr(cloud_runner, "STATE_FILE", state_file)
+
+    calls = []
+
+    def fake_api(method, path, body=None):
+        calls.append((method, path, body))
+        if path == "/runners/existing-rid/heartbeat":
+            return 200, {}
+        if path == "/runners/existing-rid":
+            return 200, {}
+        raise AssertionError(f"unexpected call {method} {path}")
+
+    monkeypatch.setattr(cloud_runner, "_api", fake_api)
+    rid = cloud_runner.pair_or_load()
+
+    assert rid == "existing-rid"
+    methods_paths = [(m, p) for m, p, _ in calls]
+    assert ("POST", "/runners/existing-rid/heartbeat") in methods_paths
+    assert ("PATCH", "/runners/existing-rid") in methods_paths
+    patch_body = next(b for m, p, b in calls if p == "/runners/existing-rid")
+    assert patch_body == {"capabilities": cloud_runner.RUNNER_CAPS}
+    # A reused runner is never re-paired via POST /runners/.
+    assert all(p != "/runners/" for _m, p in methods_paths)
+
+
+# ── transcript batching ──────────────────────────────────────────────────────
+
+def test_chunk_transcript_lines_empty(cloud_runner):
+    assert cloud_runner._chunk_transcript_lines([]) == []
+
+
+def test_chunk_transcript_lines_stays_under_cap(cloud_runner):
+    lines = [f'{{"i":{i}}}' for i in range(100)]
+    batches = cloud_runner._chunk_transcript_lines(lines, max_bytes=50)
+    assert [line for batch in batches for line in batch] == lines  # nothing lost, no reordering
+    for batch in batches:
+        assert sum(len(line.encode("utf-8")) for line in batch) <= 50 or len(batch) == 1
+
+
+def test_chunk_transcript_lines_oversized_single_line_ships_alone(cloud_runner):
+    huge = "x" * 1000
+    batches = cloud_runner._chunk_transcript_lines(["a", huge, "b"], max_bytes=10)
+    assert batches == [["a"], [huge], ["b"]]
+
+
+# ── --resume argv ────────────────────────────────────────────────────────────
+
+def test_claude_cmd_without_resume(cloud_runner):
+    cmd = cloud_runner._claude_cmd("hello")
+    assert "--resume" not in cmd
+    assert cmd[:3] == [cloud_runner.CLAUDE_BIN, "-p", "hello"]
+
+
+def test_claude_cmd_with_resume(cloud_runner):
+    cmd = cloud_runner._claude_cmd("hello", "sess-123")
+    assert cmd[-2:] == ["--resume", "sess-123"]
+
+
+# ── session continuity plumbing ──────────────────────────────────────────────
+
+def _session_turn(**overrides):
+    turn = {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "agent_slug": "ace",
+        "project": "",
+        "workspace_slug": "acme",
+        "prompt": "hi",
+        "origin_ref": {"thread_key": "thread-abc", "chat_session_id": "sess-uuid"},
+    }
+    turn.update(overrides)
+    return turn
+
+
+def test_session_thread_key_non_session_turn(cloud_runner):
+    turn = {"agent_slug": "ace", "origin_ref": {}}
+    assert cloud_runner._session_thread_key(turn) == ""
+
+
+def test_session_thread_key_falls_back_to_chat_session_id(cloud_runner):
+    turn = {"origin_ref": {"chat_session_id": "sess-uuid"}}
+    assert cloud_runner._session_thread_key(turn) == "sess-uuid"
+
+
+def test_session_resume_plan_skips_non_session_turn(cloud_runner, monkeypatch):
+    called = []
+    monkeypatch.setattr(cloud_runner, "_api", lambda *a, **k: called.append(a) or (200, {}))
+    turn = {"agent_slug": "ace", "project": "", "origin_ref": {}}
+    assert cloud_runner._session_resume_plan("runner-1", turn) == ""
+    assert not called
+
+
+def test_session_resume_plan_skips_agentless_projectless(cloud_runner, monkeypatch):
+    called = []
+    monkeypatch.setattr(cloud_runner, "_api", lambda *a, **k: called.append(a) or (200, {}))
+    turn = _session_turn(agent_slug="", project="")
+    assert cloud_runner._session_resume_plan("runner-1", turn) == ""
+    assert not called
+
+
+def test_session_resume_plan_returns_engine_handle_on_reuse(cloud_runner, monkeypatch):
+    def fake_api(method, path, body=None):
+        assert path == "/runners/runner-1/resolve-session"
+        assert body == {"thread_key": "thread-abc", "agent_slug": "ace"}
+        return 200, {"reuse": True, "emdash_task_id": "cli-sess-9", "new_thread": False}
+
+    monkeypatch.setattr(cloud_runner, "_api", fake_api)
+    turn = _session_turn()
+    assert cloud_runner._session_resume_plan("runner-1", turn) == "cli-sess-9"
+
+
+def test_session_resume_plan_no_reuse_returns_empty(cloud_runner, monkeypatch):
+    monkeypatch.setattr(
+        cloud_runner, "_api",
+        lambda *a, **k: (200, {"reuse": False, "emdash_task_id": "", "new_thread": True}),
+    )
+    turn = _session_turn()
+    assert cloud_runner._session_resume_plan("runner-1", turn) == ""
+
+
+def test_session_resume_plan_project_turn_sends_workspace(cloud_runner, monkeypatch):
+    def fake_api(method, path, body=None):
+        assert body == {"thread_key": "thread-abc", "project": "canopy-web", "workspace": "acme"}
+        return 200, {"reuse": False, "emdash_task_id": ""}
+
+    monkeypatch.setattr(cloud_runner, "_api", fake_api)
+    turn = _session_turn(agent_slug="", project="canopy-web")
+    cloud_runner._session_resume_plan("runner-1", turn)
+
+
+def test_record_session_resume_sends_both_fields(cloud_runner, monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        cloud_runner, "_api",
+        lambda *a, **k: calls.append(a) or (200, {}),
+    )
+    turn = _session_turn()
+    cloud_runner._record_session_resume("runner-1", turn, "cli-sess-9")
+    assert len(calls) == 1
+    method, path, body = calls[0]
+    assert method == "POST"
+    assert path == "/runners/runner-1/record-session"
+    assert body["emdash_task_id"] == "cli-sess-9"
+    assert body["session_id"] == "cli-sess-9"
+    assert body["thread_key"] == "thread-abc"
+
+
+def test_record_session_resume_noop_without_cli_session_id(cloud_runner, monkeypatch):
+    calls = []
+    monkeypatch.setattr(cloud_runner, "_api", lambda *a, **k: calls.append(a))
+    cloud_runner._record_session_resume("runner-1", _session_turn(), "")
+    assert not calls
+
+
+def test_record_session_resume_never_raises_on_transport_failure(cloud_runner, monkeypatch):
+    def boom(*_a, **_k):
+        raise RuntimeError("network is down")
+
+    monkeypatch.setattr(cloud_runner, "_api", boom)
+    # Must not raise — a transcript/session-record hiccup must never fail the turn.
+    cloud_runner._record_session_resume("runner-1", _session_turn(), "cli-sess-9")
+
+
+# ── run_claude: transcript forwarding + session-id capture + resume fallback ─
+
+class _FakeProc:
+    def __init__(self, lines: list[str], returncode: int = 0):
+        self.stdout = iter(lines)
+        self.returncode = returncode
+
+    def wait(self):
+        return self.returncode
+
+
+def _stream_json_lines(session_id: str, text: str) -> list[str]:
+    import json
+    return [
+        json.dumps({"type": "system", "subtype": "init", "session_id": session_id}) + "\n",
+        json.dumps({
+            "type": "assistant", "session_id": session_id,
+            "message": {"content": [{"type": "text", "text": text}]},
+        }) + "\n",
+        json.dumps({"type": "result", "session_id": session_id, "result": text, "is_error": False}) + "\n",
+    ]
+
+
+def test_run_claude_captures_session_id_and_forwards_transcript(cloud_runner, monkeypatch, tmp_path):
+    lines = _stream_json_lines("real-cli-session-1", "hello there")
+    fake_proc = _FakeProc(lines, returncode=0)
+    monkeypatch.setattr(cloud_runner.subprocess, "Popen", lambda *a, **k: fake_proc)
+
+    transcript_calls = []
+
+    def fake_api(method, path, body=None):
+        if path.endswith("/transcript"):
+            transcript_calls.append(body)
+            return 200, {}
+        raise AssertionError(f"unexpected call {method} {path}")
+
+    monkeypatch.setattr(cloud_runner, "_api", fake_api)
+
+    events = []
+    ok, text, cli_session_id = cloud_runner.run_claude(
+        "hi", "turn-abc12345", lambda batch: events.extend(batch), cwd=tmp_path,
+    )
+
+    assert ok is True
+    assert text == "hello there"
+    assert cli_session_id == "real-cli-session-1"
+    # Every raw line shipped verbatim, in order, across however many batches.
+    shipped = [line for call in transcript_calls for line in call["lines"]]
+    assert shipped == [line.strip() for line in lines]
+    # Distinct batch_ids (no accidental collisions/dedup-by-accident).
+    batch_ids = [call["batch_id"] for call in transcript_calls]
+    assert len(batch_ids) == len(set(batch_ids))
+    assert any(e["kind"] == "assistant" for e in events)
+
+
+def test_run_claude_transcript_failure_does_not_fail_turn(cloud_runner, monkeypatch, tmp_path):
+    lines = _stream_json_lines("sess-2", "ok")
+    monkeypatch.setattr(cloud_runner.subprocess, "Popen", lambda *a, **k: _FakeProc(lines))
+
+    def boom(*_a, **_k):
+        raise RuntimeError("network is down")
+
+    monkeypatch.setattr(cloud_runner, "_api", boom)
+    ok, text, cli_session_id = cloud_runner.run_claude(
+        "hi", "turn-xyz", lambda batch: None, cwd=tmp_path,
+    )
+    assert ok is True
+    assert cli_session_id == "sess-2"
+
+
+def test_run_claude_resume_fallback_to_fresh_spawn(cloud_runner, monkeypatch, tmp_path):
+    """A --resume attempt that yields NOTHING (no lines, non-zero exit) retries
+    once as a fresh spawn, dropping --resume from argv the second time."""
+    fresh_lines = _stream_json_lines("brand-new-session", "fresh reply")
+    popen_calls: list[list[str]] = []
+
+    def fake_popen(cmd, **_kwargs):
+        popen_calls.append(cmd)
+        if "--resume" in cmd:
+            return _FakeProc([], returncode=1)  # resume target gone: nothing emitted
+        return _FakeProc(fresh_lines, returncode=0)
+
+    monkeypatch.setattr(cloud_runner.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(cloud_runner, "_api", lambda *a, **k: (200, {}))
+
+    ok, text, cli_session_id = cloud_runner.run_claude(
+        "hi", "turn-resume", lambda batch: None, cwd=tmp_path,
+        resume_session_id="stale-session-id",
+    )
+
+    assert len(popen_calls) == 2
+    assert "--resume" in popen_calls[0]
+    assert "--resume" not in popen_calls[1]
+    assert ok is True
+    assert cli_session_id == "brand-new-session"
+
+
+def test_run_claude_genuine_failure_after_output_does_not_retry(cloud_runner, monkeypatch, tmp_path):
+    """A resumed session that DID produce output before failing must not be
+    silently retried fresh — that would duplicate work under a new session."""
+    import json
+    lines = [
+        json.dumps({"type": "system", "subtype": "init", "session_id": "resumed-1"}) + "\n",
+        json.dumps({"type": "result", "session_id": "resumed-1", "result": "", "is_error": True}) + "\n",
+    ]
+    popen_calls = []
+
+    def fake_popen(cmd, **_kwargs):
+        popen_calls.append(cmd)
+        return _FakeProc(lines, returncode=1)
+
+    monkeypatch.setattr(cloud_runner.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(cloud_runner, "_api", lambda *a, **k: (200, {}))
+
+    ok, text, cli_session_id = cloud_runner.run_claude(
+        "hi", "turn-genuine-fail", lambda batch: None, cwd=tmp_path,
+        resume_session_id="stale-session-id",
+    )
+
+    assert len(popen_calls) == 1  # no fallback retry
+    assert ok is False
+    assert cli_session_id == "resumed-1"

--- a/deploy/ec2-runner/tests/test_cloud_runner.py
+++ b/deploy/ec2-runner/tests/test_cloud_runner.py
@@ -617,18 +617,76 @@ def test_run_claude_periodic_flush_fires_during_a_quiet_stdout(cloud_runner, mon
     assert len(transcript_calls) >= 2
 
 
-def test_run_claude_finally_flushes_on_mid_loop_exception(cloud_runner, monkeypatch, tmp_path):
-    """review I3: an exception mid-loop (e.g. a broken WS emit) must not drop
-    buffered transcript lines — the finally block must still flush them, and
-    a cli_session_id already captured must still be returned."""
-    lines = [
-        json.dumps({"type": "system", "subtype": "init", "session_id": "sess-crash"}) + "\n",
-        json.dumps({
+class _HangingFakeProc:
+    """Simulates claude STILL ALIVE and blocked on a full, undrained stdout
+    pipe at the moment the read loop exits early via an exception (review
+    N1's exact scenario) — `_FakeProc`'s plain list-iterator stdout cannot
+    represent this, because iterating it to exhaustion is what "the loop
+    reached EOF" means; this fake is deliberately never exhausted.
+
+    Rather than literally hanging (which would hang the test suite on a
+    regression), `wait()` FAILS THE TEST LOUDLY if called before the process
+    was killed/its stdout closed, or without a bounded timeout — the two
+    preconditions the fix must establish. That makes this test deterministic
+    AND diagnostic: run against the pre-fix code (bare `proc.wait()`, no
+    kill, no timeout), it fails immediately with an assertion naming exactly
+    what's missing, instead of hanging pytest.
+    """
+
+    def __init__(self, lines):
+        self._iter = iter(lines)
+        self.returncode = None
+        self.killed = False
+        self.stdout_closed = False
+
+    @property
+    def stdout(self):
+        return self  # so both `for line in proc.stdout` and `proc.stdout.close()` work
+
+    def __iter__(self):
+        return self._iter
+
+    def close(self):
+        self.stdout_closed = True
+
+    def kill(self):
+        self.killed = True
+        if self.returncode is None:
+            self.returncode = -9
+
+    def wait(self, timeout=None):
+        if not (self.killed or self.stdout_closed):
+            raise AssertionError(
+                "wait() called on a still-alive/still-piped process — this is exactly "
+                "the pipe-deadlock regression (review N1): kill/close must happen BEFORE wait()"
+            )
+        if timeout is None:
+            raise AssertionError(
+                "wait() called with no timeout — an unbounded wait can hang the runner forever"
+            )
+        return self.returncode if self.returncode is not None else 0
+
+
+def test_run_claude_finally_reaps_safely_on_genuine_mid_loop_exception(
+    cloud_runner, monkeypatch, tmp_path,
+):
+    """review N1 (and the rewrite of the old, misnamed I3 test): the raise must
+    happen while claude is STILL RUNNING and stdout is STILL UNDRAINED — more
+    than TRANSCRIPT batch-worth of events queued so `flush()` fires INSIDE the
+    loop (not just in the `finally`), and the underlying iterator still has
+    unconsumed lines when it raises, proving the loop genuinely exited early.
+    """
+    # 11 tool_use events: the 10th triggers the in-loop `flush()` (batch >= 10),
+    # which is where `emit` raises — with a further (unconsumed) line still
+    # queued behind it in the fake's iterator.
+    lines = [json.dumps({"type": "system", "subtype": "init", "session_id": "sess-crash"}) + "\n"]
+    for i in range(11):
+        lines.append(json.dumps({
             "type": "assistant", "session_id": "sess-crash",
-            "message": {"content": [{"type": "tool_use", "name": "Bash"}]},
-        }) + "\n",
-    ]
-    monkeypatch.setattr(cloud_runner.subprocess, "Popen", lambda *a, **k: _FakeProc(lines, returncode=0))
+            "message": {"content": [{"type": "tool_use", "name": f"Bash{i}"}]},
+        }) + "\n")
+    fake_proc = _HangingFakeProc(lines)
+    monkeypatch.setattr(cloud_runner.subprocess, "Popen", lambda *a, **k: fake_proc)
 
     transcript_calls = []
 
@@ -640,14 +698,209 @@ def test_run_claude_finally_flushes_on_mid_loop_exception(cloud_runner, monkeypa
 
     monkeypatch.setattr(cloud_runner, "_api", fake_api)
 
-    def crashing_emit(_batch):
+    emitted = []
+
+    def crashing_emit(batch):
+        emitted.append(batch)
         raise RuntimeError("socket dropped")
 
     ok, text, cli_session_id = cloud_runner.run_claude(
         "hi", "turn-crash", crashing_emit, cwd=tmp_path,
     )
+
+    # The crash genuinely happened mid-loop: at least one line was still
+    # unconsumed in the fake's stdout iterator when `emit` raised — proving
+    # early exit, not a full drain (the defect the old, misnamed test missed).
+    remaining = list(fake_proc._iter)
+    assert len(remaining) > 0, "loop must exit before exhausting stdout to be a genuine mid-loop case"
+    assert len(emitted) == 1  # flush() ran exactly once, from inside the loop
+    # The fix's contract, proven via _HangingFakeProc's own assertions: kill()
+    # or stdout.close() happened, and wait() was given a bounded timeout —
+    # otherwise the fake itself would have raised inside run_claude and this
+    # call would have propagated an AssertionError instead of returning.
+    assert fake_proc.killed or fake_proc.stdout_closed
     assert ok is False
     assert "socket dropped" in text
     assert cli_session_id == "sess-crash"  # captured before the crash, not lost
+    # Whatever WAS buffered before the crash made it to the transcript, in
+    # order, as an exact PREFIX of the full stream (the trailing lines never
+    # read off stdout are correctly absent — this loop crashed, it didn't
+    # invent content it never saw).
     shipped = [line for call in transcript_calls for line in call["lines"]]
-    assert shipped == [line.strip() for line in lines]  # nothing buffered was dropped
+    all_stripped = [line.strip() for line in lines]
+    assert shipped, "the finally's flush_transcript() must have shipped something"
+    assert shipped == all_stripped[: len(shipped)]
+    assert len(shipped) < len(all_stripped), "some lines must remain unshipped — a genuine early exit"
+
+
+# ── genuine concurrency tests (review: "two real concurrency tests over ─────
+# thirteen structural ones") ─────────────────────────────────────────────────
+
+def test_run_claude_concurrent_flushes_never_reorder_duplicate_or_drop(cloud_runner, monkeypatch, tmp_path):
+    """Drives the READ LOOP's own byte-triggered flush and the PERIODIC
+    background thread's flush against each other for real: a tiny
+    TRANSCRIPT_FLUSH_SECONDS makes the periodic thread fire almost
+    continuously while a fast-yielding fake stdout keeps crossing the byte
+    threshold too, so both producers of flush_transcript() genuinely race for
+    the same buffer across ~40 lines. Asserts the property the locking is
+    FOR: every line reaches the server in original order, exactly once, and
+    batch_ids are unique (no accidental re-post) with the seq component
+    strictly increasing across the whole run — i.e. no reorder, no
+    duplication, no loss, even though two threads are contending for the
+    buffer and the post-serialization lock throughout."""
+    monkeypatch.setattr(cloud_runner, "TRANSCRIPT_FLUSH_SECONDS", 0.01)
+    monkeypatch.setattr(cloud_runner, "TRANSCRIPT_FLUSH_BYTES", 200)  # small: forces many flushes
+
+    n = 40
+    lines = [
+        json.dumps({
+            "type": "assistant", "session_id": "sess-race",
+            "message": {"content": [{"type": "text", "text": f"line-{i:03d}-" + ("x" * 30)}]},
+        }) + "\n"
+        for i in range(n)
+    ]
+    lines.append(json.dumps({"type": "result", "session_id": "sess-race", "result": "done", "is_error": False}) + "\n")
+
+    class _RealisticSlowStdout:
+        """A real generator (unlike a bare list) so the periodic thread gets
+        genuine wall-clock windows to race against the read loop — a tiny
+        sleep per line lets the 0.01s periodic timer fire multiple times
+        while lines are still arriving, without making the test slow."""
+        def __init__(self, src):
+            self._src = src
+
+        def __iter__(self):
+            for line in self._src:
+                time.sleep(0.002)
+                yield line
+
+    class _FakeProcRealistic:
+        def __init__(self, src):
+            self.stdout = _RealisticSlowStdout(src)
+            self.returncode = 0
+
+        def wait(self, timeout=None):
+            return self.returncode
+
+        def kill(self):
+            pass
+
+    monkeypatch.setattr(cloud_runner.subprocess, "Popen", lambda *a, **k: _FakeProcRealistic(lines))
+
+    transcript_calls = []
+    calls_lock = threading.Lock()
+
+    def fake_api(method, path, body=None):
+        if path.endswith("/transcript"):
+            with calls_lock:
+                transcript_calls.append(body)
+            return 200, {}
+        raise AssertionError(f"unexpected call {method} {path}")
+
+    monkeypatch.setattr(cloud_runner, "_api", fake_api)
+
+    ok, _text, _sid = cloud_runner.run_claude(
+        "hi", "turn-race", lambda batch: None, cwd=tmp_path,
+    )
+    assert ok is True
+
+    # No loss, no reorder, no duplication: the concatenation of every batch's
+    # lines, IN THE ORDER THE FAKE SERVER RECEIVED THEM, must equal the
+    # original stream exactly.
+    shipped = [line for call in transcript_calls for line in call["lines"]]
+    assert shipped == [line.strip() for line in lines]
+
+    # batch_ids: all unique (no duplicate posts), all sharing one attempt id,
+    # and seq strictly increasing in RECEIPT order (proves posts landed in
+    # swap order despite two threads producing them).
+    batch_ids = [call["batch_id"] for call in transcript_calls]
+    assert len(batch_ids) == len(set(batch_ids)), "a batch_id repeated — duplicate/racy post"
+    parsed = [bid.split(":") for bid in batch_ids]
+    assert len({p[1] for p in parsed}) == 1, "attempt id must be stable across the whole run"
+    seqs = [int(p[2]) for p in parsed]
+    assert seqs == sorted(seqs) == list(range(1, len(seqs) + 1)), "seq must be gap-free and in receipt order"
+    assert len(transcript_calls) > 1, "expected genuine contention to produce more than one flush"
+
+
+def test_run_claude_append_not_blocked_by_a_slow_transcript_post(cloud_runner, monkeypatch, tmp_path):
+    """review N2: before the fix, every per-line append held `transcript_lock`
+    for the ENTIRE duration of a flush's network POST (including retries).
+    This drives a slow POST specifically from the PERIODIC thread while the
+    read loop keeps appending fresh lines on the main thread, and asserts the
+    read loop was NOT stalled behind it: total wall-clock time stays close to
+    the (short) time it takes to feed the lines, not to
+    (slow POST duration + line-feed duration) as it would if a per-line
+    append had to wait for the in-flight POST to finish."""
+    monkeypatch.setattr(cloud_runner, "TRANSCRIPT_FLUSH_SECONDS", 0.02)
+    monkeypatch.setattr(cloud_runner, "TRANSCRIPT_FLUSH_BYTES", 10**9)  # never byte-trigger; isolate the timer
+
+    SLOW_POST_SECONDS = 0.4
+    LINE_DELAY_SECONDS = 0.01
+    N_LINES = 20  # ~0.2s of line-feeding if unblocked; << SLOW_POST_SECONDS
+
+    lines = [
+        json.dumps({
+            "type": "assistant", "session_id": "sess-slow-post",
+            "message": {"content": [{"type": "text", "text": f"l{i}"}]},
+        }) + "\n"
+        for i in range(N_LINES)
+    ]
+    lines.append(json.dumps(
+        {"type": "result", "session_id": "sess-slow-post", "result": "done", "is_error": False}
+    ) + "\n")
+
+    class _SlowLineStdout:
+        def __iter__(self):
+            for line in lines:
+                time.sleep(LINE_DELAY_SECONDS)
+                yield line
+
+    class _FakeProcSlowLines:
+        def __init__(self):
+            self.stdout = _SlowLineStdout()
+            self.returncode = 0
+
+        def wait(self, timeout=None):
+            return self.returncode
+
+        def kill(self):
+            pass
+
+    monkeypatch.setattr(cloud_runner.subprocess, "Popen", lambda *a, **k: _FakeProcSlowLines())
+
+    first_post_started = threading.Event()
+    call_count = [0]
+    calls_lock = threading.Lock()
+
+    def fake_api(method, path, body=None):
+        if path.endswith("/transcript"):
+            with calls_lock:
+                call_count[0] += 1
+                is_first = call_count[0] == 1
+            if is_first:
+                first_post_started.set()
+                time.sleep(SLOW_POST_SECONDS)  # simulate a slow/struggling canopy-web
+            return 200, {}
+        raise AssertionError(f"unexpected call {method} {path}")
+
+    monkeypatch.setattr(cloud_runner, "_api", fake_api)
+
+    start = time.monotonic()
+    ok, _text, _sid = cloud_runner.run_claude(
+        "hi", "turn-slow-post", lambda batch: None, cwd=tmp_path,
+    )
+    elapsed = time.monotonic() - start
+
+    assert ok is True
+    assert first_post_started.is_set(), "the periodic flush never fired a POST to slow down"
+    # If per-line appends were blocked behind the slow POST (the pre-N2
+    # behavior), elapsed would be at least SLOW_POST_SECONDS PLUS the line
+    # feed time serialized after it. Unblocked, the line-feeding (bounded by
+    # N_LINES * LINE_DELAY_SECONDS) overlaps the slow POST almost entirely, so
+    # total time stays close to SLOW_POST_SECONDS with generous headroom —
+    # nowhere near the fully-serialized sum.
+    serialized_lower_bound = SLOW_POST_SECONDS + (N_LINES * LINE_DELAY_SECONDS)
+    assert elapsed < serialized_lower_bound - 0.1, (
+        f"elapsed={elapsed:.3f}s is too close to the fully-serialized bound "
+        f"({serialized_lower_bound:.3f}s) — appends look blocked on the slow POST"
+    )

--- a/deploy/ec2-runner/tests/test_cloud_runner.py
+++ b/deploy/ec2-runner/tests/test_cloud_runner.py
@@ -10,6 +10,18 @@ import json
 import threading
 import time
 
+import pytest
+
+# review N7: a lock-ordering regression in run_claude's threading
+# (transcript_lock / transcript_post_lock) can DEADLOCK rather than raise or
+# fail an assertion — verified in review by reintroducing an inverse
+# acquisition order, which hung these tests until a manual --timeout stopped
+# them. Without a per-test bound, that hang stalls the whole CI job instead
+# of failing it. Applied to every test that drives run_claude's locking
+# machinery (not just the two dedicated concurrency tests), since any of them
+# could in principle hang on the same regression.
+LOCK_REGRESSION_TIMEOUT = pytest.mark.timeout(20)
+
 ENV_KEYS = (
     "RUNNER_SESSIONS", "RUNNER_HOST", "RUNNER_NAME", "RUNNER_PROJECTS",
     "RUNNER_AGENTS", "RUNNER_WORKSPACE",
@@ -378,9 +390,19 @@ class _FakeProc:
     def __init__(self, lines, returncode: int = 0):
         self.stdout = iter(lines)
         self.returncode = returncode
+        self.killed = False
 
-    def wait(self):
+    def wait(self, timeout=None):
+        # Accepting (and ignoring) `timeout` matters: without it, EVERY test
+        # using this fake would hit a TypeError on run_claude's real
+        # `proc.wait(timeout=...)` call, silently masked by the `finally`
+        # block's broad `except Exception`, and would never actually
+        # exercise the real reap path (review N4's regression lived exactly
+        # in that path).
         return self.returncode
+
+    def kill(self):
+        self.killed = True
 
 
 def _stream_json_lines(session_id: str, text: str) -> list[str]:
@@ -433,6 +455,43 @@ def test_run_claude_captures_session_id_and_forwards_transcript(cloud_runner, mo
     seqs = [int(p[2]) for p in parsed]
     assert seqs == sorted(seqs) == list(range(1, len(seqs) + 1))
     assert any(e["kind"] == "assistant" for e in events)
+    # review N4: a clean turn that reached EOF on its own must never be
+    # killed — only a genuinely hung child (bounded wait times out) may be.
+    assert fake_proc.killed is False
+
+
+def test_run_claude_clean_turn_without_result_event_is_not_killed_or_marked_failed(
+    cloud_runner, monkeypatch, tmp_path,
+):
+    """review N4: the regression's exact precondition — claude ends its
+    stdout stream (no more stream-json lines, i.e. the loop reaches EOF)
+    WITHOUT ever emitting a `result` event, then exits 0 (e.g. real `claude`
+    doing a little housekeeping — closing out its own transcript file, the
+    very file I1/C2's --resume depends on — after its last visible line).
+    An unconditional kill()-before-wait() at EOF would SIGKILL a process
+    that was already exiting cleanly, flipping this turn's outcome to a
+    stderr-tail failure even though nothing went wrong. Must stay ok=True,
+    and kill() must never be called for this shape."""
+    lines = [
+        json.dumps({"type": "system", "subtype": "init", "session_id": "sess-clean"}) + "\n",
+        json.dumps({
+            "type": "assistant", "session_id": "sess-clean",
+            "message": {"content": [{"type": "text", "text": "all done"}]},
+        }) + "\n",
+        # No `result` line — the loop still reaches EOF (proc.stdout is
+        # exhausted) and the process is about to exit 0 on its own.
+    ]
+    fake_proc = _FakeProc(lines, returncode=0)
+    monkeypatch.setattr(cloud_runner.subprocess, "Popen", lambda *a, **k: fake_proc)
+    monkeypatch.setattr(cloud_runner, "_api", lambda *a, **k: (200, {}))
+
+    ok, _text, cli_session_id = cloud_runner.run_claude(
+        "hi", "turn-clean-no-result", lambda batch: None, cwd=tmp_path,
+    )
+
+    assert fake_proc.killed is False
+    assert ok is True
+    assert cli_session_id == "sess-clean"
 
 
 def test_run_claude_transcript_failure_does_not_fail_turn(cloud_runner, monkeypatch, tmp_path):
@@ -533,6 +592,7 @@ def test_run_claude_genuine_failure_after_output_does_not_retry(cloud_runner, mo
     assert cli_session_id == "resumed-1"
 
 
+@LOCK_REGRESSION_TIMEOUT
 def test_run_claude_production_batching_crosses_flush_threshold(cloud_runner, monkeypatch, tmp_path):
     """Drives run_claude's OWN byte-threshold flush logic (not just the pure
     _chunk_transcript_lines helper) — review coverage gap: feed enough bytes
@@ -568,6 +628,7 @@ def test_run_claude_production_batching_crosses_flush_threshold(cloud_runner, mo
     assert shipped == [line.strip() for line in lines]
 
 
+@LOCK_REGRESSION_TIMEOUT
 def test_run_claude_periodic_flush_fires_during_a_quiet_stdout(cloud_runner, monkeypatch, tmp_path):
     """review I2: the byte/size flush only runs when a NEW line arrives, so a
     long-quiet stdout (a multi-minute tool call) must not sit on unflushed
@@ -667,6 +728,7 @@ class _HangingFakeProc:
         return self.returncode if self.returncode is not None else 0
 
 
+@LOCK_REGRESSION_TIMEOUT
 def test_run_claude_finally_reaps_safely_on_genuine_mid_loop_exception(
     cloud_runner, monkeypatch, tmp_path,
 ):
@@ -736,6 +798,7 @@ def test_run_claude_finally_reaps_safely_on_genuine_mid_loop_exception(
 # ── genuine concurrency tests (review: "two real concurrency tests over ─────
 # thirteen structural ones") ─────────────────────────────────────────────────
 
+@LOCK_REGRESSION_TIMEOUT
 def test_run_claude_concurrent_flushes_never_reorder_duplicate_or_drop(cloud_runner, monkeypatch, tmp_path):
     """Drives the READ LOOP's own byte-triggered flush and the PERIODIC
     background thread's flush against each other for real: a tiny
@@ -792,6 +855,18 @@ def test_run_claude_concurrent_flushes_never_reorder_duplicate_or_drop(cloud_run
 
     def fake_api(method, path, body=None):
         if path.endswith("/transcript"):
+            # Jitter (review N6): without this, the fake server returns so
+            # fast that the window between seq-allocation and the call being
+            # RECORDED is nanoseconds — a real reorder essentially never
+            # materializes even with transcript_post_lock deleted entirely
+            # (verified: that mutant passed this test 5/5 before this jitter
+            # was added). Delaying every other (odd-seq) call gives a missing
+            # lock a real chance to let a later, even-seq call's POST land
+            # and get recorded FIRST — turning "no lock" into an actually
+            # observable, not just theoretical, failure.
+            seq = int(body["batch_id"].split(":")[2])
+            if seq % 2:
+                time.sleep(0.02)
             with calls_lock:
                 transcript_calls.append(body)
             return 200, {}
@@ -822,15 +897,25 @@ def test_run_claude_concurrent_flushes_never_reorder_duplicate_or_drop(cloud_run
     assert len(transcript_calls) > 1, "expected genuine contention to produce more than one flush"
 
 
+@LOCK_REGRESSION_TIMEOUT
 def test_run_claude_append_not_blocked_by_a_slow_transcript_post(cloud_runner, monkeypatch, tmp_path):
-    """review N2: before the fix, every per-line append held `transcript_lock`
-    for the ENTIRE duration of a flush's network POST (including retries).
-    This drives a slow POST specifically from the PERIODIC thread while the
-    read loop keeps appending fresh lines on the main thread, and asserts the
-    read loop was NOT stalled behind it: total wall-clock time stays close to
-    the (short) time it takes to feed the lines, not to
-    (slow POST duration + line-feed duration) as it would if a per-line
-    append had to wait for the in-flight POST to finish."""
+    """review N2 (hardened per round-2 N7): before the fix, every per-line
+    append held `transcript_lock` for the ENTIRE duration of a flush's
+    network POST (including retries). This drives a slow POST specifically
+    from the PERIODIC thread while the read loop keeps consuming fresh lines
+    on the main thread.
+
+    Asserts STRUCTURALLY rather than on total elapsed wall-clock time (a
+    round-2 finding: a 0.43-0.44s vs. 0.5s bound is only ~13% headroom, thin
+    enough to flake on a loaded/shared CI runner): records the timestamp each
+    line is CONSUMED off stdout, and requires the LAST one to land before the
+    slow POST returns. If per-line appends were blocked behind the in-flight
+    POST, no further line could be consumed until it finished, so the last
+    line's timestamp would fall AFTER the POST's return — this cannot flake
+    on system load the way a total-duration bound can, because it compares
+    two events on the SAME timeline rather than an absolute duration against
+    a fixed constant.
+    """
     monkeypatch.setattr(cloud_runner, "TRANSCRIPT_FLUSH_SECONDS", 0.02)
     monkeypatch.setattr(cloud_runner, "TRANSCRIPT_FLUSH_BYTES", 10**9)  # never byte-trigger; isolate the timer
 
@@ -849,10 +934,13 @@ def test_run_claude_append_not_blocked_by_a_slow_transcript_post(cloud_runner, m
         {"type": "result", "session_id": "sess-slow-post", "result": "done", "is_error": False}
     ) + "\n")
 
+    line_consumed_at: list[float] = []
+
     class _SlowLineStdout:
         def __iter__(self):
             for line in lines:
                 time.sleep(LINE_DELAY_SECONDS)
+                line_consumed_at.append(time.monotonic())
                 yield line
 
     class _FakeProcSlowLines:
@@ -869,6 +957,7 @@ def test_run_claude_append_not_blocked_by_a_slow_transcript_post(cloud_runner, m
     monkeypatch.setattr(cloud_runner.subprocess, "Popen", lambda *a, **k: _FakeProcSlowLines())
 
     first_post_started = threading.Event()
+    post_finished_at: list[float] = []
     call_count = [0]
     calls_lock = threading.Lock()
 
@@ -880,27 +969,21 @@ def test_run_claude_append_not_blocked_by_a_slow_transcript_post(cloud_runner, m
             if is_first:
                 first_post_started.set()
                 time.sleep(SLOW_POST_SECONDS)  # simulate a slow/struggling canopy-web
+                post_finished_at.append(time.monotonic())
             return 200, {}
         raise AssertionError(f"unexpected call {method} {path}")
 
     monkeypatch.setattr(cloud_runner, "_api", fake_api)
 
-    start = time.monotonic()
     ok, _text, _sid = cloud_runner.run_claude(
         "hi", "turn-slow-post", lambda batch: None, cwd=tmp_path,
     )
-    elapsed = time.monotonic() - start
 
     assert ok is True
     assert first_post_started.is_set(), "the periodic flush never fired a POST to slow down"
-    # If per-line appends were blocked behind the slow POST (the pre-N2
-    # behavior), elapsed would be at least SLOW_POST_SECONDS PLUS the line
-    # feed time serialized after it. Unblocked, the line-feeding (bounded by
-    # N_LINES * LINE_DELAY_SECONDS) overlaps the slow POST almost entirely, so
-    # total time stays close to SLOW_POST_SECONDS with generous headroom —
-    # nowhere near the fully-serialized sum.
-    serialized_lower_bound = SLOW_POST_SECONDS + (N_LINES * LINE_DELAY_SECONDS)
-    assert elapsed < serialized_lower_bound - 0.1, (
-        f"elapsed={elapsed:.3f}s is too close to the fully-serialized bound "
-        f"({serialized_lower_bound:.3f}s) — appends look blocked on the slow POST"
+    assert post_finished_at, "the slow POST never returned"
+    assert line_consumed_at, "no lines were consumed"
+    assert line_consumed_at[-1] < post_finished_at[0], (
+        "the LAST line was only consumed AFTER the slow POST returned — "
+        "the read loop looks blocked behind it (review N2)"
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,14 @@ dev = [
     "pytest>=8.0,<9.0",
     "pytest-django>=4.8,<5.0",
     "pytest-asyncio>=0.23,<1.0",
+    # A lock-ordering regression in deploy/ec2-runner/cloud_runner.py's
+    # threading (transcript_lock / transcript_post_lock) can deadlock rather
+    # than fail — verified in review: reintroducing an inverse acquisition
+    # order hangs the concurrency tests, and with no per-test timeout that
+    # hangs the whole CI job instead of failing it. `--timeout` markers on
+    # those tests (see deploy/ec2-runner/tests/test_cloud_runner.py) turn a
+    # hang into a normal failed-test report.
+    "pytest-timeout>=2.3,<3.0",
     "ruff>=0.4,<1.0",
     "schemathesis>=3.30,<4.0",
     # dev-only: channels.testing.WebsocketCommunicator imports daphne's live

--- a/uv.lock
+++ b/uv.lock
@@ -460,6 +460,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-django" },
+    { name = "pytest-timeout" },
     { name = "ruff" },
     { name = "schemathesis" },
 ]
@@ -488,6 +489,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0,<9.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23,<1.0" },
     { name = "pytest-django", marker = "extra == 'dev'", specifier = ">=4.8,<5.0" },
+    { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.3,<3.0" },
     { name = "pywebpush", specifier = ">=2.3.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4,<1.0" },
     { name = "schemathesis", marker = "extra == 'dev'", specifier = ">=3.30,<4.0" },
@@ -2672,6 +2674,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/59/30/6ec8dfc678ddfd1c294212bbd7088c52d3f7fbf3f05e6d8a440c13b9741a/pytest_subtests-0.14.2.tar.gz", hash = "sha256:7154a8665fd528ee70a76d00216a44d139dc3c9c83521a0f779f7b0ad4f800de", size = 18083, upload-time = "2025-06-13T10:50:01.636Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/47/d4/9bf12e59fb882b0cf4f993871e1adbee094802224c429b00861acee1a169/pytest_subtests-0.14.2-py3-none-any.whl", hash = "sha256:8da0787c994ab372a13a0ad7d390533ad2e4385cac167b3ac501258c885d0b66", size = 9115, upload-time = "2025-06-13T10:50:00.543Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Makes canopy's headless cloud runner able to execute session turns, retain the raw transcript, and genuinely resume — PR 2 of the run-execution convergence (`docs/superpowers/specs/2026-07-26-run-execution-convergence-design.md`).

## What it does

1. **Session capability, defaulted OFF.** `RUNNER_SESSIONS` gates `capabilities.sessions`. It is opt-in **deliberately**: on labs every session is stamped `transcript_sourced` at birth, so `project_events` returns 0 and the `TurnEvent`s this runner posts are live-view only. The sole durable path is `persist_transcript_rows` ← `POST /runners/{id}/session-stream`, implemented **only** in `packages/canopy_runner`. Defaulting this on would let the runner claim chat turns it cannot durably record — the user watches the reply stream, reloads, and the conversation is empty including their own message. Flipping the default requires building that path first; there is a comment at the declaration saying so.
2. **Raw transcript retention.** Every stream-json line is forwarded verbatim to `POST /turns/{id}/transcript`, batched **by bytes** under the server's 1 MiB cap, with a stable `batch_id` per batch so a retry after a lost response cannot duplicate lines (duplicates silently inflate derived cost, which is the whole reason the store exists). A transcript failure never fails the turn.
3. **Real `--resume`.** Captures the CLI's session id and round-trips it through the existing resolve/record-session RPCs, with a filesystem existence check before ever passing `--resume` and a fallback to a fresh spawn. Replaces the synthetic `cloud-<uuid8>` placeholder.

Note: the plan named `canopy_sessions.Session.cli_session_id` as the field to use. **That field does not exist** (only `agents.AgentTurn` and `session_sharing.Session` have it), and `record_session` takes `session_id` for wire-compat while the binding keys on `session_key`. `RunnerBinding.session_key` is used instead.

## Review history — three rounds, and what they caught

This shipped through review rather than around it, and the reviews were load-bearing:

- **Round 1** — defaulting `capabilities.sessions` on (the chat data-loss path above); `--resume` could never resolve because every turn got a fresh cwd while Claude Code resolves session ids *by* cwd.
- **Round 2** — the round-1 fix introduced a **deadlock**: an unconditional `proc.wait()` in `finally` blocked forever on an undrained stdout pipe, so `lease_stop.set()` never ran and the lease thread heartbeated the turn `EXECUTING` forever, wedging the agent via `one_executing_turn_per_agent`. Also: the buffer lock was held across the network, and `flush()` cleared after `emit()` so a raising emit re-emitted the batch.
- **Round 3** — the round-2 fix killed the child **unconditionally, including on clean turns** (`returncode=-9`, `ok=True`→`ok=False`), and SIGKILL at stdout-EOF risked truncating the very `.jsonl` that `--resume` reads. Teardown is now `close()` → `wait(15s)` → kill **only on timeout** → `wait(15s)`.

**Four tests were found unable to fail for the bug they named**, including `_FakeProc` lacking `wait(timeout=...)`/`kill()` entirely — so the reap path was never exercised. All fixed, each by hand-reverting the fix and confirming the paired test fails.

Added `pytest-timeout` + `@pytest.mark.timeout(20)` on the five lock-driving tests: without it a lock-order regression **hung CI instead of failing it**.

## Verification, stated honestly

**No cloud runner or EC2 box exists, so none of this was exercised against a live `claude` binary or live endpoints.** Unit-level only: batching arithmetic, argv construction, RPC shapes, teardown ordering, and concurrency (order / no-duplication / no-loss, with jitter so a missing post-lock produces an observable reorder).

Rebased onto #425 (drain-the-queue claim loop); full suite 1615 passed / 1 skipped, ruff clean.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>