### PR TITLE
fix(chat): use the emdash session name as the title, and show "working" while thinking

### DIFF
--- a/apps/canopy_sessions/autotitle.py
+++ b/apps/canopy_sessions/autotitle.py
@@ -20,6 +20,21 @@ from .models import Message, Session
 TITLE_MAX = 80
 
 
+def _runner_binding(session):
+    """The session's RunnerBinding, or None. Local import keeps this module free
+    of an import cycle with models that reference harness."""
+    from .models import RunnerBinding
+
+    return RunnerBinding.objects.filter(session=session).first()
+
+
+def _publish_title(session) -> None:
+    groups.publish(
+        groups.session_group(session.pk),
+        {"type": "session.title_updated", "title": session.title},
+    )
+
+
 def maybe_autotitle(session_id) -> str | None:
     """Title an untitled session from its first user message. No-op (returns
     None) if the session already has a title, has no user message yet, or that
@@ -28,6 +43,24 @@ def maybe_autotitle(session_id) -> str | None:
     with transaction.atomic():
         session = Session.objects.select_for_update().get(pk=session_id)
         if session.title:
+            return None
+        # A session a runner backs is ALREADY named — by the emdash task the
+        # human sees in their own sidebar. That name is what they navigate by, so
+        # inventing a title from the first message actively makes the session
+        # harder to find (observed 2026-07-27: "I think we basically implemented
+        # everything we need to…" where the sidebar said
+        # "canopy-web-api-7716-0726-1521").
+        #
+        # The binding is checked rather than `origin`, deliberately: a session
+        # created on the phone still ends up driven by emdash, and the emdash name
+        # is the right title either way. Origin says where it STARTED; the binding
+        # says what is running it.
+        binding = _runner_binding(session)
+        if binding is not None and binding.session_key:
+            if session.title != binding.session_key:
+                session.title = binding.session_key[:200]
+                session.save(update_fields=["title"])
+                _publish_title(session)
             return None
         first = (
             Message.objects.filter(session=session, role=Message.USER)

--- a/apps/canopy_sessions/stream_map.py
+++ b/apps/canopy_sessions/stream_map.py
@@ -20,6 +20,13 @@ def turn_event_to_frames(evt: dict, resolve_message_id: Callable[[int], str]) ->
     seq = evt.get("seq")
     payload = evt.get("payload") or {}
 
+    if isinstance(kind, str) and kind.startswith("activity:"):
+        # A turn boundary, not a chat row. It answers "is the agent working right
+        # now" — which nothing else could: between a prompt and the first tool
+        # call Claude is thinking and emits no content at all, so the session read
+        # as idle for the most interesting part of a turn.
+        return [{"event": "session.activity",
+                 "data": {"state": kind.split(":", 1)[1]}}]
     if kind == "user":
         # Text a human typed straight into emdash. It reaches no web client any
         # other way — there was no optimistic echo, because no web client sent

--- a/apps/harness/api.py
+++ b/apps/harness/api.py
@@ -570,6 +570,16 @@ def post_session_stream(request: HttpRequest, runner_id: uuid.UUID, payload: Ses
         # applied only on the durable path would drop a harness marker from
         # history while still pushing it to every watching client — so it would
         # appear live, then vanish on reload. Same rule, both paths.
+        if e.kind.startswith("activity:"):
+            # Fans out, never persists — index -1 already excludes it from the
+            # durable write, and it has no transcript row to be.
+            groups.publish(sgroup, {
+                "type": "chat.turn_event",
+                "event": {"kind": e.kind, "seq": e.seq, "payload": e.payload},
+                "turn_id": None,
+            })
+            n += 1
+            continue
         if e.kind == "user" and is_system_noise((e.payload or {}).get("text", "")):
             n += 1
             continue

--- a/apps/harness/services.py
+++ b/apps/harness/services.py
@@ -1194,7 +1194,18 @@ def record_session(
         # which for an agent turn is an opaque hash (a real one leaked into the
         # Sessions list as "19f91250349ec91b"). Only retitle when the title is
         # still that fallback — never clobber a human-set chat title.
-        if emdash_task_id and binding.session.title == thread_key:
+        # Retitle when the current title is NOT a name the human chose. Two
+        # cases qualify: the raw thread_key fallback (an opaque hash for an agent
+        # turn — one leaked into the Sessions list as "19f91250349ec91b"), and an
+        # AUTOTITLE, which is the first user message truncated to 80 chars.
+        #
+        # The autotitle case is why this is more than an equality check: a
+        # phone-created session gets autotitled before any emdash task exists, so
+        # the old `title == thread_key` guard never matched and the session kept a
+        # sentence for a name while the sidebar showed the task
+        # (observed 2026-07-27). A human-set title is still never clobbered — it
+        # won't match the fallback and won't match the first message either.
+        if emdash_task_id and _title_is_derived(binding.session, thread_key):
             binding.session.title = emdash_task_id[:200]
             binding.session.save(update_fields=["title"])
         binding.live_seen_at = timezone.now()
@@ -1207,6 +1218,32 @@ def record_session(
 
 
 @transaction.atomic
+
+def _title_is_derived(session, thread_key: str) -> bool:
+    """True when a session's title was generated rather than chosen by a human.
+
+    Generated titles are safe to replace with the emdash task name; a title
+    somebody typed is not. Two generators exist: `_thread_session`'s raw
+    thread_key fallback, and `autotitle.maybe_autotitle`, which takes the first
+    user message, collapses whitespace and truncates to TITLE_MAX.
+    """
+    from apps.canopy_sessions.autotitle import TITLE_MAX
+    from apps.canopy_sessions.models import Message
+
+    title = (session.title or "").strip()
+    if not title or title == thread_key:
+        return True
+    first = (
+        Message.objects.filter(session=session, role=Message.USER)
+        .order_by("turn_index")
+        .values_list("plaintext", flat=True)
+        .first()
+    )
+    if not first:
+        return False
+    return title == " ".join(first.split())[:TITLE_MAX]
+
+
 def replace_reported_sessions(
     runner: Runner, workspace, sessions: list, archived: list[str] | None = None
 ) -> int:

--- a/frontend/packages/canopy-ui/src/chat/protocol.ts
+++ b/frontend/packages/canopy-ui/src/chat/protocol.ts
@@ -62,6 +62,10 @@ export interface Participant {
 
 export interface SessionState {
   messages: Message[];
+  /** Live agent activity, from the runner's turn-boundary hooks. Undefined when
+   *  no hook has reported yet — the caller then falls back to the server's
+   *  coarser `running` flag. */
+  activity?: "working" | "idle";
   active_draft: Draft | null;
   participants: Participant[];
   presence_user_ids: number[];
@@ -85,6 +89,9 @@ export type WsEvent =
   | { event: "session.error"; data: { code: string; message: string; detail?: unknown } }
   | { event: "session.title_updated"; data: { title: string } }
   | { event: "chat.stream_start"; data: { message_id: string; turn_index: number } }
+  // The agent started or finished a turn. Distinct from tool events: it fires
+  // while Claude is THINKING, before any content exists to show.
+  | { event: "session.activity"; data: { state: "working" | "idle" } }
   // A human typed into emdash rather than into this page. No client echoed it,
   // so this is the only way it reaches the browser before a reload.
   | { event: "chat.user_message"; data: { message_id: string; turn_index: number; plaintext: string } }

--- a/frontend/packages/canopy-ui/src/chat/sessionReducer.ts
+++ b/frontend/packages/canopy-ui/src/chat/sessionReducer.ts
@@ -50,6 +50,9 @@ export function sessionReducer(prev: SessionState, frame: WsEvent): SessionState
       return { ...prev, messages: [...prev.messages, assistant] };
     }
 
+    case "session.activity":
+      return { ...prev, activity: frame.data.state };
+
     case "chat.user_message": {
       // Someone typed into emdash, OR into this page. Both reach here, and that
       // is why matching on turn_index alone is not enough: a web send writes its

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -408,17 +408,29 @@ export function ChatPage() {
     </div>
   )
 
+  // undefined = no hook has reported for this session yet, so defer to the
+  // server's coarser flag rather than asserting idle.
+  const liveWorking =
+    socket.state.activity === undefined
+      ? undefined
+      : socket.state.activity === "working";
   const title = meta?.title?.trim() || 'Chat'
 
   return (
     <div className="flex h-full flex-col">
       <div className="flex items-center gap-2 border-b border-border bg-background px-4 py-2">
         <h1 className="truncate text-sm font-semibold text-foreground">{title}</h1>
-        {/* Running/idle indicator, from the unified session's liveness fields. */}
-        {meta?.running ? (
+        {/* Live agent activity beats the server's liveness fields when a hook has
+            reported. `meta.running` derives from the runner's session report —
+            emdash's own last_interacted_at, on a report cycle with a 120s window
+            — so it could not show "working" during the part of a turn where
+            Claude is thinking and nothing has been output yet. The hook fires the
+            instant the turn starts. Falls back to `meta.running` when no hook has
+            spoken (an older runner, or forwarding off). */}
+        {(liveWorking ?? meta?.running) ? (
           <span className="flex shrink-0 items-center gap-1 text-[12px] font-medium text-success">
             <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-success" />
-            running{meta.runner_name ? ` · ${meta.runner_name}` : ''}
+            running{meta?.runner_name ? ` · ${meta.runner_name}` : ''}
           </span>
         ) : meta?.runner_name ? (
           <span className="shrink-0 text-[12px] text-muted-foreground">

--- a/packages/canopy_runner/canopy_runner/hook_install.py
+++ b/packages/canopy_runner/canopy_runner/hook_install.py
@@ -34,7 +34,14 @@ logger = logging.getLogger("canopy_runner.hooks")
 # Safe despite PreToolUse being able to block a tool call: our hook is
 # fire-and-forget with a hard 2s cap and never returns a decision, so it has no
 # mechanism to deny or stall one.
-HOOK_EVENTS = ("PreToolUse", "PostToolUse")
+# Tool lifecycle plus turn boundaries. UserPromptSubmit/Stop are what make a
+# session read as WORKING before its first tool call — while Claude is thinking,
+# nothing else fires at all.
+#
+# emdash also hooks UserPromptSubmit and Stop, at PROJECT level, pointing at its
+# own port. Both run: Claude Code executes every matching hook, and ours is
+# additive rather than a replacement.
+HOOK_EVENTS = ("PreToolUse", "PostToolUse", "UserPromptSubmit", "Stop")
 # Marks the entry as ours so install/remove are idempotent and we never touch
 # a hook somebody else put there.
 MARKER = "canopy-hook-listener"

--- a/packages/canopy_runner/canopy_runner/hook_listener.py
+++ b/packages/canopy_runner/canopy_runner/hook_listener.py
@@ -31,7 +31,7 @@ import logging
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
-from canopy_transcript import events_for_hook
+from canopy_transcript import activity_for_hook, events_for_hook
 
 logger = logging.getLogger("canopy_runner.hooks")
 
@@ -65,6 +65,22 @@ class HookListener:
         and tests. Never raises — the caller must answer 200 regardless."""
         self.received += 1
         try:
