### PR TITLE
Live tool activity from Claude Code hooks, behind a runner switch

### DIFF
--- a/frontend/packages/canopy-ui/src/chat/sessionReducer.test.ts
+++ b/frontend/packages/canopy-ui/src/chat/sessionReducer.test.ts
@@ -355,3 +355,87 @@ describe("sessionReducer — session.error draft_version_mismatch", () => {
     expect(next).toBe(prev)
   })
 })
+
+describe("sessionReducer — live/durable reconciliation", () => {
+  const liveToolUse = {
+    event: "chat.tool_use",
+    data: {
+      parent_message_id: null,
+      tool_message_id: "seq:-1",
+      turn_index: -1,
+      block: { id: "toolu_9", name: "Bash", input: { command: "ls" }, text: "" },
+    },
+  } as WsEvent
+
+  const durableToolUse = {
+    event: "chat.tool_use",
+    data: {
+      parent_message_id: null,
+      tool_message_id: "42",
+      turn_index: 128,
+      block: { id: "toolu_9", name: "Bash", input: { command: "ls" }, text: "" },
+    },
+  } as WsEvent
+
+  it("a durable row REPLACES the live placeholder for the same tool call", () => {
+    // The same call arrives twice by design — live from a hook (no ordinal) and
+    // durably from the transcript. They share only tool_use_id, so without
+    // reconciling on it the user sees every tool call twice.
+    const live = sessionReducer(makeState(), liveToolUse)
+    expect(live.messages).toHaveLength(1)
+    const settled = sessionReducer(live, durableToolUse)
+    expect(settled.messages).toHaveLength(1)
+  })
+
+  it("the surviving row takes the durable identity, not the placeholder's", () => {
+    // Otherwise later updates key on a `seq:-1` that no longer means anything.
+    const settled = sessionReducer(
+      sessionReducer(makeState(), liveToolUse),
+      durableToolUse,
+    )
+    expect(settled.messages[0].id).toBe("42")
+    expect(settled.messages[0].turn_index).toBe(128)
+  })
+
+  it("reconciles tool_result on tool_use_id too", () => {
+    const mk = (id: string, turn_index: number) =>
+      ({
+        event: "chat.tool_result",
+        data: {
+          parent_message_id: null,
+          tool_message_id: id,
+          turn_index,
+          block: { tool_use_id: "toolu_9", is_error: false, text: "a.txt" },
+        },
+      }) as WsEvent
+    const settled = sessionReducer(
+      sessionReducer(makeState(), mk("seq:-1", -1)),
+      mk("77", 192),
+    )
+    expect(settled.messages).toHaveLength(1)
+    expect(settled.messages[0].id).toBe("77")
+  })
+
+  it("two different tool calls stay two rows", () => {
+    const other = {
+      event: "chat.tool_use",
+      data: {
+        parent_message_id: null,
+        tool_message_id: "seq:-1b",
+        turn_index: -1,
+        block: { id: "toolu_OTHER", name: "Read", input: {}, text: "" },
+      },
+    } as WsEvent
+    const next = sessionReducer(sessionReducer(makeState(), liveToolUse), other)
+    expect(next.messages).toHaveLength(2)
+  })
+
+  it("a row with no correlation id still falls back to matching on message id", () => {
+    const noId = {
+      event: "chat.tool_use",
+      data: { parent_message_id: null, tool_message_id: "t1", block: {} },
+    } as WsEvent
+    const next = sessionReducer(sessionReducer(makeState(), noId), noId)
+    expect(next.messages).toHaveLength(1)
+  })
+})

--- a/frontend/packages/canopy-ui/src/chat/sessionReducer.ts
+++ b/frontend/packages/canopy-ui/src/chat/sessionReducer.ts
@@ -115,12 +115,42 @@ export function sessionReducer(prev: SessionState, frame: WsEvent): SessionState
       const block = frame.data.block ?? {};
       const plaintext = typeof block.text === "string" ? block.text : "";
       const id = frame.data.tool_message_id;
-      const existing = prev.messages.find((m) => m.id === id);
+      // Reconcile on the CORRELATION key, not the message id. The same tool call
+      // arrives twice by design: once live from a hook (no ordinal, id `seq:-1`)
+      // and once durably from the transcript (ordinal-keyed, a real id). They
+      // share only `tool_use_id` / `id` in content, so matching on that is what
+      // makes the live row a placeholder the durable row REPLACES rather than a
+      // duplicate that sits beside it forever.
+      const correlation =
+        role === "tool_use"
+          ? (block.id as string | undefined)
+          : (block.tool_use_id as string | undefined);
+      const existing = prev.messages.find(
+        (m) =>
+          m.id === id ||
+          (m.role === role &&
+            correlation !== undefined &&
+            correlation !== "" &&
+            (m.content as Record<string, unknown>)?.[
+              role === "tool_use" ? "id" : "tool_use_id"
+            ] === correlation),
+      );
       if (existing) {
+        // Adopt the incoming id and ordinal: a durable row superseding a live
+        // placeholder must take over its identity, or the next update keys on a
+        // `seq:-1` that no longer means anything.
         return {
           ...prev,
           messages: prev.messages.map((m) =>
-            m.id === id ? { ...m, content: block, plaintext } : m,
+            m === existing
+              ? {
+                  ...m,
+                  id,
+                  turn_index: frame.data.turn_index ?? m.turn_index,
+                  content: block,
+                  plaintext,
+                }
+              : m,
           ),
         };
       }

--- a/packages/canopy_runner/canopy_runner/config.py
+++ b/packages/canopy_runner/canopy_runner/config.py
@@ -29,6 +29,22 @@ class Config:
     # supervisor's session list. Silent truncation is therefore not cosmetic — keep
     # it well above any realistic open-task count.
     session_report_limit: int = 100
