### PR TITLE
fix(storyboards): the reviewer banner counts new scenes as new, not changed

### DIFF
--- a/frontend/src/pages/NarrativeReviewPage.test.tsx
+++ b/frontend/src/pages/NarrativeReviewPage.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import NarrativeReviewPage from './NarrativeReviewPage'
+
+/**
+ * The banner tells a reviewer what moved since they last read the narrative.
+ * It counted `status !== 'unchanged'` as "changed", so a brand-new scene was
+ * reported as a rewording — on `verified-monitoring` that read "6 scenes have
+ * changed" when it was 5 reworded and 1 new.
+ */
+const payload = (over: Record<string, unknown> = {}) => ({
+  narrative_slug: 'verified-monitoring',
+  title: 'Verified Monitoring',
+  story: 'Independent, drillable proof the programme works.',
+  version: 17,
+  previous_version: 16,
+  storyboard_slug: 'rf-surveys',
+  storyboard_title: 'Proving a programme works',
+  capability: 'suggest',
+  previous_narration: [
+    { id: 'a', title: 'One', text: 'Old one.' },
+    { id: 'b', title: 'Two', text: 'Same.' },
+  ],
+  narration: [
+    { id: 'a', title: 'One', text: 'New one.' },
+    { id: 'b', title: 'Two', text: 'Same.' },
+    { id: 'c', title: 'Three', text: 'A brand new beat.' },
+  ],
+  ...over,
+})
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/narrative/verified-monitoring?b=rf-surveys&t=tok']}>
+      <Routes>
+        <Route path="/narrative/:slug" element={<NarrativeReviewPage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('NarrativeReviewPage', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => payload() }),
+    )
+  })
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+  })
+
+  it('counts a new scene as new, not as reworded', async () => {
+    renderPage()
+    expect(await screen.findByText(/1 scene reworded/)).toBeTruthy()
+    expect(screen.getByText(/1 new/)).toBeTruthy()
+  })
+
+  it('shows the before/after only on the scene that changed', async () => {
+    renderPage()
+    await screen.findByText(/1 scene reworded/)
+    expect(screen.getByText('Old one.')).toBeTruthy()
+    expect(screen.getByText('New one.')).toBeTruthy()
+    // The unchanged scene is rendered once, as plain prose — no Was/Now pair.
+    expect(screen.getAllByText('Same.')).toHaveLength(1)
+  })
+
+  it('says so plainly when nothing moved', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () =>
+          payload({
+            narration: [{ id: 'a', title: 'One', text: 'Same.' }],
+            previous_narration: [{ id: 'a', title: 'One', text: 'Same.' }],
+          }),
+      }),
+    )
+    renderPage()
+    expect(await screen.findByText(/Nothing has changed since v16/)).toBeTruthy()
+  })
+
+  it('names the tab after the narrative and its storyboard', async () => {
+    renderPage()
+    await screen.findByText(/1 scene reworded/)
+    expect(document.title).toContain('Verified Monitoring')
+    expect(document.title).toContain('Proving a programme works')
+  })
+
+  it('shows a plain message rather than an error dump on 404', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 404 }))
+    renderPage()
+    expect(await screen.findByText(/isn’t available/)).toBeTruthy()
+  })
+})

--- a/frontend/src/pages/NarrativeReviewPage.tsx
+++ b/frontend/src/pages/NarrativeReviewPage.tsx
@@ -111,7 +111,14 @@ function Review({ data, token }: { data: NarrativeRead; token: string | null }) 
     () => pairNarrationScenes(data.previous_narration, data.narration),
     [data.previous_narration, data.narration],
   )
-  const changed = pairs.filter((p) => p.status !== 'unchanged').length
+  // Count the kinds separately: with the positional fallback for legacy
+  // histories, a rewritten narrative can add a scene as well as reword others,
+  // and calling a brand-new scene "changed" misreports what the reader is
+  // looking at.
+  const edited = pairs.filter((p) => p.status === 'changed').length
+  const added = pairs.filter((p) => p.status === 'added').length
+  const cut = pairs.filter((p) => p.status === 'removed').length
+  const moved = edited + added + cut
   const q = token ? `?t=${encodeURIComponent(token)}` : ''
 
   return (
@@ -145,12 +152,19 @@ function Review({ data, token }: { data: NarrativeRead; token: string | null }) 
 
         {data.previous_version != null && (
           <p className="mb-8 rounded-lg border border-warning/25 bg-warning/[0.08] px-3 py-2.5 text-[12.5px] text-muted-foreground">
-            {changed === 0 ? (
+            {moved === 0 ? (
               <>Nothing has changed since v{data.previous_version}.</>
             ) : (
               <>
-                {changed === 1 ? 'One scene has' : `${changed} scenes have`} changed since v
-                {data.previous_version} — marked below.
+                Since v{data.previous_version}:{' '}
+                {[
+                  edited && `${edited} scene${edited === 1 ? '' : 's'} reworded`,
+                  added && `${added} new`,
+                  cut && `${cut} cut`,
+                ]
+                  .filter(Boolean)
+                  .join(', ')}{' '}
+                — marked below.
               </>
             )}
           </p>


### PR DESCRIPTION
The reviewer banner tells a domain expert what moved since they last read a narrative. It counted `status !== 'unchanged'`, so an **added** or **cut** scene was reported as a rewording.

On `verified-monitoring` v17 that read *"6 scenes have changed since v16"* when it was 5 reworded + 1 new — sending the reader to look for a before/after on a scene that has no previous version. (The added scene is real: with the positional fallback for legacy id-less histories, a rewritten narrative routinely adds a beat as well as rewording others.)

Now: `Since v16: 5 scenes reworded, 1 new — marked below.`

Adds `NarrativeReviewPage.test.tsx` — the page had none. Five tests: the motivating case, that the Was/Now pair appears only on the scene that actually changed, the nothing-moved control, the tab title, and the 404 copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)