+            activity = activity_for_hook(payload)
+            if activity is not None:
+                cwd = payload.get("cwd") or ""
+                session_id = self._resolve_session(cwd)
+                if not session_id:
+                    self.dropped_unknown_cwd += 1
+                    return "unknown-cwd"
+                if not self._forward():
+                    return "not-forwarding"
+                # A state transition, not a chat row: index -1 so it is never
+                # persisted, and a dedicated kind the server maps to a status
+                # frame rather than a message.
+                self._send(session_id, [{"kind": f"activity:{activity}",
+                                         "seq": -1, "index": -1, "payload": {}}])
+                self.forwarded += 1
+                return f"activity:{activity}"
             events = events_for_hook(payload)
             if not events:
                 return "ignored"          # not a forwarded event kind

--- a/packages/canopy_runner/tests/test_hook_listener.py
+++ b/packages/canopy_runner/tests/test_hook_listener.py
@@ -70,9 +70,28 @@ def test_a_failing_transport_never_raises_at_the_hook():
     assert lis.handle_payload(_payload()) == "error"   # not an exception
 
 
-def test_non_tool_events_are_ignored():
+def test_a_truly_unrelated_event_is_ignored():
     lis, sent = _listener()
-    assert lis.handle_payload(_payload(hook_event_name="Stop")) == "ignored"
+    assert lis.handle_payload(_payload(hook_event_name="Notification")) == "ignored"
+    assert sent == []
+
+
+def test_turn_boundaries_report_working_and_idle():
+    """The gap the tool events could not cover: between submitting a prompt and
+    the first tool call, Claude is THINKING and emits nothing, so the session
+    read as idle for the most interesting part of a turn."""
+    lis, sent = _listener()
+    assert lis.handle_payload(_payload(hook_event_name="UserPromptSubmit")) == "activity:working"
+    assert lis.handle_payload(_payload(hook_event_name="Stop")) == "activity:idle"
+    assert [e[1][0]["kind"] for e in sent] == ["activity:working", "activity:idle"]
+    # State transitions, never persisted.
+    assert all(e[1][0]["index"] == -1 for e in sent)
+
+
+def test_activity_for_an_unknown_cwd_is_dropped_too():
+    lis, sent = _listener()
+    assert lis.handle_payload(
+        _payload(hook_event_name="UserPromptSubmit", cwd="/elsewhere")) == "unknown-cwd"
     assert sent == []
 
 
