### PR TITLE
fix(chat): the interrupt marker rendered as a message you typed

### DIFF
--- a/apps/canopy_sessions/transcript_noise.py
+++ b/apps/canopy_sessions/transcript_noise.py
@@ -33,6 +33,13 @@ SYSTEM_NOISE_PREFIXES = (
     # pasted them. Found 2026-07-26 in a rebuilt session: 1 noise row in 110,
     # the only prefix the original list missed.
     "base directory for this skill:",
+    # Hitting escape in emdash writes this as a `type: "user"` record, so it
+    # rendered as a message YOU sent — in your own bubble, on your own side of
+    # the chat. You didn't type it; Claude Code did. Two variants observed
+    # across the fleet (81 rows): the bare marker and "…for tool use", both
+    # caught by this prefix. The information it carries — that the turn was
+    # interrupted — is already obvious from the message that follows it.
+    "[request interrupted by user",
 )
 
 

--- a/apps/harness/api.py
+++ b/apps/harness/api.py
@@ -562,7 +562,17 @@ def post_session_stream(request: HttpRequest, runner_id: uuid.UUID, payload: Ses
         ])
     sgroup = groups.session_group(payload.session_id)
     n = 0
+    from apps.canopy_sessions.transcript_noise import is_system_noise
+
     for e in payload.events:
+        # The noise filter has to run HERE too, not just in
+        # persist_transcript_rows. Now that user events fan out live, a filter
+        # applied only on the durable path would drop a harness marker from
+        # history while still pushing it to every watching client — so it would
+        # appear live, then vanish on reload. Same rule, both paths.
+        if e.kind == "user" and is_system_noise((e.payload or {}).get("text", "")):
+            n += 1
+            continue
         # User events ARE fanned out. They used to be withheld on the grounds
         # that "the sender's client already echoed them optimistically" — true
         # for text typed in the web, false for text typed directly into emdash,

--- a/tests/test_harness_session_streams.py
+++ b/tests/test_harness_session_streams.py
@@ -158,3 +158,25 @@ def test_user_events_are_fanned_out_live(monkeypatch):
         {"kind": "user", "seq": 64, "index": 64, "payload": {"text": "typed in emdash"}},
     ])
     assert [m["event"]["kind"] for m in published] == ["user"]
+
+
+def test_harness_markers_are_not_pushed_live_either(monkeypatch):
+    """The noise filter used to live only on the durable path. Once user events
+    started fanning out, a marker would appear live and then VANISH on reload —
+    filtered from history but not from the stream. Same rule, both paths."""
+    user, ws, runner, c = _ctx()
+    s = Session.objects.create(workspace=ws, origin=Session.ORIGIN_RUNNER, title="a")
+    RunnerBinding.objects.create(session=s, runner=runner, session_key="echo-1",
+                                 stream_desired=True)
+    published = []
+    monkeypatch.setattr("apps.realtime.groups.publish", lambda g, m: published.append(m))
+    _post_stream(c, runner, s, [
+        {"kind": "user", "seq": 64, "index": 64,
+         "payload": {"text": "[Request interrupted by user]"}},
+        {"kind": "user", "seq": 128, "index": 128,
+         "payload": {"text": "something I actually typed"}},
+    ])
+    texts = [m["event"]["payload"]["text"] for m in published]
+    assert texts == ["something I actually typed"]
+    # And it is absent from history too, so the two agree.
+    assert [m.plaintext for m in s.messages.all()] == ["something I actually typed"]

--- a/tests/test_transcript_noise.py
+++ b/tests/test_transcript_noise.py
@@ -176,3 +176,17 @@ def test_purge_apply_removes_only_the_harness_rows():
         "ship the fix",
         "<system-reminder> is injected by the harness",  # assistant text is never noise
     }
+
+
+def test_the_interrupt_marker_is_not_something_you_typed():
+    """Hitting escape in emdash writes `[Request interrupted by user]` as a
+    `type: "user"` record, so it rendered in your own bubble as if you had typed
+    it. Both observed variants are caught (81 rows across the fleet)."""
+    assert is_system_noise("[Request interrupted by user]")
+    assert is_system_noise("[Request interrupted by user for tool use]")
+
+
+def test_a_human_quoting_the_interrupt_marker_still_survives():
+    """Prefix-anchored, never a substring search — asking about the marker is a
+    real message and must not be swallowed."""
+    assert not is_system_noise('why does "[Request interrupted by user]" show up?')


### PR DESCRIPTION
Hitting escape in emdash makes Claude Code write `[Request interrupted by user]` as a `type: "user"` record — so it arrived **in your own bubble, on your own side of the chat**, as if you'd typed it.

Two variants exist across the fleet (81 rows): the bare marker and `…for tool use`. Both caught by one prefix. What it conveys — that the turn was interrupted — is already obvious from the message that follows.

**The filter had to go in two places**, which is the part worth noting. It already existed on the durable path, but user events only started fanning out live in #471. A filter on one path alone would have dropped the marker from history *while still pushing it live* — so it would appear, then vanish on reload. Same rule, both paths, asserted together.

Prefix-anchored as always: asking *about* the marker is a real message and still survives.

Backend 1,754 · ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)