### PR TITLE
fix(ec2-runner): export GH_TOKEN so `gh` works — git worked, gh never did

### DIFF
--- a/deploy/ec2-runner/bootstrap_agents.sh
+++ b/deploy/ec2-runner/bootstrap_agents.sh
@@ -103,12 +103,12 @@ install_gog() {
   trap "rm -rf '$tmp'" RETURN
 
   if command -v gh >/dev/null 2>&1; then
-    # `gh release download` with no tag pulls the LATEST release; GH_TOKEN is
+    # `gh release download` with no tag pulls the LATEST release; a token is
     # optional for a public repo but avoids the unauthenticated 60/hr rate limit.
-    # cloud_runner stages the GitHub token into git's credential store, not a
-    # GITHUB_TOKEN env var, so this is usually empty — harmless (public repo);
-    # export GITHUB_TOKEN before invoking if you hit the anonymous rate limit.
-    if ! GH_TOKEN="${GITHUB_TOKEN:-}" gh release download -R steipete/gogcli \
+    # Fall back to the inherited GH_TOKEN: cloud_runner now exports it when it
+    # stages the credential bundle, and a bare `GH_TOKEN="${GITHUB_TOKEN:-}"`
+    # would BLANK that inherited value for this one call.
+    if ! GH_TOKEN="${GITHUB_TOKEN:-${GH_TOKEN:-}}" gh release download -R steipete/gogcli \
         --pattern 'gogcli_*_linux_amd64.tar.gz' --dir "$tmp" --clobber 2>&1; then
       warn "gh release download failed; falling back to the GitHub API + curl"
     fi

--- a/deploy/ec2-runner/cloud_runner.py
+++ b/deploy/ec2-runner/cloud_runner.py
@@ -710,8 +710,20 @@ def run_claude(prompt: str, turn_id: str, emit, cwd: pathlib.Path | None = None,
 
 
 def _stage_github_token(token: str) -> None:
-    """Wire a git credential helper so `git clone` of private agent repos works
-    (used by the reconciler in the next milestone; harmless for a trivial turn)."""
+    """Make the staged GitHub token usable by BOTH `git` and `gh`.
+
+    The credential helper only teaches `git` — `gh` ignores it entirely and looks
+    for its own login or GH_TOKEN. So every agent had working clone/fetch/push but
+    `gh auth status` reported "not logged into any GitHub hosts", which blocks the
+    PR-based shipping flow the operating model is built on. Readiness drills called
+    it out as the single blocking failure for hal after everything else was green.
+
+    Exporting GH_TOKEN is the fix rather than running `gh auth login`: it needs no
+    interactive step on a headless box, it is scoped to this process tree (so it is
+    inherited by agent turns via `_agent_env`, which copies os.environ), and it
+    leaves nothing on disk to go stale.
+    """
+    os.environ["GH_TOKEN"] = token
     try:
         subprocess.run(["git", "config", "--global", "credential.helper", "store"],
                        check=False, capture_output=True)


### PR DESCRIPTION
## The bug

The runner staged its GitHub token into **git's credential store only**. That teaches `git` — `gh` ignores the credential helper entirely and looks for its own login or `GH_TOKEN`.

So every agent on the box had working `clone`/`fetch`/`push` while `gh auth status` reported *"not logged into any GitHub hosts"*, blocking the PR-based shipping flow the operating model is built on.

Readiness drills flagged it as the **single blocking failure** for `hal` once everything else was green:

> *"gh auth status reports not logged into any GitHub hosts, which would block Hal ship actions (push/PR/merge) that the operating model depends on"*

## The fix

Export `GH_TOKEN` in `_stage_github_token`, where the token is already being staged — rather than running `gh auth login`:

- no interactive step on a headless box
- scoped to the process tree, so agent turns inherit it via `_agent_env` (which copies `os.environ`)
- nothing left on disk to go stale

## Also: stop bootstrap blanking it

```bash
GH_TOKEN="${GITHUB_TOKEN:-}" gh release download ...
```

`GITHUB_TOKEN` is never set on this box, so that assignment set `GH_TOKEN=""` for the call — harmless before (public repo), but it would now **clobber the inherited token**. Falls back to `GH_TOKEN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)