+    # --- Live hook events (spec 2026-07-27) -------------------------------
+    # Claude Code hooks POST every tool call to a loopback listener this runner
+    # owns, giving the phone real-time tool activity that transcript tailing
+    # cannot (the docs are explicit that the transcript "may lag the in-memory
+    # conversation"). Same shape emdash already uses for its own hooks.
+    #
+    # forward_sessions is THE switch: the listener always accepts and always
+    # answers 200 (a hook must never fail, and PreToolUse can block a tool call),
+    # but it only forwards to canopy-web when this is on. Off means the plumbing
+    # is installed and inert — flip one box, watch it, then decide about the
+    # fleet. Default off because live events are a lossy overlay: the transcript
+    # is still the durable record either way, so nothing is lost while it's off.
+    forward_sessions: bool = False
+    # Loopback port for the hook listener. 0 disables the listener entirely (and
+    # the hook install), for a box that should never run one.
+    hook_port: int = 8787
     state_path: str = ""
     # The runner drives emdash's real UI over CDP (create/reuse sessions); it needs
     # emdash launched with --remote-debugging-port=<cdp_port> (see "Emdash CDP").

--- a/packages/canopy_runner/canopy_runner/hook_install.py
+++ b/packages/canopy_runner/canopy_runner/hook_install.py
@@ -1,0 +1,117 @@
+"""Install canopy's PostToolUse hook into the USER-level Claude Code settings.
+
+User level (`~/.claude/settings.json`), deliberately, for two reasons:
+
+1. **One install covers every session on the machine** — every emdash worktree
+   and every `claude -p` — with no per-session setup. Verified 2026-07-27: a
+   single user-level hook captured events from two concurrent sessions in
+   different worktrees at once.
+2. **emdash owns the project-level file.** Its worktrees carry a
+   `.claude/settings.local.json` that emdash writes and rewrites, with its own
+   hooks pointing at its own loopback port. Writing there would fight it.
+   emdash uses only `UserPromptSubmit` / `Notification` / `Stop`, so canopy's
+   tool events compose with them rather than colliding.
+
+The command mirrors emdash's own idiom (`curl -sf … || true`), which is the
+established pattern on these machines: silent, short-timeout, and incapable of
+failing the hook. `PostToolUse` cannot block a tool call the way `PreToolUse`
+can, but the `|| true` and `--max-time` still matter — a hook that hangs is a
+hook that slows every tool call the agent makes.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+logger = logging.getLogger("canopy_runner.hooks")
+
+HOOK_EVENT = "PostToolUse"
+# Marks the entry as ours so install/remove are idempotent and we never touch
+# a hook somebody else put there.
+MARKER = "canopy-hook-listener"
+
+# Two seconds is far above the local round trip (the listener answers before it
+# does any work) and far below anything a human would notice on a tool call.
+CURL_MAX_TIME = 2
+
+
+def hook_command(port: int, nonce: str) -> str:
+    """The shell command Claude Code runs for each tool call.
+
+    `-d @-` forwards the hook JSON verbatim on stdin — no parsing in the shell.
+    `-sf`, `--max-time` and `|| true` together guarantee the hook cannot fail,
+    hang, or print, whatever state canopy is in.
+    """
+    return (
+        f"curl -sf --max-time {CURL_MAX_TIME} -X POST "
+        f'-H "Content-Type: application/json" '
+        f'-H "X-Canopy-Token: {nonce}" '
+        f'-d @- "http://127.0.0.1:{port}/hook" || true  # {MARKER}'
+    )
+
+
+def _load(path: Path) -> dict:
+    try:
+        data = json.loads(path.read_text())
+        return data if isinstance(data, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+def _is_ours(entry: dict) -> bool:
+    return any(MARKER in str(h.get("command", ""))
+               for h in entry.get("hooks", []) if isinstance(h, dict))
+
+
+def install(settings_path: Path, *, port: int, nonce: str) -> bool:
+    """Add (or refresh) canopy's hook. Returns True if the file was written.
+
+    Idempotent: an existing canopy entry is REPLACED, so a changed port or a
+    rotated nonce takes effect without accumulating stale entries. Hooks from
+    anything else — emdash's, the user's own — are preserved untouched.
+    """
+    settings = _load(settings_path)
+    hooks = settings.setdefault("hooks", {})
+    if not isinstance(hooks, dict):
+        logger.warning("hooks in %s is not an object; refusing to touch it", settings_path)
+        return False
+    entries = [e for e in hooks.get(HOOK_EVENT, [])
+               if isinstance(e, dict) and not _is_ours(e)]
+    entries.append({"hooks": [{"type": "command",
+                               "command": hook_command(port, nonce)}]})
+    hooks[HOOK_EVENT] = entries
+    try:
+        settings_path.parent.mkdir(parents=True, exist_ok=True)
+        settings_path.write_text(json.dumps(settings, indent=2) + "\n")
+    except OSError as exc:
+        logger.warning("could not write %s: %s", settings_path, exc)
+        return False
+    return True
+
+
+def remove(settings_path: Path) -> bool:
+    """Remove canopy's hook, leaving every other hook in place.
+
+    The counterpart to `install` — a runner configured with `hook_port = 0`
+    calls this, so turning the feature off actually un-installs rather than
+    leaving a dangling curl to a port nothing is listening on.
+    """
+    settings = _load(settings_path)
+    hooks = settings.get("hooks")
+    if not isinstance(hooks, dict) or HOOK_EVENT not in hooks:
+        return False
+    kept = [e for e in hooks.get(HOOK_EVENT, [])
+            if isinstance(e, dict) and not _is_ours(e)]
+    if len(kept) == len(hooks.get(HOOK_EVENT, [])):
+        return False  # nothing of ours to remove
+    if kept:
+        hooks[HOOK_EVENT] = kept
+    else:
+        hooks.pop(HOOK_EVENT)
+    try:
+        settings_path.write_text(json.dumps(settings, indent=2) + "\n")
+    except OSError as exc:
+        logger.warning("could not write %s: %s", settings_path, exc)
+        return False
+    return True

--- a/packages/canopy_runner/canopy_runner/hook_listener.py
+++ b/packages/canopy_runner/canopy_runner/hook_listener.py
@@ -1,0 +1,137 @@
+"""Loopback listener for Claude Code hook events.
+
+Claude Code fires a hook per tool call; the hook `curl`s its JSON to this
+listener, which maps it to a canopy Session and (when forwarding is on) ships it
+as a live event. That gives the phone real-time tool activity, which transcript
+tailing cannot: the Claude Code docs are explicit that the transcript "may lag
+the in-memory conversation".
+
+This is the same shape emdash already uses for its own hooks — a loopback POST
+with a per-session nonce — so it is a pattern already proven on these machines
+rather than a new one.
+
+Three properties are load-bearing:
+
+**It always answers 200, immediately.** A hook that errors or hangs is a hook
+that can degrade the agent's own loop, so every failure path here still returns
+success. Nothing observability does may cost an agent a turn.
+
+**Forwarding is a switch, the listener is not.** `Config.forward_sessions` gates
+only the POST to canopy-web. Off means events are accepted and dropped, so the
+plumbing can be installed and watched before it carries anything.
+
+**Live events are never persisted.** They carry `index = -1`, which the server
+treats as view-only, so the durable record stays exactly one thing: the
+transcript. That is what makes it safe for this path to drop events freely.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+from canopy_transcript import events_for_hook
+
+logger = logging.getLogger("canopy_runner.hooks")
+
+# A hook body is one tool call — the largest realistic one is a big tool result,
+# and the payloads measured on a live session were ~800 bytes. This is a sanity
+# bound against a runaway body, not a working limit.
+MAX_BODY_BYTES = 4 * 1024 * 1024
+
+
+class HookListener:
+    """Owns the loopback server and the cwd -> session mapping.
+
+    `resolve_session(cwd)` is injected rather than imported so this module stays
+    testable without the runner's client, binding cache, or a live server.
+    """
+
+    def __init__(self, *, port: int, nonce: str, resolve_session, forward):
+        self.port = port
+        self.nonce = nonce
+        self._resolve_session = resolve_session
+        self._forward = forward
+        self._server: ThreadingHTTPServer | None = None
+        self.received = 0
+        self.forwarded = 0
+        self.dropped_unknown_cwd = 0
+
+    # -- request handling (pure enough to unit-test directly) ----------------
+
+    def handle_payload(self, payload: dict) -> str:
+        """Process one hook payload. Returns a short outcome string, for logs
+        and tests. Never raises — the caller must answer 200 regardless."""
+        self.received += 1
+        try:
+            events = events_for_hook(payload)
+            if not events:
+                return "ignored"          # not a forwarded event kind
+            cwd = payload.get("cwd") or ""
+            session_id = self._resolve_session(cwd)
+            if not session_id:
+                # Hooks are installed at USER level, so they fire for every
+                # Claude Code session on this machine — including ones canopy
+                # knows nothing about. Dropping them here is the expected path,
+                # not an error.
+                self.dropped_unknown_cwd += 1
+                return "unknown-cwd"
+            if not self._forward():
+                return "not-forwarding"   # accepted and dropped, by configuration
+            self._send(session_id, events)
+            self.forwarded += 1
+            return "forwarded"
+        except Exception:  # noqa: BLE001 — a hook must never see a failure
+            logger.debug("hook handling failed (non-fatal)", exc_info=True)
+            return "error"
+
+    def _send(self, session_id: str, events: list[dict]) -> None:
+        raise NotImplementedError  # set by `bind_sender`
+
+    def bind_sender(self, send) -> None:
+        """Inject the transport (the runner's client) after construction."""
+        self._send = send
+
+    # -- server lifecycle ----------------------------------------------------
+
+    def start(self) -> None:
+        if self.port <= 0 or self._server is not None:
+            return
+        listener = self
+
+        class _Handler(BaseHTTPRequestHandler):
+            def do_POST(self):  # noqa: N802
+                # Answer FIRST, work second: the hook's curl should never wait on
+                # canopy-web, and its timeout should never become the agent's.
+                token = self.headers.get("X-Canopy-Token", "")
+                length = int(self.headers.get("Content-Length") or 0)
+                body = self.rfile.read(min(length, MAX_BODY_BYTES)) if length else b""
+                self.send_response(200)
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+                if token != listener.nonce:
+                    logger.debug("hook rejected: bad nonce")
+                    return
+                try:
+                    payload = json.loads(body or b"{}")
+                except ValueError:
+                    return
+                if isinstance(payload, dict):
+                    listener.handle_payload(payload)
+
+            def log_message(self, *_args):  # silence BaseHTTPRequestHandler
+                pass
+
+        # Bound to 127.0.0.1 explicitly — never 0.0.0.0. This machine holds fleet
+        # credentials; the listener must not be reachable off-box.
+        self._server = ThreadingHTTPServer(("127.0.0.1", self.port), _Handler)
+        threading.Thread(target=self._server.serve_forever, daemon=True,
+                         name="hook-listener").start()
+        logger.info("hook listener on 127.0.0.1:%d (forwarding=%s)",
+                    self.port, self._forward())
+
+    def stop(self) -> None:
+        if self._server is not None:
+            self._server.shutdown()
+            self._server = None

