### PR TITLE
fix(storyboards): act anchors survive the board being re-imported

### DIFF
--- a/apps/storyboards/act_keys.py
+++ b/apps/storyboards/act_keys.py
@@ -1,0 +1,33 @@
+"""Deriving stable act keys — the one place, so the two write paths agree.
+
+``import_storyboard`` and ``PATCH /api/storyboards/{slug}`` both replace acts
+wholesale, and both must produce the SAME keys from the same arc, or pushing the
+file after an in-app edit would silently re-point every act note.
+"""
+from __future__ import annotations
+
+from django.utils.text import slugify
+
+_MAX = 120
+
+
+def act_key(declared: str, title: str, position: int, taken: set[str]) -> str:
+    """A key for one act, unique within ``taken`` (which this mutates).
+
+    An explicit ``key:`` wins — that is how an author keeps existing notes
+    attached through a retitle. Otherwise the title, which is stable across a
+    re-import that did not change it. A titleless act falls back to its
+    position, which is the honest answer: there is nothing else to identify it
+    by.
+    """
+    base = slugify(declared or title)[:_MAX] or f"act-{position + 1}"
+    key = base
+    n = 2
+    while key in taken:
+        # Two acts with the same title is a real (if odd) arc. Deterministic
+        # given the same order, so a re-import reproduces the same assignment.
+        suffix = f"-{n}"
+        key = f"{base[: _MAX - len(suffix)]}{suffix}"
+        n += 1
+    taken.add(key)
+    return key

--- a/apps/storyboards/api.py
+++ b/apps/storyboards/api.py
@@ -24,6 +24,7 @@ from ninja.errors import HttpError
 from apps.api.auth import session_auth
 from apps.feedback import services as feedback_services
 from apps.storyboards import services
