### PR TITLE
feat(storyboards): the people who sent the link can read what came back

### DIFF
--- a/apps/storyboards/api.py
+++ b/apps/storyboards/api.py
@@ -28,6 +28,7 @@ from apps.storyboards.act_keys import act_key
 from apps.storyboards.models import Act, Entry, Storyboard
 from apps.storyboards.schemas import (
     AnonFeedbackIn,
+    NotesOut,
     ShareTokenOut,
     StoryboardIn,
     StoryboardListOut,
@@ -48,6 +49,14 @@ def _member_boards(request: HttpRequest):
     if not request.user.is_authenticated:
         return Storyboard.objects.none()
     return Storyboard.objects.filter(workspace_id__in=wsvc.user_workspace_slugs(request.user))
+
+
+def _is_member(request: HttpRequest, board: Storyboard) -> bool:
+    """One of the people who SENT the link, rather than one it was sent to."""
+    return bool(
+        request.user.is_authenticated
+        and board.workspace_id in wsvc.user_workspace_slugs(request.user)
+    )
 
 
 def _readable_or_404(request: HttpRequest, slug: str) -> Storyboard:
@@ -161,7 +170,7 @@ def create_storyboard(request: HttpRequest, payload: StoryboardIn) -> dict:
             workspace_id=workspace_slug,
         )
         _replace_acts(board, payload.acts)
-    return services.resolve_board(board)
+    return services.resolve_board(board, is_member=True)
 
 
 @router.get(
@@ -172,7 +181,8 @@ def create_storyboard(request: HttpRequest, payload: StoryboardIn) -> dict:
 )
 def get_storyboard(request: HttpRequest, slug: str) -> dict:
     """Anonymous-capable; the handler self-enforces. See the module docstring."""
-    return services.resolve_board(_readable_or_404(request, slug))
+    board = _readable_or_404(request, slug)
+    return services.resolve_board(board, is_member=_is_member(request, board))
 
 
 @router.patch("/{slug}", response=StoryboardOut, auth=session_auth, summary="Edit a storyboard")
