### PR TITLE
fix(harness): one executing PROJECT turn blocked every agent turn (NULL NOT IN)

### DIFF
--- a/apps/harness/services.py
+++ b/apps/harness/services.py
@@ -408,7 +408,18 @@ def claim_next_turn(runner: Runner, *, lease_seconds: int = DEFAULT_LEASE_SECOND
         # prefer_local turns fall to cloud only via the Phase 2 router policy;
         # Phase 0 has no cloud runners, so keep the simple rule: cloud never
         # takes local_only.
-    busy_agents = Turn.objects.filter(status__in=EXECUTING).values("agent_id")
+    # `agent__isnull=False` is load-bearing for exactly the reason spelled out for
+    # busy_sessions below — the same trap, which was fixed there and missed here.
+    # A PROJECT turn has agent_id NULL, so without this filter one executing repo
+    # turn injected a NULL into this IN-list and every queued AGENT turn evaluated
+    # `agent_id IN (…, NULL)` -> NULL -> got wrongly excluded. Not "that agent is
+    # busy": the runner claimed NOTHING AT ALL while any project turn ran.
+    # Observed on the cloud runner — a drill sat QUEUED and pinned for 40+ minutes
+    # while the runner was online and heartbeating and POST /claim returned 204,
+    # because two canopy-web project turns happened to be executing.
+    busy_agents = Turn.objects.filter(
+        status__in=EXECUTING, agent__isnull=False
+    ).values("agent_id")
     # A session serializes like an agent: never claim a session that already has
     # an executing turn (one_executing_turn_per_session would reject the claim
     # anyway; this avoids the wasted attempt). The chat_session__isnull=False filter

--- a/tests/test_harness_claim_projects.py
+++ b/tests/test_harness_claim_projects.py
@@ -146,3 +146,58 @@ def test_a_runner_not_declaring_a_project_does_not_claim_it():
     )
 
     assert services.claim_next_turn(runner) is None
+
+
+def test_an_executing_project_turn_does_not_block_every_agent_turn():
+    """The NULL-in-NOT-IN trap: an EXECUTING *project* turn has agent_id NULL, so
+    `busy_agents` contained NULL and `.exclude(agent_id__in=busy_agents)` became
+    `NOT IN (..., NULL)` — never TRUE in SQL, which silently discarded EVERY
+    candidate. One running repo turn made the runner claim nothing at all.
+
+    Observed on the cloud runner: a drill sat QUEUED and pinned for 40+ minutes
+    while the runner was online and heartbeating, and `POST /claim` returned 204,
+    because two canopy-web project turns happened to be executing.
+
+    The identical trap is already documented and guarded for `busy_sessions` a few
+    lines below; it was simply never applied to `busy_agents`.
+    """
+    jj = _user("jj")
+    ws = _ws("dimagi", jj)
+    runner = _runner(jj, workspace=ws)
+    agent = Agent.objects.create(slug="hal", name="Hal", workspace=ws)
+
+    # A repo turn already executing on this runner (agent_id IS NULL).
+    Turn.objects.create(
+        project="canopy-web", workspace=ws, origin="api", prompt="repo work",
+        idempotency_key="busy-project-turn", status=Turn.RUNNING,
+        claimed_by=runner, claimed_at=timezone.now(),
+    )
+    # An unrelated agent turn, pinned to this very runner (a drill).
+    queued = Turn.objects.create(
+        agent=agent, workspace=ws, origin="drill", prompt="readiness drill",
+        idempotency_key="drill-hal-1", status=Turn.QUEUED, pinned_runner=runner,
+    )
+
+    got = services.claim_next_turn(runner)
+    assert got is not None, "an executing PROJECT turn must not block agent turns"
+    assert got.pk == queued.pk
+
+
+def test_an_executing_agent_turn_still_blocks_that_same_agent():
+    """The real constraint must survive the fix: one executing turn per agent."""
+    jj = _user("jj")
+    ws = _ws("dimagi", jj)
+    runner = _runner(jj, workspace=ws)
+    agent = Agent.objects.create(slug="hal", name="Hal", workspace=ws)
+
+    Turn.objects.create(
+        agent=agent, workspace=ws, origin="api", prompt="already running",
+        idempotency_key="hal-running", status=Turn.RUNNING,
+        claimed_by=runner, claimed_at=timezone.now(),
+    )
+    Turn.objects.create(
+        agent=agent, workspace=ws, origin="drill", prompt="second",
+        idempotency_key="hal-second", status=Turn.QUEUED, pinned_runner=runner,
+    )
+
+    assert services.claim_next_turn(runner) is None


### PR DESCRIPTION
## The bug

```python
busy_agents = Turn.objects.filter(status__in=EXECUTING).values("agent_id")
...
.exclude(agent_id__in=busy_agents)
```

Project turns have `agent_id = NULL`. So while any project turn was executing, that subquery contained `NULL`, and `NOT IN (…, NULL)` is **never TRUE** in SQL — it evaluates to UNKNOWN for every row, and the candidate set came back **empty**.

The effect was not "that agent is busy". While any project turn ran, the runner could claim **nothing at all** — including turns pinned directly to it.

## How it presented

The cloud runner stalled completely: a drill sat `QUEUED` **and pinned** for 40+ minutes while the runner was `online`, heartbeating every 20s, and `POST /runners/{id}/claim` returned `204`. Two canopy-web project turns happened to be executing the whole time.

`GET /turns/unclaimable` reported **0**, which is what made this so hard to see — that path builds its own query and never touches this `exclude`, so the server confidently said the turns were claimable while the claim path silently discarded them.

It also masked itself historically: the runner appeared to work whenever no project turn was running.

## The fix

The identical trap is already documented in the comment on `busy_sessions` immediately below, where `chat_session__isnull=False` guards against exactly this NULL injection. It was simply never applied to `busy_agents`. Same guard:

```python
busy_agents = Turn.objects.filter(
    status__in=EXECUTING, agent__isnull=False
).values("agent_id")
```

## Tests

- An executing **project** turn no longer blocks an unrelated agent's queued turn — verified to **fail without the fix** and pass with it.
- An executing **agent** turn still blocks that same agent (the real `one_executing_turn_per_agent` constraint, unchanged).

Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)