### PR TITLE
perf(chat): stop storing every transcript row's text twice; surface stuck runner posts

### DIFF
--- a/apps/canopy_sessions/services.py
+++ b/apps/canopy_sessions/services.py
@@ -239,6 +239,27 @@ def request_backfill(session) -> str:
     return "requested"
 
 
+def storage_content(content: dict, text: str) -> dict:
+    """The row's `content` as STORED — the wire payload minus its `text` key.
+
+    The wire and the row deliberately share one shape (the live frame's `block`,
+    the backfill payload, and this column are the same dict), and that shape has
+    to carry `text` because the client builds a message from the frame alone.
+    Storage does not: `plaintext` is its own column, and nothing on the render
+    path reads `content["text"]` — MessageItem and ToolCallPair both use
+    `plaintext`.
+
+    Keeping the copy cost 36% of all stored transcript bytes (measured over
+    20,585 rows of live transcripts, 2026-07-26: 9.4MB of 26.2MB), mostly tool
+    result bodies duplicated verbatim. Only the redundant key is dropped: a
+    `text` that somehow DIFFERS from plaintext is kept, and every other key
+    (`id`, `name`, `input`, `tool_use_id`, `client_id`) is untouched.
+    """
+    if content.get("text") != text:
+        return content
+    return {k: v for k, v in content.items() if k != "text"}
+
+
 # The transcript-ordinal scheme this build writes. Bumped whenever the mapping
 # from a transcript record to a `turn_index` changes; see Session.ordinal_scheme.
 ORDINAL_SCHEME = 1
@@ -307,13 +328,13 @@ def persist_transcript_rows(session, rows) -> int:
                     next_index = _next_index(locked)
                 index, next_index = next_index, next_index + 1
             content = row.get("content")
-            if not isinstance(content, dict) or not content:
-                content = {"text": text}
+            if not isinstance(content, dict):
+                content = {}
             # Postgres rejects NUL in text/jsonb, and the batch is ONE
             # transaction — an unscrubbed byte from a binary tool result 500s
             # every other row with it. See transcript_noise.scrub_nul.
             text = scrub_nul(text)
