### PR TITLE
fix(harness): a cosmetic retitle was 500ing the whole session report

### DIFF
--- a/apps/harness/services.py
+++ b/apps/harness/services.py
@@ -1329,10 +1329,27 @@ def replace_reported_sessions(
             #
             # `_title_is_derived` recognises only titles WE generated, so a title
             # a human chose is still never touched.
-            if _title_is_derived(binding.session, binding.thread_key or ""):
-                if binding.session.title != s.emdash_task:
-                    binding.session.title = s.emdash_task[:200]
-                    binding.session.save(update_fields=["title"])
+            # ISOLATED, and deliberately so. This is a COSMETIC repair inside the
+            # endpoint the runner calls every ~10s to report which sessions are
+            # alive — the one canopy reads liveness from. Shipping it unguarded
+            # 500'd the whole report on labs (2026-07-27), so every session on
+            # that runner stopped being reported at all: a nicety took out the
+            # liveness signal for the entire machine.
+            #
+            # The savepoint is required, not defensive: the report already holds
+            # `select_for_update` rows, and with SESSION_SAVE_EVERY_REQUEST any
+            # error inside the outer transaction poisons it (CLAUDE.md documents
+            # this trap and names this module as the precedent). Catching without
+            # a savepoint would leave the request unable to commit anything.
+            try:
+                with transaction.atomic():
+                    if _title_is_derived(binding.session, binding.thread_key or ""):
+                        if binding.session.title != s.emdash_task:
+                            binding.session.title = s.emdash_task[:200]
+                            binding.session.save(update_fields=["title"])
+            except Exception:  # noqa: BLE001 — a title must never cost liveness
+                logger.warning("could not retitle session %s from task %r",
+                               binding.session_id, s.emdash_task, exc_info=True)
             # thread_key/host are the binding's durable IDENTITY. NEVER overwrite a
             # non-empty one — an existing binding may be owned by an agent/phone
             # thread (record_session) and this report loop must not steal it (see

--- a/tests/test_harness_emdash_sessions.py
+++ b/tests/test_harness_emdash_sessions.py
@@ -255,3 +255,36 @@ def test_the_report_never_clobbers_a_title_a_human_chose():
     _report(c, runner.id, [{"emdash_task": "canopy-web-api-7716", "project": "canopy-web"}])
     session.refresh_from_db()
     assert session.title == "Ship the release"
+
+
+def test_a_failing_retitle_never_breaks_the_session_report(monkeypatch):
+    """The report is how canopy knows which sessions are alive. Shipping the
+    retitle unguarded 500'd the WHOLE report on labs, so every session on that
+    runner stopped being reported — a cosmetic nicety took out the liveness
+    signal for the entire machine.
+
+    Simulated by making the repair itself raise: the report must still succeed
+    and still upsert the binding."""
+    from django.test import Client
+
+    from apps.canopy_sessions.models import RunnerBinding, Session
+    from apps.harness import services as hsvc
+
+    jj = _user("jj-safe")
+    ws = _ws("dimagi-safe", jj)
+    runner = _runner(jj, ws)
+    session = Session.objects.create(workspace=ws, created_by=jj, title="A sentence")
+    RunnerBinding.objects.create(session=session, runner=runner,
+                                 session_key="task-x",
+                                 thread_key="emdash:task-x", host=runner.host)
+
+    def boom(*a, **k):
+        raise RuntimeError("retitle exploded")
+
+    monkeypatch.setattr(hsvc, "_title_is_derived", boom)
+    c = Client(); c.force_login(jj)
+    resp = _report(c, runner.id, [{"emdash_task": "task-x", "project": "canopy-web"}])
+    assert resp.status_code == 200, "a broken retitle must not fail the report"
+    # And the liveness half still happened.
+    binding = RunnerBinding.objects.get(session=session)
+    assert binding.live_seen_at is not None


### PR DESCRIPTION
#476's retitle **crashed `POST /runners/{id}/sessions`** on labs — found by calling the endpoint directly and getting a 500.

That endpoint is how canopy knows which sessions are **alive**, and the runner calls it every ~10s. So a title nicety took out the liveness signal for every session on that machine. It passed locally and in CI; only production had the data shape that broke it.

## Fix

The retitle now runs in its own savepoint, logging a warning on failure. The savepoint is **required, not defensive**: the report already holds  rows, and with  any error inside the outer transaction poisons it — CLAUDE.md documents that trap and names this module as the precedent. Catching without a savepoint would leave the request unable to commit anything.

## The actual lesson

Ordering, not the bug: I put a **cosmetic repair on the critical liveness path with no isolation**. Anything optional sharing a transaction with something load-bearing needs its own savepoint.

New test makes  raise and asserts the report still returns 200 *and* still stamps .

Backend 1,761.

🤖 Generated with [Claude Code](https://claude.com/claude-code)