### PR TITLE
fix(storyboards): ask the reviewer's name once, not once per note

### DIFF
--- a/frontend/src/components/storyboard/NoteComposer.test.tsx
+++ b/frontend/src/components/storyboard/NoteComposer.test.tsx
@@ -1,9 +1,20 @@
 // @vitest-environment jsdom
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { NoteComposer } from './NoteComposer'
 
 afterEach(cleanup)
+
+// jsdom here exposes a `localStorage` object whose methods are missing, which
+// is why the component guards every access — but a stub is needed to test that
+// it remembers anything at all.
+beforeEach(() => {
+  const store = new Map<string, string>()
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, v),
+  })
+})
 
 function setup(capability: 'read' | 'comment' | 'suggest', onSubmit = vi.fn().mockResolvedValue(undefined)) {
   const { container } = render(
@@ -66,6 +77,27 @@ describe('NoteComposer', () => {
 
     await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(2))
     expect(onSubmit.mock.calls[1][0].body).toBe('second')
+  })
+
+  it('asks for the reviewer’s name once, not once per note', async () => {
+    // A full review puts a composer under every act, every demo and every
+    // scene. Retyping a name twenty times is how you end up with twenty
+    // "Anonymous" notes from the one person you sent the link to.
+    const first = setup('comment')
+    fireEvent.click(screen.getByText('Leave a note'))
+    fireEvent.change(screen.getByPlaceholderText(/Your name/), { target: { value: 'Sophie' } })
+    fireEvent.change(first.note(), { target: { value: 'one' } })
+    fireEvent.click(screen.getByText('Leave note'))
+    await waitFor(() => expect(first.onSubmit).toHaveBeenCalled())
+    expect(first.onSubmit.mock.calls[0][0].author_name).toBe('Sophie')
+
+    cleanup()
+    const second = setup('comment')
+    fireEvent.click(screen.getByText('Leave a note'))
+    fireEvent.change(second.note(), { target: { value: 'two' } })
+    fireEvent.click(screen.getByText('Leave note'))
+    await waitFor(() => expect(second.onSubmit).toHaveBeenCalled())
+    expect(second.onSubmit.mock.calls[0][0].author_name).toBe('Sophie')
   })
 
   it('surfaces a failure instead of pretending it saved', async () => {

--- a/frontend/src/components/storyboard/NoteComposer.tsx
+++ b/frontend/src/components/storyboard/NoteComposer.tsx
@@ -9,6 +9,24 @@ import type { Capability, FeedbackKind, LeaveFeedbackIn } from '@/api/storyboard
  * differ only in whether the reviewer is proposing replacement words. The
  * "Suggest wording" half only exists when the link grants it.
  */
+const NAME_KEY = 'canopy.reviewer-name'
+
+function readReviewerName(): string {
+  try {
+    return localStorage.getItem(NAME_KEY) ?? ''
+  } catch {
+    return '' // Private-mode browsers throw on access; a blank name is fine.
+  }
+}
+
+function rememberReviewerName(value: string): void {
+  try {
+    localStorage.setItem(NAME_KEY, value)
+  } catch {
+    /* not worth failing a note over */
+  }
+}
+
 export function NoteComposer({
   capability,
   anchorLabel,
@@ -29,7 +47,10 @@ export function NoteComposer({
   const [open, setOpen] = useState(false)
   const [kind, setKind] = useState<FeedbackKind>('comment')
   const [text, setText] = useState('')
-  const [name, setName] = useState('')
+  // Asked once, not once per note. A full review of a three-act arc puts a
+  // composer under every act, every demo and every scene — better than twenty
+  // "Anonymous" notes from the one person you sent the link to.
+  const [name, setName] = useState(() => readReviewerName())
   const [state, setState] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
   const [error, setError] = useState('')
 
@@ -127,7 +148,10 @@ export function NoteComposer({
       <div className="flex flex-wrap items-center justify-between gap-2">
         <input
           value={name}
-          onChange={(e) => setName(e.target.value)}
+          onChange={(e) => {
+            setName(e.target.value)
+            rememberReviewerName(e.target.value)
+          }}
           placeholder="Your name (optional)"
           className="min-w-0 flex-1 rounded-md border border-input bg-background px-3 py-1.5 text-[12px] text-foreground placeholder:text-foreground-subtle focus-visible:outline-2 focus-visible:outline-primary"
         />


### PR DESCRIPTION
A full review of a three-act arc puts a composer under every act, every demo and every scene — around two dozen of them, each with its own empty "Your name (optional)" field. Retyping a name twenty times is how you end up with twenty `Anonymous` notes from the one person you sent the link to, and an anonymous note is much harder to act on than a named one.

Remembered in `localStorage`, so it survives moving between the board and the reviewer page and survives a reload mid-review. Every access is guarded — a private-mode browser throws on it, and that must not cost someone their note.

(jsdom here exposes a `localStorage` whose methods are missing, which is what surfaced the need for the guard; the test stubs it.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)