### PR TITLE
fix(storyboards): an act-level note says which act it is about

### DIFF
--- a/apps/storyboards/schemas.py
+++ b/apps/storyboards/schemas.py
@@ -19,6 +19,9 @@ class EntryOut(StrictModel):
 
 
 class ActOut(StrictModel):
+    anchor_id: str
+    """What an act-level note anchors to. Resolvable back to the act via this
+    same read — feedback carries a pointer, never a copy of the act."""
     title: str
     prose: str
     entries: list[EntryOut]

--- a/apps/storyboards/services.py
+++ b/apps/storyboards/services.py
@@ -73,6 +73,14 @@ def resolve_board(board: Storyboard) -> dict:
     for act in board.acts.all():
         acts.append(
             {
+                # What an act-level note is ABOUT. Without it every act note
+                # targets the whole board with a blank anchor, so three notes on
+                # three acts arrive indistinguishable — and the reader's most
+                # structural feedback ("act II doesn't follow from act I") is
+                # exactly the kind that loses its meaning unanchored.
+                # The pk, not the position or the title: a reorder or a retitle
+                # must not silently re-point feedback at a different act.
+                "anchor_id": f"act:{act.pk}",
                 "title": act.title,
                 "prose": act.prose,
                 "entries": [

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -4048,6 +4048,8 @@ export interface components {
         };
         /** ActOut */
         readonly ActOut: {
+            /** Anchor Id */
+            readonly anchor_id: string;
             /** Title */
             readonly title: string;
             /** Prose */

--- a/frontend/src/api/storyboards.ts
+++ b/frontend/src/api/storyboards.ts
@@ -22,6 +22,8 @@ export interface StoryboardEntry {
 }
 
 export interface StoryboardAct {
+  /** What an act-level note anchors to (`act:<id>`). */
+  anchor_id: string
   title: string
   prose: string
   entries: StoryboardEntry[]

--- a/frontend/src/pages/StoryboardPage.test.tsx
+++ b/frontend/src/pages/StoryboardPage.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi, beforeEach } from 'vitest'
-import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import StoryboardPage from './StoryboardPage'
 import * as api from '@/api/storyboards'
@@ -20,6 +20,7 @@ function board(over: Partial<api.Storyboard> = {}): api.Storyboard {
     capability: 'read',
     acts: [
       {
+        anchor_id: 'act:1',
         title: 'Six weeks to a supply base',
         prose: 'Procurement integrity you can show.',
         entries: [
@@ -72,6 +73,7 @@ describe('StoryboardPage', () => {
       board({
         acts: [
           {
+            anchor_id: 'act:9',
             title: 'Act',
             prose: '',
             entries: [
@@ -109,6 +111,25 @@ describe('StoryboardPage', () => {
     renderAt()
     expect(await screen.findByText('Leave a note on this act')).toBeTruthy()
     expect(screen.getByText('Leave a note on this demo')).toBeTruthy()
+  })
+
+  it('says which act an act-level note is about', async () => {
+    // Every act note targets the whole board, so with no anchor three notes on
+    // three acts arrive indistinguishable — and "act II doesn't follow from act
+    // I" is exactly the feedback that means nothing unanchored.
+    const leaveFeedback = api.leaveFeedback as unknown as ReturnType<typeof vi.fn>
+    leaveFeedback.mockResolvedValue({ created: 1 })
+    getStoryboard.mockResolvedValue(board({ capability: 'comment' }))
+    renderAt()
+
+    fireEvent.click(await screen.findByText('Leave a note on this act'))
+    fireEvent.change(screen.getByPlaceholderText(/What’s wrong/), {
+      target: { value: 'Act one runs long.' },
+    })
+    fireEvent.click(screen.getByText('Leave note'))
+
+    await waitFor(() => expect(leaveFeedback).toHaveBeenCalled())
+    expect(leaveFeedback.mock.calls[0][1].anchor_id).toBe('act:1')
   })
 
   it('shows a plain not-available message on 404 rather than an error dump', async () => {

--- a/frontend/src/pages/StoryboardPage.tsx
+++ b/frontend/src/pages/StoryboardPage.tsx
@@ -137,7 +137,7 @@ function Board({ board, token }: { board: Storyboard; token: string | null }) {
               capability={board.capability}
               anchorLabel={`On “${act.title}”`}
               cta="Leave a note on this act"
-              defaults={{}}
+              defaults={{ anchor_id: act.anchor_id }}
               onSubmit={(payload) => leaveFeedback(board.slug, payload, token).then(() => undefined)}
             />
           </section>

--- a/tests/test_storyboard_api.py
+++ b/tests/test_storyboard_api.py
@@ -166,6 +166,47 @@ def test_whole_board_feedback_targets_the_storyboard(board):
     assert (fb.target_kind, fb.target_ref) == ("storyboard", board.slug)
 
 
+def test_an_act_note_says_which_act(board):
+    """Act-level notes all target the board, so without an anchor a reader's
+    most structural feedback ("act II doesn't follow from act I") arrives
+    indistinguishable from a note on any other act."""
+    two = Act.objects.create(storyboard=board, title="Act two", position=1)
+    board.capability = Storyboard.CAP_COMMENT
+    board.save()
+    t = board.ensure_share_token()
+
+    read = Client().get(f"/api/storyboards/{board.slug}?t={t}").json()
+    anchors = [a["anchor_id"] for a in read["acts"]]
+    assert len(set(anchors)) == 2, "two acts, two anchors"
+
+    for anchor in anchors:
+        _post(
+            Client(),
+            f"/api/storyboards/{board.slug}/feedback?t={t}",
+            {**COMMENT, "anchor_id": anchor},
+        )
+
+    assert set(Feedback.objects.values_list("anchor_id", flat=True)) == set(anchors)
+    # And the anchor resolves back to an act — feedback holds a pointer, never a
+    # copy, so a retitle must not orphan it.
+    assert anchors[1] == f"act:{two.pk}"
+
+
+def test_an_act_anchor_survives_a_retitle_and_a_reorder(board):
+    board.capability = Storyboard.CAP_COMMENT
+    board.save()
+    t = board.ensure_share_token()
+    act = board.acts.get()
+
+    before = Client().get(f"/api/storyboards/{board.slug}?t={t}").json()["acts"][0]["anchor_id"]
+    Act.objects.create(storyboard=board, title="A new opening", position=-1)
+    act.title = "Renamed entirely"
+    act.save()
+    after = [a["anchor_id"] for a in Client().get(f"/api/storyboards/{board.slug}?t={t}").json()["acts"]]
+
+    assert before in after, "an anchor that moved would re-point old notes at the wrong act"
+
+
 def test_the_version_it_was_left_against_is_recorded(board):
     """The page FOLLOWS the current release, so without this a comment loses its
     anchor the moment the narrative moves."""


### PR DESCRIPTION
Act-level notes target the whole storyboard, and `StoryboardPage` passed `defaults={{}}` — no anchor at all. Three notes on three acts arrived in the feedback table indistinguishable from each other and from a note on the board overall.

That's the wrong feedback to lose: *"Act II doesn't follow from Act I"* is exactly what a domain expert leaves on an arc, and exactly the note that means nothing once you can't tell which act it was left on. (Scene-level notes already anchor — this was only the act composer.)

`ActOut` now carries `anchor_id` = `act:<pk>`, resolvable back through the same board read. **The pk, not the position or the title**: a reorder or a retitle must not silently re-point existing feedback at a different act — there's a test for each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)