@@ -235,7 +254,8 @@ def test_install_covers_both_halves_of_the_lifecycle(tmp_path):
     p = tmp_path / "settings.json"
     hook_install.install(p, port=8787, nonce="a")
     hooks = json.loads(p.read_text())["hooks"]
-    assert set(hook_install.HOOK_EVENTS) == {"PreToolUse", "PostToolUse"}
+    assert set(hook_install.HOOK_EVENTS) == {
+        "PreToolUse", "PostToolUse", "UserPromptSubmit", "Stop"}
     for event in hook_install.HOOK_EVENTS:
         assert any(hook_install.MARKER in h["command"]
                    for e in hooks[event] for h in e["hooks"]), event

--- a/packages/canopy_transcript/canopy_transcript/__init__.py
+++ b/packages/canopy_transcript/canopy_transcript/__init__.py
@@ -6,9 +6,11 @@ into a submodule.
 """
 from .batching import TRANSCRIPT_BATCH_MAX_BYTES, chunk_raw_lines
 from .hooks import (
+    ACTIVITY_EVENTS,
     FORWARDED_EVENTS,
     STATUS_COMPLETE,
     STATUS_PENDING,
+    activity_for_hook,
     events_for_hook,
     rows_for_hook,
 )
@@ -37,11 +39,11 @@ from .rows import (
 from .tail import TailReader
 
 __all__ = [
-    "BLOCK_STRIDE", "FORWARDED_EVENTS", "STATUS_COMPLETE", "STATUS_PENDING",
+    "ACTIVITY_EVENTS", "BLOCK_STRIDE", "FORWARDED_EVENTS", "STATUS_COMPLETE", "STATUS_PENDING",
     "TOOL_INPUT_JSON_MAX", "TOOL_INPUT_STR_MAX", "TOOL_TEXT_MAX",
     "TRANSCRIPT_BATCH_MAX_BYTES", "TailReader", "assistant_text", "chunk_raw_lines",
     "compose_index", "conversational_messages", "encode_project_dir", "end_index",
-    "emdash_task_candidates", "events_for_hook", "parse_emdash_worktree",
+    "activity_for_hook", "emdash_task_candidates", "events_for_hook", "parse_emdash_worktree",
     "read_records", "resolve_cli_transcript",
     "resolve_emdash_transcript", "rows_for_hook",
     "row_payload", "rows_for_record", "scrub", "user_text",

--- a/packages/canopy_transcript/canopy_transcript/hooks.py
+++ b/packages/canopy_transcript/canopy_transcript/hooks.py
@@ -40,6 +40,18 @@ from .rows import row_payload, scrub, _tool_input, _tool_result_text
 # on rather than a stopgap.
 FORWARDED_EVENTS = ("PreToolUse", "PostToolUse", "PostToolUseFailure")
 
+# Turn-boundary events. These carry no chat content — they answer "is the agent
+# working RIGHT NOW", which the tool events cannot: between submitting a prompt
+# and the first tool call, Claude is thinking and emits nothing at all, so the
+# session read as idle for the most interesting part of a turn (reported
+# 2026-07-27: "the fact that it's running is still not being shown before any
+# text is output").
+#
+# `last_interacted_at` could not answer this either — it comes from emdash's own
+# DB via the session report, so it lags a report cycle and has a 120s window.
+# A hook fires the instant the turn starts.
+ACTIVITY_EVENTS = ("UserPromptSubmit", "Stop")
+
 # A pending call has no result yet. The client renders it as "running…" and
 # replaces it when the matching PostToolUse (or the transcript row) lands, keyed
 # on tool_use_id.
@@ -124,6 +136,20 @@ def rows_for_hook(payload: dict) -> list[dict]:
             "content": {"tool_use_id": tool_use_id, "is_error": _is_error(payload)},
         },
     ]
+
+
+def activity_for_hook(payload: dict) -> str | None:
+    """"working" / "idle" for a turn-boundary event, else None.
+
+    Separate from `rows_for_hook` because this is not a chat row — it is a state
+    transition, with nothing to render in the transcript and nothing to persist.
+    """
+    event = payload.get("hook_event_name")
+    if event == "UserPromptSubmit":
+        return "working"
+    if event == "Stop":
+        return "idle"
+    return None
 
 
 def events_for_hook(payload: dict) -> list[dict]:

--- a/tests/test_chat_autotitle.py
+++ b/tests/test_chat_autotitle.py
@@ -116,3 +116,39 @@ def test_non_assistant_turn_event_does_not_autotitle(ctx):
     harness_services.append_events(turn, [{"kind": "tool_start", "payload": {}}])
     session.refresh_from_db()
     assert session.title == ""
+
+
+def test_a_runner_backed_session_keeps_the_emdash_task_name():
+    """The name the human sees in their own emdash sidebar is what they navigate
+    by. Autotitling over it made the session HARDER to find — observed
+    2026-07-27: "I think we basically implemented everything we need to…" where
+    the sidebar said "canopy-web-api-7716-0726-1521"."""
+    from apps.canopy_sessions.models import RunnerBinding
+    from apps.harness.models import Runner
+
+    user = User.objects.create_user("t1", "t1@dimagi.com", "pw")
+    ws = Workspace.objects.create(slug="w-title", display_name="W", created_by=user)
+    WorkspaceMembership.objects.create(user=user, workspace=ws,
+                                       role=WorkspaceMembership.OWNER)
+    runner = Runner.objects.create(name="laptop", workspace=ws, location=Runner.LOCAL,
+                                   paired_by=user)
+    session = Session.objects.create(workspace=ws, created_by=user, title="")
+    RunnerBinding.objects.create(session=session, runner=runner,
+                                 session_key="canopy-web-api-7716")
+    Message.objects.create(session=session, turn_index=0, role=Message.USER,
+                           plaintext="I think we basically implemented everything")
+
+    assert autotitle.maybe_autotitle(session.pk) is None
+    session.refresh_from_db()
+    assert session.title == "canopy-web-api-7716"
+
+
+def test_a_session_with_no_runner_still_autotitles():
+    """Web-only sessions (the dev stub, a chat no runner ever picks up) have no
+    emdash name to defer to."""
+    user = User.objects.create_user("t2", "t2@dimagi.com", "pw")
+    ws = Workspace.objects.create(slug="w-title2", display_name="W", created_by=user)
+    session = Session.objects.create(workspace=ws, created_by=user, title="")
+    Message.objects.create(session=session, turn_index=0, role=Message.USER,
+                           plaintext="hello there")
+    assert autotitle.maybe_autotitle(session.pk) == "hello there"

--- a/tests/test_chat_stream_map.py
+++ b/tests/test_chat_stream_map.py
@@ -1,6 +1,7 @@
 """TurnEvent -> canonical chat.* frame translation (pure)."""
 from __future__ import annotations
 
+from apps.canopy_sessions import stream_map
 from apps.canopy_sessions.stream_map import turn_event_to_frames
 
 
@@ -92,3 +93,14 @@ def test_a_user_event_becomes_a_client_frame():
     assert frames[0]["data"]["plaintext"] == "do the thing"
     # The ordinal rides along so the client upserts instead of appending.
     assert frames[0]["data"]["turn_index"] == 64
+
+
+def test_an_activity_event_becomes_a_status_frame():
+    """Turn boundaries answer "is the agent working right now" — which nothing
+    else could. Between a prompt and the first tool call, Claude is thinking and
+    emits no content at all, so the session read as idle for the most
+    interesting part of a turn."""
+    for kind, state in (("activity:working", "working"), ("activity:idle", "idle")):
+        frames = stream_map.turn_event_to_frames(
+            {"kind": kind, "seq": -1, "payload": {}}, lambda seq: f"seq:{seq}")
+        assert frames == [{"event": "session.activity", "data": {"state": state}}]

--- a/tests/test_harness_session_streams.py
+++ b/tests/test_harness_session_streams.py
@@ -180,3 +180,19 @@ def test_harness_markers_are_not_pushed_live_either(monkeypatch):
     assert texts == ["something I actually typed"]
     # And it is absent from history too, so the two agree.
     assert [m.plaintext for m in s.messages.all()] == ["something I actually typed"]
+
+
+def test_activity_events_fan_out_and_never_persist(monkeypatch):
+    """A turn boundary is a state transition, not a chat row: it must reach every
+    watching client and leave no trace in the transcript."""
+    user, ws, runner, c = _ctx()
+    s = Session.objects.create(workspace=ws, origin=Session.ORIGIN_RUNNER, title="a")
+    RunnerBinding.objects.create(session=s, runner=runner, session_key="echo-1",
+                                 stream_desired=True)
+    published = []
+    monkeypatch.setattr("apps.realtime.groups.publish", lambda g, m: published.append(m))
+    _post_stream(c, runner, s, [
+        {"kind": "activity:working", "seq": -1, "index": -1, "payload": {}},
+    ])
+    assert [m["event"]["kind"] for m in published] == ["activity:working"]
+    assert s.messages.count() == 0


### PR DESCRIPTION
Two things spotted from watching a live session.

## 1. The title was the first message, not the session name

This session read *"I think we basically implemented everything we need to…"* while emdash's sidebar said `canopy-web-api-7716-0726-1521`. The sidebar name is what you navigate by — inventing one made the session **harder** to find.

The report already had a retitle, but it only fired when `title == thread_key`, which never matches an autotitled session. So a session created on the phone (autotitled before any emdash task existed) kept a sentence for a name forever.

- `maybe_autotitle` now **defers** to the binding's `session_key` when a runner backs the session
- the report retitles any *generated* title — `_title_is_derived` recognises both the `thread_key` fallback and an autotitle
- a **human-set title is still never clobbered**
- existing mistitled sessions repair themselves on the next session report

Keyed on the **binding**, not `origin`: a session created on the phone still ends up driven by emdash, and the emdash name is right either way. Origin says where it *started*; the binding says what's *running* it.

## 2. "running" didn't show before any output

`PreToolUse` covers tool calls, but between submitting a prompt and the first tool call Claude is **thinking and emits nothing** — so the session read as idle for the most interesting part of a turn.

`meta.running` couldn't cover it either: it derives from emdash's own `last_interacted_at` via the session report, so it lags a report cycle and has a 120s window.

`UserPromptSubmit`/`Stop` are now forwarded as **activity events** — a state transition, not a chat row, so `index = -1` keeps them out of the durable record entirely. The header prefers the live signal and falls back to `meta.running` when no hook has spoken (older runner, forwarding off) rather than asserting idle.

Backend 1,758 · runner 215 · transcript 26 · frontend 401 · build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)