### PR TITLE
copy(storyboards): tell the reviewer what they are being asked to do

### DIFF
--- a/frontend/src/pages/StoryboardPage.test.tsx
+++ b/frontend/src/pages/StoryboardPage.test.tsx
@@ -155,6 +155,41 @@ describe('StoryboardPage', () => {
     expect(leaveFeedback.mock.calls[0][1].anchor_id).toBe('act:supply-base')
   })
 
+  describe('what the reviewer is being asked to do', () => {
+    it('is said plainly to someone who opened the link cold', async () => {
+      getStoryboard.mockResolvedValue(board({ capability: 'comment' }))
+      renderAt()
+      expect(await screen.findByText(/Leave a note anywhere something is wrong/)).toBeTruthy()
+      expect(screen.getByText(/to nobody else/)).toBeTruthy()
+    })
+
+    it('mentions suggested wording only when the link grants it', async () => {
+      getStoryboard.mockResolvedValue(board({ capability: 'comment' }))
+      renderAt()
+      await screen.findByText(/Leave a note anywhere/)
+      expect(screen.queryByText(/exact wording you would use/)).toBeNull()
+
+      cleanup()
+      getStoryboard.mockResolvedValue(board({ capability: 'suggest' }))
+      renderAt()
+      expect(await screen.findByText(/exact wording you would use/)).toBeTruthy()
+    })
+
+    it('says nothing on a read-only link, which asks for nothing', async () => {
+      getStoryboard.mockResolvedValue(board({ capability: 'read' }))
+      renderAt()
+      await screen.findByText('What the money bought')
+      expect(screen.queryByText(/Leave a note anywhere/)).toBeNull()
+    })
+
+    it('does not instruct the people who sent it', async () => {
+      getStoryboard.mockResolvedValue(board({ capability: 'suggest', is_member: true }))
+      renderAt()
+      await screen.findByText('What the money bought')
+      expect(screen.queryByText(/Leave a note anywhere/)).toBeNull()
+    })
+  })
+
   it('shows a plain not-available message on 404 rather than an error dump', async () => {
     getStoryboard.mockRejectedValue(new Error('Request failed (404)'))
     renderAt()

--- a/frontend/src/pages/StoryboardPage.tsx
+++ b/frontend/src/pages/StoryboardPage.tsx
@@ -133,6 +133,23 @@ function Board({ board, token }: { board: Storyboard; token: string | null }) {
           {board.lede && (
             <p className="mt-4 text-lg leading-relaxed text-foreground-secondary">{board.lede}</p>
           )}
+
+          {/* A domain expert opening a link cold has no way to know their notes
+              are wanted, or who reads them. The composers are further down the
+              page and their buttons only say what they do, not that doing it is
+              the point of sending this. Members already know. */}
+          {!board.is_member && board.capability !== 'read' && (
+            <p className="mt-4 text-[13.5px] leading-relaxed text-muted-foreground">
+              Watch each demo and read the scenes.{' '}
+              <span className="text-foreground-secondary">
+                Leave a note anywhere something is wrong, missing, or would be said
+                differently
+                {board.capability === 'suggest' ? ' — including the exact wording you would use' : ''}
+                .
+              </span>{' '}
+              Your notes go to the team that sent you this, and to nobody else.
+            </p>
+          )}
         </header>
 
         {board.acts.map((act, i) => (


### PR DESCRIPTION
A domain expert opening a shared arc cold has no way to know that notes are wanted, that proposing the exact wording is fair game, or who ends up reading them. The composers sit further down the page and their buttons say only what they do — not that doing it is the reason the link was sent.

One line under the lede:

> Watch each demo and read the scenes. **Leave a note anywhere something is wrong, missing, or would be said differently — including the exact wording you would use.** Your notes go to the team that sent you this, and to nobody else.

Shown only to a *reader* (members already know), only when the link grants writing at all (a read-only link asks for nothing, so it says nothing), and the suggested-wording clause only when the link grants `suggest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)