### PR TITLE
fix(storyboards): the shared link 404'd, then bounced the reader to Google

### DIFF
--- a/apps/storyboards/api.py
+++ b/apps/storyboards/api.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from django.db import transaction
 from django.http import HttpRequest
+from django.urls import get_script_prefix
 from ninja import Router
 from ninja.errors import HttpError
 
@@ -77,10 +78,19 @@ def _owned_or_404(request: HttpRequest, slug: str) -> Storyboard:
 
 
 def _share_url(request: HttpRequest, board: Storyboard) -> str | None:
+    """The absolute, token-bearing link — the thing you actually send someone.
+
+    Must include the deployment's script prefix: labs serves under
+    ``FORCE_SCRIPT_NAME=/canopy``, and ``build_absolute_uri`` on a leading-slash
+    path drops it, minting a link that 404s. Same fix apps/walkthroughs already
+    carries; reuse it rather than rediscovering it (this one shipped broken and
+    was caught by opening the link).
+    """
     if not board.share_token:
         return None
+    prefix = get_script_prefix().rstrip("/")  # "" locally, "/canopy" on labs
     return request.build_absolute_uri(
-        f"/storyboard/{board.slug}?t={board.share_token}"
+        f"{prefix}/storyboard/{board.slug}?t={board.share_token}"
     )
 
 

--- a/frontend/src/api/client.v2.ts
+++ b/frontend/src/api/client.v2.ts
@@ -94,6 +94,8 @@ function isPublicLinkRoute(): boolean {
     p.startsWith("/walkthrough/") ||
     p.startsWith("/share/") ||
     p.startsWith("/ddd-release/") ||
+    p.startsWith("/storyboard/") ||
+    p.startsWith("/narrative/") ||
     p.startsWith("/invite/")
   );
 }

--- a/frontend/src/auth/AuthProvider.tsx
+++ b/frontend/src/auth/AuthProvider.tsx
@@ -29,6 +29,8 @@ function isPublicLinkRoute(): boolean {
     path.startsWith('/walkthrough/') ||
     path.startsWith('/share/') ||
     path.startsWith('/ddd-release/') ||
+    path.startsWith('/storyboard/') ||
+    path.startsWith('/narrative/') ||
     path.startsWith('/invite/') ||
     LEGACY_WALKTHROUGH_RE.test(path)
   )

--- a/frontend/src/auth/publicLinkRoutes.test.ts
+++ b/frontend/src/auth/publicLinkRoutes.test.ts
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest'
+import clientSrc from '../api/client.v2.ts?raw'
+import authSrc from './AuthProvider.tsx?raw'
+
+/**
+ * `isPublicLinkRoute` exists TWICE — in api/client.v2.ts (which decides whether
+ * a 401 bounces the browser to Google) and in auth/AuthProvider.tsx (which
+ * decides what to paint). A route added to one and not the other sends an
+ * anonymous visitor holding a valid share link to a login screen.
+ *
+ * That is exactly what /storyboard/ did: the server served the page, the API
+ * answered the share token fine, and an incidental /api/me 401 still bounced
+ * the visitor to Google. Caught by opening the link, not by any test — hence
+ * this one.
+ */
+function publicPrefixes(source: string): string[] {
+  const fn = source.slice(source.indexOf('function isPublicLinkRoute'))
+  const body = fn.slice(0, fn.indexOf('\n}'))
+  return [...body.matchAll(/startsWith\(['"]([^'"]+)['"]\)/g)].map((m) => m[1]).sort()
+}
+
+describe('isPublicLinkRoute', () => {
+  it('lists the same routes in both copies', () => {
+    expect(publicPrefixes(clientSrc)).toEqual(publicPrefixes(authSrc))
+  })
+
+  it('covers every chrome-less public surface', () => {
+    const prefixes = publicPrefixes(clientSrc)
+    for (const route of [
+      '/review/', '/share/', '/ddd-release/', '/storyboard/', '/narrative/', '/invite/',
+    ]) {
+      expect(prefixes).toContain(route)
+    }
+  })
+})

--- a/tests/test_storyboard_api.py
+++ b/tests/test_storyboard_api.py
@@ -318,3 +318,27 @@ def test_the_reader_gets_current_and_previous_narration(board, ws):
     assert body["narration"][0]["text"] == "The new line."
     assert body["previous_narration"][0]["text"] == "The old line."
     assert body["capability"] == "read"
+
+
+def test_the_share_url_carries_the_deployment_script_prefix(member, board, settings):
+    """labs serves under FORCE_SCRIPT_NAME=/canopy. build_absolute_uri on a
+    leading-slash path DROPS it, which mints a link that 404s — this shipped
+    broken and was only caught by opening the link. apps/walkthroughs already
+    solved it with get_script_prefix(); this is the same fix."""
+    from django.urls import set_script_prefix
+
+    set_script_prefix("/canopy/")
+    try:
+        url = member.post(f"/api/storyboards/{board.slug}/share").json()["share_url"]
+        assert "/canopy/storyboard/" in url, url
+        assert "?t=" in url
+    finally:
+        set_script_prefix("/")
+
+
+def test_the_share_url_has_no_prefix_when_served_at_root(member, board):
+    from django.urls import set_script_prefix
+
+    set_script_prefix("/")
+    url = member.post(f"/api/storyboards/{board.slug}/share").json()["share_url"]
+    assert "/storyboard/" in url and "/canopy/" not in url, url


### PR DESCRIPTION
Two defects in the link I was about to send to a domain expert. **Both were invisible from curl** — the server returned the right HTML and the API answered the share token with a clean 200. Only opening it in a browser showed them.

Supersedes #436 (contains that fix plus this second one).

### 1. The link 404'd

```
https://labs.connect.dimagi.com/storyboard/rf-surveys?t=…          → 404
https://labs.connect.dimagi.com/canopy/storyboard/rf-surveys?t=…  → 200
```

labs runs under `FORCE_SCRIPT_NAME=/canopy`; `build_absolute_uri` on a leading-slash path drops the prefix. `apps/walkthroughs/api.py::_share_url` already carries this exact fix, comment and all — I wrote a second `_share_url` in #432 without reusing it.

### 2. …and then bounced the reader to Google

`isPublicLinkRoute` didn't list `/storyboard/` or `/narrative/`. That function exists **twice** — `api/client.v2.ts` decides whether a 401 bounces the browser to Google, `auth/AuthProvider.tsx` decides what to paint. So an anonymous visitor holding a valid token loaded the page, got a 200 from the API, and was *still* redirected to a Google sign-in by an incidental `/api/me` 401.

The duplication is the real hazard: the two lists can silently disagree. `publicLinkRoutes.test.ts` now pins them against each other *and* against the full set of chrome-less surfaces. I verified it fails when either entry is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)