### PR TITLE
fix(runner): an idle tick was burning the whole hook-report window

### DIFF
--- a/packages/canopy_runner/canopy_runner/main.py
+++ b/packages/canopy_runner/canopy_runner/main.py
@@ -495,9 +495,12 @@ def _maybe_report_hooks(now_fn=time.monotonic) -> None:
         return
     if _last_hook_report is not None and now_fn() - _last_hook_report < HOOK_REPORT_SECONDS:
         return
-    _last_hook_report = now_fn()
     if listener.received == 0:
-        return  # nothing has fired yet; silence is the honest report
+        # Nothing has fired yet; silence is the honest report — and crucially we
+        # do NOT stamp, or an idle tick right after startup burns the whole
+        # window and the first real report waits 5 minutes behind it.
+        return
+    _last_hook_report = now_fn()
     logger.info(
         "hooks: %d received, %d forwarded, %d dropped (cwd not a session we back), "
         "forwarding=%s",

--- a/packages/canopy_runner/tests/test_hook_listener.py
+++ b/packages/canopy_runner/tests/test_hook_listener.py
@@ -201,3 +201,27 @@ def test_the_first_report_is_not_throttled_out_at_process_start(caplog):
         assert "1 received" in caplog.text
     finally:
         main_mod._hook_listener = None
+
+
+def test_an_idle_tick_does_not_consume_the_report_window(caplog):
+    """The stamp must be taken only when something is actually logged. Taking it
+    on a no-op tick means the first tick after startup (nothing fired yet) burns
+    the whole window, and the first real report waits behind it — the same
+    5-minutes-of-silence symptom as the seed bug, from a different cause. Both
+    were found live; both had passing tests."""
+    import logging
+
+    from canopy_runner import main as main_mod
+
+    lis, _ = _listener()
+    main_mod._hook_listener = lis
+    main_mod._last_hook_report = None
+    try:
+        with caplog.at_level(logging.INFO, logger="canopy_runner"):
+            main_mod._maybe_report_hooks(now_fn=lambda: 1.0)   # idle tick, nothing fired
+            assert caplog.text == ""
+            lis.handle_payload(_payload())                      # now something fires
+            main_mod._maybe_report_hooks(now_fn=lambda: 6.0)    # 5s later, well inside the window
+        assert "1 received" in caplog.text, "the idle tick swallowed the first real report"
+    finally:
+        main_mod._hook_listener = None


### PR DESCRIPTION
Second bug in the same eight-line function, same symptom, different cause.

The last-reported stamp was taken **before** the "nothing has fired yet" guard, so the first tick after startup — when nothing has fired, by definition — consumed the full 5-minute window, and the first real report waited behind it.

**Both bugs shipped with passing tests**, which is the more useful lesson:
- the first test started its fake clock at 10,000, hiding a seed value that only misbehaves near zero;
- the second called the function once with nothing recorded and asserted silence — which is precisely the call that was quietly stamping.

The new test pins the sequence that actually happens at startup: idle tick → event → report *inside* the window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)