### PR TITLE
fix(ddd): pair legacy narrative versions positionally when no id is shared

### DIFF
--- a/frontend/src/components/ddd/narrativeScenePairing.test.ts
+++ b/frontend/src/components/ddd/narrativeScenePairing.test.ts
@@ -65,3 +65,49 @@ describe('pairNarrationScenes', () => {
     expect(pairs[1].status).toBe('changed')
   })
 })
+
+describe('legacy histories whose ids were derived from titles', () => {
+  // Real ids from verified-monitoring on labs, 2026-07-26. The author reworded
+  // every scene title between v16 and v17, and because pre-L0 ids were derived
+  // from the title, ZERO of six ids overlap — so id-matching reported six
+  // "New" scenes and no before/after, on the one narrative a domain expert had
+  // just iterated. This is the case the positional fallback exists for.
+  const v16 = [
+    { id: 'the-survey-verifies-the-program-now-maya-verifies-the-survey', text: 'Old beat one.' },
+    { id: 'the-gap-is-real-where-delivery-happened-vs-where-the-survey-checked', text: 'Old beat two.' },
+    { id: 'the-per-surveyor-scorecard-flags-a-surveyor-and-holds-the-work', text: 'Old beat three.' },
+    { id: 'the-independent-back-check-the-answers-don-t-match', text: 'Old beat four.' },
+    { id: 'the-distribution-signals-warning-signs-held-for-investigation', text: 'Old beat five.' },
+  ]
+  const v17 = [
+    { id: 'the-goal-independent-drillable-proof-the-program-works', text: 'Old beat one.' },
+    { id: 'six-bi-monthly-rounds-over-time-the-gap-holds', text: 'NEW beat two.' },
+    { id: 'where-delivery-happened-vs-where-the-survey-checked-the-map-moves', text: 'Old beat three.' },
+    { id: 'the-per-surveyor-quality-scorecard-catches-a-surveyor', text: 'NEW beat four.' },
+    { id: 'the-independent-back-check-confirms-it', text: 'Old beat five.' },
+    { id: 'gps-is-clean-the-distributions-screen-catches-the-fabrication', text: 'A genuinely new sixth beat.' },
+  ]
+
+  it('pairs positionally when no id is shared, instead of reporting all-new', () => {
+    const pairs = pairNarrationScenes(v16, v17)
+    expect(pairs.map((p) => p.status)).toEqual([
+      'unchanged', 'changed', 'unchanged', 'changed', 'unchanged', 'added',
+    ])
+    expect(pairs[1].before).toBe('Old beat two.')
+    expect(pairs[1].after).toBe('NEW beat two.')
+  })
+
+  it('still matches on id when the ids ARE comparable (post-L0 work)', () => {
+    const before = [{ id: 'the-goal', text: 'Was.' }, { id: 'the-proof', text: 'Same.' }]
+    const after = [{ id: 'the-proof', text: 'Same.' }, { id: 'the-goal', text: 'Now.' }]
+    const pairs = pairNarrationScenes(before, after)
+    // Reorder-safe: matched by id, not position.
+    expect(pairs.find((p) => p.id === 'the-goal')?.status).toBe('changed')
+    expect(pairs.find((p) => p.id === 'the-proof')?.status).toBe('unchanged')
+  })
+
+  it('does not fall back when one side is empty (a first version stays all-new)', () => {
+    const pairs = pairNarrationScenes([], [{ id: 'a', text: 'First ever.' }])
+    expect(pairs.map((p) => p.status)).toEqual(['added'])
+  })
+})

--- a/frontend/src/components/ddd/narrativeScenePairing.ts
+++ b/frontend/src/components/ddd/narrativeScenePairing.ts
@@ -29,6 +29,46 @@ function norm(s: string): string {
   return s.replace(/\s+/g, ' ').trim()
 }
 
