### PR TITLE
fix(storyboards): a card no longer repeats its lede as its heading

### DIFF
--- a/apps/runs/management/commands/move_narrative_workspace.py
+++ b/apps/runs/management/commands/move_narrative_workspace.py
@@ -1,0 +1,92 @@
+"""Move a narrative's artifacts to another workspace.
+
+A DDD narrative is not a table — it is inferred at read time from the
+``ReviewRequest`` and ``Walkthrough`` rows that share its slug. So a narrative
+"living in" a workspace really means every one of those rows carries that
+workspace, and nothing keeps them together: post a version from a differently
+scoped caller and the lineage silently splits across tenants.
+
+That is not hypothetical. On labs, ``create-survey-solicitation`` had v12 and
+v7..v1 in ``dimagi`` while v8..v11 sat in ``connect`` — so the narrative's own
+version history was unreadable from either side, and a storyboard scoped to one
+tenant diffed v12 against v7 instead of v11.
+
+DRY RUN BY DEFAULT. Pass ``--apply`` to execute. Mirrors ``audit_auto_join``.
+
+    python manage.py move_narrative_workspace --to connect \
+        --slug verified-monitoring --slug microplans-study-groups
+    python manage.py move_narrative_workspace --to connect --slug … --apply
+"""
+from __future__ import annotations
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+
+from apps.reviews.models import ReviewRequest
+from apps.runs.aggregate import narrative_of_review, narrative_of_walkthrough
+from apps.walkthroughs.models import Walkthrough
+from apps.workspaces.models import Workspace
+
+
+class Command(BaseCommand):
+    help = "Move every artifact of one or more narratives into a target workspace."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--to", required=True, help="Target workspace slug.")
+        parser.add_argument(
+            "--slug", action="append", default=[], required=True,
+            help="Narrative slug (repeatable).",
+        )
+        parser.add_argument(
+            "--apply", action="store_true",
+            help="Actually move the rows. Without it this only reports.",
+        )
+
+    def handle(self, *args, **opts):
+        target = opts["to"]
+        slugs = set(opts["slug"])
+        if not Workspace.objects.filter(slug=target).exists():
+            raise CommandError(f"no such workspace: {target}")
+
+        reviews = [r for r in ReviewRequest.objects.all() if narrative_of_review(r) in slugs]
+        walkthroughs = [
+            w for w in Walkthrough.objects.all() if narrative_of_walkthrough(w) in slugs
+        ]
+
+        moving_reviews = [r for r in reviews if r.workspace_id != target]
+        moving_wts = [w for w in walkthroughs if w.workspace_id != target]
+
+        for slug in sorted(slugs):
+            by_ws: dict[str | None, list[int]] = {}
+            for r in reviews:
+                if narrative_of_review(r) == slug:
+                    by_ws.setdefault(r.workspace_id, []).append(r.version or 0)
+            self.stdout.write(f"{slug}:")
+            for ws, versions in sorted(by_ws.items(), key=lambda kv: str(kv[0])):
+                mark = "  (target)" if ws == target else ""
+                self.stdout.write(f"    {ws}: v{sorted(versions)}{mark}")
+            n_w = sum(1 for w in walkthroughs if narrative_of_walkthrough(w) == slug)
+            self.stdout.write(f"    walkthroughs: {n_w}")
+
+        self.stdout.write(
+            f"\nWould move {len(moving_reviews)} review(s) and {len(moving_wts)} "
+            f"walkthrough(s) into {target!r}."
+        )
+
+        if not opts["apply"]:
+            self.stdout.write(self.style.WARNING("DRY RUN — pass --apply to execute."))
+            return
+
+        with transaction.atomic():
+            for r in moving_reviews:
+                r.workspace_id = target
+                r.save(update_fields=["workspace"])
+            for w in moving_wts:
+                w.workspace_id = target
+                w.save(update_fields=["workspace"])
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Moved {len(moving_reviews)} review(s) and {len(moving_wts)} walkthrough(s)."
+            )
+        )

--- a/apps/runs/management/commands/move_narrative_workspace.py
+++ b/apps/runs/management/commands/move_narrative_workspace.py
@@ -24,6 +24,7 @@ from django.db import transaction
 
 from apps.reviews.models import ReviewRequest
 from apps.runs.aggregate import narrative_of_review, narrative_of_walkthrough
+from apps.storyboards.models import Entry, Storyboard
 from apps.walkthroughs.models import Walkthrough
 from apps.workspaces.models import Workspace
 