@@ -189,7 +199,7 @@ def patch_storyboard(request: HttpRequest, slug: str, payload: StoryboardPatchIn
             board.save(update_fields=[*fields, "updated_at"])
         if payload.acts is not None:
             _replace_acts(board, payload.acts)
-    return services.resolve_board(board)
+    return services.resolve_board(board, is_member=True)
 
 
 @router.post(
@@ -267,6 +277,46 @@ def leave_feedback(request: HttpRequest, slug: str, payload: AnonFeedbackIn) -> 
         [item],
         submitted_by=request.user if request.user.is_authenticated else None,
     )
+
+
+@router.get(
+    "/{slug}/notes",
+    response=NotesOut,
+    auth=session_auth,
+    summary="Read the notes left on this board (members only)",
+)
+def list_notes(request: HttpRequest, slug: str) -> dict:
+    """What came back. Members only, and 404 — never 403 — for everyone else.
+
+    Without this the loop had no closing half: a reviewer could leave notes and
+    the people who sent them the link had no way to read them short of curl.
+
+    A token holder must not reach it. Seeing the other reviewers' notes would
+    bias exactly the independent read you asked for, and the rows carry names
+    that were given to us rather than to each other — so this uses
+    ``_owned_or_404`` (membership), not ``_readable_or_404`` (membership OR
+    token).
+    """
+    board = _owned_or_404(request, slug)
+    return {
+        "items": [
+            {
+                "id": fb.pk,
+                "kind": fb.kind,
+                "body": fb.body,
+                "suggested_text": fb.suggested_text,
+                "author_name": fb.author_name,
+                "channel": fb.channel,
+                "state": fb.state,
+                "target_kind": fb.target_kind,
+                "target_ref": fb.target_ref,
+                "target_version": fb.target_version,
+                "anchor_id": fb.anchor_id,
+                "created_at": fb.created_at.isoformat(),
+            }
+            for fb in services.board_feedback(board)
+        ]
+    }
 
 
 @router.get(

--- a/apps/storyboards/schemas.py
+++ b/apps/storyboards/schemas.py
@@ -32,7 +32,34 @@ class StoryboardOut(StrictModel):
     title: str
     lede: str
     capability: str
+    is_member: bool = False
+    """True when the caller belongs to the owning workspace — i.e. is one of the
+    people who SENT this link, not one of the people it was sent to. The only
+    thing it changes is whether returning notes are shown."""
     acts: list[ActOut]
+
+
+class NoteOut(StrictModel):
+    """One note as its recipients read it. No `author_email`, `submitted_by` or
+    `source_ref`: this view answers "what did they say", and the full record is
+    `/api/feedback/`."""
+
+    id: int
+    kind: str
+    body: str
+    suggested_text: str
+    author_name: str
+    channel: str
+    state: str
+    target_kind: str
+    target_ref: str
+    target_version: int | None
+    anchor_id: str
+    created_at: str
+
+
+class NotesOut(StrictModel):
+    items: list[NoteOut]
 
 
 class StoryboardListItemOut(StrictModel):

--- a/apps/storyboards/services.py
+++ b/apps/storyboards/services.py
@@ -12,7 +12,7 @@ remove — and ``storyboards`` is product tier, so importing product is legal.
 from __future__ import annotations
 
 from apps.runs import aggregate
-from apps.storyboards.models import Storyboard
+from apps.storyboards.models import Entry, Storyboard
 
 
 # A narrative's stored `title` is derived from the opening of its story, so on a
@@ -65,7 +65,29 @@ def _entry_payload(entry, workspace_slugs: set[str]) -> dict:
     }
 
 
-def resolve_board(board: Storyboard) -> dict:
+def board_feedback(board: Storyboard):
+    """Every note left on this board — the arc itself and the narratives on it.
+
+    Members only, enforced by the caller. A reviewer must not read what other
+    reviewers said: it biases the feedback you asked them for, and the rows
+    carry names and email addresses that were given to us, not to each other.
+    """
+    from django.db.models import Q
+
+    from apps.feedback.models import Feedback
+
+    slugs = list(
+        Entry.objects.filter(act__storyboard=board)
+        .values_list("narrative_slug", flat=True)
+        .distinct()
+    )
+    return Feedback.objects.filter(
+        Q(target_kind="storyboard", target_ref=board.slug)
+        | Q(target_kind="narrative", target_ref__in=slugs)
+    ).order_by("-created_at")
+
+
+def resolve_board(board: Storyboard, *, is_member: bool = False) -> dict:
     """The read model for the shared page: acts → entries → current release."""
     workspace_slugs = {board.workspace_id}
 
@@ -93,6 +115,8 @@ def resolve_board(board: Storyboard) -> dict:
         "title": board.title,
         "lede": board.lede,
         "capability": board.capability,
+        # The page shows returning notes only to the people who sent the link.
+        "is_member": is_member,
         "acts": acts,
     }
 

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -673,6 +673,35 @@ export interface paths {
         readonly patch?: never;
         readonly trace?: never;
     };
