### PR TITLE
fix(storyboards): a wordless row is not shown as a note

### DIFF
--- a/apps/storyboards/services.py
+++ b/apps/storyboards/services.py
@@ -100,10 +100,18 @@ def board_feedback(board: Storyboard):
         .values_list("narrative_slug", flat=True)
         .distinct()
     )
-    return Feedback.objects.filter(
-        Q(target_kind="storyboard", target_ref=board.slug)
-        | Q(target_kind="narrative", target_ref__in=slugs)
-    ).order_by("-created_at")
+    return (
+        Feedback.objects.filter(
+            Q(target_kind="storyboard", target_ref=board.slug)
+            | Q(target_kind="narrative", target_ref__in=slugs)
+        )
+        # A note with no words is not feedback. Ingest refuses to create one
+        # now, but rows that predate that guard still exist and would render as
+        # an empty card attributed to "Anonymous" — which reads as a reviewer
+        # who said nothing rather than as the artifact of a bug it is.
+        .exclude(body="", suggested_text="")
+        .order_by("-created_at")
+    )
 
 
 def resolve_board(board: Storyboard, *, is_member: bool = False) -> dict:

--- a/tests/test_storyboard_api.py
+++ b/tests/test_storyboard_api.py
@@ -559,3 +559,16 @@ def test_the_board_read_tells_a_member_it_is_theirs(member, board):
 def test_the_board_read_does_not_tell_a_token_holder_that(board):
     t = board.ensure_share_token()
     assert Client().get(f"/api/storyboards/{board.slug}?t={t}").json()["is_member"] is False
+
+
+def test_a_wordless_row_is_not_shown_as_a_note(member, board):
+    """Ingest refuses to create one now (#451), but rows that predate that guard
+    still exist on labs and would render as an empty card attributed to
+    "Anonymous" — a reviewer who appears to have said nothing."""
+    from apps.feedback.models import Feedback
+
+    Feedback.objects.create(target_kind="storyboard", target_ref=board.slug, body="")
+    Feedback.objects.create(target_kind="storyboard", target_ref=board.slug, body="Real words.")
+
+    items = member.get(f"/api/storyboards/{board.slug}/notes").json()["items"]
+    assert [i["body"] for i in items] == ["Real words."]


### PR DESCRIPTION
`ingest` refuses to create a note with neither `body` nor `suggested_text` (#451), but rows that predate that guard still exist on labs — and the new notes view would render one as an empty card attributed to "Anonymous", which reads as a reviewer who said nothing rather than as the artifact of a bug it is.

Excluded at the query. The row stays in the pool: feedback is a record, and nothing here deletes what somebody said.

🤖 Generated with [Claude Code](https://claude.com/claude-code)