--- a/packages/canopy_runner/canopy_runner/main.py
+++ b/packages/canopy_runner/canopy_runner/main.py
@@ -26,10 +26,13 @@ import json
 import logging
 import subprocess
 import time
+import uuid
 from pathlib import Path
 
-from . import chat_bridge, emdash, transcript
+from . import chat_bridge, emdash, hook_install, transcript
 from .client import Client, ClientError
+import canopy_transcript as transcript_core
+
 from .tail import TailReader
 from .config import Config
 
@@ -451,6 +454,86 @@ def _note_success(key: str) -> None:
         logger.info("recovered after %d failed attempts: %s", n, key)
 
 
+
+# --- Live hook events (spec 2026-07-27) -------------------------------------
+#
+# Claude Code fires a hook per tool call straight to a loopback listener this
+# runner owns. That is the LIVE half of a session's record: the transcript is
+# complete but lags (the docs say so explicitly), so it cannot drive a view you
+# are actively watching. The transcript remains the durable record, which is
+# what makes it safe for this path to drop events freely.
+#
+# `{(project, session_key): session_id}`, refreshed from the stream sync each
+# tick — the hook reports a cwd, and this is what turns that back into a canopy
+# Session.
+_hook_sessions: dict[tuple[str, str], str] = {}
+_hook_listener = None
+
+
+def _resolve_hook_session(cwd: str) -> str:
+    """A hook's cwd -> canopy session id, or "" if this isn't a session we back.
+
+    Hooks are installed at USER level, so they fire for every Claude Code
+    session on the machine. Most are not ours; returning "" is the expected
+    path, not a failure.
+    """
+    if not cwd:
+        return ""
+    parsed = transcript_core.parse_emdash_worktree(cwd, home=Path.home())
+    if parsed is None:
+        return ""
+    project, task = parsed
+    # The worktree dir may carry emdash's random de-dupe suffix, so try the exact
+    # name first and the stripped one second — matching against sessions we
+    # actually know rather than guessing which it is.
+    for candidate in transcript_core.emdash_task_candidates(task):
+        session_id = _hook_sessions.get((project, candidate))
+        if session_id:
+            return session_id
+    return ""
+
+
+def _start_hook_listener(cfg: Config, client: Client):
+    """Install the user-level hook and start the loopback listener.
+
+    Returns the listener, or None when disabled (`hook_port = 0`), in which case
+    any previously-installed canopy hook is REMOVED — turning the feature off
+    must not leave a curl pointing at a port nothing is listening on.
+    """
+    global _hook_listener
+    settings_path = Path.home() / ".claude" / "settings.json"
+    if cfg.hook_port <= 0:
+        if hook_install.remove(settings_path):
+            logger.info("hook listener disabled; removed canopy's hook from %s",
+                        settings_path)
+        return None
+    from .hook_listener import HookListener
+
+    nonce = uuid.uuid4().hex
+    listener = HookListener(
+        port=cfg.hook_port, nonce=nonce,
+        resolve_session=_resolve_hook_session,
+        forward=lambda: cfg.forward_sessions,
+    )
+    listener.bind_sender(
+        lambda session_id, events: client.post_session_stream(
+            cfg.runner_id, session_id, events)
+    )
+    try:
+        listener.start()
+    except OSError as exc:
+        # Another process already holds the port (a second runner, a stale
+        # process). Live events are an overlay, so this is a warning, not fatal.
+        logger.warning("hook listener could not bind :%d (%s); live events off",
+                       cfg.hook_port, exc)
+        return None
+    hook_install.install(settings_path, port=cfg.hook_port, nonce=nonce)
+    logger.info("live hook events: listener on :%d, forwarding=%s",
+                cfg.hook_port, cfg.forward_sessions)
+    _hook_listener = listener
+    return listener
+
+
 def _post_stream_rows(cfg: Config, client: Client, sid: str, rows: list[dict]) -> bool:
     """Ship conversational rows as live events. seq == index (the composite
     transcript ordinal): monotonic per session forever, so the WS-derived
@@ -496,7 +579,11 @@ def _sync_session_streams(cfg: Config, client: Client) -> None:
         if sid not in desired:
             _stream_readers.pop(sid, None)
 
+    # The hook path resolves a cwd against these, so refresh it wholesale here
+    # rather than accumulating stale entries for detached sessions.
+    _hook_sessions.clear()
     for sid, s in desired.items():
+        _hook_sessions[(s.get("project") or "", s.get("session_key") or "")] = sid
         st = _stream_readers.setdefault(sid, {
             "reader": None, "count": 0,
             "session_key": s.get("session_key") or "", "project": s.get("project") or "",
@@ -806,6 +893,7 @@ def main() -> None:
     wake_on = waker.start()
     if wake_on:
         logger.info("  wake: WS control channel connected — claims fire on enqueue, not just poll")
+    _start_hook_listener(cfg, client)
 
     def _wait(seconds: float) -> None:
         # With a live wake channel, block until a nudge OR the poll interval,

--- a/packages/canopy_runner/tests/test_hook_listener.py
+++ b/packages/canopy_runner/tests/test_hook_listener.py
@@ -1,0 +1,131 @@
+"""The loopback hook listener and its user-level install.
+
+The properties under test are the safety ones: a hook must never fail, the
+forwarding switch must actually gate, and installing must not disturb hooks
+canopy did not put there (emdash owns its own).
+"""
+import json
+
+from canopy_runner import hook_install
+from canopy_runner.hook_listener import HookListener
+
+
+def _payload(cwd="/w/repo/emdash/task", **over):
+    base = {
+        "hook_event_name": "PostToolUse",
+        "cwd": cwd,
+        "tool_name": "Bash",
+        "tool_use_id": "toolu_1",
+        "tool_input": {"command": "ls"},
+        "tool_response": {"stdout": "out"},
+    }
+    base.update(over)
+    return base
+
+
+def _listener(*, forward=True, known=("/w/repo/emdash/task",)):
+    sent = []
+    lis = HookListener(
+        port=0, nonce="n",
+        resolve_session=lambda cwd: "sess-1" if cwd in known else "",
+        forward=lambda: forward,
+    )
+    lis.bind_sender(lambda session_id, events: sent.append((session_id, events)))
+    return lis, sent
+
+
+def test_forwarding_off_accepts_and_drops():
+    """THE switch: the listener always accepts, but only forwards when on. Off
+    means the plumbing is installed and inert."""
+    lis, sent = _listener(forward=False)
+    assert lis.handle_payload(_payload()) == "not-forwarding"
+    assert sent == []
+    assert lis.received == 1
+
+
+def test_forwarding_on_ships_a_complete_tool_pair():
+    lis, sent = _listener()
+    assert lis.handle_payload(_payload()) == "forwarded"
+    (session_id, events), = sent
+    assert session_id == "sess-1"
+    assert [e["kind"] for e in events] == ["tool_use", "tool_result"]
+    # Live rows are view-only; persisting them would give the durable record a
+    # second, unordered source.
+    assert all(e["index"] == -1 for e in events)
+
+
+def test_a_session_canopy_does_not_know_is_dropped_quietly():
+    """User-level hooks fire for EVERY Claude Code session on the machine. Most
+    are not canopy's; dropping them is the expected path, not an error."""
+    lis, sent = _listener()
+    assert lis.handle_payload(_payload(cwd="/somewhere/else")) == "unknown-cwd"
+    assert sent == []
+    assert lis.dropped_unknown_cwd == 1
+
+
+def test_a_failing_transport_never_raises_at_the_hook():
+    """A hook that sees a failure is a hook that can degrade the agent's loop."""
+    lis, _ = _listener()
+    lis.bind_sender(lambda *a: (_ for _ in ()).throw(RuntimeError("canopy down")))
+    assert lis.handle_payload(_payload()) == "error"   # not an exception
+
+
+def test_non_tool_events_are_ignored():
+    lis, sent = _listener()
+    assert lis.handle_payload(_payload(hook_event_name="Stop")) == "ignored"
+    assert sent == []
+
+
+# ── install ────────────────────────────────────────────────────────────────
+
+def test_install_is_idempotent_and_refreshes_in_place(tmp_path):
+    p = tmp_path / "settings.json"
+    assert hook_install.install(p, port=8787, nonce="a") is True
+    assert hook_install.install(p, port=9999, nonce="b") is True
+    entries = json.loads(p.read_text())["hooks"]["PostToolUse"]
+    assert len(entries) == 1, "a re-install must replace, not accumulate"
+    assert "9999" in entries[0]["hooks"][0]["command"]
+    assert "nonce" not in entries[0]["hooks"][0]["command"]
+
+
+def test_install_preserves_hooks_canopy_did_not_write(tmp_path):
+    """emdash writes its own hooks. Ours compose with them; they are not ours to
+    edit."""
+    p = tmp_path / "settings.json"
+    p.write_text(json.dumps({"hooks": {
+        "PostToolUse": [{"hooks": [{"type": "command", "command": "emdash-thing"}]}],
+        "Stop": [{"hooks": [{"type": "command", "command": "emdash-stop"}]}],
+    }}))
+    hook_install.install(p, port=8787, nonce="a")
+    hooks = json.loads(p.read_text())["hooks"]
+    commands = [h["command"] for e in hooks["PostToolUse"] for h in e["hooks"]]
+    assert "emdash-thing" in commands
+    assert any(hook_install.MARKER in c for c in commands)
+    assert hooks["Stop"][0]["hooks"][0]["command"] == "emdash-stop"
+
+
+def test_remove_takes_only_ours(tmp_path):
+    p = tmp_path / "settings.json"
+    p.write_text(json.dumps({"hooks": {"PostToolUse": [
+        {"hooks": [{"type": "command", "command": "someone-elses"}]}]}}))
+    hook_install.install(p, port=8787, nonce="a")
+    assert hook_install.remove(p) is True
+    commands = [h["command"] for e in json.loads(p.read_text())["hooks"]["PostToolUse"]
+                for h in e["hooks"]]
+    assert commands == ["someone-elses"]
+    assert hook_install.remove(p) is False   # nothing of ours left
+
+
+def test_the_command_cannot_fail_or_hang_the_hook(tmp_path):
+    cmd = hook_install.hook_command(8787, "secret")
+    assert "|| true" in cmd, "a failing curl must not fail the hook"
+    assert "--max-time" in cmd, "a hung canopy must not slow every tool call"
+    assert "-d @-" in cmd, "the hook JSON is forwarded verbatim on stdin"
+    assert "127.0.0.1" in cmd, "never off-box: this machine holds fleet credentials"
+
+
+def test_a_settings_file_with_a_malformed_hooks_key_is_left_alone(tmp_path):
+    p = tmp_path / "settings.json"
+    p.write_text(json.dumps({"hooks": "not-an-object"}))
+    assert hook_install.install(p, port=8787, nonce="a") is False
+    assert json.loads(p.read_text())["hooks"] == "not-an-object"

