### PR TITLE
fix(chat): a NUL byte in a tool result could brick a session's history

### DIFF
--- a/apps/canopy_sessions/services.py
+++ b/apps/canopy_sessions/services.py
@@ -22,7 +22,7 @@ from apps.harness.models import Turn
 
 from . import attach
 from .models import Message, Session
-from .transcript_noise import is_system_noise
+from .transcript_noise import is_system_noise, scrub_nul
 
 # Ledger kinds we surface as transcript rows, and the Message role each maps to.
 _ROLE_FOR_KIND = {
@@ -309,6 +309,11 @@ def persist_transcript_rows(session, rows) -> int:
             content = row.get("content")
             if not isinstance(content, dict) or not content:
                 content = {"text": text}
+            # Postgres rejects NUL in text/jsonb, and the batch is ONE
+            # transaction — an unscrubbed byte from a binary tool result 500s
+            # every other row with it. See transcript_noise.scrub_nul.
+            text = scrub_nul(text)
+            content = scrub_nul(content)
             _, created = Message.objects.get_or_create(
                 session=locked, turn_index=index,
                 defaults={"role": role, "plaintext": text, "content": content},

--- a/apps/canopy_sessions/transcript_noise.py
+++ b/apps/canopy_sessions/transcript_noise.py
@@ -36,6 +36,31 @@ SYSTEM_NOISE_PREFIXES = (
 )
 
 
+def scrub_nul(value):
+    """Strip NUL bytes from every string in `value` (str / dict / list).
+
+    Postgres rejects 0x00 outright in text and jsonb. A tool result is raw bytes
+    from whatever the tool touched, so a `Read` of a compressed or binary file
+    carries one straight into the write path — observed on labs 2026-07-26: one
+    row in 683 took down the whole batch with a 500, and because the write is a
+    single transaction and the runner retries forever, that session's history
+    could never rebuild.
+
+    Server-side for the same reason the noise filter is (see the module
+    docstring): the runner has its own copy, but a producer-side scrub only
+    covers producers that have been updated, and the runner is a laptop daemon
+    on a checkout that lags. This is the single durable write path, so enforcing
+    it here is what makes the guarantee hold.
+    """
+    if isinstance(value, str):
+        return value.replace("\x00", "") if "\x00" in value else value
+    if isinstance(value, dict):
+        return {k: scrub_nul(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [scrub_nul(v) for v in value]
+    return value
+
+
 def is_system_noise(text: str) -> bool:
     """True when this record is harness output wearing a user record's clothes.
 

--- a/packages/canopy_runner/canopy_runner/chat_bridge.py
+++ b/packages/canopy_runner/canopy_runner/chat_bridge.py
@@ -142,7 +142,21 @@ TOOL_INPUT_STR_MAX = 4_000  # any single string inside a tool's input
 TOOL_INPUT_JSON_MAX = 16_000
 
 
+def scrub(text: str) -> str:
+    """Drop NUL bytes. Postgres rejects them outright in text and jsonb columns.
+
+    A tool result is raw bytes from whatever the tool touched, so `Read` on a
+    compressed or binary file puts one straight into the stream (found on labs
+    2026-07-26, one row in 683). The write is a single transaction, so ONE such
+    row 500s the whole batch — the session's history never rebuilds and the
+    runner retries it every tick forever. Only NUL is stripped: every other
+    control character is legal in Postgres text and is real transcript content.
+    """
+    return text.replace("\x00", "") if "\x00" in text else text
+
+
 def _truncate(text: str, limit: int) -> str:
+    text = scrub(text)
     if len(text) <= limit:
         return text
     return text[:limit] + f"\n… [truncated {len(text) - limit} chars]"
@@ -155,7 +169,7 @@ def _truncate_input(value, depth: int = 0):
     if depth > 6:
         return "…"
     if isinstance(value, str):
-        return _truncate(value, TOOL_INPUT_STR_MAX)
+        return _truncate(value, TOOL_INPUT_STR_MAX)  # _truncate scrubs NUL
     if isinstance(value, dict):
         return {k: _truncate_input(v, depth + 1) for k, v in value.items()}
     if isinstance(value, list):
@@ -218,7 +232,7 @@ def _rows_for_record(rec: dict) -> list[dict]:
 
     # A bare-string content is always a single plain message at block 0.
     if not isinstance(content, list):
-        text = _user_text(content) if kind == "user" else _assistant_text(content)
+        text = scrub(_user_text(content) if kind == "user" else _assistant_text(content))
         return [{"block": 0, "role": kind, "text": text, "content": {}}] if text else []
 
     # Overflow can only happen if a record ever carries more blocks than the
@@ -244,7 +258,7 @@ def _rows_for_blocks(kind: str, content: list) -> list[dict]:
             continue
         btype = block.get("type")
         if btype == "text":
-            text = str(block.get("text", "")).strip()
+            text = scrub(str(block.get("text", "")).strip())
             if text:
                 rows.append({"block": b_i, "role": kind, "text": text, "content": {}})
         elif btype == "tool_use":

--- a/packages/canopy_runner/tests/test_chat_bridge.py
+++ b/packages/canopy_runner/tests/test_chat_bridge.py
@@ -270,3 +270,32 @@ def test_end_index_marks_the_whole_file_as_already_seen():
         {"type": "tool_use", "id": "t1", "name": "X", "input": {}},
     ]}}]
     assert conversational_messages(recs, chat_bridge.end_index(len(recs))) == []
+
+
+def test_nul_bytes_are_stripped_from_tool_payloads():
+    """Postgres rejects NUL in text/jsonb, and the server writes a backfill batch
+    in ONE transaction — so a single binary tool result (a Read of a compressed
+    file) 500s the whole batch and the session's history can never rebuild.
+    Labs 2026-07-26: exactly one row in 683 did this."""
+    recs = [
+        {"type": "user", "message": {"content": [
+            {"type": "tool_result", "tool_use_id": "t1",
+             "content": "binary\x00payload"}]}},
+        {"type": "assistant", "message": {"content": [
+            {"type": "tool_use", "id": "t1", "name": "Write",
+             "input": {"content": "also\x00bad"}}]}},
+        {"type": "assistant", "message": {"content": [
+            {"type": "text", "text": "prose\x00too"}]}},
+    ]
+    result, use, prose = conversational_messages(recs, -1)
+    assert "\x00" not in result["text"]
+    assert "\x00" not in use["content"]["input"]["content"]
+    assert "\x00" not in prose["text"]
+    # Stripped, not mangled — the surrounding content survives.
+    assert result["text"] == "binarypayload"
+
+
+def test_scrub_leaves_other_control_characters_alone():
+    """Only NUL is rejected by Postgres; tabs/newlines/escapes are real content
+    and stripping them would corrupt every terminal capture we ship."""
+    assert chat_bridge.scrub("a\tb\nc\x1b[0m") == "a\tb\nc\x1b[0m"

--- a/tests/test_transcript_persistence.py
+++ b/tests/test_transcript_persistence.py
@@ -375,3 +375,27 @@ def test_tool_rows_persist_their_structured_content():
     assert use.role == Message.TOOL_USE and use.content["name"] == "Read"
     res = Message.objects.get(session=s, turn_index=128)
     assert res.role == Message.TOOL_RESULT and res.content["tool_use_id"] == "t1"
+
+
+def test_a_nul_byte_cannot_take_down_the_whole_batch():
+    """Postgres rejects NUL in text/jsonb. The batch is ONE transaction, so an
+    unscrubbed byte from a binary tool result (a Read of a compressed file) 500s
+    every other row with it — and since the runner retries forever, that
+    session's history could never rebuild. Labs 2026-07-26: one row in 683.
+
+    Scrubbed server-side because the runner's own copy only covers runners that
+    have been updated, and this is the single durable write path."""
+    _u, _ws, _r, s, _c = _ctx()
+    written = services.persist_transcript_rows(s, [
+        {"index": 0, "role": "user", "text": "before\x00after",
+         "content": {"text": "before\x00after"}},
+        {"index": 64, "role": "tool_result", "text": "bin\x00ary",
+         "content": {"tool_use_id": "t1", "is_error": False, "blob": "x\x00y"}},
+    ])
+    assert written == 2
+    rows = list(s.messages.order_by("turn_index"))
+    assert rows[0].plaintext == "beforeafter"
+    assert rows[1].plaintext == "binary"
+    assert rows[1].content["blob"] == "xy"          # nested strings too
+    assert rows[1].content["tool_use_id"] == "t1"   # non-strings untouched
+    assert rows[1].content["is_error"] is False


### PR DESCRIPTION
Found in production minutes after #427 deployed — a session whose backfill 500'd on every attempt, retried forever, and could never rebuild its history.

```
psycopg.DataError: PostgreSQL text fields cannot contain NUL (0x00) bytes
```

## What happened

A tool result is raw bytes from whatever the tool touched, so a `Read` of a compressed or binary file carries a NUL straight into the write path. Postgres rejects `0x00` outright in `text` and `jsonb`.

The backfill writes as **one transaction**, so a single bad row takes down every other row with it. On labs: **one row in 683** blocked a 683-row rebuild — permanently, because the runner re-attempts a failed backfill every tick and only logs the failure at `debug`.

That silent-retry-forever property is what turned a one-byte problem into a session that could never show its history.

## Fix

Scrubbed at **both layers**, for the reason `transcript_noise` already documents:

- **Runner** — payloads are clean on the wire, and stay small.
- **`persist_transcript_rows`** — a producer-side filter only ever covers producers that have been *updated*, and the runner is a laptop daemon on a checkout that lags. This is the single durable write path, so it's where the guarantee actually holds.

**Only NUL is stripped.** Every other control character is legal in Postgres text and is real transcript content — stripping tabs, newlines, or ANSI escapes would corrupt every terminal capture we ship.

## Verification

Re-ran the extractor over the exact transcript that caused it: **683 rows, 0 remaining NULs**. Suites: backend 1,680, runner 201.

Tests cover both layers, including that nested strings inside `content` are scrubbed while non-string values (`is_error: false`) are left alone.

(Supersedes #439, which diverged against its own squash-merged parent.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)