### PR TITLE
feat(runner): the laptop runner retains each chat turn's raw transcript

### DIFF
--- a/packages/canopy_runner/canopy_runner/chat_bridge.py
+++ b/packages/canopy_runner/canopy_runner/chat_bridge.py
@@ -358,6 +358,55 @@ IDLE_TICKS = 180          # ~15 min of a completely silent transcript
 MAX_TICKS = 2880          # ~4 h total, so a wedged bridge can't hold a session forever
 
 
+# --- Retained raw transcript (per turn) --------------------------------------
+#
+# A turn's raw JSONL is the durable artifact cost and structure are re-derived
+# from (spec 2026-07-26-run-execution-convergence): per-line `usage` and `model`,
+# uuid/parentUuid nesting, tool ids and inputs, the CLI's own timestamps. The
+# TurnEvent ledger is deliberately reduced and cannot answer those.
+#
+# On this runner a "turn's transcript" is the slice of the ongoing emdash session
+# .jsonl written while the bridge was open — which is exactly the window
+# LiveBridge already tails. Work a human does directly in emdash outside a canopy
+# turn belongs to no turn, and is correctly absent.
+#
+# The server 422s a single request whose line bytes exceed 1 MiB
+# (apps/harness/api.py::TRANSCRIPT_APPEND_MAX_BYTES), so batches are bounded by
+# BYTES, not line count: one tool-result line can be enormous on its own.
+TRANSCRIPT_BATCH_MAX_BYTES = 900 * 1024
+
+
+def chunk_raw_lines(lines: list[str], max_bytes: int = TRANSCRIPT_BATCH_MAX_BYTES) -> list[list[str]]:
+    """Split raw JSONL lines into batches whose UTF-8 size stays under `max_bytes`.
+
+    A single line larger than the cap can never fit, even alone — the server
+    rejects the whole request on total bytes. Shipping it anyway would fail every
+    retry and stall the flush, so it is replaced by a marker line: a consumer
+    re-deriving cost from this transcript then SEES a gap instead of silently
+    reading an incomplete turn as a complete one.
+    """
+    batches: list[list[str]] = []
+    current: list[str] = []
+    size = 0
+    for line in lines:
+        n = len(line.encode("utf-8")) + 1  # +1 for the newline the server joins on
+        if n > max_bytes:
+            if current:
+                batches.append(current)
+                current, size = [], 0
+            batches.append([json.dumps({"type": "canopy_runner_line_dropped",
+                                        "bytes": n})])
+            continue
+        if size + n > max_bytes and current:
+            batches.append(current)
+            current, size = [], 0
+        current.append(line)
+        size += n
+    if current:
+        batches.append(current)
+    return batches
+
+
 @dataclass
 class LiveBridge:
     """One chat turn being bridged, ACROSS runner ticks.
@@ -379,10 +428,21 @@ class LiveBridge:
     idle_ticks: int = 0
     ticks: int = 0
     done_reason: str = ""
+    # Raw JSONL awaiting a flush to POST /turns/{id}/transcript, and the count of
+    # batches already accepted (the batch_id's sequence number, so a lost-ack
+    # retry dedupes server-side instead of double-appending).
+    raw_pending: list[str] = field(default_factory=list)
+    raw_batches_sent: int = 0
+    transcript_truncated: bool = False
 
-    def step(self, new_records: list[dict]) -> None:
-        """Consume one tick's worth of newly-appended records."""
+    def step(self, new_records: list[dict], raw_lines: list[str] | None = None) -> None:
+        """Consume one tick's worth of newly-appended records.
+
+        `raw_lines` is the verbatim JSONL for those records (TailReader.last_raw).
+        Optional so the state machine still unit-tests from records alone."""
         self.ticks += 1
+        if raw_lines and not self.transcript_truncated:
+            self.raw_pending.extend(raw_lines)
         if new_records:
             self.idle_ticks = 0
         else:
@@ -400,7 +460,13 @@ class LiveBridge:
     @property
     def finished(self) -> bool:
         """Done AND fully delivered — undelivered text keeps the turn open so the
-        next tick can retry it."""
+        next tick can retry it.
+
+        Deliberately does NOT wait on `raw_pending`: the retained transcript is a
+        derived artifact, the reply is the turn's actual product, and holding a
+        finished turn open over a transcript flush would make a storage hiccup
+        look like an agent still working. The pump makes a final flush attempt at
+        finish time instead."""
         return bool(self.done_reason) and not self.pending
 
     @property

--- a/packages/canopy_runner/canopy_runner/client.py
+++ b/packages/canopy_runner/canopy_runner/client.py
@@ -142,6 +142,16 @@ class Client:
     def post_events(self, turn_id: str, events: list[dict]) -> None:
         self._call("POST", f"/turns/{turn_id}/events", {"events": events})
 
+    def post_transcript(self, turn_id: str, lines: list[str], batch_id: str = "") -> bool:
+        """Append raw JSONL to a turn's retained transcript. Returns False once the
+        server reports the turn's per-turn ceiling is hit, so the caller can stop
+        flushing for this turn (every later batch would be a silent no-op)."""
+        _, payload = self._call(
+            "POST", f"/turns/{turn_id}/transcript",
+            {"lines": lines, "batch_id": batch_id},
+        )
+        return not (payload or {}).get("truncated", False)
+
     def sync_schedules(self, runner_id: str) -> list[dict]:
         """The schedules this runner may fire (tenant-scoped server-side). The runner
         evaluates their cron locally and reports what came due — the server stores the

--- a/packages/canopy_runner/canopy_runner/main.py
+++ b/packages/canopy_runner/canopy_runner/main.py
@@ -338,10 +338,12 @@ def _pump_chat_bridges(cfg: Config, client: Client) -> None:
             continue
         try:
             new_records = bridge.reader.read_new()
+            raw_lines = list(getattr(bridge.reader, "last_raw", ()) or ())
         except Exception:  # noqa: BLE001 — an unreadable transcript is a quiet tick
             logger.debug("chat turn=%s: transcript read failed", turn_id, exc_info=True)
-            new_records = []
-        bridge.step(new_records)
+            new_records, raw_lines = [], []
+        bridge.step(new_records, raw_lines)
+        _flush_turn_transcript(client, bridge)
         if bridge.pending:
             events = [{"kind": "assistant", "payload": {"text": t}} for t in bridge.pending]
             try:
@@ -350,7 +352,49 @@ def _pump_chat_bridges(cfg: Config, client: Client) -> None:
             except Exception:  # noqa: BLE001 — keep it queued and retry next tick
                 logger.debug("chat turn=%s: event post failed, retrying", turn_id, exc_info=True)
         if bridge.finished:
+            # One last attempt before the turn closes: whatever the agent wrote in
+            # its final tick is exactly the part a cost aggregator needs (the
+            # `result` line carries the turn's totals).
+            _flush_turn_transcript(client, bridge, final=True)
             _finish_chat_bridge(cfg, client, bridge, status="done", note=bridge.note)