--- a/packages/canopy_transcript/canopy_transcript/__init__.py
+++ b/packages/canopy_transcript/canopy_transcript/__init__.py
@@ -5,7 +5,14 @@ Re-exports the names consumers actually use so a caller writes
 into a submodule.
 """
 from .batching import TRANSCRIPT_BATCH_MAX_BYTES, chunk_raw_lines
-from .paths import encode_project_dir, resolve_cli_transcript, resolve_emdash_transcript
+from .hooks import FORWARDED_EVENTS, events_for_hook, rows_for_hook
+from .paths import (
+    emdash_task_candidates,
+    encode_project_dir,
+    parse_emdash_worktree,
+    resolve_cli_transcript,
+    resolve_emdash_transcript,
+)
 from .records import read_records
 from .rows import (
     BLOCK_STRIDE,
@@ -24,9 +31,11 @@ from .rows import (
 from .tail import TailReader
 
 __all__ = [
-    "BLOCK_STRIDE", "TOOL_INPUT_JSON_MAX", "TOOL_INPUT_STR_MAX", "TOOL_TEXT_MAX",
+    "BLOCK_STRIDE", "FORWARDED_EVENTS", "TOOL_INPUT_JSON_MAX", "TOOL_INPUT_STR_MAX", "TOOL_TEXT_MAX",
     "TRANSCRIPT_BATCH_MAX_BYTES", "TailReader", "assistant_text", "chunk_raw_lines",
     "compose_index", "conversational_messages", "encode_project_dir", "end_index",
-    "read_records", "resolve_cli_transcript", "resolve_emdash_transcript",
+    "emdash_task_candidates", "events_for_hook", "parse_emdash_worktree",
+    "read_records", "resolve_cli_transcript",
+    "resolve_emdash_transcript", "rows_for_hook",
     "row_payload", "rows_for_record", "scrub", "user_text",
 ]

--- a/packages/canopy_transcript/canopy_transcript/hooks.py
+++ b/packages/canopy_transcript/canopy_transcript/hooks.py
@@ -1,0 +1,98 @@
+"""Claude Code hook payloads -> the same row shape the transcript produces.
+
+Hooks are the *live* half of canopy's session record. The transcript is complete
+but lags — the Claude Code docs are explicit that it "may lag the in-memory
+conversation" — so it can't drive a view you're actively watching. Hooks push
+the same content the moment it happens, on a documented schema, for both
+emdash-driven and `claude -p` sessions.
+
+The two surfaces reconcile because they share one key: `tool_use_id`. A hook
+passes it directly; the transcript carries it as `tool_use.id` /
+`tool_result.tool_use_id`. That is what lets a live row be *replaced* by its
+durable row rather than duplicated.
+
+One thing hooks do better than the transcript: **`PostToolUse` carries the
+result as well as the input**, so a single event is a complete tool_use +
+tool_result pair. The transcript splits those across two records.
+
+Live rows carry NO ordinal (`index = -1`). That is deliberate and load-bearing:
+the server persists only ordinal-keyed rows, so a hook event fans out to
+watching clients and is never written. The durable record stays exactly one
+thing — the transcript — and the hook path is therefore allowed to drop events.
+"""
+from __future__ import annotations
+
+from .rows import row_payload, scrub, _tool_input, _tool_result_text
+
+# The hook events worth forwarding. PreToolUse is deliberately absent: it can
+# BLOCK a tool call, and nothing about observability should be able to stall an
+# agent. PostToolUse alone already carries input and result together.
+FORWARDED_EVENTS = ("PostToolUse", "PostToolUseFailure")
+
+
+def _result_text(response) -> str:
+    """A hook's `tool_response` as display text.
+
+    Bash-family tools return a dict (`stdout`/`stderr`/…); others return a bare
+    string or a block list, which is the transcript's own shape and so is read
+    with the transcript's own reader.
+    """
+    if isinstance(response, dict):
+        for key in ("stdout", "content", "text", "result"):
+            value = response.get(key)
+            if isinstance(value, str) and value.strip():
+                return _tool_result_text(value)
+        err = response.get("stderr")
+        if isinstance(err, str) and err.strip():
+            return _tool_result_text(err)
+        return ""
+    return _tool_result_text(response)
+
+
+def _is_error(payload: dict) -> bool:
+    if payload.get("hook_event_name") == "PostToolUseFailure":
+        return True
+    response = payload.get("tool_response")
+    return bool(isinstance(response, dict) and response.get("is_error"))
+
+
+def rows_for_hook(payload: dict) -> list[dict]:
+    """The live chat rows one hook event contributes.
+
+    Returns the tool_use and its tool_result as a pair, since PostToolUse
+    carries both. `index` is -1 on every row: live events are a view overlay and
+    must never be persisted (see the module docstring).
+
+    Returns [] for any event that isn't a forwarded tool event, or that carries
+    no `tool_use_id` — without that key a row cannot be reconciled against its
+    durable counterpart, and an unreconcilable row would duplicate forever.
+    """
+    if payload.get("hook_event_name") not in FORWARDED_EVENTS:
+        return []
+    tool_use_id = payload.get("tool_use_id")
+    if not isinstance(tool_use_id, str) or not tool_use_id:
+        return []
+    name = scrub(str(payload.get("tool_name") or ""))
+    return [
+        {
+            "index": -1, "role": "tool_use", "text": "",
+            "content": {
+                "id": tool_use_id,
+                "name": name,
+                "input": _tool_input(payload.get("tool_input")),
+            },
+        },
+        {
+            "index": -1, "role": "tool_result",
+            "text": _result_text(payload.get("tool_response")),
+            "content": {"tool_use_id": tool_use_id, "is_error": _is_error(payload)},
+        },
+    ]
+
+
+def events_for_hook(payload: dict) -> list[dict]:
+    """`rows_for_hook`, shaped as the wire events `/session-stream` accepts."""
+    return [
+        {"kind": r["role"], "seq": -1, "index": -1, "payload": row_payload(r)}
+        for r in rows_for_hook(payload)
+    ]

--- a/packages/canopy_transcript/canopy_transcript/paths.py
+++ b/packages/canopy_transcript/canopy_transcript/paths.py
@@ -94,3 +94,47 @@ def resolve_cli_transcript(
         return path if path.is_file() else None
     except OSError:
         return None
+
+
+def parse_emdash_worktree(cwd: Path | str, *, home: Path) -> tuple[str, str] | None:
+    """The inverse of `_worktree_bases`: a worktree path -> (repo, task), or None.
+
+    A Claude Code hook reports the session's `cwd`, but canopy identifies a
+    session by (project, session_key) — so the live path needs to run the
+    convention backwards. Handles both observed layouts
+    (`<repo>/emdash/<task>` and `<repo>/<task>`) and strips emdash's random
+    de-dupe suffix, so `…/canopy-web/emdash/runner-yipnn` resolves to
+    ("canopy-web", "runner").
+
+    The suffix strip is ambiguous by construction — a task legitimately named
+    `foo-bar` is indistinguishable from task `foo` with suffix `bar`. Both
+    candidates are therefore returned to the caller's matcher via
+    `emdash_task_candidates`; this returns the *exact* pair only, and None when
+    the path is not under the worktree root at all.
+    """
+    try:
+        rel = Path(cwd).resolve().relative_to((home / "emdash" / "worktrees").resolve())
+    except (ValueError, OSError):
+        return None
+    parts = rel.parts
+    if len(parts) >= 3 and parts[1] == "emdash":
+        return parts[0], parts[2]
+    if len(parts) >= 2:
+        return parts[0], parts[1]
+    return None
+
+
+def emdash_task_candidates(task: str) -> list[str]:
+    """The task names a worktree dir could correspond to, most-specific first.
+
+    emdash appends a random `-<suffix>` to de-dupe worktree dirs, and a task may
+    also legitimately contain a hyphen, so the mapping is genuinely ambiguous:
+    `runner-yipnn` is either task `runner-yipnn` or task `runner`. Returning both
+    lets the caller match against the sessions it actually knows about instead of
+    guessing — the exact name wins when it exists.
+    """
+    out = [task]
+    stripped = _SUFFIX_RE.sub("", task)
+    if stripped and stripped != task:
+        out.append(stripped)
+    return out

--- a/packages/canopy_transcript/tests/test_hooks.py
+++ b/packages/canopy_transcript/tests/test_hooks.py
@@ -1,0 +1,89 @@
+"""Hook payloads -> live rows.
+
+Shapes verified against real PostToolUse payloads captured from a live
+emdash-driven session (2026-07-27).
+"""
+import canopy_transcript as ct
+
+
+def _payload(**over):
+    base = {
+        "hook_event_name": "PostToolUse",
+        "session_id": "sess-1",
+        "cwd": "/Users/x/emdash/worktrees/repo/emdash/task",
+        "tool_name": "Bash",
+        "tool_use_id": "toolu_01ABC",
+        "tool_input": {"command": "ls"},
+        "tool_response": {"stdout": "a.txt\n", "stderr": "", "interrupted": False},
+        "duration_ms": 16,
+    }
+    base.update(over)
+    return base
+
+
+def test_one_hook_event_is_a_complete_tool_pair():
+    """PostToolUse carries the result as well as the input, so a single event
+    yields both rows — where the transcript splits them across two records."""
+    use, result = ct.rows_for_hook(_payload())
+    assert use["role"] == "tool_use"
+    assert use["content"] == {"id": "toolu_01ABC", "name": "Bash",
+                              "input": {"command": "ls"}}
+    assert result["role"] == "tool_result"
+    assert result["content"] == {"tool_use_id": "toolu_01ABC", "is_error": False}
+    assert result["text"] == "a.txt"
+
+
+def test_live_rows_carry_no_ordinal():
+    """index = -1 is what keeps a hook event OUT of the durable store: the server
+    persists only ordinal-keyed rows. The transcript stays the one record."""
+    assert all(r["index"] == -1 for r in ct.rows_for_hook(_payload()))
+    assert all(e["index"] == -1 and e["seq"] == -1
+               for e in ct.events_for_hook(_payload()))
+
+
+def test_an_event_with_no_tool_use_id_is_dropped():
+    """Without the correlation key a live row can never be reconciled against
+    its durable counterpart, so it would duplicate forever."""
+    assert ct.rows_for_hook(_payload(tool_use_id="")) == []
+    assert ct.rows_for_hook(_payload(tool_use_id=None)) == []
+
+
+def test_pretooluse_is_never_forwarded():
+    """PreToolUse can BLOCK a tool call. Observability must not be able to stall
+    an agent, so it is not in the forwarded set at all."""
+    assert "PreToolUse" not in ct.FORWARDED_EVENTS
+    assert ct.rows_for_hook(_payload(hook_event_name="PreToolUse")) == []
+
+
+def test_a_failure_event_marks_the_result_as_an_error():
+    rows = ct.rows_for_hook(_payload(hook_event_name="PostToolUseFailure"))
+    assert rows[1]["content"]["is_error"] is True
+
+
+def test_stderr_is_used_when_there_is_no_stdout():
+    rows = ct.rows_for_hook(_payload(
+        tool_response={"stdout": "", "stderr": "command not found"}))
+    assert rows[1]["text"] == "command not found"
+
+
+def test_a_string_tool_response_reads_like_the_transcript():
+    rows = ct.rows_for_hook(_payload(tool_response="plain output"))
+    assert rows[1]["text"] == "plain output"
+
+
+def test_hook_payloads_are_capped_like_transcript_rows():
+    """A hook carries the same enormous tool bodies the transcript does, and
+    reaches the same phone over the same websocket."""
+    rows = ct.rows_for_hook(_payload(
+        tool_input={"content": "x" * 100_000},
+        tool_response={"stdout": "y" * 100_000}))
+    assert len(rows[0]["content"]["input"]["content"]) < ct.TOOL_INPUT_STR_MAX + 100
+    assert len(rows[1]["text"]) < ct.TOOL_TEXT_MAX + 100
+
+
+def test_nul_bytes_are_scrubbed_on_the_hook_path_too():
+    """Postgres rejects NUL. The hook path doesn't persist today, but it feeds
+    the same shape into the same code, so it must not be the one path that
+    reintroduces the byte that took down a whole batch."""
+    rows = ct.rows_for_hook(_payload(tool_response={"stdout": "bin\x00ary"}))
+    assert "\x00" not in rows[1]["text"]

--- a/packages/canopy_transcript/tests/test_rows.py
+++ b/packages/canopy_transcript/tests/test_rows.py
@@ -193,3 +193,29 @@ def test_scrub_leaves_other_control_characters_alone():
     """Only NUL is rejected by Postgres; tabs/newlines/escapes are real content
     and stripping them would corrupt every terminal capture we ship."""
     assert ct.scrub("a\tb\nc\x1b[0m") == "a\tb\nc\x1b[0m"
+
+
+# ── cwd -> (repo, task): the inverse the live hook path needs ───────────────
+
+def test_parse_worktree_handles_both_observed_layouts(tmp_path):
+    home = tmp_path
+    (home / "emdash" / "worktrees" / "repo" / "emdash" / "task").mkdir(parents=True)
+    (home / "emdash" / "worktrees" / "repo2" / "task2").mkdir(parents=True)
+    assert ct.parse_emdash_worktree(
+        home / "emdash/worktrees/repo/emdash/task", home=home) == ("repo", "task")
+    assert ct.parse_emdash_worktree(
+        home / "emdash/worktrees/repo2/task2", home=home) == ("repo2", "task2")
+
+
+def test_parse_worktree_rejects_a_path_outside_the_root(tmp_path):
+    """A hook fires for EVERY session on the machine, most of them not canopy's.
+    A path we can't place must resolve to nothing, never to a wrong session."""
+    assert ct.parse_emdash_worktree("/somewhere/else", home=tmp_path) is None
+
+
+def test_task_candidates_keep_the_suffix_ambiguity_open():
+    """`runner-yipnn` is either task `runner-yipnn` or task `runner` + emdash's
+    de-dupe suffix. Both are offered so the caller matches against sessions it
+    actually has rather than guessing."""
+    assert ct.emdash_task_candidates("runner-yipnn") == ["runner-yipnn", "runner"]
+    assert ct.emdash_task_candidates("plain") == ["plain"]