+    readonly "/api/storyboards/{slug}/notes": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        /**
+         * Read the notes left on this board (members only)
+         * @description What came back. Members only, and 404 — never 403 — for everyone else.
+         *
+         *     Without this the loop had no closing half: a reviewer could leave notes and
+         *     the people who sent them the link had no way to read them short of curl.
+         *
+         *     A token holder must not reach it. Seeing the other reviewers' notes would
+         *     bias exactly the independent read you asked for, and the rows carry names
+         *     that were given to us rather than to each other — so this uses
+         *     ``_owned_or_404`` (membership), not ``_readable_or_404`` (membership OR
+         *     token).
+         */
+        readonly get: operations["apps_storyboards_api_list_notes"];
+        readonly put?: never;
+        readonly post?: never;
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
     readonly "/api/storyboards/{slug}/narratives/{narrative_slug}": {
         readonly parameters: {
             readonly query?: never;
@@ -4084,6 +4113,11 @@ export interface components {
             readonly lede: string;
             /** Capability */
             readonly capability: string;
+            /**
+             * Is Member
+             * @default false
+             */
+            readonly is_member: boolean;
             /** Acts */
             readonly acts: readonly components["schemas"]["ActOut"][];
         };
@@ -4207,6 +4241,43 @@ export interface components {
              * @default
              */
             readonly author_email: string;
+        };
+        /**
+         * NoteOut
+         * @description One note as its recipients read it. No `author_email`, `submitted_by` or
+         *     `source_ref`: this view answers "what did they say", and the full record is
+         *     `/api/feedback/`.
+         */
+        readonly NoteOut: {
+            /** Id */
+            readonly id: number;
+            /** Kind */
+            readonly kind: string;
+            /** Body */
+            readonly body: string;
+            /** Suggested Text */
+            readonly suggested_text: string;
+            /** Author Name */
+            readonly author_name: string;
+            /** Channel */
+            readonly channel: string;
+            /** State */
+            readonly state: string;
+            /** Target Kind */
+            readonly target_kind: string;
+            /** Target Ref */
+            readonly target_ref: string;
+            /** Target Version */
+            readonly target_version: number | null;
+            /** Anchor Id */
+            readonly anchor_id: string;
+            /** Created At */
+            readonly created_at: string;
+        };
+        /** NotesOut */
+        readonly NotesOut: {
+            /** Items */
+            readonly items: readonly components["schemas"]["NoteOut"][];
         };
         /** NarrationItemOut */
         readonly NarrationItemOut: {
@@ -9179,6 +9250,28 @@ export interface operations {
                     readonly "application/json": {
                         readonly [key: string]: unknown;
                     };
+                };
+            };
+        };
+    };
+    readonly apps_storyboards_api_list_notes: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path: {
+                readonly slug: string;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description OK */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["NotesOut"];
                 };
             };
         };

