### PR TITLE
fix(storyboards): name the tab, and give each demo video an accessible name

### DIFF
--- a/frontend/src/pages/NarrativeReviewPage.tsx
+++ b/frontend/src/pages/NarrativeReviewPage.tsx
@@ -103,6 +103,10 @@ function Centered({ children }: { children: React.ReactNode }) {
 }
 
 function Review({ data, token }: { data: NarrativeRead; token: string | null }) {
+  useEffect(() => {
+    document.title = `${data.title} · ${data.storyboard_title} · Canopy`
+  }, [data.title, data.storyboard_title])
+
   const pairs = useMemo(
     () => pairNarrationScenes(data.previous_narration, data.narration),
     [data.previous_narration, data.narration],

--- a/frontend/src/pages/StoryboardPage.test.tsx
+++ b/frontend/src/pages/StoryboardPage.test.tsx
@@ -116,4 +116,22 @@ describe('StoryboardPage', () => {
     renderAt()
     expect(await screen.findByText(/isn’t available/)).toBeTruthy()
   })
+
+  it('names the tab after the storyboard, not the app', async () => {
+    // A shared link gets bookmarked and sits among a dozen other tabs; "Canopy"
+    // does not say which one this is.
+    getStoryboard.mockResolvedValue(board())
+    renderAt()
+    await screen.findByText('What the money bought')
+    expect(document.title).toContain('What the money bought')
+  })
+
+  it('gives each demo video an accessible name', async () => {
+    getStoryboard.mockResolvedValue(board())
+    const { container } = renderAt()
+    await screen.findByText('What the money bought')
+    const videos = [...container.querySelectorAll('video')]
+    expect(videos.length).toBeGreaterThan(0)
+    for (const v of videos) expect(v.getAttribute('aria-label')).toBeTruthy()
+  })
 })

--- a/frontend/src/pages/StoryboardPage.tsx
+++ b/frontend/src/pages/StoryboardPage.tsx
@@ -84,6 +84,12 @@ function Centered({ children }: { children: React.ReactNode }) {
 }
 
 function Board({ board, token }: { board: Storyboard; token: string | null }) {
+  // A shared link gets bookmarked and sits among a dozen other tabs. "Canopy"
+  // tells the reader nothing about which one this is.
+  useEffect(() => {
+    document.title = `${board.title} · Canopy`
+  }, [board.title])
+
   return (
     <div className="min-h-screen bg-background text-foreground">
       <div className="mx-auto max-w-3xl px-6 py-12 md:py-16">
@@ -163,6 +169,7 @@ function EntryCard({
           <video
             controls
             preload="metadata"
+            aria-label={`Demo video: ${entry.title}`}
             className="h-full w-full object-cover"
             src={withBase(entry.video_url)}
           />


### PR DESCRIPTION
Two gaps found by inspecting the live page.

**Every shared page reported `document.title` as "Canopy".** A link you email gets bookmarked and sits among a dozen other tabs — the tab has to say which one this is. Now `<storyboard> · Canopy`, and on the reviewer surface `<narrative> · <storyboard> · Canopy`.

**All three `<video>` elements had no accessible name** — a screen reader announced three identical unlabelled players. Each now carries the demo it shows.

Neither is visible from the API, and neither would have failed any existing test. Both are the kind of thing a recipient notices and the author never does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)