+from apps.storyboards.act_keys import act_key
 from apps.storyboards.models import Act, Entry, Storyboard
 from apps.storyboards.schemas import (
     AnonFeedbackIn,
@@ -104,9 +105,14 @@ def _replace_acts(board: Storyboard, acts) -> None:
     the UI cannot drift apart.
     """
     board.acts.all().delete()
+    taken: set[str] = set()
     for a_pos, act_in in enumerate(acts):
         act = Act.objects.create(
-            storyboard=board, title=act_in.title, prose=act_in.prose, position=a_pos
+            storyboard=board,
+            key=act_key(act_in.key, act_in.title, a_pos, taken),
+            title=act_in.title,
+            prose=act_in.prose,
+            position=a_pos,
         )
         for e_pos, entry_in in enumerate(act_in.entries):
             Entry.objects.create(

--- a/apps/storyboards/management/commands/import_storyboard.py
+++ b/apps/storyboards/management/commands/import_storyboard.py
@@ -13,6 +13,7 @@ the source and this command stays safe to re-run in CI.
     capability: comment          # read | comment | suggest
     acts:
       - title: Six weeks to a supply base
+        key: supply-base        # optional; keeps act notes attached through a retitle
         prose: Procurement integrity you can show, not assert.
         entries: [procurement-eoi, supplier-registry]
       - title: Where the RUTF is, and who is short
@@ -28,6 +29,7 @@ import yaml
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 
+from apps.storyboards.act_keys import act_key
 from apps.storyboards.models import Act, Entry, Storyboard
 
 
@@ -61,10 +63,13 @@ class Command(BaseCommand):
             # Wholesale replace: reordering is a rewrite, not a diff, and the
             # file is the source of truth for structure.
             board.acts.all().delete()
+            taken: set[str] = set()
             for a_pos, act_raw in enumerate(raw.get("acts") or []):
+                title = act_raw.get("title") or f"Act {a_pos + 1}"
                 act = Act.objects.create(
                     storyboard=board,
-                    title=act_raw.get("title") or f"Act {a_pos + 1}",
+                    key=act_key(act_raw.get("key") or "", title, a_pos, taken),
+                    title=title,
                     prose=act_raw.get("prose") or "",
                     position=a_pos,
                 )

--- a/apps/storyboards/migrations/0002_act_key.py
+++ b/apps/storyboards/migrations/0002_act_key.py
@@ -1,0 +1,47 @@
+"""Give every act a stable key.
+
+The backfill sits BETWEEN the add and the constraint on purpose: every existing
+act would otherwise share the default `""` and the unique constraint would
+refuse to build on any board with more than one act.
+
+Keys are derived exactly as the write paths derive them, so re-importing a
+storyboard file after this migration reproduces the same keys and leaves
+existing act notes attached.
+"""
+from django.db import migrations, models
+
+
+def backfill(apps, schema_editor):
+    from apps.storyboards.act_keys import act_key
+
+    Act = apps.get_model("storyboards", "Act")
+    Storyboard = apps.get_model("storyboards", "Storyboard")
+    for board in Storyboard.objects.all():
+        taken = set()
+        for pos, act in enumerate(board.acts.order_by("position", "id")):
+            act.key = act_key("", act.title, pos, taken)
+            act.save(update_fields=["key"])
+
+
+def noop(apps, schema_editor):
+    """Reversing drops the column anyway."""
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('storyboards', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='act',
+            name='key',
+            field=models.SlugField(blank=True, default='', max_length=120),
+        ),
+        migrations.RunPython(backfill, noop),
+        migrations.AddConstraint(
+            model_name='act',
+            constraint=models.UniqueConstraint(fields=('storyboard', 'key'), name='uniq_act_storyboard_key'),
+        ),
+    ]

--- a/apps/storyboards/models.py
+++ b/apps/storyboards/models.py
@@ -109,6 +109,19 @@ class Act(models.Model):
     """One act of the arc: a title, connective prose, and ordered entries."""
 
     storyboard = models.ForeignKey(Storyboard, on_delete=models.CASCADE, related_name="acts")
+    key = models.SlugField(max_length=120, blank=True, default="")
+    """What act-level feedback anchors to — and the reason it is not the pk.
+
+    Both write paths (the import command and ``PATCH /storyboards/{slug}``)
+    replace acts WHOLESALE: ``board.acts.all().delete()`` then recreate, because
+    reordering an arc is a rewrite, not a diff. So a row id lives exactly as
+    long as the next re-import, and anchoring feedback to it would orphan every
+    act note the first time the file was pushed again.
+
+    Derived from the title when the author does not declare one, which is
+    stable across a re-import that changes nothing. An author who reworders a
+    title and wants the existing notes to follow declares ``key:`` in the
+    storyboard YAML — identity is stated, never guessed."""
     title = models.CharField(max_length=300)
     prose = models.TextField(blank=True, default="")
     """The connective tissue — why this act follows the last one. This is the
@@ -117,6 +130,33 @@ class Act(models.Model):
 
     class Meta:
         ordering = ["position", "id"]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["storyboard", "key"], name="uniq_act_storyboard_key"
+            ),
+        ]
+
+    @property
+    def anchor_id(self) -> str:
+        """What a note left on this act records."""
+        return f"act:{self.key}"
+
+    def save(self, *args, **kwargs):
+        """Derive a key when none was given, so no write path can create an
+        anchorless act. The batch paths pass one explicitly (they need the whole
+        arc's keys to be deterministic); this covers everything else."""
+        if not self.key:
+            from apps.storyboards.act_keys import act_key
+
+            taken = set(
+                Act.objects.filter(storyboard_id=self.storyboard_id)
+                .exclude(pk=self.pk)
+                .values_list("key", flat=True)
+            )
+            self.key = act_key("", self.title, self.position, taken)
+            if kwargs.get("update_fields") is not None:
+                kwargs["update_fields"] = [*kwargs["update_fields"], "key"]
+        super().save(*args, **kwargs)
 
     def __str__(self) -> str:  # pragma: no cover
         return f"act:{self.storyboard_id}:{self.position}:{self.title[:40]}"

--- a/apps/storyboards/schemas.py
+++ b/apps/storyboards/schemas.py
@@ -55,6 +55,9 @@ class EntryIn(StrictModel):
 
 
 class ActIn(StrictModel):
+    key: str = ""
+    """Optional stable identity. Declare it to keep act notes attached through
+    a retitle; otherwise it is derived from the title."""
     title: str
     prose: str = ""
     entries: list[EntryIn] = []

