### PR TITLE
fix(storyboards): the share link must carry the deployment's script prefix

### DIFF
--- a/apps/storyboards/api.py
+++ b/apps/storyboards/api.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from django.db import transaction
 from django.http import HttpRequest
+from django.urls import get_script_prefix
 from ninja import Router
 from ninja.errors import HttpError
 
@@ -77,10 +78,19 @@ def _owned_or_404(request: HttpRequest, slug: str) -> Storyboard:
 
 
 def _share_url(request: HttpRequest, board: Storyboard) -> str | None:
+    """The absolute, token-bearing link — the thing you actually send someone.
+
+    Must include the deployment's script prefix: labs serves under
+    ``FORCE_SCRIPT_NAME=/canopy``, and ``build_absolute_uri`` on a leading-slash
+    path drops it, minting a link that 404s. Same fix apps/walkthroughs already
+    carries; reuse it rather than rediscovering it (this one shipped broken and
+    was caught by opening the link).
+    """
     if not board.share_token:
         return None
+    prefix = get_script_prefix().rstrip("/")  # "" locally, "/canopy" on labs
     return request.build_absolute_uri(
-        f"/storyboard/{board.slug}?t={board.share_token}"
+        f"{prefix}/storyboard/{board.slug}?t={board.share_token}"
     )
 
 

--- a/tests/test_storyboard_api.py
+++ b/tests/test_storyboard_api.py
@@ -318,3 +318,27 @@ def test_the_reader_gets_current_and_previous_narration(board, ws):
     assert body["narration"][0]["text"] == "The new line."
     assert body["previous_narration"][0]["text"] == "The old line."
     assert body["capability"] == "read"
+
+
+def test_the_share_url_carries_the_deployment_script_prefix(member, board, settings):
+    """labs serves under FORCE_SCRIPT_NAME=/canopy. build_absolute_uri on a
+    leading-slash path DROPS it, which mints a link that 404s — this shipped
+    broken and was only caught by opening the link. apps/walkthroughs already
+    solved it with get_script_prefix(); this is the same fix."""
+    from django.urls import set_script_prefix
+
+    set_script_prefix("/canopy/")
+    try:
+        url = member.post(f"/api/storyboards/{board.slug}/share").json()["share_url"]
+        assert "/canopy/storyboard/" in url, url
+        assert "?t=" in url
+    finally:
+        set_script_prefix("/")
+
+
+def test_the_share_url_has_no_prefix_when_served_at_root(member, board):
+    from django.urls import set_script_prefix
+
+    set_script_prefix("/")
+    url = member.post(f"/api/storyboards/{board.slug}/share").json()["share_url"]
+    assert "/storyboard/" in url and "/canopy/" not in url, url


### PR DESCRIPTION
**The minted share link 404s.** Confirmed against live labs:

```
https://labs.connect.dimagi.com/storyboard/rf-surveys?t=…          → 404
https://labs.connect.dimagi.com/canopy/storyboard/rf-surveys?t=…  → 200
```

labs serves under `FORCE_SCRIPT_NAME=/canopy`, and `build_absolute_uri` on a leading-slash path drops the prefix.

`apps/walkthroughs/api.py::_share_url` already carries this exact fix, comment and all — `# "" locally, "/canopy" on labs`. I wrote a second `_share_url` in #432 without reusing it, which is the whole failure: the codebase already knew.

Caught by opening the link before sending it to a reviewer, which is the only reason it didn't go out dead.

Two tests pin both deployments: prefixed under `/canopy`, unprefixed at root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)