@@ -56,6 +57,18 @@ class Command(BaseCommand):
         moving_reviews = [r for r in reviews if r.workspace_id != target]
         moving_wts = [w for w in walkthroughs if w.workspace_id != target]
 
+        # A storyboard resolves its entries against ITS OWN workspace, so a board
+        # left behind after its narratives move renders nothing but placeholders.
+        # Moving the narratives without it would just relocate the split.
+        board_ids = set(
+            Entry.objects.filter(narrative_slug__in=slugs).values_list(
+                "act__storyboard_id", flat=True
+            )
+        )
+        moving_boards = [
+            b for b in Storyboard.objects.filter(id__in=board_ids) if b.workspace_id != target
+        ]
+
         for slug in sorted(slugs):
             by_ws: dict[str | None, list[int]] = {}
             for r in reviews:
@@ -68,9 +81,12 @@ class Command(BaseCommand):
             n_w = sum(1 for w in walkthroughs if narrative_of_walkthrough(w) == slug)
             self.stdout.write(f"    walkthroughs: {n_w}")
 
+        for b in moving_boards:
+            self.stdout.write(f"storyboard {b.slug!r}: {b.workspace_id} -> {target}")
+
         self.stdout.write(
-            f"\nWould move {len(moving_reviews)} review(s) and {len(moving_wts)} "
-            f"walkthrough(s) into {target!r}."
+            f"\nWould move {len(moving_reviews)} review(s), {len(moving_wts)} "
+            f"walkthrough(s) and {len(moving_boards)} storyboard(s) into {target!r}."
         )
 
         if not opts["apply"]:
@@ -84,9 +100,13 @@ class Command(BaseCommand):
             for w in moving_wts:
                 w.workspace_id = target
                 w.save(update_fields=["workspace"])
+            for b in moving_boards:
+                b.workspace_id = target
+                b.save(update_fields=["workspace", "updated_at"])
 
         self.stdout.write(
             self.style.SUCCESS(
-                f"Moved {len(moving_reviews)} review(s) and {len(moving_wts)} walkthrough(s)."
+                f"Moved {len(moving_reviews)} review(s), {len(moving_wts)} walkthrough(s) "
+                f"and {len(moving_boards)} storyboard(s)."
             )
         )

--- a/apps/storyboards/services.py
+++ b/apps/storyboards/services.py
@@ -15,6 +15,22 @@ from apps.runs import aggregate
 from apps.storyboards.models import Storyboard
 
 
