### PR TITLE
feat(storyboards): the Canopy bar on the public surfaces, and "Show changes"

### DIFF
--- a/frontend/src/components/PublicHeader.test.tsx
+++ b/frontend/src/components/PublicHeader.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { ThemeProvider } from '@/theme/ThemeProvider'
+import { PublicHeader } from './PublicHeader'
+import { AuthContext } from '@/auth/AuthProvider'
+
+/**
+ * The public surfaces were chrome-less because AppLayout's header fires authed
+ * calls that bounce an anonymous visitor to Google. This header must carry the
+ * brand without carrying that hazard.
+ */
+function renderAs(status: 'authenticated' | 'anonymous') {
+  return render(
+    <MemoryRouter>
+      <ThemeProvider>
+      <AuthContext.Provider
+        value={
+          status === 'authenticated'
+            ? {
+                status,
+                user: { name: 'Jonathan Jackson', email: 'jj@dimagi.com', avatar_url: '' },
+              }
+            : { status, user: null }
+        }
+      >
+        <PublicHeader trail="Proving a programme works" />
+      </AuthContext.Provider>
+      </ThemeProvider>
+    </MemoryRouter>,
+  )
+}
+
+describe('PublicHeader', () => {
+  afterEach(cleanup)
+
+  it('shows the Canopy mark to an anonymous reviewer', () => {
+    renderAs('anonymous')
+    expect(screen.getByText('Canopy')).toBeTruthy()
+    expect(screen.getByText('Proving a programme works')).toBeTruthy()
+  })
+
+  it('offers a signed-out reviewer no link into the app', () => {
+    // Every route behind it is a login wall, so the link would be a trapdoor.
+    const { container } = renderAs('anonymous')
+    expect(container.querySelectorAll('a')).toHaveLength(0)
+  })
+
+  it('links home for someone who has one', () => {
+    renderAs('authenticated')
+    expect(screen.getByText('Canopy').closest('a')?.getAttribute('href')).toBe('/')
+  })
+
+  it('lets either of them change the theme', () => {
+    renderAs('anonymous')
+    expect(screen.getByRole('button', { name: /Switch to/ })).toBeTruthy()
+  })
+})

--- a/frontend/src/components/PublicHeader.tsx
+++ b/frontend/src/components/PublicHeader.tsx
@@ -1,0 +1,44 @@
+import { Link } from 'react-router-dom'
+import { useAuth } from '@/auth/AuthProvider'
+import { ThemeToggle } from '@/theme/ThemeProvider'
+
+/**
+ * The Canopy bar on public pages.
+ *
+ * Deliberately NOT `AppLayout`'s header. That one mounts `WorkspaceProvider`,
+ * a workspace switcher and a user menu that polls the AI backend — all authed
+ * calls, and an anonymous reviewer following a share link would be bounced to a
+ * Google login by the first one. Being chrome-less was that hazard's blunt
+ * answer; this is the precise one: the same wordmark and the same tokens, with
+ * nothing behind it that a stranger cannot call.
+ *
+ * The wordmark links home only when there IS a home to go to — an anonymous
+ * visitor clicking it would land on the login wall, which is a worse answer
+ * than not offering the link.
+ */
+export function PublicHeader({ trail }: { trail?: React.ReactNode }) {
+  const auth = useAuth()
+  const isAuthed = auth.status === 'authenticated'
+
+  return (
+    <header className="border-b border-border bg-background">
+      <div className="mx-auto flex max-w-7xl items-center justify-between gap-3 px-4 py-3 sm:px-6">
+        <div className="flex min-w-0 items-baseline gap-3">
+          {isAuthed ? (
+            <Link to="/" className="shrink-0 text-lg font-semibold text-foreground">
+              Canopy<span className="text-primary">.</span>
+            </Link>
+          ) : (
+            <span className="shrink-0 text-lg font-semibold text-foreground">
+              Canopy<span className="text-primary">.</span>
+            </span>
+          )}
+          {trail && (
+            <span className="truncate text-[12.5px] text-muted-foreground">{trail}</span>
+          )}
+        </div>
+        <ThemeToggle />
+      </div>
+    </header>
+  )
+}

