### PR TITLE
fix(chat): the title repair went into a path that barely runs

### DIFF
--- a/apps/harness/services.py
+++ b/apps/harness/services.py
@@ -1318,6 +1318,21 @@ def replace_reported_sessions(
             binding.thread_key = f"emdash:{s.emdash_task}"
             binding.host = runner.host
         else:
+            # Correct a GENERATED title on an existing session. A brand-new
+            # session above is titled from the emdash task, but an existing one
+            # never was — so a session created on the phone kept its autotitle
+            # (the first user message, truncated) forever, while emdash's own
+            # sidebar showed the task name. The first fix went into
+            # `record_session`, which only runs when a TURN is routed; this is
+            # the path that runs every ~10s, which is why the repair never
+            # actually happened (observed 2026-07-27, after shipping it).
+            #
+            # `_title_is_derived` recognises only titles WE generated, so a title
+            # a human chose is still never touched.
+            if _title_is_derived(binding.session, binding.thread_key or ""):
+                if binding.session.title != s.emdash_task:
+                    binding.session.title = s.emdash_task[:200]
+                    binding.session.save(update_fields=["title"])
             # thread_key/host are the binding's durable IDENTITY. NEVER overwrite a
             # non-empty one — an existing binding may be owned by an agent/phone
             # thread (record_session) and this report loop must not steal it (see

--- a/tests/test_harness_emdash_sessions.py
+++ b/tests/test_harness_emdash_sessions.py
@@ -208,3 +208,50 @@ def test_list_is_newest_first_by_last_interacted_at():
     rows = c.get("/api/harness/sessions").json()
     tasks = [r["emdash_task"] for r in rows]
     assert tasks == ["newer", "older"]
+
+
+def test_the_report_corrects_an_autotitled_session():
+    """A session created on the phone is autotitled (first message, truncated)
+    before any emdash task exists, so it kept a sentence for a name while the
+    sidebar showed the task. The first fix went into `record_session`, which only
+    runs when a TURN is routed — this is the path that runs every ~10s, and
+    missing it is why the repair never happened (observed 2026-07-27, after
+    shipping it)."""
+    from django.test import Client
+
+    from apps.canopy_sessions.models import Message, RunnerBinding, Session
+
+    jj = _user("jj-title")
+    ws = _ws("dimagi-title", jj)
+    runner = _runner(jj, ws)
+    title = "I think we basically implemented everything"
+    session = Session.objects.create(workspace=ws, created_by=jj, title=title)
+    Message.objects.create(session=session, turn_index=0, role=Message.USER,
+                           plaintext=title)
+    RunnerBinding.objects.create(session=session, runner=runner,
+                                 session_key="canopy-web-api-7716",
+                                 thread_key="emdash:canopy-web-api-7716",
+                                 host=runner.host)
+    c = Client(); c.force_login(jj)
+    _report(c, runner.id, [{"emdash_task": "canopy-web-api-7716", "project": "canopy-web"}])
+    session.refresh_from_db()
+    assert session.title == "canopy-web-api-7716"
+
+
+def test_the_report_never_clobbers_a_title_a_human_chose():
+    from django.test import Client
+
+    from apps.canopy_sessions.models import RunnerBinding, Session
+
+    jj = _user("jj-human")
+    ws = _ws("dimagi-human", jj)
+    runner = _runner(jj, ws)
+    session = Session.objects.create(workspace=ws, created_by=jj, title="Ship the release")
+    RunnerBinding.objects.create(session=session, runner=runner,
+                                 session_key="canopy-web-api-7716",
+                                 thread_key="emdash:canopy-web-api-7716",
+                                 host=runner.host)
+    c = Client(); c.force_login(jj)
+    _report(c, runner.id, [{"emdash_task": "canopy-web-api-7716", "project": "canopy-web"}])
+    session.refresh_from_db()
+    assert session.title == "Ship the release"


### PR DESCRIPTION
#475 claimed existing mistitled sessions would repair themselves on the next session report. **They didn't** — verified against labs right after deploying, where this session's title stayed the first-message sentence through six report cycles.

The repair went into `record_session`, which only runs when a **turn is routed**. The session report — the thing that runs every ~10s — is `replace_reported_sessions`, and it titled a *brand-new* session from the emdash task while never correcting an *existing* one. The one case that needed repairing was the one case not covered.

Now the report retitles too, gated by the same `_title_is_derived` so a human-chosen title is still never touched.

**Why the tests passed anyway**, which is the part worth recording: they exercised `record_session` directly — a real path that genuinely worked. Nothing asserted the behaviour through the endpoint the runner actually calls ten times a minute. So *"the fix works"* and *"the fix runs"* came apart, and only checking production told them apart. The new tests go through `POST /runners/{id}/sessions`.

Backend 1,760.

🤖 Generated with [Claude Code](https://claude.com/claude-code)