+
+
+def _flush_turn_transcript(client: Client, bridge, *, final: bool = False) -> None:
+    """Ship the bridge's accumulated raw JSONL to the turn's retained transcript.
+
+    Best-effort and non-blocking for the turn: the reply is the product, this is
+    a derived artifact. A failed batch stays queued and is retried next tick; on
+    the FINAL flush an unshippable batch is dropped rather than holding the turn
+    open, and says so in the log.
+
+    Batches carry `<turn>:<n>` as their batch_id so a lost-ack retry dedupes
+    server-side instead of double-appending (apps/harness/services.append_transcript).
+    """
+    if bridge.transcript_truncated or not bridge.raw_pending:
+        return
+    for batch in chat_bridge.chunk_raw_lines(bridge.raw_pending):
+        batch_id = f"{bridge.turn_id}:{bridge.raw_batches_sent}"
+        try:
+            still_open = client.post_transcript(bridge.turn_id, batch, batch_id)
+        except Exception:  # noqa: BLE001
+            if final:
+                _note_failure(f"transcript:{bridge.turn_id}",
+                              f"final transcript flush ({len(batch)} lines, dropped)")
+                bridge.raw_pending.clear()
+            else:
+                _note_failure(f"transcript:{bridge.turn_id}", "transcript flush")
+            return
+        bridge.raw_batches_sent += 1
+        del bridge.raw_pending[:len(batch)]
+        if not still_open:
+            # Per-turn ceiling reached; every further batch is a server-side
+            # no-op, so stop paying for them.
+            bridge.transcript_truncated = True
+            bridge.raw_pending.clear()
+            logger.info("chat turn=%s: transcript ceiling reached; no further flushes",
+                        bridge.turn_id)
+            return
+    _note_success(f"transcript:{bridge.turn_id}")
 
 
 def _drain_chat_bridges(cfg: Config, client: Client, *, poll: float = 1.0,

--- a/packages/canopy_runner/canopy_runner/tail.py
+++ b/packages/canopy_runner/canopy_runner/tail.py
@@ -29,6 +29,14 @@ class TailReader:
         self.path = os.fspath(path)
         self.offset = 0
         self._partial = b""
+        # The RAW text of the lines the most recent read_new() consumed, in the
+        # same order. Kept alongside the parsed records because a turn's retained
+        # transcript must be the CLI's own bytes — re-encoding a parsed record
+        # would change field order and number formatting, and the whole point of
+        # storing raw JSONL is that a consumer can re-derive from it exactly.
+        # A line that fails to parse is still raw content, so it is kept here
+        # even though it produces no record.
+        self.last_raw: list[str] = []
 
     def seek_end(self) -> None:
         try:
@@ -38,6 +46,7 @@ class TailReader:
         self._partial = b""
 
     def read_new(self) -> list[dict]:
+        self.last_raw = []
         try:
             size = os.path.getsize(self.path)
         except OSError:
@@ -62,6 +71,9 @@ class TailReader:
             line = line.strip()
             if not line:
                 continue
+            # Decoded, never re-encoded: this is the CLI's own byte content, and
+            # a retained transcript is only re-derivable if it stays verbatim.
+            self.last_raw.append(line.decode("utf-8", errors="replace"))
             try:
                 out.append(json.loads(line))
             except ValueError:

--- a/packages/canopy_runner/tests/test_chat_pump.py
+++ b/packages/canopy_runner/tests/test_chat_pump.py
@@ -150,3 +150,136 @@ def test_pump_finish_failure_still_drops_the_bridge():
     _register([[_asst("done", stop="end_turn")]])
     main._pump_chat_bridges(_cfg(), _Client())
     assert chat_bridge.IN_FLIGHT == {}
+
+
+# --- Retained raw transcript (per turn) -------------------------------------
+
+
+class _TranscriptClient:
+    """Records transcript posts; can fail or report the per-turn ceiling."""
+
+    def __init__(self, *, fail=False, truncate_after=None):
+        self.posts = []           # (turn_id, lines, batch_id)
+        self.fail = fail
+        self.truncate_after = truncate_after
+        self.events = []
+        self.finished = []
+
+    def post_transcript(self, turn_id, lines, batch_id=""):
+        if self.fail:
+            raise RuntimeError("network")
+        self.posts.append((turn_id, lines, batch_id))
+        if self.truncate_after is not None and len(self.posts) >= self.truncate_after:
+            return False
+        return True
+
+    def post_events(self, turn_id, events):
+        self.events.append((turn_id, events))
+
+    def finish_turn(self, *a, **k):
+        self.finished.append((a, k))
+
+    def heartbeat(self, *a, **k):
+        pass
+
+
+class _RawReader:
+    """A TailReader stand-in that also exposes last_raw."""
+
+    def __init__(self, batches):
+        self.batches = [(recs, raw) for recs, raw in batches]
+        self.last_raw = []
+
+    def read_new(self):
+        if not self.batches:
+            self.last_raw = []
+            return []
+        recs, raw = self.batches.pop(0)
+        self.last_raw = list(raw)
+        return recs
+
+
+def test_the_turns_raw_jsonl_is_retained_verbatim(monkeypatch):
+    """The retained transcript is the durable artifact cost and structure are
+    re-derived from; it only works if the bytes are the CLI's own."""
+    from canopy_runner import chat_bridge
+
+    chat_bridge.IN_FLIGHT.clear()
+    raw1 = ['{"type":"assistant","message":{"usage":{"input_tokens":5}}}']
+    raw2 = ['{"type":"result","total_cost_usd":0.01}']
+    bridge = chat_bridge.LiveBridge(
+        turn_id="t1", task="task-1",
+        reader=_RawReader([([_asst("working")], raw1),
+                           ([_asst("done", stop="end_turn")], raw2)]),
+    )
+    chat_bridge.IN_FLIGHT["t1"] = bridge
+    c = _TranscriptClient()
+    cfg = _cfg()
+    main._pump_chat_bridges(cfg, c)
+    main._pump_chat_bridges(cfg, c)
+
+    shipped = [line for _t, lines, _b in c.posts for line in lines]
+    assert shipped == raw1 + raw2
+    # batch_ids are sequential per turn, so a lost-ack retry dedupes server-side.
+    assert [b for _t, _l, b in c.posts] == ["t1:0", "t1:1"]
+
+
+def test_a_failed_flush_keeps_the_lines_for_the_next_tick():
+    from canopy_runner import chat_bridge
+
+    chat_bridge.IN_FLIGHT.clear()
+    bridge = chat_bridge.LiveBridge(turn_id="t1", task="x", reader=_RawReader([]))
+    bridge.raw_pending = ['{"a":1}']
+    main._flush_turn_transcript(_TranscriptClient(fail=True), bridge)
+    assert bridge.raw_pending == ['{"a":1}']    # nothing lost
+
+
+def test_a_transcript_hiccup_never_holds_the_turn_open():
+    """The reply is the turn's product; the transcript is derived. A storage
+    problem must not make a finished agent look like it is still working."""
+    from canopy_runner import chat_bridge
+
+    bridge = chat_bridge.LiveBridge(turn_id="t1", task="x", reader=_RawReader([]))
+    bridge.step([_asst("the answer", stop="end_turn")], ['{"raw":1}'])
+    bridge.pending.clear()                      # the reply was delivered
+    assert bridge.raw_pending                   # transcript still queued
+    assert bridge.finished is True
+
+
+def test_flushing_stops_once_the_server_reports_the_ceiling():
+    from canopy_runner import chat_bridge
+
+    bridge = chat_bridge.LiveBridge(turn_id="t1", task="x", reader=_RawReader([]))
+    bridge.raw_pending = ['{"a":1}']
+    c = _TranscriptClient(truncate_after=1)
+    main._flush_turn_transcript(c, bridge)
+    assert bridge.transcript_truncated is True
+    bridge.step([], ['{"b":2}'])                # further lines aren't even queued
+    assert bridge.raw_pending == []
+    main._flush_turn_transcript(c, bridge)
+    assert len(c.posts) == 1                    # and nothing more is sent
+
+
+def test_batches_are_bounded_by_bytes_not_line_count():
+    """The server 422s on total request bytes, and ONE tool-result line can be
+    enormous — a count-based batch would sail past the cap."""
+    from canopy_runner import chat_bridge
+
+    small = ['{"n":%d}' % i for i in range(5)]
+    batches = chat_bridge.chunk_raw_lines(small, max_bytes=25)
+    assert len(batches) > 1
+    for b in batches:
+        assert sum(len(x.encode()) + 1 for x in b) <= 25
+    assert [x for b in batches for x in b] == small
+
+
+def test_an_oversized_single_line_becomes_a_visible_gap():
+    """It can never fit, so shipping it would fail every retry. A marker means a
+    cost aggregator SEES the gap instead of reading a partial turn as complete."""
+    from canopy_runner import chat_bridge
+
+    huge = '{"x":"' + "y" * 5000 + '"}'
+    batches = chat_bridge.chunk_raw_lines(["{}", huge, "{}"], max_bytes=1000)
+    flat = [x for b in batches for x in b]
+    assert huge not in flat
+    assert any("canopy_runner_line_dropped" in x for x in flat)

--- a/tests/test_turn_transcript_roundtrip.py
+++ b/tests/test_turn_transcript_roundtrip.py
@@ -13,7 +13,7 @@ import pytest
 sys.path.insert(0, "packages/canopy_runner")
 from django.contrib.auth.models import User
 from apps.harness import services as hs
-from apps.harness.models import Runner, Turn
+from apps.harness.models import Turn
 from apps.agents.models import Agent
 from apps.workspaces.models import Workspace
 from canopy_runner import chat_bridge as cb

--- a/tests/test_turn_transcript_roundtrip.py
+++ b/tests/test_turn_transcript_roundtrip.py
@@ -1,0 +1,54 @@
+"""The laptop runner's transcript writer, end to end against the real server code.
+
+The retained raw transcript is what cost and structure are re-derived from
+(spec 2026-07-26-run-execution-convergence), so the only property that matters is
+that what the runner ships comes back byte-identical. That spans two packages —
+the runner's byte-chunker and the server's gzip-member append — and neither side's
+unit tests can see the seam, which is why this test imports both.
+"""
+import sys
+
+import pytest
+
+sys.path.insert(0, "packages/canopy_runner")
+from django.contrib.auth.models import User
+from apps.harness import services as hs
+from apps.harness.models import Runner, Turn
+from apps.agents.models import Agent
+from apps.workspaces.models import Workspace
+from canopy_runner import chat_bridge as cb
+
+pytestmark = pytest.mark.django_db
+
+
+def test_round_trip_is_byte_identical():
+    """The laptop runner's chunker + the server's append must reproduce the
+    original JSONL exactly — that is the whole premise of retaining raw bytes."""
+    u = User.objects.create_user("a", "a@d.com", "p")
+    ws = Workspace.objects.create(slug="w", display_name="W", created_by=u)
+    ag = Agent.objects.create(slug="ace", name="Ace", workspace=ws)
+    t = Turn.objects.create(agent=ag, prompt="x", idempotency_key="k1")
+
+    lines = [
+        '{"type":"assistant","message":{"usage":{"input_tokens":5,"output_tokens":7},"model":"claude-opus-5"}}',
+        '{"type":"user","message":{"content":[{"type":"tool_result","content":"' + "z" * 3000 + '"}]}}',
+        '{"type":"result","total_cost_usd":0.0123}',
+    ]
+    n = 0
+    # Cap above the largest single line but below the total, so this splits
+    # into real batches instead of tripping the oversized-line path.
+    for batch in cb.chunk_raw_lines(lines, max_bytes=3100):
+        hs.append_transcript(t, batch, batch_id=f"{t.id}:{n}")
+        n += 1
+    assert n > 1, "the fixture must actually exercise multi-batch"
+    assert hs.read_transcript(t).decode() == "\n".join(lines)
+
+
+def test_a_lost_ack_retry_does_not_double_append():
+    u = User.objects.create_user("b", "b@d.com", "p")
+    ws = Workspace.objects.create(slug="w2", display_name="W2", created_by=u)
+    ag = Agent.objects.create(slug="ada", name="Ada", workspace=ws)
+    t = Turn.objects.create(agent=ag, prompt="x", idempotency_key="k2")
+    hs.append_transcript(t, ['{"a":1}'], batch_id=f"{t.id}:0")
+    hs.append_transcript(t, ['{"a":1}'], batch_id=f"{t.id}:0")   # the retry
+    assert hs.read_transcript(t).decode() == '{"a":1}'


### PR DESCRIPTION
`TurnTranscript` has had a model, services and HTTP routes since #420, and the **cloud** runner writes it. The **laptop** runner — which is what actually executes chat today — did not. So the durable artifact behind per-turn cost and structure was empty for every turn a human actually ran.

## What a turn's transcript is here

The slice of the ongoing emdash session `.jsonl` written while the bridge was open — exactly the window `LiveBridge` already tails. This is a second *consumer* of an existing read, not a second reader. Work a human does directly in emdash outside a canopy turn belongs to no turn and is correctly absent.

## Design points

**Raw, not re-encoded.** `TailReader` now keeps `last_raw` alongside the parsed records. Re-serializing a parsed record would change field order and number formatting, and "re-derivable from the bytes" is the entire premise. A line that fails to parse is still content, so it's retained even though it yields no record.

**Batched by bytes, not line count** (900KB, under the server's 1 MiB request cap) — one tool-result line can be enormous on its own. Each batch carries `<turn>:<n>` as its `batch_id`, so a lost-ack retry dedupes server-side instead of double-appending.

**An unshippable line becomes a visible gap.** A single line over the cap can never fit even alone, so retrying is futile; it's replaced with a marker. A consumer re-deriving cost then *sees* the gap instead of reading a partial turn as a complete one.

**Never holds the turn open.** `finished` deliberately ignores `raw_pending` — the reply is the turn's product, the transcript is derived. A storage hiccup must not make a finished agent look like it's still working. Failed batches stay queued for the next tick; the final flush drops what it can't ship and says so. Once the server reports the per-turn ceiling, flushing stops rather than paying for no-ops.

## Verification

`tests/test_turn_transcript_roundtrip.py` runs the runner's chunker against the **real server append/read code**: a multi-batch ship comes back **byte-identical**, and a replayed `batch_id` doesn't double-append. That seam spans two packages and neither side's unit tests can see it.

Backend 1,684 · runner 210.

🤖 Generated with [Claude Code](https://claude.com/claude-code)