### PR DESCRIPTION
Slice 3 of the [convergence spec](docs/superpowers/specs/2026-07-27-runner-convergence-and-live-observability-design.md). Slices 1–2 landed in #449.

**Ships inert:** `forward_sessions` defaults **off**, so nothing changes on any machine until you flip it.

## Why hooks

The transcript is complete but **lags** — the Claude Code docs say so explicitly — so it can't drive a view you're actively watching. Hooks push the same content the moment it happens, on a documented schema, for both emdash-driven and `claude -p` sessions. That makes them the convergence point, not just a latency win.

## The switch is where you asked for it

The runner hosts the listener and owns the toggle. `Config.forward_sessions` gates **only** the POST to canopy-web — the listener always accepts and always answers 200, so the plumbing installs and runs while carrying nothing. `hook_port = 0` disables the listener *and removes the installed hook*, so turning it off doesn't leave a curl pointing at a dead port.

## Three load-bearing properties

**A hook must never fail.** Every failure path answers 200; the curl carries `-sf --max-time 2 || true`; the listener replies *before* doing any work. `PreToolUse` is deliberately not forwarded at all — it can **block** a tool call, and nothing about observability may stall an agent.

**Live rows are never persisted.** They carry `index = -1`, which the server already treats as view-only. The durable record stays exactly one thing — the transcript — and *that* is what makes it safe for this path to drop events freely. No queue, no retry, no durability.

**Reconciliation is on `tool_use_id`.** The same call arrives twice by design: live from a hook (no ordinal) and durably from the transcript. They share only that key, so the reducer matches on it and the durable row **replaces** the live placeholder, adopting its id and ordinal. Matching on message id instead would show every tool call twice, forever.

## Installation

**User level** (`~/.claude/settings.json`), which the spike proved covers every concurrent session on the machine at once. emdash owns the project-level file in its worktrees and uses only `UserPromptSubmit`/`Notification`/`Stop`, so ours **compose** rather than collide — install/remove touch only entries carrying our marker and leave everything else untouched (tested).

A hook reports a `cwd`, so the live path runs the worktree convention **backwards**. `emdash_task_candidates` keeps the de-dupe-suffix ambiguity open (`runner-yipnn` is either task `runner-yipnn` or task `runner`) and matches against sessions the runner actually knows rather than guessing.

## Verification

Backend 1,749 · runner 207 · transcript 25 · frontend 371 · build clean.

New tests pin the safety properties specifically: forwarding-off accepts and drops, a failing transport never raises at the hook, an unknown cwd is dropped quietly, install preserves foreign hooks, remove takes only ours, and a durable row replaces rather than duplicates its live placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)