### PR TITLE
fix(storyboards): stop the reviewer surface printing the story twice

### DIFF
--- a/apps/storyboards/services.py
+++ b/apps/storyboards/services.py
@@ -125,10 +125,16 @@ def resolve_narrative(board: Storyboard, narrative_slug: str) -> dict | None:
             for n in (v.get("narration") or [])
         ]
 
+    # Same treatment as the cards: the stored title is derived from the opening
+    # of the story, so using it verbatim makes the heading a truncated copy of
+    # the text beneath it. And the STORY here is the whole narration
+    # concatenated — printing it above a scene-by-scene breakdown makes the
+    # reader read everything twice. One sentence is the hook; the scenes are the
+    # substance.
     return {
         "narrative_slug": narrative_slug,
-        "title": (current or {}).get("title") or narrative.get("title") or narrative_slug,
-        "story": narrative.get("story") or "",
+        "title": _card_title(narrative_slug, (current or {}).get("title") or narrative.get("title")),
+        "story": aggregate._lede_from_story(narrative.get("story") or "", None) or "",
         "version": (current or {}).get("version"),
         "previous_version": (previous or {}).get("version"),
         "narration": _narration(current or {}),

--- a/frontend/src/components/storyboard/NoteComposer.tsx
+++ b/frontend/src/components/storyboard/NoteComposer.tsx
@@ -12,11 +12,16 @@ import type { Capability, FeedbackKind, LeaveFeedbackIn } from '@/api/storyboard
 export function NoteComposer({
   capability,
   anchorLabel,
+  cta,
   defaults,
   onSubmit,
 }: {
   capability: Capability
   anchorLabel: string
+  /** What the button says. Two composers can sit next to each other (an act and
+   *  the demo inside it), so "Leave a note" twice is ambiguous — name the
+   *  target. */
+  cta: string
   defaults: LeaveFeedbackIn
   onSubmit: (payload: LeaveFeedbackIn) => Promise<void>
 }) {
@@ -45,7 +50,7 @@ export function NoteComposer({
         onClick={() => setOpen(true)}
         className="mt-3 self-start rounded-md border border-border px-3 py-1 text-[12px] text-foreground-secondary transition-colors hover:border-input hover:text-primary"
       >
-        Leave a note
+        {cta}
       </button>
     )
   }

--- a/frontend/src/pages/NarrativeReviewPage.tsx
+++ b/frontend/src/pages/NarrativeReviewPage.tsx
@@ -198,6 +198,7 @@ function Review({ data, token }: { data: NarrativeRead; token: string | null }) 
               <NoteComposer
                 capability={data.capability}
                 anchorLabel={`Scene ${i + 1}${data.version != null ? ` · v${data.version}` : ''}`}
+                cta={`Leave a note on scene ${i + 1}`}
                 defaults={{
                   narrative_slug: data.narrative_slug,
                   target_version: data.version,

--- a/frontend/src/pages/StoryboardPage.test.tsx
+++ b/frontend/src/pages/StoryboardPage.test.tsx
@@ -99,13 +99,16 @@ describe('StoryboardPage', () => {
     getStoryboard.mockResolvedValue(board({ capability: 'read' }))
     renderAt()
     await screen.findByText('What the money bought')
-    expect(screen.queryByText('Leave a note')).toBeNull()
+    expect(screen.queryByText(/Leave a note/)).toBeNull()
   })
 
-  it('offers a composer once the link grants comment', async () => {
+  it('names what each composer attaches to', async () => {
+    // An act and the demo inside it each get a composer, so they sit side by
+    // side — two buttons reading "Leave a note" gave no way to tell them apart.
     getStoryboard.mockResolvedValue(board({ capability: 'comment' }))
     renderAt()
-    expect((await screen.findAllByText('Leave a note')).length).toBeGreaterThan(0)
+    expect(await screen.findByText('Leave a note on this act')).toBeTruthy()
+    expect(screen.getByText('Leave a note on this demo')).toBeTruthy()
   })
 
   it('shows a plain not-available message on 404 rather than an error dump', async () => {

--- a/frontend/src/pages/StoryboardPage.tsx
+++ b/frontend/src/pages/StoryboardPage.tsx
@@ -130,6 +130,7 @@ function Board({ board, token }: { board: Storyboard; token: string | null }) {
             <NoteComposer
               capability={board.capability}
               anchorLabel={`On “${act.title}”`}
+              cta="Leave a note on this act"
               defaults={{}}
               onSubmit={(payload) => leaveFeedback(board.slug, payload, token).then(() => undefined)}
             />
@@ -209,6 +210,7 @@ function EntryCard({
           <NoteComposer
             capability={board.capability}
             anchorLabel={`On “${entry.title}” · v${entry.version}`}
+            cta="Leave a note on this demo"
             defaults={{ narrative_slug: entry.narrative_slug, target_version: entry.version }}
             onSubmit={(payload) =>
               leaveFeedback(board.slug, payload, token).then(() => undefined)

--- a/tests/test_storyboard_api.py
+++ b/tests/test_storyboard_api.py
@@ -342,3 +342,41 @@ def test_the_share_url_has_no_prefix_when_served_at_root(member, board):
     set_script_prefix("/")
     url = member.post(f"/api/storyboards/{board.slug}/share").json()["share_url"]
     assert "/storyboard/" in url and "/canopy/" not in url, url
+
+
+def test_the_reviewer_surface_heading_is_not_a_copy_of_its_own_body(board, ws):
+    """The stored title is derived from the story's opening, so using it verbatim
+    made the <h1> a truncated copy of the paragraph beneath it — and the story
+    itself is the whole narration concatenated, printed above a scene-by-scene
+    breakdown of the same text. Observed on the live rf-surveys arc."""
+    from apps.reviews.models import ReviewRequest
+
+    long_story = (
+        "Since the independent survey is what verifies the program, Maya can also "
+        "inspect the quality of the survey itself — the focus shifts from reviewing "
+        "program performance to reviewing the surveyors. Maya opens the dashboard."
+    )
+    ReviewRequest.objects.create(
+        run_id="verified-monitoring-2026-07-26-001",
+        request_json={
+            "gate": "concept_change",
+            "narrative_slug": "verified-monitoring",
+            "narrative": long_story,
+            "narration": [{"id": "the-goal", "title": "The goal", "text": long_story}],
+        },
+        gate="concept_change",
+        visibility="link",
+        workspace_id=ws.slug,
+        version=1,
+    )
+
+    t = board.ensure_share_token()
+    body = Client().get(
+        f"/api/storyboards/{board.slug}/narratives/verified-monitoring?t={t}"
+    ).json()
+
+    assert body["title"] == "Verified Monitoring"
+    assert not body["story"].startswith(body["title"])
+    # One sentence, not the whole narration — the scenes below carry the rest.
+    assert body["story"].endswith(".")
+    assert len(body["story"]) < len(long_story)


### PR DESCRIPTION
Three defects, all found by **reading the rendered page** on labs rather than the API.

### 1. The heading was a truncated copy of its own body

Same root cause as #443 — canopy-web derives a narrative's title from the story's opening — but the reviewer surface has its own copy of that code and I only fixed the cards.

### 2. The whole story was printed twice

The full narration appeared as a wall of text *above* a scene-by-scene breakdown of the same words. A reviewer read everything, then read it again in pieces, before reaching the part they're meant to comment on. One sentence is the hook; the scenes are the substance.

### 3. Two identical "Leave a note" buttons

Every act rendered one composer for the act and one for the demo inside it — side by side, same label, no way to tell which was which. Each now names its target ("…on this act" / "…on this demo" / "…on scene 3").

Verified on the live arc first: the storyboard page renders correctly, and #438's positional fallback is working — `verified-monitoring` shows scenes 01–05 as Was/Now and 06 as New, rather than six "New" scenes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)