--- a/apps/storyboards/services.py
+++ b/apps/storyboards/services.py
@@ -78,9 +78,8 @@ def resolve_board(board: Storyboard) -> dict:
                 # three acts arrive indistinguishable — and the reader's most
                 # structural feedback ("act II doesn't follow from act I") is
                 # exactly the kind that loses its meaning unanchored.
-                # The pk, not the position or the title: a reorder or a retitle
-                # must not silently re-point feedback at a different act.
-                "anchor_id": f"act:{act.pk}",
+                # See Act.key for why this is not the row id.
+                "anchor_id": act.anchor_id,
                 "title": act.title,
                 "prose": act.prose,
                 "entries": [

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -4089,6 +4089,11 @@ export interface components {
         };
         /** ActIn */
         readonly ActIn: {
+            /**
+             * Key
+             * @default
+             */
+            readonly key: string;
             /** Title */
             readonly title: string;
             /**

--- a/tests/test_storyboard_api.py
+++ b/tests/test_storyboard_api.py
@@ -188,23 +188,76 @@ def test_an_act_note_says_which_act(board):
 
     assert set(Feedback.objects.values_list("anchor_id", flat=True)) == set(anchors)
     # And the anchor resolves back to an act — feedback holds a pointer, never a
-    # copy, so a retitle must not orphan it.
-    assert anchors[1] == f"act:{two.pk}"
+    # copy of the act.
+    assert anchors[1] == f"act:{two.key}"
 
 
-def test_an_act_anchor_survives_a_retitle_and_a_reorder(board):
+def test_an_act_anchor_survives_the_board_being_re_imported(member, board, ws):
+    """The guarantee that matters, because BOTH write paths replace acts
+    wholesale (`board.acts.all().delete()` then recreate). Anchoring to the row
+    id would orphan every act note the first time the file was pushed again —
+    which is the normal way this board is edited."""
     board.capability = Storyboard.CAP_COMMENT
     board.save()
     t = board.ensure_share_token()
-    act = board.acts.get()
-
     before = Client().get(f"/api/storyboards/{board.slug}?t={t}").json()["acts"][0]["anchor_id"]
-    Act.objects.create(storyboard=board, title="A new opening", position=-1)
-    act.title = "Renamed entirely"
-    act.save()
-    after = [a["anchor_id"] for a in Client().get(f"/api/storyboards/{board.slug}?t={t}").json()["acts"]]
+    old_pk = board.acts.get().pk
 
-    assert before in after, "an anchor that moved would re-point old notes at the wrong act"
+    body = {
+        "title": board.title,
+        "acts": [
+            {
+                "title": "Act one",
+                "prose": "Now with connective tissue.",
+                "entries": [{"narrative_slug": "verified-monitoring"}],
+            }
+        ],
+    }
+    r = member.patch(
+        f"/api/storyboards/{board.slug}", json.dumps(body), content_type="application/json"
+    )
+    assert r.status_code == 200, r.content
+
+    after = Client().get(f"/api/storyboards/{board.slug}?t={t}").json()["acts"][0]["anchor_id"]
+    assert after == before
+    assert board.acts.get().pk != old_pk, (
+        "the row was replaced, as this write path always does — which is exactly "
+        "why the anchor cannot be the row id"
+    )
+
+
+def test_a_declared_key_keeps_act_notes_attached_through_a_retitle(member, board):
+    """Identity is stated, never guessed: without a declared key a retitle is
+    indistinguishable from replacing the act, and re-pointing a stranger's note
+    at different words is worse than dropping it."""
+    t = board.ensure_share_token()
+
+    def _put(title, key):
+        return member.patch(
+            f"/api/storyboards/{board.slug}",
+            json.dumps({"acts": [{"key": key, "title": title, "entries": []}]}),
+            content_type="application/json",
+        )
+
+    assert _put("Six weeks to a supply base", "supply-base").status_code == 200
+    before = Client().get(f"/api/storyboards/{board.slug}?t={t}").json()["acts"][0]["anchor_id"]
+    assert _put("What six weeks of procurement bought", "supply-base").status_code == 200
+    after = Client().get(f"/api/storyboards/{board.slug}?t={t}").json()["acts"][0]["anchor_id"]
+
+    assert before == after == "act:supply-base"
+
+
+def test_two_acts_with_the_same_title_still_get_distinct_anchors(member, board):
+    assert (
+        member.patch(
+            f"/api/storyboards/{board.slug}",
+            json.dumps({"acts": [{"title": "Act", "entries": []}, {"title": "Act", "entries": []}]}),
+            content_type="application/json",
+        ).status_code
+        == 200
+    )
+    keys = list(board.acts.values_list("key", flat=True))
+    assert keys == ["act", "act-2"]
 
 
 def test_the_version_it_was_left_against_is_recorded(board):

--- a/tests/test_storyboard_import.py
+++ b/tests/test_storyboard_import.py
@@ -7,7 +7,7 @@ from django.contrib.auth.models import User
 from django.core.management import call_command
 from django.core.management.base import CommandError
 
-from apps.storyboards.models import Entry, Storyboard
+from apps.storyboards.models import Act, Entry, Storyboard
 from apps.workspaces.models import Workspace
 
 pytestmark = pytest.mark.django_db
@@ -112,3 +112,28 @@ def test_an_entry_without_a_narrative_slug_is_a_loud_error(tmp_path, ws):
 def test_a_missing_file_is_a_loud_error(ws):
     with pytest.raises(CommandError, match="no such file"):
         call_command("import_storyboard", "/nope/storyboard.yaml", workspace="dimagi")
+
+
+def test_re_importing_keeps_the_same_act_anchors(tmp_path, ws):
+    """The import deletes and recreates every act, so an anchor tied to the row
+    id would orphan every act note on each push. Keys must reproduce."""
+    raw = {**BOARD, "acts": [{"title": "Six weeks", "entries": ["a"]}, {"title": "Where it is", "entries": ["b"]}]}
+    path = _write(tmp_path, raw)
+
+    call_command("import_storyboard", path, workspace="dimagi")
+    before = list(Act.objects.order_by("position").values_list("key", flat=True))
+    pks = set(Act.objects.values_list("pk", flat=True))
+
+    call_command("import_storyboard", path, workspace="dimagi")
+    assert list(Act.objects.order_by("position").values_list("key", flat=True)) == before
+    assert not (pks & set(Act.objects.values_list("pk", flat=True))), "rows were replaced"
+
+
+def test_a_declared_key_survives_a_retitle_in_the_file(tmp_path, ws):
+    first = {**BOARD, "acts": [{"key": "supply-base", "title": "Six weeks", "entries": ["a"]}]}
+    call_command("import_storyboard", _write(tmp_path, first), workspace="dimagi")
+    second = {**BOARD, "acts": [{"key": "supply-base", "title": "What six weeks bought", "entries": ["a"]}]}
+    call_command("import_storyboard", _write(tmp_path, second), workspace="dimagi")
+
+    act = Act.objects.get()
+    assert (act.key, act.title) == ("supply-base", "What six weeks bought")


### PR DESCRIPTION
#455 anchored act-level feedback to the `Act` row id. That is stable against everything except the normal way this object changes.

Both write paths — `import_storyboard` and `PATCH /storyboards/{slug}` — replace acts **wholesale** (`board.acts.all().delete()` then recreate), because reordering an arc is a rewrite and not a diff. A row id therefore lives exactly as long as the next push of the storyboard file, and every act note would have been orphaned the first time the arc was edited.

Anchor on `Act.key` instead:

- derived from the title when the author doesn't declare one — stable across a re-import that changed nothing else
- declarable as `key:` in the storyboard YAML, which is how you keep existing notes attached through a retitle

**Identity is stated, never guessed.** Silently re-pointing a stranger's note at different words is worse than leaving it where it was said, so a retitle without a declared key moves the anchor rather than pretending the act is the same one.

One derivation (`apps/storyboards/act_keys.py`) shared by both write paths, `Act.save()` for one-off creates, and the migration that backfills existing acts — so pushing the file after an in-app edit cannot re-key the arc. The backfill runs between the AddField and the AddConstraint, since every existing act would otherwise share the default `""`.

Tests: re-import reproduces the keys *while the row ids churn* (the assertion that would have caught #455), a declared key survives a retitle on both write paths, duplicate titles get distinct anchors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)