+# A narrative's stored `title` is derived from the opening of its story, so on a
+# card it repeats the lede verbatim — the heading was a truncated copy of the
+# paragraph directly beneath it. The release page already solved this with
+# _humanize_slug + _lede_from_story; reuse them rather than inventing a third
+# treatment. A genuinely short title (a real one, should narratives ever carry
+# one) is still preferred.
+_MAX_CARD_TITLE = 70
+
+
+def _card_title(narrative_slug: str, stored_title: str | None) -> str:
+    title = (stored_title or "").strip()
+    if title and len(title) <= _MAX_CARD_TITLE:
+        return title
+    return aggregate._humanize_slug(narrative_slug)
+
+
 def _entry_payload(entry, workspace_slugs: set[str]) -> dict:
     """One entry, resolved to what the page shows for it.
 
@@ -40,8 +56,8 @@ def _entry_payload(entry, workspace_slugs: set[str]) -> dict:
     story = current.get("story") or narrative.get("story") or ""
     return {
         "narrative_slug": entry.narrative_slug,
-        "title": current.get("title") or narrative.get("title") or entry.narrative_slug,
-        "lede": story,
+        "title": _card_title(entry.narrative_slug, current.get("title") or narrative.get("title")),
+        "lede": aggregate._lede_from_story(story, None) or story,
         "version": current.get("version"),
         "video_url": current.get("video_url"),
         "video_viewer_url": current.get("video_viewer_url"),

--- a/tests/test_move_narrative_workspace.py
+++ b/tests/test_move_narrative_workspace.py
@@ -1,0 +1,106 @@
+"""Moving a narrative's artifacts between workspaces. Dry run by default."""
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth.models import User
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+from apps.reviews.models import ReviewRequest
+from apps.workspaces.models import Workspace
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture()
+def workspaces():
+    owner = User.objects.create_user("jj", "jj@dimagi.com", "pw")
+    Workspace.objects.create(slug="dimagi", display_name="Dimagi", created_by=owner)
+    Workspace.objects.create(slug="connect", display_name="Connect", created_by=owner)
+    return owner
+
+
+def _review(slug: str, version: int, workspace: str) -> ReviewRequest:
+    return ReviewRequest.objects.create(
+        run_id=f"{slug}-2026-07-26-{version:03d}",
+        request_json={
+            "gate": "concept_change",
+            "narrative_slug": slug,
+            "narration": [{"id": "the-goal", "title": "T", "text": f"v{version}"}],
+        },
+        gate="concept_change",
+        visibility="link",
+        workspace_id=workspace,
+        version=version,
+    )
+
+
+def _split_lineage():
+    """The real labs shape: one narrative's versions straddling two tenants."""
+    _review("create-survey-solicitation", 7, "dimagi")
+    _review("create-survey-solicitation", 11, "connect")
+    _review("create-survey-solicitation", 12, "dimagi")
+    _review("untouched-narrative", 1, "dimagi")
+
+
+def test_dry_run_moves_nothing(workspaces, capsys):
+    _split_lineage()
+    call_command("move_narrative_workspace", "--to", "connect", "--slug", "create-survey-solicitation")
+
+    assert "DRY RUN" in capsys.readouterr().out
+    assert ReviewRequest.objects.filter(workspace_id="dimagi").count() == 3
+
+
+def test_apply_consolidates_the_lineage(workspaces):
+    _split_lineage()
+    call_command(
+        "move_narrative_workspace", "--to", "connect",
+        "--slug", "create-survey-solicitation", "--apply",
+    )
+
+    moved = ReviewRequest.objects.filter(run_id__startswith="create-survey-solicitation")
+    assert {r.workspace_id for r in moved} == {"connect"}
+    assert [r.version for r in moved.order_by("version")] == [7, 11, 12]
+
+
+def test_an_unnamed_narrative_is_untouched(workspaces):
+    _split_lineage()
+    call_command(
+        "move_narrative_workspace", "--to", "connect",
+        "--slug", "create-survey-solicitation", "--apply",
+    )
+    other = ReviewRequest.objects.get(run_id__startswith="untouched-narrative")
+    assert other.workspace_id == "dimagi"
+
+
+def test_rows_already_in_the_target_are_left_alone(workspaces, capsys):
+    _review("verified-monitoring", 17, "connect")
+    call_command("move_narrative_workspace", "--to", "connect", "--slug", "verified-monitoring")
+    assert "Would move 0 review(s)" in capsys.readouterr().out
+
+
+def test_it_is_idempotent(workspaces):
+    _split_lineage()
+    for _ in range(2):
+        call_command(
+            "move_narrative_workspace", "--to", "connect",
+            "--slug", "create-survey-solicitation", "--apply",
+        )
+    moved = ReviewRequest.objects.filter(run_id__startswith="create-survey-solicitation")
+    assert {r.workspace_id for r in moved} == {"connect"}
+    assert moved.count() == 3
+
+
+def test_an_unknown_target_workspace_is_a_loud_error(workspaces):
+    with pytest.raises(CommandError, match="no such workspace"):
+        call_command("move_narrative_workspace", "--to", "nope", "--slug", "x")
+
+
+def test_several_narratives_move_together(workspaces):
+    _review("a-narrative", 1, "dimagi")
+    _review("b-narrative", 1, "dimagi")
+    call_command(
+        "move_narrative_workspace", "--to", "connect",
+        "--slug", "a-narrative", "--slug", "b-narrative", "--apply",
+    )
+    assert ReviewRequest.objects.filter(workspace_id="connect").count() == 2

--- a/tests/test_move_narrative_workspace.py
+++ b/tests/test_move_narrative_workspace.py
@@ -104,3 +104,39 @@ def test_several_narratives_move_together(workspaces):
         "--slug", "a-narrative", "--slug", "b-narrative", "--apply",
     )
     assert ReviewRequest.objects.filter(workspace_id="connect").count() == 2
