### PR TITLE
fix(chat): typed-in-emdash text never reached the web, and tool churn buried the conversation

### DIFF
--- a/apps/canopy_sessions/stream_map.py
+++ b/apps/canopy_sessions/stream_map.py
@@ -20,6 +20,15 @@ def turn_event_to_frames(evt: dict, resolve_message_id: Callable[[int], str]) ->
     seq = evt.get("seq")
     payload = evt.get("payload") or {}
 
+    if kind == "user":
+        # Text a human typed straight into emdash. It reaches no web client any
+        # other way — there was no optimistic echo, because no web client sent
+        # it. Carries the transcript ordinal so the client can upsert rather
+        # than append, which is what keeps a re-delivery from doubling it.
+        mid = resolve_message_id(seq)
+        return [{"event": "chat.user_message",
+                 "data": {"message_id": mid, "turn_index": seq,
+                          "plaintext": payload.get("text", "")}}]
     if kind == "assistant":
         mid = resolve_message_id(seq)
         return [

--- a/apps/harness/api.py
+++ b/apps/harness/api.py
@@ -563,12 +563,18 @@ def post_session_stream(request: HttpRequest, runner_id: uuid.UUID, payload: Ses
     sgroup = groups.session_group(payload.session_id)
     n = 0
     for e in payload.events:
-        if e.kind != "user":
-            groups.publish(sgroup, {
-                "type": "chat.turn_event",
-                "event": {"kind": e.kind, "seq": e.seq, "payload": e.payload},
-                "turn_id": None,
-            })
+        # User events ARE fanned out. They used to be withheld on the grounds
+        # that "the sender's client already echoed them optimistically" — true
+        # for text typed in the web, false for text typed directly into emdash,
+        # which no web client ever saw. The result was that typing in emdash and
+        # watching on the phone silently dropped your own words until a reload
+        # (observed 2026-07-27). The client upserts on turn_index, so a message
+        # that does arrive twice collapses instead of doubling.
+        groups.publish(sgroup, {
+            "type": "chat.turn_event",
+            "event": {"kind": e.kind, "seq": e.seq, "payload": e.payload},
+            "turn_id": None,
+        })
         n += 1
     return {"count": n}
 

--- a/frontend/packages/canopy-ui/src/chat/MessageList.tsx
+++ b/frontend/packages/canopy-ui/src/chat/MessageList.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState, type ReactNode } from "react";
-import { ChevronsDownUp, ChevronsUpDown } from "lucide-react";
+import { ChevronRight, ChevronsDownUp, ChevronsUpDown } from "lucide-react";
 
 import type { Message } from "./protocol";
 import { Button } from "../ui/button";
@@ -7,6 +7,7 @@ import type { RenderMarkdown } from "./MessageItem";
 import { MessageItem } from "./MessageItem";
 import { ToolCallPair } from "./ToolCallPair";
 import { pairToolMessages } from "./pairToolMessages";
+import { groupToolRuns, runHasError, summariseRun } from "./groupToolRuns";
 
 interface Props {
   messages: Message[];
@@ -22,10 +23,14 @@ const TOOLBAR_THRESHOLD = 5;
 type BulkState = "default" | "all" | "none";
 
 export function MessageList({ messages, emptyState, renderMarkdown }: Props) {
-  const rows = useMemo(() => pairToolMessages(messages), [messages]);
+  const paired = useMemo(() => pairToolMessages(messages), [messages]);
+  // Collapse back-to-back tool calls into one row. An agent mid-task emits long
+  // stretches of them, and one row each pushes the prose you actually read off
+  // the screen.
+  const rows = useMemo(() => groupToolRuns(paired), [paired]);
   const toolPairCount = useMemo(
-    () => rows.filter((r) => r.kind === "tool_pair").length,
-    [rows],
+    () => paired.filter((r) => r.kind === "tool_pair").length,
+    [paired],
   );
   // ``default`` = each <details> uses its own native state (collapsed
   // initially, user can toggle individually). The bulk toggles flip
@@ -70,6 +75,43 @@ export function MessageList({ messages, emptyState, renderMarkdown }: Props) {
       )}
       <div className="flex flex-col gap-2 p-4">
         {rows.map((row) => {
+          if (row.kind === "tool_run") {
+            // One line for a whole run, open on demand. `open` when the bulk
+            // toggle says so, and always when something in it failed — a
+            // collapsed group must never hide an error.
+            const failed = runHasError(row.rows);
+            return (
+              <details
+                key={row.key}
+                open={forceToolOpen ?? (failed || undefined)}
+                className="group my-1 rounded border border-border bg-muted/40 text-sm"
+              >
+                <summary className="flex cursor-pointer items-center gap-2 px-2 py-1.5 text-muted-foreground hover:bg-muted/60 select-none [&::-webkit-details-marker]:hidden">
+                  <ChevronRight className="h-3 w-3 shrink-0 transition-transform group-open:rotate-90" />
+                  <span className="text-xs font-medium text-foreground">
+                    {summariseRun(row.rows)}
+                  </span>
+                  {failed && (
+                    <span className="text-xs font-medium text-destructive">
+                      · contains an error
+                    </span>
+                  )}
+                </summary>
+                <div className="space-y-1 border-t border-border/60 p-2">
+                  {row.rows.map((r) =>
+                    r.kind === "tool_pair" ? (
+                      <ToolCallPair
+                        key={r.key}
+                        use={r.use}
+                        result={r.result}
+                        forceOpen={forceToolOpen}
+                      />
+                    ) : null,
+                  )}
+                </div>
+              </details>
+            );
+          }
           if (row.kind === "tool_pair") {
             return (
               <ToolCallPair

--- a/frontend/packages/canopy-ui/src/chat/groupToolRuns.test.ts
+++ b/frontend/packages/canopy-ui/src/chat/groupToolRuns.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest"
+
+import { MIN_RUN_TO_GROUP, groupToolRuns, runHasError, summariseRun } from "./groupToolRuns"
+import type { ChatRow } from "./pairToolMessages"
+import type { Message } from "./protocol"
+
+function msg(over: Partial<Message> = {}): Message {
+  return {
+    id: "m", turn_index: 0, role: "tool_use", content: {}, plaintext: "",
+    status: "complete", error_detail: null, started_at: null, completed_at: null,
+    created_at: "", ...over,
+  }
+}
+
+const pair = (i: number, name = "Bash", result?: Partial<Message>): ChatRow => ({
+  kind: "tool_pair",
+  use: msg({ id: `u${i}`, content: { id: `t${i}`, name } }),
+  result: result ? msg({ id: `r${i}`, role: "tool_result", ...result }) : msg({ id: `r${i}`, role: "tool_result" }),
+  key: `pair-${i}`,
+})
+
+const prose = (i: number): ChatRow => ({
+  kind: "message",
+  message: msg({ id: `p${i}`, role: "assistant", plaintext: "words" }),
+  key: `msg-${i}`,
+})
+
+describe("groupToolRuns", () => {
+  it("collapses a run of consecutive tool calls into one row", () => {
+    const out = groupToolRuns([pair(1), pair(2), pair(3), pair(4)])
+    expect(out).toHaveLength(1)
+    expect(out[0].kind).toBe("tool_run")
+  })
+
+  it("prose breaks a run, so the conversation stays legible", () => {
+    // The whole point: an agent's own words must never be buried inside a
+    // collapsed group of the calls that surrounded them.
+    const out = groupToolRuns([pair(1), pair(2), pair(3), prose(1), pair(4), pair(5), pair(6)])
+    expect(out.map((r) => r.kind)).toEqual(["tool_run", "message", "tool_run"])
+  })
+
+  it("leaves short runs alone", () => {
+    // Wrapping one or two calls costs a click and hides nothing.
+    const out = groupToolRuns([pair(1), pair(2)])
+    expect(out.map((r) => r.kind)).toEqual(["tool_pair", "tool_pair"])
+    expect(MIN_RUN_TO_GROUP).toBe(3)
+  })
+
+  it("keeps every call, in order, inside the group", () => {
+    const out = groupToolRuns([pair(1), pair(2), pair(3)])
+    const run = out[0] as { rows: ChatRow[] }
+    expect(run.rows.map((r) => r.key)).toEqual(["pair-1", "pair-2", "pair-3"])
+  })
+
+  it("summarises a run by count and the tools it used", () => {
+    expect(summariseRun([pair(1, "Bash"), pair(2, "Read"), pair(3, "Bash")]))
+      .toBe("3 tool calls · Bash, Read")
+  })
+
+  it("flags a run containing a failure", () => {
+    // A collapsed group must not hide the one thing worth stopping for.
+    expect(runHasError([pair(1), pair(2)])).toBe(false)
+    expect(runHasError([pair(1), pair(2, "Bash", { status: "error" })])).toBe(true)
+    expect(runHasError([pair(1, "Bash", { content: { is_error: true } })])).toBe(true)
+  })
+
+  it("a session of only prose is untouched", () => {
+    const out = groupToolRuns([prose(1), prose(2)])
+    expect(out.map((r) => r.kind)).toEqual(["message", "message"])
+  })
+})

--- a/frontend/packages/canopy-ui/src/chat/groupToolRuns.ts
+++ b/frontend/packages/canopy-ui/src/chat/groupToolRuns.ts
@@ -1,0 +1,76 @@
+import type { ChatRow } from "./pairToolMessages";
+
+/**
+ * Collapse a run of consecutive tool calls into ONE row.
+ *
+ * An agent working on something emits long stretches of back-to-back tool
+ * calls. Rendered one per row they push everything you actually read — the
+ * agent's prose, your own messages — off the screen, and a session you glance
+ * at becomes a wall of `Bash` you have to scroll past. Claude Code's own answer
+ * is a single "Running 5 shell commands…" line you can open if you care, and
+ * this is that.
+ *
+ * A run is broken by any non-tool row, so prose always separates groups and the
+ * conversation stays legible. Runs of one are left alone: wrapping a single
+ * call in a group adds a click without hiding anything.
+ */
+export type GroupedRow =
+  | ChatRow
+  | { kind: "tool_run"; rows: ChatRow[]; key: string };
+
+/** Below this, a run renders as individual rows — grouping one or two calls
+ *  costs a click and saves no space. */
+export const MIN_RUN_TO_GROUP = 3;
+
+export function groupToolRuns(
+  rows: ChatRow[],
+  minRun: number = MIN_RUN_TO_GROUP,
+): GroupedRow[] {
+  const out: GroupedRow[] = [];
+  let run: ChatRow[] = [];
+
+  const flush = () => {
+    if (run.length === 0) return;
+    if (run.length >= minRun) {
+      out.push({ kind: "tool_run", rows: run, key: `run-${run[0].key}` });
+    } else {
+      out.push(...run);
+    }
+    run = [];
+  };
+
+  for (const row of rows) {
+    if (row.kind === "tool_pair") {
+      run.push(row);
+      continue;
+    }
+    flush();
+    out.push(row);
+  }
+  flush();
+  return out;
+}
+
+/** A short label for a collapsed run: "5 tool calls · Bash, Read". */
+export function summariseRun(rows: ChatRow[]): string {
+  const names = new Set<string>();
+  for (const row of rows) {
+    if (row.kind !== "tool_pair") continue;
+    const name = (row.use.content as { name?: unknown } | undefined)?.name;
+    if (typeof name === "string" && name) names.add(name);
+  }
+  const kinds = [...names].slice(0, 3).join(", ");
+  const plural = rows.length === 1 ? "call" : "calls";
+  return kinds ? `${rows.length} tool ${plural} · ${kinds}` : `${rows.length} tool ${plural}`;
+}
+
+/** True when any call in the run failed — a collapsed run must not hide an
+ *  error, or you'd scroll past the one thing worth stopping for. */
+export function runHasError(rows: ChatRow[]): boolean {
+  return rows.some(
+    (row) =>
+      row.kind === "tool_pair" &&
+      (row.result?.status === "error" ||
+        (row.result?.content as { is_error?: unknown } | undefined)?.is_error === true),
+  );
+}

--- a/frontend/packages/canopy-ui/src/chat/protocol.ts
+++ b/frontend/packages/canopy-ui/src/chat/protocol.ts
@@ -85,6 +85,9 @@ export type WsEvent =
   | { event: "session.error"; data: { code: string; message: string; detail?: unknown } }
   | { event: "session.title_updated"; data: { title: string } }
   | { event: "chat.stream_start"; data: { message_id: string; turn_index: number } }
+  // A human typed into emdash rather than into this page. No client echoed it,
+  // so this is the only way it reaches the browser before a reload.
+  | { event: "chat.user_message"; data: { message_id: string; turn_index: number; plaintext: string } }
   | { event: "chat.delta"; data: { message_id: string; text: string } }
   // `turn_index` is the row's transcript ordinal — the same key the persisted
   // Message carries, so a live tool row sorts into exactly the position it will

--- a/frontend/packages/canopy-ui/src/chat/sessionReducer.ts
+++ b/frontend/packages/canopy-ui/src/chat/sessionReducer.ts
@@ -50,6 +50,40 @@ export function sessionReducer(prev: SessionState, frame: WsEvent): SessionState
       return { ...prev, messages: [...prev.messages, assistant] };
     }
 
+    case "chat.user_message": {
+      // Someone typed into emdash. Upsert on turn_index — the transcript
+      // ordinal is stable, so a re-delivery (reconnect catch-up, a retried
+      // post) collapses onto the same row instead of doubling the message.
+      const existing = prev.messages.find(
+        (m) => m.id === frame.data.message_id ||
+          (m.role === "user" && m.turn_index === frame.data.turn_index),
+      );
+      if (existing) {
+        return {
+          ...prev,
+          messages: prev.messages.map((m) =>
+            m === existing
+              ? { ...m, id: frame.data.message_id, plaintext: frame.data.plaintext }
+              : m,
+          ),
+        };
+      }
+      const nowIso = new Date().toISOString();
+      const user: Message = {
+        id: frame.data.message_id,
+        turn_index: frame.data.turn_index,
+        role: "user",
+        content: { text: frame.data.plaintext },
+        plaintext: frame.data.plaintext,
+        status: "complete",
+        error_detail: null,
+        started_at: null,
+        completed_at: null,
+        created_at: nowIso,
+      };
+      return { ...prev, messages: [...prev.messages, user] };
+    }
+
     case "chat.delta":
       return {
         ...prev,

--- a/tests/test_chat_stream_map.py
+++ b/tests/test_chat_stream_map.py
@@ -76,3 +76,19 @@ def test_error_maps_to_stream_error():
     frames = turn_event_to_frames({"seq": 9, "kind": "error", "payload": {"detail": "boom"}, "ts": "t"}, _rid)
     assert frames[0]["event"] == "chat.stream_error"
     assert frames[0]["data"]["detail"] == "boom"
+
+
+def test_a_user_event_becomes_a_client_frame():
+    """Text typed straight into emdash. It reaches no web client any other way —
+    there was no optimistic echo, because no web client sent it. Before this,
+    `stream_map` had no `user` branch at all and the message simply never
+    appeared until a reload (observed 2026-07-27)."""
+    frames = turn_event_to_frames(
+        {"kind": "user", "seq": 64, "payload": {"text": "do the thing"}},
+        lambda seq: f"seq:{seq}",
+    )
+    assert len(frames) == 1
+    assert frames[0]["event"] == "chat.user_message"
+    assert frames[0]["data"]["plaintext"] == "do the thing"
+    # The ordinal rides along so the client upserts instead of appending.
+    assert frames[0]["data"]["turn_index"] == 64

--- a/tests/test_harness_session_streams.py
+++ b/tests/test_harness_session_streams.py
@@ -141,3 +141,20 @@ def test_plain_text_rows_store_no_redundant_content():
     msg = Message.objects.get(session=s, turn_index=64)
     assert msg.plaintext == "hello"
     assert msg.content == {}
+
+
+def test_user_events_are_fanned_out_live(monkeypatch):
+    """They used to be withheld because "the sender's client already echoed
+    them" — true for the web, false for emdash, where nothing echoed. The result
+    was that typing in emdash and watching on the phone dropped your own words
+    until a reload."""
+    user, ws, runner, c = _ctx()
+    s = Session.objects.create(workspace=ws, origin=Session.ORIGIN_RUNNER, title="a")
+    RunnerBinding.objects.create(session=s, runner=runner, session_key="echo-1",
+                                 stream_desired=True)
+    published = []
+    monkeypatch.setattr("apps.realtime.groups.publish", lambda g, m: published.append(m))
+    _post_stream(c, runner, s, [
+        {"kind": "user", "seq": 64, "index": 64, "payload": {"text": "typed in emdash"}},
+    ])
+    assert [m["event"]["kind"] for m in published] == ["user"]

--- a/tests/test_transcript_persistence.py
+++ b/tests/test_transcript_persistence.py
@@ -86,7 +86,7 @@ def _post_stream(c, runner, session, events):
     )
 
 
-def test_stream_post_persists_ordinal_rows_and_fans_out_assistant_only(monkeypatch):
+def test_stream_post_persists_ordinal_rows_and_fans_out_both_roles(monkeypatch):
     published = []
     monkeypatch.setattr("apps.realtime.groups.publish", lambda g, m: published.append((g, m)))
     _u, _w, runner, s, c = _ctx()
@@ -96,10 +96,13 @@ def test_stream_post_persists_ordinal_rows_and_fans_out_assistant_only(monkeypat
     ]).json()
     assert body == {"count": 2}
     assert _rows(s) == [(5, "user", "q1"), (7, "assistant", "a1")]
-    # The user's own words are NOT live-pushed (the frontend already echoed them
-    # optimistically); only the assistant frame fans out.
+    # BOTH roles fan out now. User events used to be withheld on the grounds
+    # that "the frontend already echoed them optimistically" — true for text
+    # typed in the web, FALSE for text typed straight into emdash, which no web
+    # client ever saw. That assumption silently dropped your own words from the
+    # phone until a reload (observed 2026-07-27).
     kinds = [m["event"]["kind"] for _g, m in published]
-    assert kinds == ["assistant"]
+    assert kinds == ["user", "assistant"]
 
 
 def test_stream_post_without_ordinal_does_not_persist(monkeypatch):


### PR DESCRIPTION
Both found by watching a live session side by side with emdash.

## 1. Text typed into emdash never reached the web

`post_session_stream` withheld user events from the live fan-out, with the comment *"the sender's client already echoed them optimistically."*

That's true for text typed **in the web**. It's false for text typed straight into **emdash** — no web client ever echoed it — so your own messages didn't appear on the phone until a reload.

`stream_map` had no `user` branch either, so even a published event produced no frame. Both halves needed changing. The client upserts on the transcript ordinal, so a message that *does* arrive twice collapses instead of doubling.

## 2. A churn of tool calls buried the conversation

An agent mid-task emits long stretches of back-to-back calls. One row each pushed the prose you actually read off the screen — a session you glance at became a wall of `Bash` to scroll past. Claude Code's own answer is *"Running 5 shell commands…"*, and this is that: consecutive calls collapse into one expandable row, `5 tool calls · Bash, Read`.

Three rules keep it honest:

- **Prose breaks a run** — an agent's words are never buried inside the calls that surrounded them.
- **Runs under three are left alone** — wrapping one call costs a click and hides nothing.
- **A run containing a failure opens by default and says so** — a collapsed group must never hide the one thing worth stopping for.

## Verified live

The same session confirmed the reconciliation from #464 is working: **25 tool calls, each rendering exactly once**, despite arriving from both the hook and the transcript.

Backend 1,751 · frontend 390 · ruff and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)