+
+/** How many scene ids appear on both sides. 0 means the ids are incomparable. */
+function sharedIdCount(before: DddNarration[], after: DddNarration[]): number {
+  const ids = (list: DddNarration[]) =>
+    new Set(list.map((n) => (n.id != null ? String(n.id).trim() : '')).filter(Boolean))
+  const a = ids(before)
+  if (a.size === 0) return 0
+  let shared = 0
+  ids(after).forEach((id) => {
+    if (a.has(id)) shared += 1
+  })
+  return shared
+}
+
+/** Index-for-index pairing, for histories whose ids cannot be compared. */
+function pairByPosition(before: DddNarration[], after: DddNarration[]): NarrativeScenePair[] {
+  const pairs: NarrativeScenePair[] = []
+  const len = Math.max(before.length, after.length)
+  for (let i = 0; i < len; i += 1) {
+    const b = before[i]
+    const a = after[i]
+    if (a && b) {
+      const beforeText = textOf(b)
+      const afterText = textOf(a)
+      pairs.push({
+        id: a.id != null ? String(a.id) : null,
+        title: a.title ?? b.title ?? null,
+        before: beforeText,
+        after: afterText,
+        status: norm(beforeText) === norm(afterText) ? 'unchanged' : 'changed',
+      })
+    } else if (a) {
+      pairs.push({ id: a.id != null ? String(a.id) : null, title: a.title ?? null, before: null, after: textOf(a), status: 'added' })
+    } else if (b) {
+      pairs.push({ id: b.id != null ? String(b.id) : null, title: b.title ?? null, before: textOf(b), after: null, status: 'removed' })
+    }
+  }
+  return pairs
+}
+
 /**
  * Pair the scenes of two narrative versions for a plain-language before/after.
  *
@@ -40,6 +80,20 @@ export function pairNarrationScenes(
   before: DddNarration[],
   after: DddNarration[],
 ): NarrativeScenePair[] {
+  // Legacy histories pair POSITIONALLY, because their ids were derived from
+  // scene titles — so a version where the author reworded every title shares no
+  // id with its predecessor, and matching on id would report every scene as
+  // added+removed. That is precisely the case a domain expert cares about: on
+  // `verified-monitoring` v16→v17, zero of six ids overlapped and the diff
+  // would have shown six "New" scenes and no before/after at all.
+  //
+  // Zero overlap is the signal — with the stable ids authored since L0, a real
+  // rewrite still shares most ids, so this never fires on new work. Requiring
+  // BOTH sides non-empty keeps a genuine "all scenes replaced" edit honest.
+  if (before.length > 0 && after.length > 0 && sharedIdCount(before, after) === 0) {
+    return pairByPosition(before, after)
+  }
+
   const beforeByKey = new Map<string, DddNarration>()
   before.forEach((n, i) => {
     const k = keyOf(n, i)


### PR DESCRIPTION
Found while verifying the live `rf-surveys` arc on real data.

On **`verified-monitoring`** — the narrative the domain expert had just iterated — **zero of six scene ids overlap between v16 and v17**:

```
v16: the-survey-verifies-the-program-now-maya-verifies-the-survey, …
v17: the-goal-independent-drillable-proof-the-program-works, …
overlap: 0 of 6
```

So the reviewer surface would have shown six **"New"** scenes and no before/after — the one feature she needs, missing on the one narrative she cares most about.

**Cause:** pre-L0 ids were derived from scene *titles*, and her iteration reworded every title. L0 fixed that going forward, but every historical version already stored on canopy-web still carries title-derived ids. This is the "history is disposable" trade-off surfacing exactly where it hurts.

**Fix:** when the two versions share *no* id at all, pair index-for-index instead. Zero overlap is a reliable signal — with stable ids even a heavy rewrite shares most of them, so this never fires on post-L0 work. Requiring both sides non-empty keeps a genuine "all scenes replaced" edit honest, and a first version still reads as all-new.

Tests use the **real** v16/v17 ids from labs, and pin that id-matching still wins (reorder-safe) whenever ids are comparable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)