### PR TITLE
fix(runner): the first hook report was throttled out at process start

### DIFF
--- a/packages/canopy_runner/canopy_runner/main.py
+++ b/packages/canopy_runner/canopy_runner/main.py
@@ -470,7 +470,12 @@ _hook_sessions: dict[tuple[str, str], str] = {}
 _hook_listener = None
 
 
-_last_hook_report = 0.0
+# None, NOT 0.0: `time.monotonic()` is near zero early in a process's life, so
+# seeding this with 0.0 reads as "already reported just now" and suppresses the
+# first report for a whole window — exactly when you are watching for it, because
+# you have just turned the feature on. Found on the first live enablement; the
+# original test hid it by starting its fake clock at 10,000.
+_last_hook_report: float | None = None
 # Same cadence as the idle-cycle line: often enough to answer "is it working?"
 # without turning a busy agent into a log flood.
 HOOK_REPORT_SECONDS = 300
@@ -488,7 +493,7 @@ def _maybe_report_hooks(now_fn=time.monotonic) -> None:
     listener = _hook_listener
     if listener is None:
         return
-    if now_fn() - _last_hook_report < HOOK_REPORT_SECONDS:
+    if _last_hook_report is not None and now_fn() - _last_hook_report < HOOK_REPORT_SECONDS:
         return
     _last_hook_report = now_fn()
     if listener.received == 0:

--- a/packages/canopy_runner/tests/test_hook_listener.py
+++ b/packages/canopy_runner/tests/test_hook_listener.py
@@ -143,7 +143,7 @@ def test_hook_counters_are_reported_but_stay_quiet_until_something_fires(caplog)
 
     lis, _ = _listener()
     main_mod._hook_listener = lis
-    main_mod._last_hook_report = 0.0
+    main_mod._last_hook_report = None
     try:
         clock = [10_000.0]
         with caplog.at_level(logging.INFO, logger="canopy_runner"):
@@ -169,7 +169,7 @@ def test_hook_report_is_throttled(caplog):
     lis, _ = _listener()
     lis.handle_payload(_payload())
     main_mod._hook_listener = lis
-    main_mod._last_hook_report = 0.0
+    main_mod._last_hook_report = None
     try:
         clock = [10_000.0]
         with caplog.at_level(logging.INFO, logger="canopy_runner"):
@@ -178,5 +178,26 @@ def test_hook_report_is_throttled(caplog):
             clock[0] += 5  # well inside the window
             main_mod._maybe_report_hooks(now_fn=lambda: clock[0])
         assert caplog.text == "", "a busy agent must not flood the log"
+    finally:
+        main_mod._hook_listener = None
+
+
+def test_the_first_report_is_not_throttled_out_at_process_start(caplog):
+    """time.monotonic() is near zero early in a process, so seeding the
+    last-report time with 0.0 read as "already reported" and swallowed the first
+    report for a whole window — precisely when you are watching for it, because
+    you have just enabled the feature. Clock starts where it really starts."""
+    import logging
+
+    from canopy_runner import main as main_mod
+
+    lis, _ = _listener()
+    lis.handle_payload(_payload())
+    main_mod._hook_listener = lis
+    main_mod._last_hook_report = None
+    try:
+        with caplog.at_level(logging.INFO, logger="canopy_runner"):
+            main_mod._maybe_report_hooks(now_fn=lambda: 0.4)
+        assert "1 received" in caplog.text
     finally:
         main_mod._hook_listener = None


### PR DESCRIPTION
Found minutes after #465 shipped, while enabling it on the local runner.

`_last_hook_report = 0.0` reads as *"reported at monotonic 0"*. `time.monotonic()` is near zero early in a process's life, so the very first report was suppressed for a full 5-minute window — **exactly when you're watching for it**, because you've just turned the feature on.

The original test hid it by starting its fake clock at 10,000. The new test starts the clock where it actually starts (0.4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)