--- a/frontend/src/api/storyboards.ts
+++ b/frontend/src/api/storyboards.ts
@@ -34,7 +34,24 @@ export interface Storyboard {
   title: string
   lede: string
   capability: Capability
+  /** True for the people who SENT the link — the only ones shown the notes. */
+  is_member: boolean
   acts: StoryboardAct[]
+}
+
+export interface Note {
+  id: number
+  kind: FeedbackKind
+  body: string
+  suggested_text: string
+  author_name: string
+  channel: string
+  state: string
+  target_kind: string
+  target_ref: string
+  target_version: number | null
+  anchor_id: string
+  created_at: string
 }
 
 export interface LeaveFeedbackIn {
@@ -68,6 +85,11 @@ async function getJson<T>(url: string): Promise<T> {
 
 export function getStoryboard(slug: string, token?: string | null): Promise<Storyboard> {
   return getJson(withToken(`/api/storyboards/${encodeURIComponent(slug)}`, token))
+}
+
+/** What came back. Members only — a 401/404 here just means "not yours". */
+export function getStoryboardNotes(slug: string): Promise<{ items: Note[] }> {
+  return getJson(`/api/storyboards/${encodeURIComponent(slug)}/notes`)
 }
 
 /** Leave a note. Returns the ingest summary; throws with a readable message on 403. */

--- a/frontend/src/components/storyboard/NotesReturned.tsx
+++ b/frontend/src/components/storyboard/NotesReturned.tsx
@@ -1,0 +1,72 @@
+import type { Note } from '@/api/storyboards'
+
+/**
+ * What came back, shown to the people who sent the link and to nobody else.
+ *
+ * Rendered IN PLACE — under the act or the demo the note was left on — because
+ * that is the only reading of it that carries meaning. A flat list of forty
+ * comments detached from what they are about is the thing this whole surface
+ * exists to avoid.
+ */
+
+function when(iso: string): string {
+  const d = new Date(iso)
+  return Number.isNaN(d.getTime())
+    ? ''
+    : d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+}
+
+export function NotesReturned({ notes, label }: { notes: Note[]; label?: string }) {
+  if (notes.length === 0) return null
+  return (
+    <div className="mt-3 flex flex-col gap-2 rounded-lg border border-info/25 bg-info/[0.06] p-3">
+      <span className="text-[11px] font-semibold uppercase tracking-[0.16em] text-info">
+        {label ?? (notes.length === 1 ? '1 note back' : `${notes.length} notes back`)}
+      </span>
+      {notes.map((n) => (
+        <article key={n.id} className="flex flex-col gap-1 border-t border-info/15 pt-2 first:border-t-0 first:pt-0">
+          <div className="flex flex-wrap items-baseline gap-2 text-[11px] text-muted-foreground">
+            <span className="font-medium text-foreground-secondary">
+              {n.author_name || 'Anonymous'}
+            </span>
+            {n.kind === 'suggestion' && (
+              <span className="rounded-full border border-special/30 bg-special/10 px-1.5 py-px text-[10px] text-special">
+                Suggested wording
+              </span>
+            )}
+            {n.target_version != null && <span className="tabular-nums">v{n.target_version}</span>}
+            {n.channel !== 'web' && <span>via {n.channel}</span>}
+            <span>{when(n.created_at)}</span>
+            {n.state !== 'open' && <span className="italic">{n.state}</span>}
+          </div>
+          <p className="whitespace-pre-wrap text-[13px] leading-relaxed text-foreground">
+            {n.body || n.suggested_text}
+          </p>
+        </article>
+      ))}
+    </div>
+  )
+}
+
+/** Group notes by where they belong on the board. */
+export function groupNotes(notes: Note[]) {
+  const byAnchor = new Map<string, Note[]>()
+  const byNarrative = new Map<string, Note[]>()
+  const loose: Note[] = []
+
+  for (const n of notes) {
+    if (n.target_kind === 'narrative') {
+      const list = byNarrative.get(n.target_ref) ?? []
+      list.push(n)
+      byNarrative.set(n.target_ref, list)
+    } else if (n.anchor_id) {
+      const list = byAnchor.get(n.anchor_id) ?? []
+      list.push(n)
+      byAnchor.set(n.anchor_id, list)
+    } else {
+      // Board-level notes, and act notes left before acts carried an anchor.
+      loose.push(n)
+    }
+  }
+  return { byAnchor, byNarrative, loose }
+}

--- a/frontend/src/pages/StoryboardPage.test.tsx
+++ b/frontend/src/pages/StoryboardPage.test.tsx
@@ -7,10 +7,29 @@ import * as api from '@/api/storyboards'
 
 vi.mock('@/api/storyboards', async () => {
   const actual = await vi.importActual<typeof api>('@/api/storyboards')
-  return { ...actual, getStoryboard: vi.fn(), leaveFeedback: vi.fn() }
+  return { ...actual, getStoryboard: vi.fn(), leaveFeedback: vi.fn(), getStoryboardNotes: vi.fn() }
 })
 
 const getStoryboard = api.getStoryboard as unknown as ReturnType<typeof vi.fn>
+const getStoryboardNotes = api.getStoryboardNotes as unknown as ReturnType<typeof vi.fn>
+
+function note(over: Partial<api.Note> = {}): api.Note {
+  return {
+    id: 1,
+    kind: 'comment',
+    body: 'Act one runs long.',
+    suggested_text: '',
+    author_name: 'Sophie',
+    channel: 'web',
+    state: 'open',
+    target_kind: 'storyboard',
+    target_ref: 'ecf-supply',
+    target_version: null,
+    anchor_id: 'act:supply-base',
+    created_at: '2026-07-26T10:00:00Z',
+    ...over,
+  }
+}
 
 function board(over: Partial<api.Storyboard> = {}): api.Storyboard {
   return {
@@ -18,9 +37,10 @@ function board(over: Partial<api.Storyboard> = {}): api.Storyboard {
     title: 'What the money bought',
     lede: 'From the first purchase order to the child who recovered.',
     capability: 'read',
+    is_member: false,
     acts: [
       {
-        anchor_id: 'act:1',
+        anchor_id: 'act:supply-base',
         title: 'Six weeks to a supply base',
         prose: 'Procurement integrity you can show.',
         entries: [
@@ -51,7 +71,10 @@ function renderAt(url = '/storyboard/ecf-supply?t=tok') {
 }
 
 describe('StoryboardPage', () => {
-  beforeEach(() => vi.clearAllMocks())
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getStoryboardNotes.mockResolvedValue({ items: [] })
+  })
   afterEach(cleanup)
 
   it('renders the arc with acts numbered', async () => {
@@ -129,7 +152,7 @@ describe('StoryboardPage', () => {
     fireEvent.click(screen.getByText('Leave note'))
 
     await waitFor(() => expect(leaveFeedback).toHaveBeenCalled())
-    expect(leaveFeedback.mock.calls[0][1].anchor_id).toBe('act:1')
+    expect(leaveFeedback.mock.calls[0][1].anchor_id).toBe('act:supply-base')
   })
 
   it('shows a plain not-available message on 404 rather than an error dump', async () => {
@@ -145,6 +168,81 @@ describe('StoryboardPage', () => {
     renderAt()
     await screen.findByText('What the money bought')
     expect(document.title).toContain('What the money bought')
+  })
+
+  describe('the notes that came back', () => {
+    it('are not fetched at all for someone holding the link', async () => {
+      getStoryboard.mockResolvedValue(board({ is_member: false }))
+      renderAt()
+      await screen.findByText('What the money bought')
+      expect(getStoryboardNotes).not.toHaveBeenCalled()
+    })
+
+    it('never render a reviewer another reviewer’s words', async () => {
+      // The fetch 401s for a non-member anyway; this is the second lock.
+      getStoryboard.mockResolvedValue(board({ is_member: false }))
+      getStoryboardNotes.mockResolvedValue({ items: [note()] })
+      renderAt()
+      await screen.findByText('What the money bought')
+      expect(screen.queryByText('Act one runs long.')).toBeNull()
+    })
+
+    it('appear under the act they were left on', async () => {
+      getStoryboard.mockResolvedValue(board({ is_member: true }))
+      getStoryboardNotes.mockResolvedValue({ items: [note()] })
+      renderAt()
+      expect(await screen.findByText('Act one runs long.')).toBeTruthy()
+      expect(screen.getByText('Sophie')).toBeTruthy()
+    })
+
+    it('appear under the demo they were left on', async () => {
+      getStoryboard.mockResolvedValue(board({ is_member: true }))
+      getStoryboardNotes.mockResolvedValue({
+        items: [
+          note({
+            id: 2,
+            target_kind: 'narrative',
+            target_ref: 'procurement',
+            target_version: 4,
+            anchor_id: 'the-goal',
+            body: 'Amina would not say it that way.',
+          }),
+        ],
+      })
+      renderAt()
+      expect(await screen.findByText('Amina would not say it that way.')).toBeTruthy()
+      // The version it was left against, alongside the card's own version chip.
+      expect(screen.getAllByText('v4')).toHaveLength(2)
+    })
+
+    it('collect board-wide notes rather than dropping them', async () => {
+      getStoryboard.mockResolvedValue(board({ is_member: true }))
+      getStoryboardNotes.mockResolvedValue({
+        items: [note({ id: 3, anchor_id: '', body: 'The whole arc is too long.' })],
+      })
+      renderAt()
+      expect(await screen.findByText('On the arc as a whole')).toBeTruthy()
+      expect(screen.getByText('The whole arc is too long.')).toBeTruthy()
+    })
+
+    it('show a suggestion’s proposed wording, which lives in another field', async () => {
+      getStoryboard.mockResolvedValue(board({ is_member: true }))
+      getStoryboardNotes.mockResolvedValue({
+        items: [
+          note({ id: 4, kind: 'suggestion', body: '', suggested_text: '…a QC re-visit.' }),
+        ],
+      })
+      renderAt()
+      expect(await screen.findByText('…a QC re-visit.')).toBeTruthy()
+      expect(screen.getByText('Suggested wording')).toBeTruthy()
+    })
+
+    it('say nothing at all when none have come back', async () => {
+      getStoryboard.mockResolvedValue(board({ is_member: true }))
+      renderAt()
+      await screen.findByText('What the money bought')
+      expect(screen.queryByText(/notes? back/)).toBeNull()
+    })
   })
 
   it('gives each demo video an accessible name', async () => {

--- a/frontend/src/pages/StoryboardPage.tsx
+++ b/frontend/src/pages/StoryboardPage.tsx
@@ -1,8 +1,15 @@
 import { useEffect, useState } from 'react'
 import { useParams, useSearchParams, Link } from 'react-router-dom'
-import { getStoryboard, leaveFeedback, type Storyboard } from '@/api/storyboards'
+import {
+  getStoryboard,
+  getStoryboardNotes,
+  leaveFeedback,
+  type Note,
+  type Storyboard,
+} from '@/api/storyboards'
 import { withBase } from '@/lib/basePath'
 import { NoteComposer } from '@/components/storyboard/NoteComposer'
+import { NotesReturned, groupNotes } from '@/components/storyboard/NotesReturned'
 
 /**
  * The shared arc — several DDD narratives, in acts, as one link.
@@ -90,6 +97,23 @@ function Board({ board, token }: { board: Storyboard; token: string | null }) {
     document.title = `${board.title} · Canopy`
   }, [board.title])
 
+  // The closing half of the loop: the people who sent this link open the same
+  // page to read what came back, in place. Reviewers never see it — the fetch
+  // is only made for members and 401s for anyone else regardless.
+  const [notes, setNotes] = useState<Note[]>([])
+  useEffect(() => {
+    if (!board.is_member) return
+    let live = true
+    getStoryboardNotes(board.slug)
+      .then((r) => live && setNotes(r.items))
+      .catch(() => undefined) // Nothing to read is not an error worth shouting.
+    return () => {
+      live = false
+    }
+  }, [board.is_member, board.slug])
+
+  const grouped = groupNotes(notes)
+
   return (
     <div className="min-h-screen bg-background text-foreground">
       <div className="mx-auto max-w-3xl px-6 py-12 md:py-16">
@@ -130,8 +154,16 @@ function Board({ board, token }: { board: Storyboard; token: string | null }) {
             </div>
 
             {act.entries.map((entry) => (
-              <EntryCard key={entry.narrative_slug} entry={entry} board={board} token={token} />
+              <EntryCard
+                key={entry.narrative_slug}
+                entry={entry}
+                board={board}
+                token={token}
+                notes={grouped.byNarrative.get(entry.narrative_slug) ?? []}
+              />
             ))}
+
+            <NotesReturned notes={grouped.byAnchor.get(act.anchor_id) ?? []} />
 
             <NoteComposer
               capability={board.capability}
@@ -142,6 +174,17 @@ function Board({ board, token }: { board: Storyboard; token: string | null }) {
             />
           </section>
         ))}
+
+        {grouped.loose.length > 0 && (
+          <section className="mt-11 flex flex-col gap-4">
+            <div className="border-b border-border pb-3">
+              <h2 className="text-xl font-semibold leading-tight tracking-tight text-foreground">
+                On the arc as a whole
+              </h2>
+            </div>
+            <NotesReturned notes={grouped.loose} />
+          </section>
+        )}
 
         <footer className="mt-16 flex items-center justify-between border-t border-border pt-6 text-[11px] text-muted-foreground">
           <span>
@@ -157,10 +200,12 @@ function EntryCard({
   entry,
   board,
   token,
+  notes,
 }: {
   entry: Storyboard['acts'][number]['entries'][number]
   board: Storyboard
   token: string | null
+  notes: Note[]
 }) {
   return (
     <article className="grid grid-cols-1 gap-4 rounded-lg border border-border bg-card p-3.5 sm:grid-cols-[168px_1fr]">
@@ -212,6 +257,8 @@ function EntryCard({
             </span>
           )}
         </div>
+
+        <NotesReturned notes={notes} />
 
         {entry.published && (
           <NoteComposer

--- a/tests/test_storyboard_api.py
+++ b/tests/test_storyboard_api.py
@@ -484,3 +484,78 @@ def test_an_empty_note_is_refused_rather_than_silently_stored(board):
               {"body": "   ", "author_name": "Ellyn"})
     assert r.status_code == 422
     assert Feedback.objects.count() == 0
+
+
+# ---------------------------------------------------------------- reading back
+
+
+def _leave(board, **over):
+    t = board.share_token or board.ensure_share_token()
+    return _post(Client(), f"/api/storyboards/{board.slug}/feedback?t={t}", {**COMMENT, **over})
+
+
+def test_a_member_reads_the_notes_left_on_the_board(member, board):
+    """The closing half of the loop. Without it a reviewer could leave notes and
+    the people who sent them the link had no way to read them short of curl."""
+    board.capability = Storyboard.CAP_COMMENT
+    board.save()
+    _leave(board, body="Act one runs long.", anchor_id=board.acts.get().anchor_id)
+    _leave(board, body="This scene is the one.", narrative_slug="verified-monitoring")
+
+    r = member.get(f"/api/storyboards/{board.slug}/notes")
+    assert r.status_code == 200, r.content
+    items = r.json()["items"]
+    assert {i["body"] for i in items} == {"Act one runs long.", "This scene is the one."}
+    assert {i["target_kind"] for i in items} == {"storyboard", "narrative"}
+
+
+def test_a_token_holder_cannot_read_the_notes(board):
+    """A reviewer reading the other reviewers' notes is exactly the bias you were
+    trying to avoid by asking them separately — and the rows carry names given
+    to us, not to each other. The read token grants the board, never this."""
+    board.capability = Storyboard.CAP_COMMENT
+    board.save()
+    t = board.ensure_share_token()
+    _leave(board, body="Something private.")
+
+    r = Client().get(f"/api/storyboards/{board.slug}/notes?t={t}")
+    assert r.status_code in (401, 404)
+    assert b"Something private." not in r.content
+    # And it answers a real board exactly as it answers a fictional one, so the
+    # refusal cannot be used to probe which boards exist.
+    assert r.status_code == Client().get("/api/storyboards/no-such-board/notes").status_code
+
+
+def test_a_non_member_cannot_read_the_notes(outsider, board):
+    c = Client()
+    c.force_login(outsider)
+    assert c.get(f"/api/storyboards/{board.slug}/notes").status_code == 404
+
+
+def test_the_notes_view_does_not_hand_out_author_emails(member, board):
+    board.capability = Storyboard.CAP_COMMENT
+    board.save()
+    _leave(board, author_email="sophie@example.org", body="Reachable elsewhere.")
+    item = member.get(f"/api/storyboards/{board.slug}/notes").json()["items"][0]
+    assert "author_email" not in item
+
+
+def test_notes_from_another_board_do_not_appear(member, board, ws):
+    other = Storyboard.objects.create(slug="other", title="Other", workspace=ws)
+    other.capability = Storyboard.CAP_COMMENT
+    other.save()
+    act = Act.objects.create(storyboard=other, title="Only act", position=0)
+    Entry.objects.create(act=act, narrative_slug="somewhere-else", position=0)
+    _leave(other, body="Belongs to the other board.")
+
+    bodies = [i["body"] for i in member.get(f"/api/storyboards/{board.slug}/notes").json()["items"]]
+    assert "Belongs to the other board." not in bodies
+
+
+def test_the_board_read_tells_a_member_it_is_theirs(member, board):
+    assert member.get(f"/api/storyboards/{board.slug}").json()["is_member"] is True
+
+
+def test_the_board_read_does_not_tell_a_token_holder_that(board):
+    t = board.ensure_share_token()
+    assert Client().get(f"/api/storyboards/{board.slug}?t={t}").json()["is_member"] is False


### PR DESCRIPTION
The feedback loop had no closing half. A reviewer could leave notes and **no surface anywhere showed them** — `GET /api/feedback/` and curl were the whole story, which makes "send this to Sophie" a request you can't act on without an agent in the middle.

The same storyboard page now shows the notes, **in place**: under the act or the demo each was left on, with the version it was left against, plus a final group for notes about the arc as a whole. In place rather than as a list, because a flat column of forty comments detached from what they're about is precisely what this surface exists to avoid.

**Members only.** A reviewer reading the other reviewers' notes would bias the independent read you asked for, and the rows carry names given to *us*, not to each other. So `GET /api/storyboards/{slug}/notes` is membership-gated (`_owned_or_404`, not `_readable_or_404`) — a share token grants the board and never this — refuses a real board exactly as it refuses a fictional one, and never returns `author_email`.

`StoryboardOut.is_member` tells the page whether to fetch at all; the UI is a second lock behind the route's.

12 new tests across both halves, including the two that matter: a token holder gets nothing, and a non-member's page renders nothing even if notes were somehow handed to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)