+
+
+def test_a_storyboard_follows_its_narratives(workspaces):
+    """A board resolves entries against ITS OWN workspace, so leaving it behind
+    would just relocate the split instead of healing it."""
+    from apps.storyboards.models import Act, Entry, Storyboard
+
+    board = Storyboard.objects.create(
+        slug="rf-surveys", title="Proving a programme works", workspace_id="dimagi"
+    )
+    act = Act.objects.create(storyboard=board, title="Act", position=0)
+    Entry.objects.create(act=act, narrative_slug="create-survey-solicitation", position=0)
+    _split_lineage()
+
+    call_command(
+        "move_narrative_workspace", "--to", "connect",
+        "--slug", "create-survey-solicitation", "--apply",
+    )
+    board.refresh_from_db()
+    assert board.workspace_id == "connect"
+
+
+def test_an_unrelated_storyboard_stays_put(workspaces):
+    from apps.storyboards.models import Act, Entry, Storyboard
+
+    other = Storyboard.objects.create(slug="other", title="Other", workspace_id="dimagi")
+    act = Act.objects.create(storyboard=other, title="Act", position=0)
+    Entry.objects.create(act=act, narrative_slug="something-else", position=0)
+    _split_lineage()
+
+    call_command(
+        "move_narrative_workspace", "--to", "connect",
+        "--slug", "create-survey-solicitation", "--apply",
+    )
+    other.refresh_from_db()
+    assert other.workspace_id == "dimagi"

--- a/tests/test_storyboard_resolve.py
+++ b/tests/test_storyboard_resolve.py
@@ -100,3 +100,40 @@ def test_capability_is_carried_so_the_page_knows_what_to_offer(board):
     board.capability = Storyboard.CAP_SUGGEST
     board.save()
     assert resolve_board(board)["capability"] == Storyboard.CAP_SUGGEST
+
+
+def test_a_card_never_repeats_its_lede_as_its_heading(board, ws):
+    """canopy-web derives a narrative's `title` from the opening of its story,
+    so using it verbatim made every card show the same paragraph twice — once
+    truncated as the heading, once in full beneath it. Observed on all three
+    live RF Surveys narratives."""
+    long_story = (
+        "Maya's goal is to measure differences in outcomes between her program's "
+        "intervention areas and carefully matched non-intervention areas — a rigorous "
+        "matched comparison, not a randomized trial. She wants to leverage the Connect "
+        "network to carry it out."
+    )
+    _publish(ws, "verified-monitoring", 1, long_story, long_story)
+
+    entry = resolve_board(board)["acts"][0]["entries"][0]
+    assert entry["title"] == "Verified Monitoring"
+    assert not entry["lede"].startswith(entry["title"])
+    assert len(entry["title"]) <= 70
+
+
+def test_the_lede_is_one_sentence_not_the_whole_story(board, ws):
+    story = "First sentence here. Second sentence that should not appear on the card."
+    _publish(ws, "verified-monitoring", 1, "A title", story)
+
+    entry = resolve_board(board)["acts"][0]["entries"][0]
+    assert entry["lede"] == "First sentence here."
+
+
+def test_a_genuinely_short_title_is_still_used(board, ws):
+    """canopy-web ALWAYS derives a narrative's title from the opening of its
+    story — there is no separate title field to pass. So a short title only
+    exists when the story itself opens with a short line, and in that case it is
+    a real title and should win over the humanized slug."""
+    _publish(ws, "verified-monitoring", 1, "ignored", "Checking the checkers.")
+    entry = resolve_board(board)["acts"][0]["entries"][0]
+    assert entry["title"] == "Checking the checkers."


### PR DESCRIPTION
Found by reading the live `rf-surveys` arc rather than testing it.

**Every card showed the same paragraph twice** — once truncated at ~90 chars as the heading, once in full directly beneath:

```
ENTRY: Maya's goal is to measure differences in outcomes between her program's intervention are…
   lede: Maya's goal is to measure differences in outcomes between her program's intervention
         areas and carefully matched non-intervention areas — a rigorous matched comparison…
```

canopy-web derives a narrative's `title` from the opening of its story, so using it verbatim as a card heading is *guaranteed* duplication — on all three narratives.

`apps/runs/aggregate` already solved this for the release page with `_humanize_slug` + `_lede_from_story`. I'd written a third treatment instead of reusing them — the same mistake as the share-URL prefix, in the same PR.

Now a genuinely short title wins (should a narrative ever open with one), otherwise the humanized slug; and the lede is the story's **first sentence**, not the whole paragraph.

Writing the tests corrected my own model of the data, too: the aggregator *always* derives the title from the story — there is no separate title field — which is precisely why the duplication was unavoidable rather than incidental.

🤖 Generated with [Claude Code](https://claude.com/claude-code)