### PR TITLE
feat(runner): report hook-listener counters, so the live path is observable

### DIFF
--- a/packages/canopy_runner/canopy_runner/main.py
+++ b/packages/canopy_runner/canopy_runner/main.py
@@ -470,6 +470,37 @@ _hook_sessions: dict[tuple[str, str], str] = {}
 _hook_listener = None
 
 
+_last_hook_report = 0.0
+# Same cadence as the idle-cycle line: often enough to answer "is it working?"
+# without turning a busy agent into a log flood.
+HOOK_REPORT_SECONDS = 300
+
+
+def _maybe_report_hooks(now_fn=time.monotonic) -> None:
+    """Log what the hook listener has seen.
+
+    Without this the live path is unobservable from the runner side: events are
+    accepted, resolved and forwarded entirely silently, so "is it working?" can
+    only be answered from the server's logs — which is exactly the question you
+    have when you cannot reach them. Counters are cumulative since start.
+    """
+    global _last_hook_report
+    listener = _hook_listener
+    if listener is None:
+        return
+    if now_fn() - _last_hook_report < HOOK_REPORT_SECONDS:
+        return
+    _last_hook_report = now_fn()
+    if listener.received == 0:
+        return  # nothing has fired yet; silence is the honest report
+    logger.info(
+        "hooks: %d received, %d forwarded, %d dropped (cwd not a session we back), "
+        "forwarding=%s",
+        listener.received, listener.forwarded, listener.dropped_unknown_cwd,
+        listener._forward(),
+    )
+
+
 def _resolve_hook_session(cwd: str) -> str:
     """A hook's cwd -> canopy session id, or "" if this isn't a session we back.
 
@@ -708,6 +739,7 @@ def run_once(cfg: Config, client: Client) -> str:
     # Before the reports: an in-flight reply is the freshest thing on this box, and
     # finishing a turn here frees the session for the next message. Runs even while
     # CDP is down — the transcript keeps growing whether or not we can drive emdash.
+    _maybe_report_hooks()
     _pump_chat_bridges(cfg, client)
     _maybe_report_sessions(cfg, client)
     _sync_session_streams(cfg, client)

--- a/packages/canopy_runner/tests/test_hook_listener.py
+++ b/packages/canopy_runner/tests/test_hook_listener.py
@@ -129,3 +129,54 @@ def test_a_settings_file_with_a_malformed_hooks_key_is_left_alone(tmp_path):
     p.write_text(json.dumps({"hooks": "not-an-object"}))
     assert hook_install.install(p, port=8787, nonce="a") is False
     assert json.loads(p.read_text())["hooks"] == "not-an-object"
+
+
+# ── counter reporting ───────────────────────────────────────────────────────
+
+def test_hook_counters_are_reported_but_stay_quiet_until_something_fires(caplog):
+    """Without this the live path is unobservable from the runner side — which
+    is exactly the gap that showed up the first time the server logs weren't
+    reachable."""
+    import logging
+
+    from canopy_runner import main as main_mod
+
+    lis, _ = _listener()
+    main_mod._hook_listener = lis
+    main_mod._last_hook_report = 0.0
+    try:
+        clock = [10_000.0]
+        with caplog.at_level(logging.INFO, logger="canopy_runner"):
+            main_mod._maybe_report_hooks(now_fn=lambda: clock[0])
+            assert caplog.text == "", "nothing fired yet — silence is the honest report"
+
+            lis.handle_payload(_payload())
+            lis.handle_payload(_payload(cwd="/not/ours"))
+            clock[0] += main_mod.HOOK_REPORT_SECONDS + 1
+            main_mod._maybe_report_hooks(now_fn=lambda: clock[0])
+        assert "2 received" in caplog.text
+        assert "1 forwarded" in caplog.text
+        assert "1 dropped" in caplog.text
+    finally:
+        main_mod._hook_listener = None
+
+
+def test_hook_report_is_throttled(caplog):
+    import logging
+
+    from canopy_runner import main as main_mod
+
+    lis, _ = _listener()
+    lis.handle_payload(_payload())
+    main_mod._hook_listener = lis
+    main_mod._last_hook_report = 0.0
+    try:
+        clock = [10_000.0]
+        with caplog.at_level(logging.INFO, logger="canopy_runner"):
+            main_mod._maybe_report_hooks(now_fn=lambda: clock[0])
+            caplog.clear()
+            clock[0] += 5  # well inside the window
+            main_mod._maybe_report_hooks(now_fn=lambda: clock[0])
+        assert caplog.text == "", "a busy agent must not flood the log"
+    finally:
+        main_mod._hook_listener = None


### PR DESCRIPTION
Follow-on to #464, found while enabling it on the local runner.

The listener accepted, resolved and forwarded events **entirely silently**. "Is it working?" could only be answered from canopy-web's server logs — which is exactly the question you have when you can't reach them. An expired AWS SSO token during this feature's own first enablement is how it surfaced.

Adds cumulative counters on the same cadence as the idle-cycle line: `received`, `forwarded`, `dropped` (cwd isn't a session we back). Silent until something has actually fired, so a runner with the feature off stays quiet.

Runner 209 · backend 1,749 · ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)