--- a/frontend/src/pages/NarrativeReviewPage.test.tsx
+++ b/frontend/src/pages/NarrativeReviewPage.test.tsx
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { ThemeProvider } from '@/theme/ThemeProvider'
 import NarrativeReviewPage from './NarrativeReviewPage'
 import * as api from '@/api/storyboards'
 
@@ -44,9 +45,11 @@ const payload = (over: Record<string, unknown> = {}) => ({
 function renderPage() {
   return render(
     <MemoryRouter initialEntries={['/narrative/verified-monitoring?b=rf-surveys&t=tok']}>
+      <ThemeProvider>
       <Routes>
         <Route path="/narrative/:slug" element={<NarrativeReviewPage />} />
       </Routes>
+      </ThemeProvider>
     </MemoryRouter>,
   )
 }
@@ -66,7 +69,7 @@ describe('NarrativeReviewPage', () => {
   })
 
   const showChanges = async () => {
-    fireEvent.click(await screen.findByRole('button', { name: /Changes since v16/ }))
+    fireEvent.click(await screen.findByRole('button', { name: /Show changes/ }))
   }
 
   it('reads clean until you ask what changed', async () => {
@@ -103,7 +106,7 @@ describe('NarrativeReviewPage', () => {
     )
     renderPage()
     await screen.findByText('New one.')
-    expect(screen.queryByRole('button', { name: /Changes since/ })).toBeNull()
+    expect(screen.queryByRole('button', { name: /Show changes/ })).toBeNull()
   })
 
   it('shows the before/after only on the scene that changed', async () => {

--- a/frontend/src/pages/NarrativeReviewPage.tsx
+++ b/frontend/src/pages/NarrativeReviewPage.tsx
@@ -3,6 +3,7 @@ import { useParams, useSearchParams, Link } from 'react-router-dom'
 import { apiUrl } from '@/api/base'
 import { leaveFeedback, type Capability } from '@/api/storyboards'
 import { NoteComposer } from '@/components/storyboard/NoteComposer'
+import { PublicHeader } from '@/components/PublicHeader'
 import { pairNarrationScenes } from '@/components/ddd/narrativeScenePairing'
 import type { DddNarration } from '@/api/ddd'
 
@@ -99,8 +100,9 @@ export default function NarrativeReviewPage() {
 
 function Centered({ children }: { children: React.ReactNode }) {
   return (
-    <div className="min-h-screen bg-background text-foreground">
-      <div className="mx-auto flex min-h-screen max-w-3xl items-center justify-center px-6 text-center">
+    <div className="flex min-h-screen flex-col bg-background text-foreground">
+      <PublicHeader />
+      <div className="mx-auto flex max-w-3xl flex-1 items-center justify-center px-6 text-center">
         <div>{children}</div>
       </div>
     </div>
@@ -144,6 +146,7 @@ function Review({ data, token }: { data: NarrativeRead; token: string | null }) 
 
   return (
     <div className="min-h-screen bg-background text-foreground">
+      <PublicHeader trail={data.storyboard_title} />
       <div className="mx-auto max-w-3xl px-6 py-12 md:py-16">
         <div className="mb-8 flex flex-wrap items-center justify-between gap-3">
           <Link
@@ -164,7 +167,7 @@ function Review({ data, token }: { data: NarrativeRead; token: string | null }) 
                     : 'border-border text-muted-foreground hover:border-input hover:text-foreground'
                 }`}
               >
-                {showChanges ? 'Hide changes' : `Changes since v${data.previous_version}`}
+                {showChanges ? 'Hide changes' : 'Show changes'}
               </button>
             )}
             {data.version != null && (

--- a/frontend/src/pages/StoryboardPage.test.tsx
+++ b/frontend/src/pages/StoryboardPage.test.tsx
@@ -2,6 +2,7 @@
 import { afterEach, describe, expect, it, vi, beforeEach } from 'vitest'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { ThemeProvider } from '@/theme/ThemeProvider'
 import StoryboardPage from './StoryboardPage'
 import * as api from '@/api/storyboards'
 
@@ -63,9 +64,11 @@ function board(over: Partial<api.Storyboard> = {}): api.Storyboard {
 function renderAt(url = '/storyboard/ecf-supply?t=tok') {
   return render(
     <MemoryRouter initialEntries={[url]}>
+      <ThemeProvider>
       <Routes>
         <Route path="/storyboard/:slug" element={<StoryboardPage />} />
       </Routes>
+      </ThemeProvider>
     </MemoryRouter>,
   )
 }

--- a/frontend/src/pages/StoryboardPage.tsx
+++ b/frontend/src/pages/StoryboardPage.tsx
@@ -10,6 +10,7 @@ import {
 import { withBase } from '@/lib/basePath'
 import { NoteComposer } from '@/components/storyboard/NoteComposer'
 import { NotesReturned, groupNotes } from '@/components/storyboard/NotesReturned'
+import { PublicHeader } from '@/components/PublicHeader'
 
 /**
  * The shared arc — several DDD narratives as one link.
@@ -83,8 +84,9 @@ export default function StoryboardPage() {
 
 function Centered({ children }: { children: React.ReactNode }) {
   return (
-    <div className="min-h-screen bg-background text-foreground">
-      <div className="mx-auto flex min-h-screen max-w-3xl items-center justify-center px-6 text-center">
+    <div className="flex min-h-screen flex-col bg-background text-foreground">
+      <PublicHeader />
+      <div className="mx-auto flex max-w-3xl flex-1 items-center justify-center px-6 text-center">
         <div>{children}</div>
       </div>
     </div>
@@ -118,13 +120,8 @@ function Board({ board, token }: { board: Storyboard; token: string | null }) {
 
   return (
     <div className="min-h-screen bg-background text-foreground">
+      <PublicHeader />
       <div className="mx-auto max-w-3xl px-6 py-12 md:py-16">
-        <div className="mb-10 flex items-center justify-between">
-          <span className="text-[11px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
-            Canopy · Demo
-          </span>
-        </div>
-
         <header className="mb-4">
           <p className="mb-2 text-[11px] font-semibold uppercase tracking-[0.2em] text-primary">
             {narrativeCount === 1 ? 'One narrative' : `${narrativeCount} narratives`}


### PR DESCRIPTION
### The header
The shared arc and the reviewer page rendered with **no app chrome at all**, which makes a link we send to an outsider look like it came from nowhere.

They were chrome-less for a real reason: `AppLayout`'s header mounts `WorkspaceProvider`, a workspace switcher, and a user menu that polls the AI backend — all authed calls, and the first one bounces an anonymous reviewer to a Google login. Being chrome-less was that hazard's blunt answer.

`PublicHeader` is the precise one — the same wordmark and the same tokens, with nothing behind it a stranger cannot call. Two details:
- The mark links home **only when there is a home to go to**. For a signed-out reviewer every route behind it is a login wall, so the link would be a trapdoor.
- The reviewer page carries the storyboard's name beside the mark, so a deep link says which arc it belongs to.

It's also on the not-found/error states, so a dead link is a Canopy page rather than one sentence on a black screen.

### The pill
Reads **"Show changes"** / "Hide changes" instead of naming the version it would compare against.

### One thing worth noting
The page tests now mount `ThemeProvider` — which the router *already* puts above these routes. The test tree was thinner than the real one, which is how a header that works in the app failed in tests. Worth remembering the next time a public-surface test passes.

383 frontend tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)