-            content = scrub_nul(content)
+            content = storage_content(scrub_nul(content), text)
             _, created = Message.objects.get_or_create(
                 session=locked, turn_index=index,
                 defaults={"role": role, "plaintext": text, "content": content},

--- a/packages/canopy_runner/canopy_runner/main.py
+++ b/packages/canopy_runner/canopy_runner/main.py
@@ -376,6 +376,37 @@ def _drain_chat_bridges(cfg: Config, client: Client, *, poll: float = 1.0,
         time.sleep(poll)
 
 
+# Persistent per-key failure counters for the best-effort transcript paths
+# (stream posts, backfill posts). These retry every tick forever by design, so
+# logging each failure would spam and logging none is what actually happened:
+# the NUL-byte bug (2026-07-26) was a hard 500 on every backfill attempt for one
+# session, invisible in the runner log because the handler logged at DEBUG. A
+# failure that REPEATS is the interesting kind — it means stuck, not flaky.
+_failures: dict[str, int] = {}
+
+# Warn on the first failure, then every Nth, so a permanently-stuck session stays
+# visible in the log without drowning it (~5 min apart at the default tick).
+_REWARN_EVERY = 60
+
+
+def _note_failure(key: str, what: str) -> None:
+    """Count a best-effort failure and log it at a level someone will see."""
+    n = _failures.get(key, 0) + 1
+    _failures[key] = n
+    if n == 1 or n % _REWARN_EVERY == 0:
+        logger.warning("%s failed (attempt %d, still retrying): %s", what, n, key,
+                       exc_info=True)
+    else:
+        logger.debug("%s failed (attempt %d): %s", what, n, key, exc_info=True)
+
+
+def _note_success(key: str) -> None:
+    """Clear a failure streak; log the recovery if there was one to clear."""
+    n = _failures.pop(key, 0)
+    if n:
+        logger.info("recovered after %d failed attempts: %s", n, key)
+
+
 def _post_stream_rows(cfg: Config, client: Client, sid: str, rows: list[dict]) -> bool:
     """Ship conversational rows as live events. seq == index (the composite
     transcript ordinal): monotonic per session forever, so the WS-derived
@@ -388,9 +419,10 @@ def _post_stream_rows(cfg: Config, client: Client, sid: str, rows: list[dict]) -
     ]
     try:
         client.post_session_stream(cfg.runner_id, sid, events)
+        _note_success(f"stream:{sid}")
         return True
     except Exception:  # noqa: BLE001
-        logger.debug("stream post failed (non-fatal)", exc_info=True)
+        _note_failure(f"stream:{sid}", "stream post")
         return False
 
 
@@ -485,8 +517,11 @@ def _drain_backfills(cfg: Config, client: Client) -> None:
         messages = chat_bridge.conversational_messages(chat_bridge.read_records(path), -1)
         try:
             client.post_session_backfill(cfg.runner_id, sid, messages)
+            _note_success(f"backfill:{sid}")
         except Exception:  # noqa: BLE001
-            logger.debug("backfill post failed (non-fatal)", exc_info=True)
+            # A backfill that keeps failing never rebuilds the session's history
+            # and never stops trying — exactly the case that must not be silent.
+            _note_failure(f"backfill:{sid}", f"backfill post ({len(messages)} rows)")
 
 
 def run_once(cfg: Config, client: Client) -> str:

--- a/packages/canopy_runner/tests/test_main.py
+++ b/packages/canopy_runner/tests/test_main.py
@@ -542,3 +542,46 @@ def test_maybe_report_sessions_throttled(db, tmp_path, monkeypatch):
     clock[0] += cfg.session_report_seconds + 1
     m._maybe_report_sessions(cfg, client, now_fn=now)   # window elapsed -> reports
     assert len(calls) == 2
+
+
+# --- Best-effort failure visibility ----------------------------------------
+
+
+def test_repeated_backfill_failures_are_warned_not_swallowed(caplog):
+    """The NUL-byte bug (2026-07-26) was a hard 500 on EVERY backfill attempt for
+    one session, invisible in the runner log because the handler logged at DEBUG.
+    A failure that repeats means stuck, not flaky, and must be visible."""
+    import logging
+
+    main_mod._failures.clear()
+    with caplog.at_level(logging.WARNING, logger="canopy_runner"):
+        main_mod._note_failure("backfill:s1", "backfill post")
+        assert "attempt 1" in caplog.text
+        caplog.clear()
+        # Quiet in between, so a stuck session can't drown the log...
+        for _ in range(main_mod._REWARN_EVERY - 2):
+            main_mod._note_failure("backfill:s1", "backfill post")
+        assert caplog.text == ""
+        # ...but it re-surfaces, so it can't be forgotten either.
+        main_mod._note_failure("backfill:s1", "backfill post")
+        assert f"attempt {main_mod._REWARN_EVERY}" in caplog.text
+
+
+def test_recovery_clears_the_streak_and_says_so(caplog):
+    import logging
+
+    main_mod._failures.clear()
+    main_mod._note_failure("stream:s1", "stream post")
+    with caplog.at_level(logging.INFO, logger="canopy_runner"):
+        main_mod._note_success("stream:s1")
+    assert "recovered after 1" in caplog.text
+    assert "stream:s1" not in main_mod._failures
+
+
+def test_success_with_no_prior_failure_is_silent(caplog):
+    import logging
+
+    main_mod._failures.clear()
+    with caplog.at_level(logging.INFO, logger="canopy_runner"):
+        main_mod._note_success("stream:s1")
+    assert caplog.text == ""

--- a/tests/test_harness_session_streams.py
+++ b/tests/test_harness_session_streams.py
@@ -125,9 +125,10 @@ def test_tool_frames_reach_the_client_live(monkeypatch):
     assert [m["event"]["kind"] for m in published] == ["tool_use"]
 
 
-def test_plain_text_rows_keep_their_legacy_content_shape():
-    """Back-compat: an older runner posts {"text": ...} and nothing else, and its
-    rows must still store the same content they always did."""
+def test_plain_text_rows_store_no_redundant_content():
+    """An older runner posts {"text": ...} and nothing else. That whole payload is
+    a duplicate of plaintext, so the stored content is empty — see
+    services.storage_content. The row itself is unchanged."""
     from apps.canopy_sessions.models import Message
 
     user, ws, runner, c = _ctx()
@@ -138,5 +139,5 @@ def test_plain_text_rows_keep_their_legacy_content_shape():
         {"kind": "assistant", "seq": 64, "index": 64, "payload": {"text": "hello"}},
     ])
     msg = Message.objects.get(session=s, turn_index=64)
-    assert msg.content == {"text": "hello"}
     assert msg.plaintext == "hello"
+    assert msg.content == {}

--- a/tests/test_transcript_persistence.py
+++ b/tests/test_transcript_persistence.py
@@ -399,3 +399,33 @@ def test_a_nul_byte_cannot_take_down_the_whole_batch():
     assert rows[1].content["blob"] == "xy"          # nested strings too
     assert rows[1].content["tool_use_id"] == "t1"   # non-strings untouched
     assert rows[1].content["is_error"] is False
+
+
+def test_content_does_not_duplicate_plaintext():
+    """The wire payload and the stored row share one shape, but `text` is the
+    one key storage doesn't need — plaintext is its own column and nothing on
+    the render path reads content["text"]. Keeping it cost 36% of all stored
+    transcript bytes (20,585 rows measured, 2026-07-26)."""
+    _u, _ws, _r, s, _c = _ctx()
+    services.persist_transcript_rows(s, [
+        {"index": 0, "role": "assistant", "text": "hello", "content": {"text": "hello"}},
+        {"index": 64, "role": "tool_result", "text": "a.txt",
+         "content": {"tool_use_id": "t1", "is_error": False, "text": "a.txt"}},
+    ])
+    prose, result = list(s.messages.order_by("turn_index"))
+    assert prose.plaintext == "hello" and prose.content == {}
+    # Every OTHER key survives — those are what the UI pairs and renders on.
+    assert result.plaintext == "a.txt"
+    assert result.content == {"tool_use_id": "t1", "is_error": False}
+
+
+def test_a_text_that_differs_from_plaintext_is_kept():
+    """Only the redundant copy is dropped. A `text` that disagrees is real data
+    and losing it would be a silent edit, not a saving."""
+    _u, _ws, _r, s, _c = _ctx()
+    services.persist_transcript_rows(s, [
+        {"index": 0, "role": "assistant", "text": "shown",
+         "content": {"text": "different", "id": "x"}},
+    ])
+    msg = s.messages.get()
+    assert msg.content == {"text": "different", "id": "x"}


### PR DESCRIPTION
Two follow-ups to #427, both found by looking at what it actually produced.

## 1. Storage — 37% of stored transcript bytes were a duplicate

The wire payload and the stored row deliberately share one shape, and that shape carries `text` because the client builds a message from the live frame alone. **Storage doesn't need it** — `plaintext` is its own column, and nothing on the render path reads `content["text"]` (`MessageItem` and `ToolCallPair` both use `plaintext`).

Measured over 20,735 rows of live transcripts:

| | plaintext | content (jsonb) | total |
|---|---|---|---|
| before | 9.06 MB | 17.35 MB | **26.41 MB** |
| after | 9.06 MB | 7.71 MB | **16.76 MB** |

Almost all of it was tool-result bodies stored verbatim twice.

Only the redundant key is dropped. A `text` that *differs* from plaintext is real data and is kept; every other key (`id`, `name`, `input`, `tool_use_id`, `client_id`) is untouched.

**The indexing needed nothing** — the `(session, turn_index)` unique constraint already serves both query shapes (the tail's `ORDER BY turn_index DESC LIMIT n`, scrollback's `turn_index < x`), and Postgres TOASTs the large values out of the heap automatically.

## 2. Observability — a stuck runner post was silent by construction

The NUL-byte bug (#441) was a hard 500 on **every** backfill attempt for one session, retried every tick forever, and invisible in the runner log because the handler logged at `debug`.

These paths are best-effort by design, so silence was a deliberate choice. The distinction that was missing: **a failure that repeats means stuck, not flaky.** Failures now warn on the first attempt and every 60th (~5 min apart at the default tick), so a wedged session stays visible without drowning the log — and a recovery logs the streak it ended.

## Not done, and why

"Render thinking blocks and sub-agent sidechains" was on the plan until I checked the data. Across **all 99 transcripts on this machine (96,975 records)**:

- **11,010 thinking blocks, exactly 1 with any text** — the rest are redacted, signature-only
- **0 sidechain records**

Building it would render ~11,000 empty boxes. It stays unbuilt until something in the fleet actually produces that content.

## Verification

Backend 1,682 · runner 204 · frontend unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)