### PR TITLE
feat(chat): show that a session is WORKING, not just that something happened

### DIFF
--- a/frontend/packages/canopy-ui/src/chat/MessageList.tsx
+++ b/frontend/packages/canopy-ui/src/chat/MessageList.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState, type ReactNode } from "react";
-import { ChevronRight, ChevronsDownUp, ChevronsUpDown } from "lucide-react";
+import { ChevronRight, ChevronsDownUp, ChevronsUpDown, Loader2 } from "lucide-react";
 
 import type { Message } from "./protocol";
 import { Button } from "../ui/button";
@@ -7,7 +7,7 @@ import type { RenderMarkdown } from "./MessageItem";
 import { MessageItem } from "./MessageItem";
 import { ToolCallPair } from "./ToolCallPair";
 import { pairToolMessages } from "./pairToolMessages";
-import { groupToolRuns, runHasError, summariseRun } from "./groupToolRuns";
+import { groupToolRuns, runHasError, runIsActive, summariseRun } from "./groupToolRuns";
 
 interface Props {
   messages: Message[];
@@ -80,6 +80,9 @@ export function MessageList({ messages, emptyState, renderMarkdown }: Props) {
             // toggle says so, and always when something in it failed — a
             // collapsed group must never hide an error.
             const failed = runHasError(row.rows);
+            // A run with a call still in flight must say so: collapsed, an agent
+            // mid-task would otherwise look idle.
+            const active = runIsActive(row.rows);
             return (
               <details
                 key={row.key}
@@ -91,6 +94,11 @@ export function MessageList({ messages, emptyState, renderMarkdown }: Props) {
                   <span className="text-xs font-medium text-foreground">
                     {summariseRun(row.rows)}
                   </span>
+                  {active && (
+                    <span className="flex items-center gap-1 text-xs text-muted-foreground">
+                      <Loader2 className="h-3 w-3 animate-spin" /> running
+                    </span>
+                  )}
                   {failed && (
                     <span className="text-xs font-medium text-destructive">
                       · contains an error

--- a/frontend/packages/canopy-ui/src/chat/groupToolRuns.test.ts
+++ b/frontend/packages/canopy-ui/src/chat/groupToolRuns.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 
-import { MIN_RUN_TO_GROUP, groupToolRuns, runHasError, summariseRun } from "./groupToolRuns"
+import { MIN_RUN_TO_GROUP, groupToolRuns, runHasError, runIsActive, summariseRun } from "./groupToolRuns"
 import type { ChatRow } from "./pairToolMessages"
 import type { Message } from "./protocol"
 
@@ -67,5 +67,15 @@ describe("groupToolRuns", () => {
   it("a session of only prose is untouched", () => {
     const out = groupToolRuns([prose(1), prose(2)])
     expect(out.map((r) => r.kind)).toEqual(["message", "message"])
+  })
+})
+
+describe("runIsActive", () => {
+  it("a run with a call still in flight reports active", () => {
+    // Collapsed, an agent mid-task would otherwise look idle — which is the
+    // exact question "is this session working?" asks.
+    const pending: ChatRow = { kind: "tool_pair", use: msg({ id: "u9" }), result: null, key: "pair-9" }
+    expect(runIsActive([pair(1), pending])).toBe(true)
+    expect(runIsActive([pair(1), pair(2)])).toBe(false)
   })
 })

--- a/frontend/packages/canopy-ui/src/chat/groupToolRuns.ts
+++ b/frontend/packages/canopy-ui/src/chat/groupToolRuns.ts
@@ -51,6 +51,12 @@ export function groupToolRuns(
   return out;
 }
 
+/** True when any call in the run is still running — a collapsed group should say
+ *  so, or an agent mid-task looks idle. */
+export function runIsActive(rows: ChatRow[]): boolean {
+  return rows.some((row) => row.kind === "tool_pair" && row.result === null);
+}
+
 /** A short label for a collapsed run: "5 tool calls · Bash, Read". */
 export function summariseRun(rows: ChatRow[]): string {
   const names = new Set<string>();

--- a/frontend/packages/canopy-ui/src/chat/sessionReducer.test.ts
+++ b/frontend/packages/canopy-ui/src/chat/sessionReducer.test.ts
@@ -439,3 +439,56 @@ describe("sessionReducer — live/durable reconciliation", () => {
     expect(next.messages).toHaveLength(1)
   })
 })
+
+describe("sessionReducer — pending → complete lifecycle", () => {
+  const mk = (status: string, id = "seq:-1") =>
+    ({
+      event: "chat.tool_use",
+      data: {
+        parent_message_id: null,
+        tool_message_id: id,
+        turn_index: -1,
+        block: { id: "toolu_LIVE", name: "Bash", input: { command: "npm test" }, status, text: "" },
+      },
+    }) as WsEvent
+
+  it("a pending row from PreToolUse appears immediately, with no result", () => {
+    // The whole point: a long tool call should read as RUNNING, not as nothing
+    // happening. Before PreToolUse was forwarded, the row only appeared once the
+    // call had already finished.
+    const next = sessionReducer(makeState(), mk("pending"))
+    expect(next.messages).toHaveLength(1)
+    expect(next.messages[0].role).toBe("tool_use")
+    expect(next.messages[0].content.status).toBe("pending")
+    // No tool_result row — that's what makes ToolCallPair render "running…".
+    expect(next.messages.some((m) => m.role === "tool_result")).toBe(false)
+  })
+
+  it("the completed row REPLACES the pending one rather than doubling it", () => {
+    const pending = sessionReducer(makeState(), mk("pending"))
+    const done = sessionReducer(pending, mk("complete", "seq:-1"))
+    expect(done.messages).toHaveLength(1)
+    expect(done.messages[0].content.status).toBe("complete")
+  })
+
+  it("the durable transcript row then supersedes both", () => {
+    // Three deliveries of one call — pending hook, completed hook, transcript —
+    // must converge on a single row carrying the durable identity.
+    const durable = {
+      event: "chat.tool_use",
+      data: {
+        parent_message_id: null,
+        tool_message_id: "991",
+        turn_index: 4096,
+        block: { id: "toolu_LIVE", name: "Bash", input: { command: "npm test" }, text: "" },
+      },
+    } as WsEvent
+    const settled = sessionReducer(
+      sessionReducer(sessionReducer(makeState(), mk("pending")), mk("complete")),
+      durable,
+    )
+    expect(settled.messages).toHaveLength(1)
+    expect(settled.messages[0].id).toBe("991")
+    expect(settled.messages[0].turn_index).toBe(4096)
+  })
+})

--- a/packages/canopy_runner/canopy_runner/hook_install.py
+++ b/packages/canopy_runner/canopy_runner/hook_install.py
@@ -1,4 +1,4 @@
-"""Install canopy's PostToolUse hook into the USER-level Claude Code settings.
+"""Install canopy's tool-lifecycle hooks into the USER-level Claude Code settings.
 
 User level (`~/.claude/settings.json`), deliberately, for two reasons:
 
@@ -14,9 +14,10 @@ User level (`~/.claude/settings.json`), deliberately, for two reasons:
 
 The command mirrors emdash's own idiom (`curl -sf … || true`), which is the
 established pattern on these machines: silent, short-timeout, and incapable of
-failing the hook. `PostToolUse` cannot block a tool call the way `PreToolUse`
-can, but the `|| true` and `--max-time` still matter — a hook that hangs is a
-hook that slows every tool call the agent makes.
+failing the hook. That matters most for `PreToolUse`, which CAN block a tool
+call — ours cannot, because it never returns a decision and gives up after two
+seconds. It matters for `PostToolUse` too: a hook that hangs slows every tool
+call the agent makes, whether or not it can deny one.
 """
 from __future__ import annotations
 
@@ -26,7 +27,14 @@ from pathlib import Path
 
 logger = logging.getLogger("canopy_runner.hooks")
 
-HOOK_EVENT = "PostToolUse"
+# Both halves of the lifecycle. PreToolUse gives "started" the instant a call
+# begins, PostToolUse gives the result — together they turn the view from
+# "something happened" into "it is running `npm test` right now".
+#
+# Safe despite PreToolUse being able to block a tool call: our hook is
+# fire-and-forget with a hard 2s cap and never returns a decision, so it has no
+# mechanism to deny or stall one.
+HOOK_EVENTS = ("PreToolUse", "PostToolUse")
 # Marks the entry as ours so install/remove are idempotent and we never touch
 # a hook somebody else put there.
 MARKER = "canopy-hook-listener"
@@ -76,11 +84,12 @@ def install(settings_path: Path, *, port: int, nonce: str) -> bool:
     if not isinstance(hooks, dict):
         logger.warning("hooks in %s is not an object; refusing to touch it", settings_path)
         return False
-    entries = [e for e in hooks.get(HOOK_EVENT, [])
-               if isinstance(e, dict) and not _is_ours(e)]
-    entries.append({"hooks": [{"type": "command",
-                               "command": hook_command(port, nonce)}]})
-    hooks[HOOK_EVENT] = entries
+    for event in HOOK_EVENTS:
+        entries = [e for e in hooks.get(event, [])
+                   if isinstance(e, dict) and not _is_ours(e)]
+        entries.append({"hooks": [{"type": "command",
+                                   "command": hook_command(port, nonce)}]})
+        hooks[event] = entries
     try:
         settings_path.parent.mkdir(parents=True, exist_ok=True)
         settings_path.write_text(json.dumps(settings, indent=2) + "\n")
@@ -99,16 +108,21 @@ def remove(settings_path: Path) -> bool:
     """
     settings = _load(settings_path)
     hooks = settings.get("hooks")
-    if not isinstance(hooks, dict) or HOOK_EVENT not in hooks:
+    if not isinstance(hooks, dict):
         return False
-    kept = [e for e in hooks.get(HOOK_EVENT, [])
-            if isinstance(e, dict) and not _is_ours(e)]
-    if len(kept) == len(hooks.get(HOOK_EVENT, [])):
-        return False  # nothing of ours to remove
-    if kept:
-        hooks[HOOK_EVENT] = kept
-    else:
-        hooks.pop(HOOK_EVENT)
+    changed = False
+    for event in HOOK_EVENTS:
+        existing = hooks.get(event, [])
+        kept = [e for e in existing if isinstance(e, dict) and not _is_ours(e)]
+        if len(kept) == len(existing):
+            continue  # nothing of ours under this event
+        changed = True
+        if kept:
+            hooks[event] = kept
+        else:
+            hooks.pop(event)
+    if not changed:
+        return False
     try:
         settings_path.write_text(json.dumps(settings, indent=2) + "\n")
     except OSError as exc:

--- a/packages/canopy_runner/tests/test_hook_listener.py
+++ b/packages/canopy_runner/tests/test_hook_listener.py
@@ -82,9 +82,11 @@ def test_install_is_idempotent_and_refreshes_in_place(tmp_path):
     p = tmp_path / "settings.json"
     assert hook_install.install(p, port=8787, nonce="a") is True
     assert hook_install.install(p, port=9999, nonce="b") is True
-    entries = json.loads(p.read_text())["hooks"]["PostToolUse"]
-    assert len(entries) == 1, "a re-install must replace, not accumulate"
-    assert "9999" in entries[0]["hooks"][0]["command"]
+    hooks = json.loads(p.read_text())["hooks"]
+    for event in hook_install.HOOK_EVENTS:
+        entries = hooks[event]
+        assert len(entries) == 1, f"{event}: a re-install must replace, not accumulate"
+        assert "9999" in entries[0]["hooks"][0]["command"]
     assert "nonce" not in entries[0]["hooks"][0]["command"]
 
 
@@ -225,3 +227,28 @@ def test_an_idle_tick_does_not_consume_the_report_window(caplog):
         assert "1 received" in caplog.text, "the idle tick swallowed the first real report"
     finally:
         main_mod._hook_listener = None
+
+
+def test_install_covers_both_halves_of_the_lifecycle(tmp_path):
+    """PreToolUse gives "started", PostToolUse gives the result. Only installing
+    the second is what made a long tool call look like nothing happening."""
+    p = tmp_path / "settings.json"
+    hook_install.install(p, port=8787, nonce="a")
+    hooks = json.loads(p.read_text())["hooks"]
+    assert set(hook_install.HOOK_EVENTS) == {"PreToolUse", "PostToolUse"}
+    for event in hook_install.HOOK_EVENTS:
+        assert any(hook_install.MARKER in h["command"]
+                   for e in hooks[event] for h in e["hooks"]), event
+
+
+def test_remove_clears_both_events_and_spares_foreign_hooks(tmp_path):
+    p = tmp_path / "settings.json"
+    p.write_text(json.dumps({"hooks": {
+        "PreToolUse": [{"hooks": [{"type": "command", "command": "someone-elses-pre"}]}],
+    }}))
+    hook_install.install(p, port=8787, nonce="a")
+    assert hook_install.remove(p) is True
+    hooks = json.loads(p.read_text())["hooks"]
+    assert [h["command"] for e in hooks["PreToolUse"] for h in e["hooks"]] == ["someone-elses-pre"]
+    assert "PostToolUse" not in hooks   # ours was the only entry there
+    assert hook_install.remove(p) is False

--- a/packages/canopy_transcript/canopy_transcript/__init__.py
+++ b/packages/canopy_transcript/canopy_transcript/__init__.py
@@ -5,7 +5,13 @@ Re-exports the names consumers actually use so a caller writes
 into a submodule.
 """
 from .batching import TRANSCRIPT_BATCH_MAX_BYTES, chunk_raw_lines
-from .hooks import FORWARDED_EVENTS, events_for_hook, rows_for_hook
+from .hooks import (
+    FORWARDED_EVENTS,
+    STATUS_COMPLETE,
+    STATUS_PENDING,
+    events_for_hook,
+    rows_for_hook,
+)
 from .paths import (
     emdash_task_candidates,
     encode_project_dir,
@@ -31,7 +37,8 @@ from .rows import (
 from .tail import TailReader
 
 __all__ = [
-    "BLOCK_STRIDE", "FORWARDED_EVENTS", "TOOL_INPUT_JSON_MAX", "TOOL_INPUT_STR_MAX", "TOOL_TEXT_MAX",
+    "BLOCK_STRIDE", "FORWARDED_EVENTS", "STATUS_COMPLETE", "STATUS_PENDING",
+    "TOOL_INPUT_JSON_MAX", "TOOL_INPUT_STR_MAX", "TOOL_TEXT_MAX",
     "TRANSCRIPT_BATCH_MAX_BYTES", "TailReader", "assistant_text", "chunk_raw_lines",
     "compose_index", "conversational_messages", "encode_project_dir", "end_index",
     "emdash_task_candidates", "events_for_hook", "parse_emdash_worktree",

--- a/packages/canopy_transcript/canopy_transcript/hooks.py
+++ b/packages/canopy_transcript/canopy_transcript/hooks.py
@@ -24,10 +24,27 @@ from __future__ import annotations
 
 from .rows import row_payload, scrub, _tool_input, _tool_result_text
 
-# The hook events worth forwarding. PreToolUse is deliberately absent: it can
-# BLOCK a tool call, and nothing about observability should be able to stall an
-# agent. PostToolUse alone already carries input and result together.
-FORWARDED_EVENTS = ("PostToolUse", "PostToolUseFailure")
+# PreToolUse fires when a call STARTS, PostToolUse when it finishes. Both are
+# forwarded, which is what turns the view from "something happened" into a
+# lifecycle: a row appears the instant a tool starts and fills in when it
+# completes.
+#
+# PreToolUse was excluded at first because it CAN block a tool call. That risk
+# belongs to a hook that denies or hangs; ours does neither — it is
+# fire-and-forget with a hard 2s cap and never returns a decision, so it has no
+# way to stall an agent. The safety argument does not survive the hook being
+# unable to answer.
+#
+# This also happens to be the shape ACP already specifies (`tool_call` then
+# `tool_call_update`, carrying a status), so it is the right model to converge
+# on rather than a stopgap.
+FORWARDED_EVENTS = ("PreToolUse", "PostToolUse", "PostToolUseFailure")
+
+# A pending call has no result yet. The client renders it as "running…" and
+# replaces it when the matching PostToolUse (or the transcript row) lands, keyed
+# on tool_use_id.
+STATUS_PENDING = "pending"
+STATUS_COMPLETE = "complete"
 
 
 def _result_text(response) -> str:
@@ -59,20 +76,38 @@ def _is_error(payload: dict) -> bool:
 def rows_for_hook(payload: dict) -> list[dict]:
     """The live chat rows one hook event contributes.
 
-    Returns the tool_use and its tool_result as a pair, since PostToolUse
-    carries both. `index` is -1 on every row: live events are a view overlay and
-    must never be persisted (see the module docstring).
+    PreToolUse yields the tool_use ALONE — the call has started and has no
+    result yet, so the client shows it as running. PostToolUse yields the pair,
+    because it carries input and result together, and its tool_use row replaces
+    the pending one by `tool_use_id`.
+
+    `index` is -1 on every row: live events are a view overlay and must never be
+    persisted (see the module docstring).
 
     Returns [] for any event that isn't a forwarded tool event, or that carries
     no `tool_use_id` — without that key a row cannot be reconciled against its
     durable counterpart, and an unreconcilable row would duplicate forever.
     """
-    if payload.get("hook_event_name") not in FORWARDED_EVENTS:
+    event = payload.get("hook_event_name")
+    if event not in FORWARDED_EVENTS:
         return []
     tool_use_id = payload.get("tool_use_id")
     if not isinstance(tool_use_id, str) or not tool_use_id:
         return []
     name = scrub(str(payload.get("tool_name") or ""))
+    if event == "PreToolUse":
+        # Starting: the tool_use row only. No tool_result is emitted, precisely
+        # so the UI can show "running…" rather than a call that looks finished
+        # with an empty result.
+        return [{
+            "index": -1, "role": "tool_use", "text": "",
+            "content": {
+                "id": tool_use_id,
+                "name": name,
+                "input": _tool_input(payload.get("tool_input")),
+                "status": STATUS_PENDING,
+            },
+        }]
     return [
         {
             "index": -1, "role": "tool_use", "text": "",
@@ -80,6 +115,7 @@ def rows_for_hook(payload: dict) -> list[dict]:
                 "id": tool_use_id,
                 "name": name,
                 "input": _tool_input(payload.get("tool_input")),
+                "status": STATUS_COMPLETE,
             },
         },
         {

--- a/packages/canopy_transcript/tests/test_hooks.py
+++ b/packages/canopy_transcript/tests/test_hooks.py
@@ -27,7 +27,7 @@ def test_one_hook_event_is_a_complete_tool_pair():
     use, result = ct.rows_for_hook(_payload())
     assert use["role"] == "tool_use"
     assert use["content"] == {"id": "toolu_01ABC", "name": "Bash",
-                              "input": {"command": "ls"}}
+                              "input": {"command": "ls"}, "status": "complete"}
     assert result["role"] == "tool_result"
     assert result["content"] == {"tool_use_id": "toolu_01ABC", "is_error": False}
     assert result["text"] == "a.txt"
@@ -48,11 +48,27 @@ def test_an_event_with_no_tool_use_id_is_dropped():
     assert ct.rows_for_hook(_payload(tool_use_id=None)) == []
 
 
-def test_pretooluse_is_never_forwarded():
-    """PreToolUse can BLOCK a tool call. Observability must not be able to stall
-    an agent, so it is not in the forwarded set at all."""
-    assert "PreToolUse" not in ct.FORWARDED_EVENTS
-    assert ct.rows_for_hook(_payload(hook_event_name="PreToolUse")) == []
+def test_pretooluse_yields_a_pending_row_and_no_result():
+    """The point of forwarding PreToolUse: a row the instant the call STARTS, so
+    a long tool call reads as running rather than as nothing happening. It must
+    NOT emit a tool_result — an empty result would render as a finished call.
+
+    Safe to forward because our hook cannot block: fire-and-forget, 2s cap, and
+    it never returns a decision."""
+    rows = ct.rows_for_hook(_payload(hook_event_name="PreToolUse", tool_response=None))
+    assert len(rows) == 1
+    assert rows[0]["role"] == "tool_use"
+    assert rows[0]["content"]["status"] == "pending"
+    assert rows[0]["content"]["name"] == "Bash"
+
+
+def test_the_completed_row_replaces_the_pending_one_by_id():
+    """Both carry the same tool_use_id, which is what lets the client upsert
+    rather than show the call twice — once running, once done."""
+    pre = ct.rows_for_hook(_payload(hook_event_name="PreToolUse"))[0]
+    post_use = ct.rows_for_hook(_payload())[0]
+    assert pre["content"]["id"] == post_use["content"]["id"]
+    assert (pre["content"]["status"], post_use["content"]["status"]) == ("pending", "complete")
 
 
 def test_a_failure_event_marks_the_result_as_an_error():


### PR DESCRIPTION
Answers the question directly: *can canopy-web show that the session is working?*

## The gap

- The `running` badge means "runner online **and** `last_interacted_at` within 120s" — lags up to two minutes, can't tell thinking from wedged.
- Only `PostToolUse` was forwarded, so a tool call appeared **only once it had finished**. A 90-second `npm test` looked like nothing happening.

## The fix

`PreToolUse` is forwarded too, giving a real lifecycle:

| | |
|---|---|
| `PreToolUse` | row appears immediately, `status=pending`, **no** `tool_result` |
| `PostToolUse` | replaces it by `tool_use_id`, `status=complete` + result |
| transcript row | supersedes both, adopting the durable ordinal |

Three deliveries of one call → **one row**. `ToolCallPair` already rendered `running…` when a result is absent, so that code needed no change.

**On the safety reversal:** I excluded `PreToolUse` originally because it *can* block a tool call. That risk belongs to a hook that **denies or hangs**. Ours does neither — fire-and-forget, hard 2s cap, never returns a decision. The argument doesn't survive the hook being unable to answer.

## Also: collapsed runs no longer look idle

Grouping fixed the wall-of-Bash, but introduced a new way to look dead — an agent mid-task collapsed into one quiet line. A run with a call in flight now shows a spinner and `running`.

## Converges on ACP

This is deliberately the shape ACP specifies (`tool_call` → `tool_call_update` with a `status`), so it moves toward the protocol we intend to adopt rather than being a stopgap.

Backend 1,754 · runner 213 · transcript 26 · frontend 95 · build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)