### PR TITLE
fix(storyboards): never hand a reader a video they cannot stream

### DIFF
--- a/apps/storyboards/services.py
+++ b/apps/storyboards/services.py
@@ -31,7 +31,18 @@ def _card_title(narrative_slug: str, stored_title: str | None) -> str:
     return aggregate._humanize_slug(narrative_slug)
 
 
-def _entry_payload(entry, workspace_slugs: set[str]) -> dict:
+def _streamable_anonymously(video_url: str | None) -> bool:
+    """Whether a reader with no login can actually play this.
+
+    Not an inference: ``aggregate._content_url`` appends ``?t=<share_token>``
+    exactly when the walkthrough is ``visibility=link``, and the stream 404s for
+    an anonymous caller in every other case. So the token's presence IS the
+    answer.
+    """
+    return bool(video_url) and "t=" in (video_url or "")
+
+
+def _entry_payload(entry, workspace_slugs: set[str], *, is_member: bool) -> dict:
     """One entry, resolved to what the page shows for it.
 
     A narrative with nothing published yet resolves to a PLACEHOLDER rather than
@@ -54,13 +65,21 @@ def _entry_payload(entry, workspace_slugs: set[str]) -> dict:
 
     current = narrative.get("current_version") or {}
     story = current.get("story") or narrative.get("story") or ""
+
+    # The board FOLLOWS the current release, so the next version's walkthrough
+    # can land private under a link that has already been sent. Handing a reader
+    # a <video> they cannot stream renders a black box with no explanation;
+    # say the artifact is not shared instead.
+    video_url = current.get("video_url")
+    shared = is_member or _streamable_anonymously(video_url)
+
     return {
         "narrative_slug": entry.narrative_slug,
         "title": _card_title(entry.narrative_slug, current.get("title") or narrative.get("title")),
         "lede": aggregate._lede_from_story(story, None) or story,
         "version": current.get("version"),
-        "video_url": current.get("video_url"),
-        "video_viewer_url": current.get("video_viewer_url"),
+        "video_url": video_url if shared else None,
+        "video_viewer_url": current.get("video_viewer_url") if shared else None,
         "published": bool(current),
     }
 
@@ -105,7 +124,8 @@ def resolve_board(board: Storyboard, *, is_member: bool = False) -> dict:
                 "title": act.title,
                 "prose": act.prose,
                 "entries": [
-                    _entry_payload(e, workspace_slugs) for e in act.entries.all()
+                    _entry_payload(e, workspace_slugs, is_member=is_member)
+                    for e in act.entries.all()
                 ],
             }
         )

--- a/frontend/src/pages/StoryboardPage.tsx
+++ b/frontend/src/pages/StoryboardPage.tsx
@@ -220,7 +220,10 @@ function EntryCard({
           />
         ) : (
           <div className="grid h-full w-full place-items-center px-2 text-center text-[11px] text-foreground-subtle">
-            Not filmed yet
+            {/* Two different situations, and telling a reader "not filmed yet"
+                about a demo that was filmed but never made public sends them
+                to ask the wrong question. */}
+            {entry.published ? 'Video not shared' : 'Not filmed yet'}
           </div>
         )}
       </div>

--- a/tests/test_storyboard_resolve.py
+++ b/tests/test_storyboard_resolve.py
@@ -137,3 +137,47 @@ def test_a_genuinely_short_title_is_still_used(board, ws):
     _publish(ws, "verified-monitoring", 1, "ignored", "Checking the checkers.")
     entry = resolve_board(board)["acts"][0]["entries"][0]
     assert entry["title"] == "Checking the checkers."
+
+
+def _film(ws, owner, review, visibility: str):
+    """The walkthrough that IS this narrative version's demo."""
+    from apps.walkthroughs.models import Walkthrough
+
+    w = Walkthrough.objects.create(
+        title="Demo",
+        kind=Walkthrough.KIND_VIDEO,
+        narrative_review_id=review.id,
+        visibility=visibility,
+        workspace_id=ws.slug,
+        owner=owner,
+        drive_file_id="f",
+        drive_folder_id="d",
+        content_type="video/mp4",
+        size_bytes=1,
+    )
+    if visibility == Walkthrough.VISIBILITY_LINK:
+        w.ensure_share_token()
+    return w
+
+
+def test_a_reader_is_not_handed_a_video_they_cannot_stream(board, ws, owner):
+    """The board FOLLOWS the current release, so the next version's walkthrough
+    can land private under a link that has already been sent. A <video> pointing
+    at a stream that 404s renders a black box with no explanation."""
+    review = _publish(ws, "verified-monitoring", 1, "Cut", "The story.")
+    _film(ws, owner, review, "private")
+
+    entry = resolve_board(board, is_member=False)["acts"][0]["entries"][0]
+    assert entry["published"] is True, "the narrative IS published; only its film is not shared"
+    assert entry["video_url"] is None
+
+    mine = resolve_board(board, is_member=True)["acts"][0]["entries"][0]
+    assert mine["video_url"], "a member streams a private artifact through their session"
+
+
+def test_a_public_film_still_reaches_the_reader(board, ws, owner):
+    review = _publish(ws, "verified-monitoring", 1, "Cut", "The story.")
+    _film(ws, owner, review, "link")
+
+    entry = resolve_board(board, is_member=False)["acts"][0]["entries"][0]
+    assert "t=" in entry["video_url"], "an anonymous stream needs the artifact's own token"


### PR DESCRIPTION
The board **follows** each narrative's current release — that's the point, so an emailed link never goes stale. The corollary is that the next version's walkthrough can land `visibility=private` under a link that has already been sent, and the card would render a `<video>` pointing at a stream that 404s for that reader: a black box with no explanation, on the one surface whose entire job is to be readable by an outsider.

`aggregate._content_url` appends `?t=<share_token>` **exactly when** the artifact is public and the stream will serve an anonymous caller, so the token's presence isn't an inference — it is the answer. When it's absent and the viewer isn't a member, the card drops the player and says **"Video not shared"**, which is a different sentence from "Not filmed yet" and sends the reader to ask the right question.

Members are unaffected: their session streams private artifacts fine.

(Checked the live `rf-surveys` board first — all three films currently carry tokens, so this is a guard, not a live break.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)