### PR TITLE
fix(storyboards): a cut scene is history, not scene N

### DIFF
--- a/frontend/src/pages/NarrativeReviewPage.test.tsx
+++ b/frontend/src/pages/NarrativeReviewPage.test.tsx
@@ -1,8 +1,16 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import NarrativeReviewPage from './NarrativeReviewPage'
+import * as api from '@/api/storyboards'
+
+vi.mock('@/api/storyboards', async () => {
+  const actual = await vi.importActual<typeof api>('@/api/storyboards')
+  return { ...actual, leaveFeedback: vi.fn() }
+})
+
+const leaveFeedback = api.leaveFeedback as unknown as ReturnType<typeof vi.fn>
 
 /**
  * The banner tells a reviewer what moved since they last read the narrative.
@@ -43,6 +51,8 @@ function renderPage() {
 
 describe('NarrativeReviewPage', () => {
   beforeEach(() => {
+    vi.clearAllMocks()
+    leaveFeedback.mockResolvedValue({ created: 1 })
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => payload() }),
@@ -90,6 +100,72 @@ describe('NarrativeReviewPage', () => {
     await screen.findByText(/1 scene reworded/)
     expect(document.title).toContain('Verified Monitoring')
     expect(document.title).toContain('Proving a programme works')
+  })
+
+  /**
+   * A cut scene is history — it is not in the narrative being read. Numbering
+   * it alongside the others made the scene after it read one higher than it is,
+   * and made the footer promise more scenes than the story has.
+   */
+  describe('a cut scene', () => {
+    const withACut = () =>
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          status: 200,
+          json: async () =>
+            payload({
+              previous_narration: [
+                { id: 'a', title: 'One', text: 'Kept.' },
+                { id: 'gone', title: 'Dropped', text: 'This beat was removed.' },
+                { id: 'b', title: 'Two', text: 'Also kept.' },
+              ],
+              narration: [
+                { id: 'a', title: 'One', text: 'Kept.' },
+                { id: 'b', title: 'Two', text: 'Also kept.' },
+              ],
+            }),
+        }),
+      )
+
+    it('is not numbered among the scenes that remain', async () => {
+      withACut()
+      const { container } = renderPage()
+      await screen.findByText(/1 cut/)
+      const numbers = [...container.querySelectorAll('section span.font-mono')].map(
+        (n) => n.textContent,
+      )
+      expect(numbers).toEqual(['01', '02', '—'])
+    })
+
+    it('is not counted as a scene of the current narrative', async () => {
+      withACut()
+      renderPage()
+      await screen.findByText(/1 cut/)
+      expect(screen.getByText(/2 scenes/)).toBeTruthy()
+    })
+
+    it('is not badged as if it were new', async () => {
+      withACut()
+      renderPage()
+      expect(await screen.findByText(/Cut since v16/)).toBeTruthy()
+    })
+
+    it('files a note against the version the scene actually exists in', async () => {
+      withACut()
+      renderPage()
+      fireEvent.click(await screen.findByText('Leave a note on the cut scene'))
+      fireEvent.change(screen.getByPlaceholderText(/What’s wrong/), {
+        target: { value: 'Put this back.' },
+      })
+      fireEvent.click(screen.getByText('Leave note'))
+      await waitFor(() => expect(leaveFeedback).toHaveBeenCalled())
+      expect(leaveFeedback.mock.calls[0][1]).toMatchObject({
+        anchor_id: 'gone',
+        target_version: 16,
+      })
+    })
   })
 
   it('shows a plain message rather than an error dump on 404', async () => {

--- a/frontend/src/pages/NarrativeReviewPage.tsx
+++ b/frontend/src/pages/NarrativeReviewPage.tsx
@@ -121,6 +121,16 @@ function Review({ data, token }: { data: NarrativeRead; token: string | null }) 
   const moved = edited + added + cut
   const q = token ? `?t=${encodeURIComponent(token)}` : ''
 
+  // A cut scene is history, not part of the story being read. Numbering it
+  // alongside the others made scene 4 read as scene 5 and made the footer
+  // promise more scenes than the narrative has. Number only what is still in
+  // the narrative; a cut scene gets a dash.
+  const sceneNumbers = new Map<number, number>()
+  pairs.forEach((p, i) => {
+    if (p.status !== 'removed') sceneNumbers.set(i, sceneNumbers.size + 1)
+  })
+  const sceneCount = sceneNumbers.size
+
   return (
     <div className="min-h-screen bg-background text-foreground">
       <div className="mx-auto max-w-3xl px-6 py-12 md:py-16">
@@ -171,21 +181,37 @@ function Review({ data, token }: { data: NarrativeRead; token: string | null }) 
         )}
 
         <div>
-          {pairs.map((pair, i) => (
+          {pairs.map((pair, i) => {
+            const n = sceneNumbers.get(i)
+            const isCut = pair.status === 'removed'
+            return (
             <section
               key={pair.id ?? i}
               className="flex flex-col gap-3 border-t border-border py-5 first:border-t-0"
             >
               <div className="flex flex-wrap items-baseline gap-2.5">
                 <span className="font-mono text-[11px] tabular-nums text-foreground-subtle">
-                  {String(i + 1).padStart(2, '0')}
+                  {n != null ? String(n).padStart(2, '0') : '—'}
                 </span>
                 {pair.title && (
                   <h2 className="text-[15px] font-semibold text-foreground">{pair.title}</h2>
                 )}
                 {pair.status !== 'unchanged' && (
-                  <span className="rounded-full border border-success/30 bg-success/10 px-2 py-0.5 text-[11px] text-success">
-                    {pair.status === 'added' ? 'New' : pair.status === 'removed' ? 'Cut' : 'Changed'}
+                  // A cut scene is not an addition; badging it in the same
+                  // green said "look at this new thing" about something that is
+                  // no longer there.
+                  <span
+                    className={
+                      isCut
+                        ? 'rounded-full border border-border bg-muted px-2 py-0.5 text-[11px] text-muted-foreground'
+                        : 'rounded-full border border-success/30 bg-success/10 px-2 py-0.5 text-[11px] text-success'
+                    }
+                  >
+                    {pair.status === 'added'
+                      ? 'New'
+                      : isCut
+                        ? `Cut since v${data.previous_version}`
+                        : 'Changed'}
                   </span>
                 )}
               </div>
@@ -208,18 +234,30 @@ function Review({ data, token }: { data: NarrativeRead; token: string | null }) 
                   </div>
                 </div>
               ) : (
-                <p className="text-[13.5px] leading-relaxed text-foreground-secondary">
+                <p
+                  className={
+                    isCut
+                      ? 'text-[13.5px] leading-relaxed text-foreground-subtle line-through decoration-foreground-subtle/50'
+                      : 'text-[13.5px] leading-relaxed text-foreground-secondary'
+                  }
+                >
                   {pair.after ?? pair.before}
                 </p>
               )}
 
               <NoteComposer
                 capability={data.capability}
-                anchorLabel={`Scene ${i + 1}${data.version != null ? ` · v${data.version}` : ''}`}
-                cta={`Leave a note on scene ${i + 1}`}
+                anchorLabel={
+                  isCut
+                    ? `Cut scene · v${data.previous_version}`
+                    : `Scene ${n}${data.version != null ? ` · v${data.version}` : ''}`
+                }
+                cta={isCut ? 'Leave a note on the cut scene' : `Leave a note on scene ${n}`}
                 defaults={{
                   narrative_slug: data.narrative_slug,
-                  target_version: data.version,
+                  // A cut scene exists only in the previous version, so filing
+                  // the note against the current one points it at nothing.
+                  target_version: isCut ? data.previous_version : data.version,
                   anchor_id: pair.id ?? '',
                 }}
                 onSubmit={(payload) =>
@@ -227,13 +265,14 @@ function Review({ data, token }: { data: NarrativeRead; token: string | null }) 
                 }
               />
             </section>
-          ))}
+            )
+          })}
         </div>
 
         <footer className="mt-14 flex flex-wrap items-center justify-between gap-2 border-t border-border pt-6 text-[11px] text-muted-foreground">
           <span>
             <span className="font-mono">{data.narrative_slug}</span>
-            {data.version != null && ` · v${data.version}`} · {pairs.length} scenes
+            {data.version != null && ` · v${data.version}`} · {sceneCount} scenes
           </span>
         </footer>
       </div>


### PR DESCRIPTION
A scene removed since the previous version was rendered as if it were part of the story being read:

- **numbered inline** — in the positional pairing path (every pre-L0 narrative) a cut at position 3 pushed the rest up, so the reader's scene 4 was the page's "scene 5"
- **counted in the footer** — "12 scenes" for a narrative that has 11
- **badged in the same green as New** — "look at this new thing" about something that is no longer there
- **in body-copy black**, indistinguishable from current prose
- **note composer filed against the current version** — the one version that scene is not in

Now: cut scenes get a dash instead of a number, struck-through text, a neutral `Cut since v16` badge, and a note anchored to `previous_version`. Four tests, including the numbering one that motivated it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)