### PR TITLE
Source vocabulary on Turn.origin (source-aware routing, 1/8)

### DIFF
--- a/apps/canopy_sessions/services.py
+++ b/apps/canopy_sessions/services.py
@@ -708,7 +708,7 @@ def send_message(
             origin_ref["attachments"] = attachments
         turn, _created = harness_services.enqueue_turn(
             session=session,
-            origin=Turn.ORIGIN_API,
+            origin=Turn.ORIGIN_CANOPY_WEB_CHAT,
             idempotency_key=f"chat:{session.id.hex}:{client_id or index}",
             prompt=text,
             origin_ref=origin_ref,
@@ -792,7 +792,7 @@ def _send_transcript_sourced_message(
         origin_ref["attachments"] = attachments
     turn, _created = harness_services.enqueue_turn(
         session=session,
-        origin=Turn.ORIGIN_API,
+        origin=Turn.ORIGIN_CANOPY_WEB_CHAT,
         idempotency_key=f"chat:{session.id.hex}:{client_id or uuid.uuid4().hex}",
         prompt=text,
         origin_ref=origin_ref,

--- a/apps/harness/migrations/0030_source_vocabulary.py
+++ b/apps/harness/migrations/0030_source_vocabulary.py
@@ -1,0 +1,53 @@
+"""The source vocabulary (spec 2026-07-27): widen both origin columns and remap
+the retired values. Widening a varchar in Postgres is metadata-only — no rewrite.
+
+The reverse is deliberately lossy: `api` fans back out to board/manual/drill with
+no way to tell which, so it maps everything back to `api` and only un-renames
+canopy_scheduler. Reversing this migration restores a runnable schema, not the
+exact prior labels.
+"""
+from django.db import migrations, models
+
+FORWARD = {"cron": "canopy_scheduler", "manual": "api", "drill": "api", "board": "api"}
+BACKWARD = {"canopy_scheduler": "cron", "canopy_web_chat": "api"}
+
+CHOICES = [
+    ("api", "API"), ("ace_web", "ace-web"),
+    ("canopy_web_chat", "canopy-web chat"),
+    ("canopy_scheduler", "canopy scheduler"),
+    ("email", "Email"), ("slack", "Slack"),
+]
+
+
+def _remap(apps, mapping):
+    Turn = apps.get_model("harness", "Turn")
+    Item = apps.get_model("harness", "Item")
+    for old, new in mapping.items():
+        Turn.objects.filter(origin=old).update(origin=new)
+        Item.objects.filter(origin=old).update(origin=new)
+
+
+def forwards(apps, schema_editor):
+    _remap(apps, FORWARD)
+
+
+def backwards(apps, schema_editor):
+    _remap(apps, BACKWARD)
+
+
+class Migration(migrations.Migration):
+    dependencies = [("harness", "0029_turntranscript_last_batch_id_and_more")]
+
+    operations = [
+        migrations.AlterField(
+            model_name="turn",
+            name="origin",
+            field=models.CharField(max_length=32, choices=CHOICES),
+        ),
+        migrations.AlterField(
+            model_name="item",
+            name="origin",
+            field=models.CharField(max_length=32, choices=CHOICES),
+        ),
+        migrations.RunPython(forwards, backwards),
+    ]

--- a/apps/harness/models.py
+++ b/apps/harness/models.py
@@ -175,13 +175,41 @@ class Turn(models.Model):
     TERMINAL = {DONE, FAILED, LOST, MISSED, CANCELLED}
     NON_TERMINAL = {QUEUED, CLAIMED, RUNNING, NEEDS_HUMAN}
 
-    ORIGIN_BOARD, ORIGIN_API, ORIGIN_SLACK, ORIGIN_CRON, ORIGIN_MANUAL, ORIGIN_EMAIL, ORIGIN_DRILL = (
-        "board", "api", "slack", "cron", "manual", "email", "drill",
-    )
+    # THE SOURCE VOCABULARY (spec 2026-07-27-source-aware-runner-routing).
+    # `origin` is not just provenance any more — it is what per-agent routing
+    # rules key on, so the values are the words the operator sees in the routing
+    # UI and the turn log. `api` stays the honest catch-all; everything that had
+    # a real producer got named.
+    ORIGIN_API, ORIGIN_ACE_WEB, ORIGIN_CANOPY_WEB_CHAT = "api", "ace_web", "canopy_web_chat"
+    ORIGIN_CANOPY_SCHEDULER, ORIGIN_EMAIL, ORIGIN_SLACK = "canopy_scheduler", "email", "slack"
     ORIGIN_CHOICES = [
-        (ORIGIN_BOARD, "Board"), (ORIGIN_API, "API"), (ORIGIN_SLACK, "Slack"),
-        (ORIGIN_CRON, "Cron"), (ORIGIN_MANUAL, "Manual"), (ORIGIN_EMAIL, "Email"),
-        (ORIGIN_DRILL, "Drill"),
+        (ORIGIN_API, "API"), (ORIGIN_ACE_WEB, "ace-web"),
+        (ORIGIN_CANOPY_WEB_CHAT, "canopy-web chat"),
+        (ORIGIN_CANOPY_SCHEDULER, "canopy scheduler"),
+        (ORIGIN_EMAIL, "Email"), (ORIGIN_SLACK, "Slack"),
+    ]
+    # What an external caller may POST. The rest are set by exactly one in-repo
+    # producer each, and letting a caller spell them would let it borrow another
+    # source's routing rule. Enforced at the request boundary (schemas.Origin),
+    # NOT in TurnSpec.from_dict — server-authored dispatch specs (the schedule
+    # nag) legitimately carry `canopy_scheduler`.
+    POSTABLE_ORIGINS = {ORIGIN_API, ORIGIN_ACE_WEB, ORIGIN_EMAIL, ORIGIN_SLACK}
+    # Retired values the live fleet may still be posting. Normalized (same mapping
+    # migration 0030 applied to existing rows) rather than 422'd, so shipping this
+    # does not break Echo/Ada mid-flight. Applied BOTH at the request boundary and
+    # in enqueue_turn: TurnSpec.from_dict parses stored Item JSON with no schema in
+    # the path, and Items open across the deploy carry the old spellings. Remove
+    # one release after the fleet is confirmed clean.
+    LEGACY_ORIGIN_ALIASES = {
+        "board": ORIGIN_API, "manual": ORIGIN_API, "drill": ORIGIN_API,
+        "cron": ORIGIN_CANOPY_SCHEDULER,
+    }
+    # What a per-agent routing rule may name. Every value: a rule on a source
+    # nothing produces is inert, not harmful, and `slack` is deliberately
+    # reserved for the producer that does not exist yet.
+    ROUTABLE_ORIGINS = [
+        ORIGIN_ACE_WEB, ORIGIN_EMAIL, ORIGIN_CANOPY_SCHEDULER,
+        ORIGIN_CANOPY_WEB_CHAT, ORIGIN_SLACK, ORIGIN_API,
     ]
 
     PREFER_LOCAL, LOCAL_ONLY, ANY = "prefer_local", "local_only", "any"
@@ -233,7 +261,7 @@ class Turn(models.Model):
         "Item", on_delete=models.SET_NULL, null=True, blank=True,
         related_name="dispatched_turns",
     )
-    origin = models.CharField(max_length=10, choices=ORIGIN_CHOICES)
+    origin = models.CharField(max_length=32, choices=ORIGIN_CHOICES)
     origin_ref = models.JSONField(default=dict, blank=True)
     prompt = models.TextField(blank=True, default="")
     routing = models.CharField(max_length=15, choices=ROUTING_CHOICES, default=PREFER_LOCAL)
@@ -523,7 +551,7 @@ class Item(models.Model):
                   "a turn (an email poll, a manual post).",
     )
 
-    origin = models.CharField(max_length=10, choices=Turn.ORIGIN_CHOICES)
+    origin = models.CharField(max_length=32, choices=Turn.ORIGIN_CHOICES)
     origin_ref = models.JSONField(default=dict, blank=True)
 
     kind = models.CharField(max_length=10, choices=KIND_CHOICES, default=REVIEW)

--- a/apps/harness/schemas.py
+++ b/apps/harness/schemas.py
@@ -10,13 +10,39 @@ from ninja import Schema
 from pydantic import Field, field_validator
 
 # Kept in lockstep with Turn.ORIGIN_CHOICES / Turn.ROUTING_CHOICES (models.py).
-# These are the values the DB columns accept (origin max_length=10, routing
+# These are the values the DB columns accept (origin max_length=32, routing
 # max_length=15); typing the INPUT schemas as Literals turns an out-of-set value
 # into a 422 at the API boundary instead of a Postgres "value too long" 500 that
 # SQLite CI can't reproduce. Output schemas stay `str` — they serialize values the
 # DB already validated, and a Literal there would break on any legacy row.
-Origin = Literal["board", "api", "slack", "cron", "manual", "email"]
+#
+# POST-able sources only. `canopy_web_chat` / `canopy_scheduler` are server-set
+# (one in-repo producer each) — a caller spelling them would borrow that source's
+# routing rule. Retired spellings are normalized, not rejected: the live fleet
+# posts `cron`/`manual` today and 422'ing them would break Echo/Ada mid-flight.
+Origin = Literal[
+    "api", "ace_web", "email", "slack",           # postable
+    "board", "cron", "manual", "drill",           # legacy, normalized below
+]
+# What a per-agent routing rule may name — the full vocabulary, including the
+# server-only sources (a rule NAMES a source, it does not produce one).
+RoutableSource = Literal[
+    "ace_web", "email", "canopy_scheduler", "canopy_web_chat", "slack", "api",
+]
 Routing = Literal["prefer_local", "local_only", "any"]
+
+
+def normalize_origin(value: str) -> str:
+    """Map a retired spelling onto its replacement. Shared by every input schema
+    carrying an `origin`, so the boundary can't normalize inconsistently.
+
+    `enqueue_turn` applies the SAME mapping, deliberately: TurnSpec.from_dict
+    parses stored Item JSON with no schema in the path, so a request-boundary-only
+    rule would miss every Item raised before this shipped.
+    """
+    from apps.harness.models import Turn
+
+    return Turn.LEGACY_ORIGIN_ALIASES.get(value, value)
 
 
 class RunnerIn(Schema):
@@ -200,6 +226,8 @@ class TurnIn(Schema):
     prompt: str = ""
     origin_ref: dict = {}
     routing: Routing = "prefer_local"
+
+    _norm_origin = field_validator("origin")(staticmethod(normalize_origin))
 
 
 class TurnOut(Schema):
@@ -536,6 +564,8 @@ class TurnSpecIn(Schema):
     origin_ref: dict[str, Any] = Field(default_factory=dict)
     routing: Routing = "prefer_local"
 
+    _norm_origin = field_validator("origin")(staticmethod(normalize_origin))
+
 
 class ItemIn(Schema):
     # No `notify` kind: an FYI asks nothing of you, and that is the timeline.
@@ -548,6 +578,8 @@ class ItemIn(Schema):
     batch_key: str = ""
     idempotency_key: str = Field(min_length=1, max_length=128)
     raised_by: uuid.UUID | None = None
+
+    _norm_origin = field_validator("origin")(staticmethod(normalize_origin))
 
 
 class ItemOut(Schema):

--- a/apps/harness/services.py
+++ b/apps/harness/services.py
@@ -65,6 +65,13 @@ def enqueue_turn(
     fails it closed without one, so accepting it here would silently queue a turn
     nothing can ever run. Session turns derive tenancy from session.workspace.
     """
+    # One chokepoint for the retired spellings, because not every producer comes
+    # through a request schema: TurnSpec.from_dict parses origin as a free string
+    # out of Item JSON written before this deploy. The input schemas normalize too
+    # (so a caller gets a clean 422 on a genuinely unknown value rather than a
+    # silent rewrite); this is the leg that catches stored payloads and internal
+    # callers. Remove with the aliases, one release on.
+    origin = Turn.LEGACY_ORIGIN_ALIASES.get(origin, origin)
     if sum([bool(agent), bool(project), bool(session)]) != 1:
         raise ValueError("a turn targets exactly one of agent / project / session")
     if project and workspace is None:
@@ -150,7 +157,10 @@ def sweep_expired_leases() -> int:
             # Mirror that hook here for both sweep outcomes (finding M2): a
             # cancel-requested drill whose runner then disappears is just as
             # stranded as a plain lost one without this.
-            if turn.origin == Turn.ORIGIN_DRILL and status in (Turn.LOST, Turn.CANCELLED):
+            # A drill turn is identified by its RunnerDrill FK, not by its origin
+            # (drills are ordinary `api` turns that name a runner). The filter
+            # below no-ops for a non-drill turn.
+            if status in (Turn.LOST, Turn.CANCELLED):
                 summary = (
                     "drill turn cancelled (lease expired after cancel was requested)"
                     if status == Turn.CANCELLED
@@ -851,7 +861,9 @@ def finish_turn(
     # origin filter, so a queued drill can be cancelled out from under itself —
     # without this it would strand OUTCOME_PENDING forever, the same failure
     # mode this hook exists to prevent for FAILED.
-    if turn.origin == Turn.ORIGIN_DRILL and status in (Turn.FAILED, Turn.CANCELLED):
+    # Keyed on the RunnerDrill FK, not the origin: a drill is an ordinary `api`
+    # turn that names its runner, and the filter no-ops for a non-drill turn.
+    if status in (Turn.FAILED, Turn.CANCELLED):
         if status == Turn.CANCELLED:
             summary = "drill turn cancelled"
         else:
@@ -900,11 +912,11 @@ def cancel_turn(turn: Turn) -> Turn | None:
                 "payload": {"status": Turn.CANCELLED, "result_note": "cancelled"},
             }])
             # Mirror finish_turn's drill hook (bypassed above) so a queued
-            # drill cancelled this way doesn't strand OUTCOME_PENDING.
-            if turn.origin == Turn.ORIGIN_DRILL:
-                RunnerDrill.objects.filter(
-                    turn=turn, outcome=RunnerDrill.OUTCOME_PENDING
-                ).update(outcome=RunnerDrill.OUTCOME_FAIL, summary="drill turn cancelled", finished_at=now)
+            # drill cancelled this way doesn't strand OUTCOME_PENDING. Keyed on
+            # the RunnerDrill FK — no-ops for a non-drill turn.
+            RunnerDrill.objects.filter(
+                turn=turn, outcome=RunnerDrill.OUTCOME_PENDING
+            ).update(outcome=RunnerDrill.OUTCOME_FAIL, summary="drill turn cancelled", finished_at=now)
             return turn
         # Lost the race: the turn is no longer QUEUED (claimed out from under
         # us, or already terminal). Fall through to the freshly-refreshed
@@ -964,7 +976,7 @@ def fire_schedule(schedule, slot: dt.datetime) -> tuple[Turn, bool]:
             supersede_open_turns(schedule, reason=f"superseded by slot {slot.isoformat()}")
         turn, created = enqueue_turn(
             agent=schedule.agent,
-            origin=Turn.ORIGIN_CRON,
+            origin=Turn.ORIGIN_CANOPY_SCHEDULER,
             idempotency_key=key,
             prompt=schedule.prompt,
             origin_ref={"schedule_id": schedule.id, "slot": slot.isoformat()},
@@ -984,15 +996,18 @@ def run_schedule_now(schedule) -> Turn:
     clears the nag (it is the newest occurrence) while the slot turn sits queued
     and still owed, and the work runs a second time when it is claimed later.
 
-    origin=manual with a uuid-suffixed key, so an ad-hoc run never collides with
-    a real slot, and last_slot is untouched — the CADENCE is unaffected (the next
-    real slot still fires on time).
+    origin=canopy_scheduler with origin_ref["manual"]=True and a uuid-suffixed
+    key, so an ad-hoc run never collides with a real slot, and last_slot is
+    untouched — the CADENCE is unaffected (the next real slot still fires on
+    time). The manual flag lives in origin_ref rather than in origin because WHO
+    fired it is not a different SOURCE: both route as scheduler work, which is
+    the point of naming the source.
     """
     with transaction.atomic():
         supersede_open_turns(schedule, reason="superseded by a manual run")
         turn, _ = enqueue_turn(
             agent=schedule.agent,
-            origin=Turn.ORIGIN_MANUAL,
+            origin=Turn.ORIGIN_CANOPY_SCHEDULER,
             idempotency_key=f"sched:{schedule.id}:manual:{uuid.uuid4()}",
             prompt=schedule.prompt,
             origin_ref={"schedule_id": schedule.id, "manual": True},
@@ -1679,13 +1694,13 @@ def _raise_schedule_nag(schedule, turn: Turn) -> None:
             f"“{schedule.name}” fired but was left unattended past "
             f"{schedule.grace_minutes}m. Implement to run it now, or skip."
         ),
-        "origin": Turn.ORIGIN_CRON,
+        "origin": Turn.ORIGIN_CANOPY_SCHEDULER,
         "origin_ref": {
             "schedule_id": schedule.id, "turn_id": str(turn.id), "kind": "schedule_nag",
         },
         "dispatch": [{
             "prompt": schedule.prompt,
-            "origin": Turn.ORIGIN_MANUAL,
+            "origin": Turn.ORIGIN_CANOPY_SCHEDULER,
             "origin_ref": {"schedule_id": schedule.id, "manual": True},
             "routing": schedule.routing,
         }],
@@ -1745,7 +1760,7 @@ def start_drill(runner: Runner, agents: list) -> list[RunnerDrill]:
         report_url = f"{settings.CANOPY_PUBLIC_BASE_URL}/api/harness/drills/{drill.id}/report"
         turn, _created = enqueue_turn(
             agent=agent,
-            origin=Turn.ORIGIN_DRILL,
+            origin=Turn.ORIGIN_API,
             idempotency_key=f"drill:{runner.id}:{agent.slug}:{uuid.uuid4().hex[:8]}",
             prompt=DRILL_PROMPT.format(agent_slug=agent.slug, report_url=report_url),
             pinned_runner=runner,

--- a/apps/mcp/tests/test_schedule_tools.py
+++ b/apps/mcp/tests/test_schedule_tools.py
@@ -83,7 +83,8 @@ def test_run_now_audit_carries_schedule_name(member):
         _call("run_schedule_now", {"agent_slug": "eva", "schedule_id": sid})
     row = MCPAuditLog.objects.filter(tool="run_schedule_now").latest("id")
     assert "Weekly" in row.args_summary
-    assert Turn.objects.filter(origin=Turn.ORIGIN_MANUAL).count() == 1
+    # Run-now is scheduler work fired off-cycle, not a separate source.
+    assert Turn.objects.filter(origin=Turn.ORIGIN_CANOPY_SCHEDULER).count() == 1
 
 
 def test_non_member_gets_error_not_leak(member):

--- a/docs/superpowers/plans/2026-07-27-source-aware-runner-routing.md
+++ b/docs/superpowers/plans/2026-07-27-source-aware-runner-routing.md
@@ -19,6 +19,21 @@
 - **Backend tests:** `uv run pytest`. **Frontend:** `cd frontend && npm run build` (type check) and `npx vitest run <file>`.
 - **Migrations:** write them the obvious way; destructive is fine. They run before cutover.
 - **Commit after every task.** Open the PR with auto-merge armed: `gh pr merge <n> --auto --squash`.
+- **Line numbers in this plan are a hint, not an address.** `apps/harness/services.py` has moved since the plan was written (the nag block is ~1682/1688, `start_drill` ~1748). Locate every edit by its enclosing symbol and grep for the quoted line; never trust the number alone.
+
+## Prerequisite outside this repo
+
+**Nothing produces `ace_web` until ace-web is changed.** The headline case — ace-web
+delegated execution landing on the cloud runner — depends on ace-web's `turn_driver`
+POSTing `origin="ace_web"` to `/api/harness/turns/`. That lives in another repo and is
+not a task here. Until it ships, a strict `ace_web` rule routes **zero** turns while
+real ace-web work keeps arriving as `api` and following the default order — silently,
+because a rule on a source nothing produces is inert by design.
+
+Do this in the order: land this PR → change ace-web's `turn_driver` → verify on labs
+that an ace-web turn shows `origin: ace_web` in the turn log → only then add the strict
+rule. Task 8 Step 9 checks that the fleet is actually emitting the value before the
+feature is called done.
 
 ---
 
@@ -29,8 +44,8 @@ Replaces `board`/`cron`/`manual`/`drill` with the six-value source vocabulary, w
 **Files:**
 - Modify: `apps/harness/models.py:178-185` (the ORIGIN block), `:236` (`Turn.origin` field), `:526` (`Item.origin` field — line is inside `class Item`, find `origin = models.CharField(max_length=10, choices=Turn.ORIGIN_CHOICES)`)
 - Create: `apps/harness/migrations/0030_source_vocabulary.py`
-- Modify: `apps/harness/schemas.py:18` (the `Origin` literal)
-- Modify: `apps/harness/services.py:153`, `:854`, `:904` (drop drill origin pre-filters), `:967`, `:995` (schedule origins), `:1648`, `:1654` (nag origins), `:1714` (drill origin)
+- Modify: `apps/harness/schemas.py:18` (the `Origin` literal), `class TurnIn`, `class ItemIn`, `class TurnSpecIn`
+- Modify: `apps/harness/services.py` — `sweep_expired_leases`, `finish_turn`, `cancel_turn` (drop the drill origin pre-filters), `enqueue_turn` (the alias chokepoint), `fire_schedule`, `run_schedule_now`, `_raise_schedule_nag`, `start_drill`. Find each by symbol; the numbers in the steps below have drifted.
 - Modify: `apps/canopy_sessions/services.py:711`, `:795` (chat sends)
 - Modify: `frontend/src/components/activity/turnLog.ts:20-29`
 - Test: `tests/test_origin_vocabulary.py` (new), `frontend/src/components/activity/turnLog.test.ts`
@@ -280,13 +295,46 @@ def normalize_origin(value: str) -> str:
     return Turn.LEGACY_ORIGIN_ALIASES.get(value, value)
 ```
 
-Add the validator to both input schemas that carry an origin. In `class TurnIn` (after the field declarations):
+Add the validator to **all three** input schemas that carry an origin — `class TurnIn`, `class ItemIn`, and `class TurnSpecIn` (it declares `origin: Origin = "api"`, and it is the dispatch path, so it is not optional):
 
 ```python
     _norm_origin = field_validator("origin")(staticmethod(normalize_origin))
 ```
 
-Add the identical line to `class ItemIn`. Also add it to `class TurnSpecIn` if that schema declares an `origin` field — check with `grep -n "class TurnSpecIn" -A 10 apps/harness/schemas.py`; if it types `origin` as `Origin`, add the validator there too.
+- [ ] **Step 5b: Normalize at the `enqueue_turn` chokepoint too**
+
+The schema validator only sees values arriving through a request. `TurnSpec.from_dict`
+(`apps/harness/dispatch.py`) reads `origin` as a free string out of **stored** Item JSON,
+and `_raise_schedule_nag` writes `Turn.ORIGIN_MANUAL` into that JSON *today*. Every Item
+already open when this deploys would therefore enqueue a turn carrying a retired value —
+outside `ORIGIN_CHOICES`, matching no source rule, matching no turn-log filter, and
+invisible to every test that only exercises the API.
+
+In `apps/harness/services.py`, at the top of `enqueue_turn` (before the target check):
+
+```python
+    # One chokepoint for the retired spellings, because not every producer comes
+    # through a request schema: TurnSpec.from_dict parses origin as a free string
+    # out of Item JSON written before this deploy. The input schemas normalize too
+    # (so a caller gets a clean 422 on a genuinely unknown value rather than a
+    # silent rewrite); this is the leg that catches stored payloads and internal
+    # callers. Remove with the aliases, one release on.
+    origin = Turn.LEGACY_ORIGIN_ALIASES.get(origin, origin)
+```
+
+Add to `tests/test_origin_vocabulary.py`:
+
+```python
+def test_a_stored_dispatch_spec_with_a_retired_origin_still_enqueues_a_valid_one():
+    """Items raised before this deploy carry origin="manual" in their dispatch JSON,
+    and TurnSpec.from_dict hands it straight to enqueue_turn without a schema in the
+    path. A turn born with a retired origin matches no rule and no log filter."""
+    agent = Agent.objects.create(slug="echo", name="Echo", workspace=a_workspace())
+    turn, _ = services.enqueue_turn(agent=agent, origin="manual", idempotency_key="legacy-1")
+    assert turn.origin == Turn.ORIGIN_API
+```
+
+(add `from apps.harness import services` to the test module's imports)
 
 - [ ] **Step 6: Repoint the producers**
 
@@ -305,6 +353,16 @@ Add the identical line to `class ItemIn`. Also add it to `class TurnSpecIn` if t
 # ~line 1714, in start_drill — a drill is an api turn that names its runner; the
 # RunnerDrill row is what identifies it.
             origin=Turn.ORIGIN_API,
+```
+
+`run_schedule_now`'s docstring still opens "origin=manual with a uuid-suffixed key" — update that sentence to name `canopy_scheduler` and point at `origin_ref["manual"]`, which is now the only thing distinguishing an off-cycle run from a fired slot:
+
+```python
+    origin=canopy_scheduler with origin_ref["manual"]=True and a uuid-suffixed key,
+    so an ad-hoc run never collides with a real slot, and last_slot is untouched —
+    the CADENCE is unaffected (the next real slot still fires on time). The manual
+    flag lives in origin_ref rather than in origin because WHO fired it is not a
+    different SOURCE: both route as scheduler work, which is the point.
 ```
 
 `apps/canopy_sessions/services.py` — both send paths (lines ~711 and ~795):
@@ -342,14 +400,18 @@ In `frontend/src/components/activity/turnLog.ts`, replace `originLabel` and its 
 
 ```ts
 /** The Trigger column: what caused this turn.
- * - canopy_scheduler → "canopy_scheduler · <fired slot>" (slot lives in origin_ref.slot)
+ * - canopy_scheduler → the fired slot, or "run now" when a human fired it
+ *   off-cycle (run_schedule_now sets origin_ref.manual and no launcher — both
+ *   are scheduler work, so the distinction lives in origin_ref, not in origin)
  * - anything with a launcher → "<origin> · <who enqueued it>" (the old `manual`
  *   branch — "manual" is now just an api turn, so the launcher is the signal)
  * - otherwise → the bare origin string */
 export function originLabel(turn: Turn): string {
   if (turn.origin === "canopy_scheduler") {
     const slot = turn.origin_ref?.slot;
-    return typeof slot === "string" ? `canopy_scheduler · ${slot}` : "canopy_scheduler";
+    if (typeof slot === "string") return `canopy_scheduler · ${slot}`;
+    if (turn.origin_ref?.manual) return "canopy_scheduler · run now";
+    return "canopy_scheduler";
   }
   if (turn.enqueued_by_email) {
     return `${turn.origin} · ${turn.enqueued_by_email}`;
@@ -374,6 +436,10 @@ In `frontend/src/components/activity/turnLog.test.ts`, replace the three `origin
   });
   it("passes email / api through as the bare origin", () => {
     expect(originLabel(turn({ origin: "email", enqueued_by_email: null }))).toBe("email");
+  });
+  it("names an off-cycle scheduler run", () => {
+    const t = turn({ origin: "canopy_scheduler", origin_ref: { manual: true } });
+    expect(originLabel(t)).toContain("run now");
   });
 ```
 
@@ -1103,7 +1169,37 @@ def test_a_turn_its_rule_can_run_is_not_reported(fleet):
     _stuck_turn(a, Turn.ORIGIN_EMAIL, "k-mail")
 
     assert services.unclaimable_queued_turns(fleet["user"]) == []
+
+
+def test_a_bound_session_turn_is_not_reported_when_its_holder_is_not_assigned(fleet):
+    """The refinement must mirror the claim loop's bound_to_me short-circuit.
+
+    A session bound to a runner claims on THAT runner regardless of assignments —
+    that is what stickiness means. Applying the per-source assignment check to it
+    would report a live chat as 'no runner is assigned; fix your routing' while
+    claiming takes it happily. Surviving runner_target_q is what IDENTIFIES the
+    binding holder, so 'it was already filtered' is exactly backwards here.
+    """
+    from apps.canopy_sessions.models import RunnerBinding, Session
+
+    a, cloud = fleet["agent"], fleet["cloud"]
+    # cloud is assigned NOTHING for this agent — only the binding routes to it.
+    RunnerAssignment.objects.create(agent=a, runner=fleet["laptop"], rank=0)
+    Runner.objects.filter(pk=cloud.pk).update(capabilities={"sessions": True})
+    cloud.refresh_from_db()
+    session = Session.objects.create(agent=a, workspace=a.workspace, title="chat")
+    RunnerBinding.objects.create(session=session, runner=cloud, live_seen_at=timezone.now())
+    turn = Turn.objects.create(
+        chat_session=session, origin=Turn.ORIGIN_CANOPY_WEB_CHAT, idempotency_key="c1"
+    )
+    Turn.objects.filter(pk=turn.pk).update(
+        created_at=timezone.now() - services.UNCLAIMABLE_GRACE - dt.timedelta(seconds=30)
+    )
+
+    assert services.unclaimable_queued_turns(fleet["user"]) == []
 ```
+
+Check `Session` / `RunnerBinding`'s actual required fields before running this — `grep -n "class Session" -A 30 apps/canopy_sessions/models.py` — and adjust the constructor kwargs rather than the assertion.
 
 - [ ] **Step 2: Run the test to verify it fails**
 
@@ -1112,7 +1208,14 @@ Expected: FAIL — `test_an_online_runner_excluded_by_a_strict_rule_does_not_mas
 
 - [ ] **Step 3: Refine coverage per (turn, runner)**
 
-In `unclaimable_queued_turns`, after the `ids = {t.id for t in queued}` line, add the row load, then replace `_covered_by`:
+First widen the `queued` queryset's `select_related` — the refinement below reads
+`t.chat_session.agent_id` and the binding, once per turn per runner:
+
+```python
+        .select_related("agent", "chat_session", "chat_session__runner_binding")
+```
+
+Then, after the `ids = {t.id for t in queued}` line, add the row load and replace `_covered_by`:
 
 ```python
     ids = {t.id for t in queued}
@@ -1135,25 +1238,44 @@ In `unclaimable_queued_turns`, after the `ids = {t.id for t in queued}` line, ad
             q = runner_target_q(r) | Q(pinned_runner=r)
             for t in (
                 Turn.objects.filter(pk__in=ids).filter(q)
-                .select_related("agent", "chat_session")
+                .select_related("agent", "chat_session", "chat_session__runner_binding")
             ):
-                # Then the SAME per-source refinement the claim loop applies. A
-                # runner assigned the agent but excluded by a strict rule for this
-                # turn's source does NOT cover it, and saying otherwise would mask
-                # a genuinely parked queue.
-                if t.pinned_runner_id != r.id:
-                    routed_agent = t.agent_id or (
-                        t.chat_session.agent_id if t.chat_session_id else None
-                    )
-                    if routed_agent:
-                        rows = assignment_rows_for(routed_agent, t.origin, defaults, priorities)
-                        if not any(rr.id == r.id for _rank, rr in rows):
-                            continue
-                out.add(t.pk)
+                # Then the SAME per-source refinement the claim loop applies —
+                # INCLUDING its two short-circuits, in the same order. A runner
+                # assigned the agent but excluded by a strict rule for this turn's
+                # source does NOT cover it, and saying otherwise would mask a
+                # genuinely parked queue.
+                if _refined_allows(r, t):
+                    out.add(t.pk)
         return out
 ```
 
-Note `runner_target_q` already excludes a bound session whose holder is someone else, so a bound session turn reaching this refinement is one this runner holds — its `routed_agent` check is harmless and keeps the unbound case correct.
+and add the shared refinement just above `_covered_by`, so it and the claim loop are one rule rather than two that agree:
+
+```python
+    def _refined_allows(r, t) -> bool:
+        # A pin trumps everything below it (claim_next_turn: `pinned_here`).
+        if t.pinned_runner_id == r.id:
+            return True
+        if t.chat_session_id:
+            # STICKINESS, mirroring claim_next_turn's bound_to_me short-circuit: a
+            # session bound to this runner claims on it regardless of assignments.
+            # Surviving runner_target_q is what IDENTIFIES the holder, so running
+            # the assignment check here would report a live chat as `config`
+            # ("no runner is assigned") while claiming takes it happily.
+            binding = getattr(t.chat_session, "runner_binding", None)
+            if binding is not None and binding.runner_id == r.id:
+                return True
+            routed_agent = t.chat_session.agent_id
+        else:
+            routed_agent = t.agent_id
+        if not routed_agent:
+            return True  # project turn / agentless session: runner_target_q had the last word
+        rows = assignment_rows_for(routed_agent, t.origin, defaults, priorities)
+        return any(rr.id == r.id for _rank, rr in rows)
+```
+
+(close over `defaults`/`priorities` like `_covered_by` does, and drop them from the call signature — shown as parameters above only to name the dependency.)
 
 - [ ] **Step 4: Run the test to verify it passes**
 
@@ -1779,8 +1901,11 @@ export async function putAgentRunnerRules(
   const res = await apiV2.PUT('/api/agents/{slug}/runner-rules', {
     params: { path: { slug } },
     body: {
+      // Cast against the REQUEST body's source type, not the response's:
+      // AgentRunnerRuleOut.source is a plain `str` by the repo's
+      // output-schemas-stay-str rule, so casting to it type-checks nothing.
       rules: rules.map((r) => ({
-        source: r.source as AgentRunnerRuleOut['source'],
+        source: r.source as Schemas['AgentRunnerRuleIn']['source'],
         runner_id: r.runnerId,
         strict: r.strict,
       })),
@@ -1843,7 +1968,7 @@ function toRows(rules: readonly AgentRunnerRuleOut[]): RuleRow[] {
 export function nextRulesForAdd(
   rules: readonly RuleRow[], source: string, runnerId: string,
 ): RuleRow[] {
-  return [...toRows(rules as AgentRunnerRuleOut[] as never), { source, runnerId, strict: false }]
+  return [...rules, { source, runnerId, strict: false }]
 }
 
 export function nextRulesForRunner(
@@ -2061,8 +2186,14 @@ export function RunnerSourceRules({ agentSlug }: { agentSlug: string }): JSX.Ele
         )}
       </div>
 
+      {/* The precedence ladder, and the one place `enabled` means two things: a
+          runner switched OFF in Default order still takes the work of any source
+          that names it, because the rule is its own row with its own toggle. Left
+          unsaid, a greyed chip up top reads as "this box is off" while it is
+          quietly answering email. */}
       <p className="text-[10px] text-foreground-subtle">
         A named runner wins over a rule; a live chat stays on the box hosting it.
+        A rule still routes to its runner even when that runner is switched off above.
       </p>
 
       {error && <span className="text-[11px] text-destructive">{error}</span>}
@@ -2071,17 +2202,15 @@ export function RunnerSourceRules({ agentSlug }: { agentSlug: string }): JSX.Ele
 }
 ```
 
-- [ ] **Step 5: Fix the `nextRulesForAdd` cast**
+- [ ] **Step 5: Take the fleet as a prop instead of re-fetching it**
 
-The cast in Step 4's `nextRulesForAdd` is wrong — `toRows` takes API rows, but this helper receives `RuleRow[]`. Replace that function with:
-
-```tsx
-export function nextRulesForAdd(
-  rules: readonly RuleRow[], source: string, runnerId: string,
-): RuleRow[] {
-  return [...rules, { source, runnerId, strict: false }]
-}
-```
+Step 4's component calls `listRunners()` itself, but its parent `RunnerAssignments`
+already holds the fleet in state — and the Runners tab renders one `RunnerAssignments`
+per agent, so self-fetching costs one extra `GET /api/harness/runners/` per agent on
+every visit. Change the signature to
+`{ agentSlug, fleet }: { agentSlug: string; fleet: RunnerOut[] }`, drop the
+`listRunners` import and the `setFleet` state, and load only the rules in the effect.
+Pass it at the mount site in Step 7: `<RunnerSourceRules agentSlug={agentSlug} fleet={fleet} />`.
 
 - [ ] **Step 6: Run the test to verify it passes**
 
@@ -2116,7 +2245,7 @@ and close the new inner div plus append the rules editor immediately before the 
 
 ```tsx
       </div>
-      <RunnerSourceRules agentSlug={agentSlug} />
+      <RunnerSourceRules agentSlug={agentSlug} fleet={fleet} />
     </div>
 ```
 
@@ -2351,7 +2480,25 @@ Expected: all green. Then confirm the generated types are fresh:
 Run: `cd frontend && npm run gen:api:local && git diff --stat src/api/generated.ts`
 Expected: no diff (already regenerated in Tasks 5 and 6).
 
-- [ ] **Step 8: Commit and open the PR**
+- [ ] **Step 8: Record what is NOT yet live**
+
+Add to the PR body (see Step 9) and to the spec's status line: `ace_web` has no
+producer in this repo. The rule model, the API and the UI all ship here; the value
+starts appearing only once ace-web's `turn_driver` posts it. Do not add a strict
+`ace_web` rule on labs until the turn log actually shows the origin — a strict rule on
+a source nothing emits routes nothing, while the real work keeps flowing through `api`
+on the default order, and the two failures look identical from the Runners tab.
+
+Verification once ace-web ships (not part of this PR):
+
+```bash
+# on labs, after an ace-web delegated run
+curl -s "$CANOPY/api/harness/turns/?agent=ace" -H "Authorization: Bearer $PAT" \
+  | jq -r '.items[] | "\(.origin)\t\(.created_at)"' | head
+# expect `ace_web`, not `api`
+```
+
+- [ ] **Step 9: Commit and open the PR**
 
 ```bash
 git add tests/test_source_routing_e2e.py CLAUDE.md \
@@ -2392,4 +2539,11 @@ gh pr merge --auto --squash
 
 **Spec coverage:** vocabulary + both column widenings + remap (Task 1); boundary enforcement incl. the `TurnSpec.from_dict` hole (Task 1, Step 5 — validation lives in the input schemas, `from_dict` untouched); rule columns + constraints + composition (Task 2); claim wiring incl. strictness-past-grace and the session leg (Task 3); `unclaimable` parity (Task 4); `runner_id` (Task 5); rules API + the scoped delete (Task 6); UI option A incl. the parked warning and the precedence line (Task 7); the three real cases + docs (Task 8). Session binding, project turns, and retire-cascade are asserted as unchanged rather than modified, matching the spec's "what is unchanged" section.
 
-**One deliberate divergence from the spec, recorded here:** the spec says server-only origins are rejected at the boundary. The plan additionally *normalizes* the retired spellings (`board`/`manual`/`drill`/`cron`) instead of 422'ing them, because the live fleet posts them today and a hard rejection would break Echo and Ada the moment this deploys. `cron` therefore reaches `canopy_scheduler` through the alias — a one-release shim, flagged for removal in the model comment.
+**One deliberate divergence from the spec, recorded here:** the spec says server-only origins are rejected at the boundary. The plan additionally *normalizes* the retired spellings (`board`/`manual`/`drill`/`cron`) instead of 422'ing them, because the live fleet posts them today and a hard rejection would break Echo and Ada the moment this deploys. `cron` therefore reaches `canopy_scheduler` through the alias — a one-release shim, flagged for removal in the model comment. Normalization additionally happens at `enqueue_turn` (Task 1, Step 5b), not only in the input schemas: `TurnSpec.from_dict` parses stored Item JSON with no schema in the path, and Items open across the deploy carry the retired spellings.
+
+**Review pass, 2026-07-27 — folded in:**
+
+1. **`unclaimable`'s refinement must mirror the claim loop's `bound_to_me` short-circuit** (Task 4). Applying the per-source assignment check to a session bound to this runner reports a live chat as `config` while claiming takes it — the binding is what routes it, not the assignment. The original note ("runner_target_q already filtered it, so the check is harmless") had it backwards: surviving that filter is precisely what identifies the holder. Now shared as `_refined_allows`, with a regression test.
+2. **`ace_web` has no producer in this repo** — an out-of-repo prerequisite, now stated up front and re-checked in Task 8 rather than discovered when a strict rule silently routes nothing.
+3. **Alias normalization moved to a chokepoint** (above).
+4. Smaller: `select_related` for the new `chat_session`/binding reads; `TurnSpecIn`'s validator is unconditional; `run_schedule_now`'s docstring and the turn log's "run now" label (`origin_ref.manual` is now the only thing separating an off-cycle run from a fired slot); the rules editor takes the fleet as a prop rather than re-fetching it per agent; the source cast targets the request type; `nextRulesForAdd` is written correctly the first time; and the precedence line states that a rule outranks a runner switched off in Default order — the one place `enabled` means two things.

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -6767,7 +6767,7 @@ export interface components {
              * @default api
              * @enum {string}
              */
-            readonly origin: "board" | "api" | "slack" | "cron" | "manual" | "email";
+            readonly origin: "api" | "ace_web" | "email" | "slack" | "board" | "cron" | "manual" | "drill";
             /** Origin Ref */
             readonly origin_ref?: {
                 readonly [key: string]: unknown;
@@ -6805,7 +6805,7 @@ export interface components {
              * @default api
              * @enum {string}
              */
-            readonly origin: "board" | "api" | "slack" | "cron" | "manual" | "email";
+            readonly origin: "api" | "ace_web" | "email" | "slack" | "board" | "cron" | "manual" | "drill";
             /** Origin Ref */
             readonly origin_ref?: {
                 readonly [key: string]: unknown;
@@ -7615,7 +7615,7 @@ export interface components {
              * Origin
              * @enum {string}
              */
-            readonly origin: "board" | "api" | "slack" | "cron" | "manual" | "email";
+            readonly origin: "api" | "ace_web" | "email" | "slack" | "board" | "cron" | "manual" | "drill";
             /** Idempotency Key */
             readonly idempotency_key: string;
             /**

--- a/frontend/src/components/activity/turnLog.test.ts
+++ b/frontend/src/components/activity/turnLog.test.ts
@@ -9,7 +9,7 @@ function turn(over: Partial<Turn>): Turn {
     project: "",
     target: "eva",
     workspace_slug: "alpha",
-    origin: "manual",
+    origin: "api",
     status: "done",
     routing: "prefer_local",
     prompt: "",
@@ -37,13 +37,19 @@ describe("agentLabel", () => {
 });
 
 describe("originLabel", () => {
-  it("labels a cron turn with its fired slot from origin_ref", () => {
-    const t = turn({ origin: "cron", origin_ref: { slot: "2026-07-20T13:00:00Z" } });
-    expect(originLabel(t)).toContain("cron");
+  it("surfaces the fired slot for a scheduler turn", () => {
+    const t = turn({ origin: "canopy_scheduler", origin_ref: { slot: "2026-07-20T13:00:00Z" } });
+    expect(originLabel(t)).toContain("canopy_scheduler");
     expect(originLabel(t)).toContain("2026"); // the slot is surfaced
   });
-  it("labels a manual turn with the enqueuer email", () => {
-    expect(originLabel(turn({ origin: "manual", enqueued_by_email: "jj@dimagi.com" }))).toContain("jj@dimagi.com");
+  it("names an off-cycle scheduler run", () => {
+    // run_schedule_now is scheduler work too — WHO fired it is not a different
+    // source, so the distinction lives in origin_ref, not in origin.
+    const t = turn({ origin: "canopy_scheduler", origin_ref: { manual: true } });
+    expect(originLabel(t)).toContain("run now");
+  });
+  it("names the launcher when a human enqueued it", () => {
+    expect(originLabel(turn({ origin: "api", enqueued_by_email: "jj@dimagi.com" }))).toContain("jj@dimagi.com");
   });
   it("passes email / api through as the bare origin", () => {
     expect(originLabel(turn({ origin: "email", enqueued_by_email: null }))).toBe("email");
@@ -52,15 +58,15 @@ describe("originLabel", () => {
 });
 
 describe("matchesTurnFilters", () => {
-  const t = turn({ agent_slug: "eva", origin: "cron", status: "done" });
+  const t = turn({ agent_slug: "eva", origin: "canopy_scheduler", status: "done" });
   it("matches when all filters are null (identity)", () => {
     expect(matchesTurnFilters(t, { agent: null, origin: null, status: null })).toBe(true);
   });
   it("matches when every set filter agrees", () => {
-    expect(matchesTurnFilters(t, { agent: "eva", origin: "cron", status: "done" })).toBe(true);
+    expect(matchesTurnFilters(t, { agent: "eva", origin: "canopy_scheduler", status: "done" })).toBe(true);
   });
   it("rejects when any set filter disagrees (AND)", () => {
-    expect(matchesTurnFilters(t, { agent: "eva", origin: "manual", status: null })).toBe(false);
+    expect(matchesTurnFilters(t, { agent: "eva", origin: "api", status: null })).toBe(false);
   });
   it("filters project turns by their project:<name> agent label", () => {
     const p = turn({ agent_slug: null, project: "canopy-web" });

--- a/frontend/src/components/activity/turnLog.ts
+++ b/frontend/src/components/activity/turnLog.ts
@@ -14,16 +14,21 @@ export function agentLabel(turn: Turn): string {
 }
 
 /** The Trigger column: what caused this turn.
- * - cron   → "cron · <fired slot>" (the slot lives in origin_ref.slot)
- * - manual → "manual · <who enqueued it>"
- * - email/api (or anything else) → the bare origin string */
+ * - canopy_scheduler → the fired slot, or "run now" when a human fired it
+ *   off-cycle (run_schedule_now sets origin_ref.manual and no launcher — both
+ *   are scheduler work, so the distinction lives in origin_ref, not in origin)
+ * - anything with a launcher → "<origin> · <who enqueued it>" (the old `manual`
+ *   branch — "manual" is now just an api turn, so the launcher is the signal)
+ * - otherwise → the bare origin string */
 export function originLabel(turn: Turn): string {
-  if (turn.origin === "cron") {
+  if (turn.origin === "canopy_scheduler") {
     const slot = turn.origin_ref?.slot;
-    return typeof slot === "string" ? `cron · ${slot}` : "cron";
+    if (typeof slot === "string") return `canopy_scheduler · ${slot}`;
+    if (turn.origin_ref?.manual) return "canopy_scheduler · run now";
+    return "canopy_scheduler";
   }
-  if (turn.origin === "manual" && turn.enqueued_by_email) {
-    return `manual · ${turn.enqueued_by_email}`;
+  if (turn.enqueued_by_email) {
+    return `${turn.origin} · ${turn.enqueued_by_email}`;
   }
   return turn.origin;
 }

--- a/tests/test_claim_schedule_parity.py
+++ b/tests/test_claim_schedule_parity.py
@@ -131,7 +131,7 @@ def test_what_a_runner_may_fire_is_exactly_what_it_may_claim(fleet):
     runner = fleet["runner"]
     for agent in fleet["agents"].values():
         services.enqueue_turn(
-            agent=agent, origin=Turn.ORIGIN_CRON, idempotency_key=f"k-{agent.slug}"
+            agent=agent, origin=Turn.ORIGIN_CANOPY_SCHEDULER, idempotency_key=f"k-{agent.slug}"
         )
 
     syncable = _syncable_agent_slugs(runner)
@@ -152,7 +152,7 @@ def test_a_second_workspace_of_the_pairer_is_not_lost_to_the_runner_fk(fleet):
     assert "elsewhere" in _syncable_agent_slugs(runner)
 
     services.enqueue_turn(
-        agent=fleet["agents"]["elsewhere"], origin=Turn.ORIGIN_CRON, idempotency_key="k1"
+        agent=fleet["agents"]["elsewhere"], origin=Turn.ORIGIN_CANOPY_SCHEDULER, idempotency_key="k1"
     )
     assert _claimable_agent_slugs(runner) == {"elsewhere"}
 
@@ -168,7 +168,7 @@ def test_an_orphaned_runner_can_neither_fire_nor_claim(fleet):
     runner.save(update_fields=["paired_by"])
     for agent in fleet["agents"].values():
         services.enqueue_turn(
-            agent=agent, origin=Turn.ORIGIN_CRON, idempotency_key=f"o-{agent.slug}"
+            agent=agent, origin=Turn.ORIGIN_CANOPY_SCHEDULER, idempotency_key=f"o-{agent.slug}"
         )
 
     assert _syncable_agent_slugs(runner) == set()
@@ -186,7 +186,7 @@ def test_losing_a_membership_narrows_both_sides_together(fleet):
 
     for agent in fleet["agents"].values():
         services.enqueue_turn(
-            agent=agent, origin=Turn.ORIGIN_CRON, idempotency_key=f"r-{agent.slug}"
+            agent=agent, origin=Turn.ORIGIN_CANOPY_SCHEDULER, idempotency_key=f"r-{agent.slug}"
         )
 
     assert _syncable_agent_slugs(runner) == {"here"}

--- a/tests/test_harness_authz.py
+++ b/tests/test_harness_authz.py
@@ -319,7 +319,7 @@ def test_list_turns_excludes_other_tenants_project_and_session_turns(owner_clien
     Mirrors the same split-by-target-kind fix `claim_next_turn`
     (apps/harness/services.py) already applies to its own tenant_q."""
     Turn.objects.create(
-        project="secret-repo", workspace=workspace, origin=Turn.ORIGIN_MANUAL,
+        project="secret-repo", workspace=workspace, origin=Turn.ORIGIN_API,
         idempotency_key="p-secret", prompt="secret project prompt",
     )
     resp = stranger_client.get("/api/harness/turns/")

--- a/tests/test_harness_cancel_turn.py
+++ b/tests/test_harness_cancel_turn.py
@@ -40,7 +40,7 @@ def cli(client, jj, canopy):
 
 def test_cancel_a_queued_project_turn(cli, canopy):
     turn = Turn.objects.create(
-        project="canopy-web", workspace=canopy, origin=Turn.ORIGIN_MANUAL, idempotency_key="k1"
+        project="canopy-web", workspace=canopy, origin=Turn.ORIGIN_API, idempotency_key="k1"
     )
     resp = cli.post(f"/api/harness/turns/{turn.id}/cancel")
 
@@ -52,7 +52,7 @@ def test_cancel_a_queued_project_turn(cli, canopy):
 
 def test_cancel_a_queued_agent_turn(cli, canopy):
     agent = Agent.objects.create(slug="echo", name="Echo", workspace=canopy)
-    turn = Turn.objects.create(agent=agent, origin=Turn.ORIGIN_MANUAL, idempotency_key="k1")
+    turn = Turn.objects.create(agent=agent, origin=Turn.ORIGIN_API, idempotency_key="k1")
 
     assert cli.post(f"/api/harness/turns/{turn.id}/cancel").status_code == 200
     turn.refresh_from_db()
@@ -64,7 +64,7 @@ def test_cannot_cancel_a_running_turn(cli, canopy):
     Cancel is un-queue, not kill."""
     agent = Agent.objects.create(slug="echo", name="Echo", workspace=canopy)
     turn = Turn.objects.create(
-        agent=agent, origin=Turn.ORIGIN_MANUAL, idempotency_key="k1", status=Turn.RUNNING
+        agent=agent, origin=Turn.ORIGIN_API, idempotency_key="k1", status=Turn.RUNNING
     )
     resp = cli.post(f"/api/harness/turns/{turn.id}/cancel")
 
@@ -75,7 +75,7 @@ def test_cannot_cancel_a_running_turn(cli, canopy):
 
 def test_cancel_is_idempotent(cli, canopy):
     turn = Turn.objects.create(
-        project="canopy-web", workspace=canopy, origin=Turn.ORIGIN_MANUAL, idempotency_key="k1"
+        project="canopy-web", workspace=canopy, origin=Turn.ORIGIN_API, idempotency_key="k1"
     )
     assert cli.post(f"/api/harness/turns/{turn.id}/cancel").status_code == 200
     # second cancel: already FAILED (terminal) -> still 200, no error
@@ -88,7 +88,7 @@ def test_a_cancelled_turn_is_not_claimable(cli, canopy, jj):
     from django.utils import timezone
 
     turn = Turn.objects.create(
-        project="canopy-web", workspace=canopy, origin=Turn.ORIGIN_MANUAL, idempotency_key="k1"
+        project="canopy-web", workspace=canopy, origin=Turn.ORIGIN_API, idempotency_key="k1"
     )
     cli.post(f"/api/harness/turns/{turn.id}/cancel")
 
@@ -102,7 +102,7 @@ def test_a_cancelled_turn_is_not_claimable(cli, canopy, jj):
 def test_cannot_cancel_another_tenants_turn(client, canopy, jj):
     """_turn_or_404 gates the cancel: a non-member gets 404, not a cancel."""
     turn = Turn.objects.create(
-        project="canopy-web", workspace=canopy, origin=Turn.ORIGIN_MANUAL, idempotency_key="k1"
+        project="canopy-web", workspace=canopy, origin=Turn.ORIGIN_API, idempotency_key="k1"
     )
     mallory = _user("mallory")
     _ws("mallory-space", mallory)
@@ -125,7 +125,7 @@ def test_cancel_turn_unqueues_as_cancelled(canopy):
     from apps.harness import services
 
     turn = Turn.objects.create(
-        project="canopy-web", workspace=canopy, origin=Turn.ORIGIN_MANUAL, idempotency_key="k-cancel-1"
+        project="canopy-web", workspace=canopy, origin=Turn.ORIGIN_API, idempotency_key="k-cancel-1"
     )
     out = services.cancel_turn(turn)
     assert out.status == Turn.CANCELLED
@@ -142,7 +142,7 @@ def test_cancel_turn_signals_running_turn(canopy, jj, monkeypatch):
         last_heartbeat_at=timezone.now(), capabilities={"agents": ["echo"]},
     )
     turn = Turn.objects.create(
-        agent=agent, origin=Turn.ORIGIN_MANUAL, idempotency_key="k-cancel-2",
+        agent=agent, origin=Turn.ORIGIN_API, idempotency_key="k-cancel-2",
         status=Turn.RUNNING, claimed_by=runner,
     )
     published = []
@@ -167,7 +167,7 @@ def test_sweep_finishes_cancel_requested_as_cancelled(canopy):
         name="jj-mbp", kind=Runner.EMDASH, status=Runner.ONLINE, last_heartbeat_at=timezone.now(),
     )
     turn = Turn.objects.create(
-        agent=agent, origin=Turn.ORIGIN_MANUAL, idempotency_key="k-cancel-3",
+        agent=agent, origin=Turn.ORIGIN_API, idempotency_key="k-cancel-3",
         status=Turn.RUNNING, claimed_by=runner,
         lease_expires_at=timezone.now() - dt.timedelta(minutes=1),
     )
@@ -195,7 +195,7 @@ def test_finish_turn_done_is_coerced_to_cancelled_when_cancel_was_requested(cano
         last_heartbeat_at=timezone.now(),
     )
     turn = Turn.objects.create(
-        agent=agent, origin=Turn.ORIGIN_MANUAL, idempotency_key="k-i2-1",
+        agent=agent, origin=Turn.ORIGIN_API, idempotency_key="k-i2-1",
         status=Turn.RUNNING, claimed_by=runner,
     )
     services.append_events(turn, [{"kind": "cancel_requested", "payload": {}}])
@@ -218,7 +218,7 @@ def test_finish_turn_done_without_cancel_request_stays_done(canopy, jj):
         last_heartbeat_at=timezone.now(),
     )
     turn = Turn.objects.create(
-        agent=agent, origin=Turn.ORIGIN_MANUAL, idempotency_key="k-i2-2",
+        agent=agent, origin=Turn.ORIGIN_API, idempotency_key="k-i2-2",
         status=Turn.RUNNING, claimed_by=runner,
     )
 
@@ -243,7 +243,7 @@ def test_cancel_turn_race_guard_does_not_force_cancel_a_claimed_turn(canopy, jj,
         last_heartbeat_at=timezone.now(),
     )
     turn = Turn.objects.create(
-        agent=agent, origin=Turn.ORIGIN_MANUAL, idempotency_key="k-race-1", status=Turn.QUEUED,
+        agent=agent, origin=Turn.ORIGIN_API, idempotency_key="k-race-1", status=Turn.QUEUED,
     )
     # Simulate the race: the in-memory `turn` object still reads QUEUED (as if
     # cancel_turn had just loaded it), but a runner claimed it in the DB in the

--- a/tests/test_harness_claim_projects.py
+++ b/tests/test_harness_claim_projects.py
@@ -46,7 +46,7 @@ def test_a_projects_only_runner_claims_a_project_turn():
     ws = _ws("canopy", jj)
     runner = _runner(jj)
     turn = Turn.objects.create(
-        project="canopy-web", workspace=ws, origin=Turn.ORIGIN_MANUAL,
+        project="canopy-web", workspace=ws, origin=Turn.ORIGIN_API,
         idempotency_key="p1", prompt="fix the header",
     )
 
@@ -76,7 +76,7 @@ def test_a_runner_paired_by_a_non_member_cannot_claim_another_tenants_project_tu
     attacker = _runner(mallory, name="mallory-box")
 
     Turn.objects.create(
-        project="canopy-web", workspace=victim_ws, origin=Turn.ORIGIN_MANUAL,
+        project="canopy-web", workspace=victim_ws, origin=Turn.ORIGIN_API,
         idempotency_key="p1",
     )
 
@@ -90,7 +90,7 @@ def test_a_project_turn_with_no_workspace_is_not_claimable():
     _ws("canopy", jj)
     runner = _runner(jj)
     Turn.objects.create(
-        project="canopy-web", workspace=None, origin=Turn.ORIGIN_MANUAL,
+        project="canopy-web", workspace=None, origin=Turn.ORIGIN_API,
         idempotency_key="p1",
     )
 
@@ -108,10 +108,10 @@ def test_a_busy_agent_does_not_block_a_project_turn():
 
     # Echo is mid-turn — that must serialize ECHO, and nothing else.
     Turn.objects.create(
-        agent=echo, origin=Turn.ORIGIN_BOARD, idempotency_key="a1", status=Turn.RUNNING
+        agent=echo, origin=Turn.ORIGIN_API, idempotency_key="a1", status=Turn.RUNNING
     )
     project_turn = Turn.objects.create(
-        project="canopy-web", workspace=ws, origin=Turn.ORIGIN_MANUAL, idempotency_key="p1"
+        project="canopy-web", workspace=ws, origin=Turn.ORIGIN_API, idempotency_key="p1"
     )
 
     claimed = services.claim_next_turn(runner)
@@ -128,7 +128,7 @@ def test_pausing_an_agent_does_not_pause_the_repos():
     runner = _runner(jj, capabilities={"agents": ["echo"], "projects": ["canopy-web"]})
     Agent.objects.create(slug="echo", name="Echo", workspace=ws)
     project_turn = Turn.objects.create(
-        project="canopy-web", workspace=ws, origin=Turn.ORIGIN_MANUAL, idempotency_key="p1"
+        project="canopy-web", workspace=ws, origin=Turn.ORIGIN_API, idempotency_key="p1"
     )
 
     claimed = services.claim_next_turn(runner, exclude_slugs=["echo"])
@@ -142,7 +142,7 @@ def test_a_runner_not_declaring_a_project_does_not_claim_it():
     ws = _ws("canopy", jj)
     runner = _runner(jj, capabilities={"projects": ["some-other-repo"]})
     Turn.objects.create(
-        project="canopy-web", workspace=ws, origin=Turn.ORIGIN_MANUAL, idempotency_key="p1"
+        project="canopy-web", workspace=ws, origin=Turn.ORIGIN_API, idempotency_key="p1"
     )
 
     assert services.claim_next_turn(runner) is None

--- a/tests/test_harness_claim_sessions.py
+++ b/tests/test_harness_claim_sessions.py
@@ -116,7 +116,7 @@ def test_busy_session_exclude_does_not_strand_project_turns():
     runner = _runner(jj, kind=Runner.CLOUD, capabilities={"projects": ["canopy-web"], "sessions": True})
     _session_turn(_session(ws, jj), "sx", status=Turn.RUNNING)  # a busy session exists
     pturn = Turn.objects.create(
-        project="canopy-web", workspace=ws, origin=Turn.ORIGIN_MANUAL, idempotency_key="p1"
+        project="canopy-web", workspace=ws, origin=Turn.ORIGIN_API, idempotency_key="p1"
     )
 
     claimed = services.claim_next_turn(runner)

--- a/tests/test_harness_events_signal.py
+++ b/tests/test_harness_events_signal.py
@@ -18,7 +18,7 @@ pytestmark = pytest.mark.django_db(transaction=True)
 
 def _turn():
     agent = Agent.objects.create(slug="echo", name="Echo", workspace=a_workspace())
-    return Turn.objects.create(agent=agent, origin=Turn.ORIGIN_BOARD, idempotency_key="k1")
+    return Turn.objects.create(agent=agent, origin=Turn.ORIGIN_API, idempotency_key="k1")
 
 
 def test_append_events_fires_signal_after_commit():

--- a/tests/test_harness_models.py
+++ b/tests/test_harness_models.py
@@ -24,44 +24,44 @@ def _runner(**kw):
 
 
 def test_turn_defaults_to_queued():
-    t = Turn.objects.create(agent=_agent(), origin=Turn.ORIGIN_BOARD, idempotency_key="k1")
+    t = Turn.objects.create(agent=_agent(), origin=Turn.ORIGIN_API, idempotency_key="k1")
     assert t.status == Turn.QUEUED
     assert t.routing == Turn.PREFER_LOCAL
 
 
 def test_queued_turns_stack_freely():
     a = _agent()
-    Turn.objects.create(agent=a, origin=Turn.ORIGIN_BOARD, idempotency_key="k1")
-    Turn.objects.create(agent=a, origin=Turn.ORIGIN_BOARD, idempotency_key="k2")  # no raise
+    Turn.objects.create(agent=a, origin=Turn.ORIGIN_API, idempotency_key="k1")
+    Turn.objects.create(agent=a, origin=Turn.ORIGIN_API, idempotency_key="k2")  # no raise
     assert Turn.objects.filter(agent=a, status=Turn.QUEUED).count() == 2
 
 
 def test_one_executing_turn_per_agent():
     a = _agent()
-    Turn.objects.create(agent=a, origin=Turn.ORIGIN_BOARD, idempotency_key="k1", status=Turn.CLAIMED)
+    Turn.objects.create(agent=a, origin=Turn.ORIGIN_API, idempotency_key="k1", status=Turn.CLAIMED)
     with pytest.raises(IntegrityError):
-        Turn.objects.create(agent=a, origin=Turn.ORIGIN_BOARD, idempotency_key="k2", status=Turn.RUNNING)
+        Turn.objects.create(agent=a, origin=Turn.ORIGIN_API, idempotency_key="k2", status=Turn.RUNNING)
 
 
 def test_terminal_turn_frees_the_execution_slot():
     a = _agent()
-    t = Turn.objects.create(agent=a, origin=Turn.ORIGIN_BOARD, idempotency_key="k1", status=Turn.RUNNING)
+    t = Turn.objects.create(agent=a, origin=Turn.ORIGIN_API, idempotency_key="k1", status=Turn.RUNNING)
     t.status = Turn.DONE
     t.save()
-    Turn.objects.create(agent=a, origin=Turn.ORIGIN_BOARD, idempotency_key="k2", status=Turn.CLAIMED)  # no raise
+    Turn.objects.create(agent=a, origin=Turn.ORIGIN_API, idempotency_key="k2", status=Turn.CLAIMED)  # no raise
 
 
 def test_idempotency_key_unique():
     a = _agent()
-    t = Turn.objects.create(agent=a, origin=Turn.ORIGIN_BOARD, idempotency_key="k1")
+    t = Turn.objects.create(agent=a, origin=Turn.ORIGIN_API, idempotency_key="k1")
     t.status = Turn.DONE
     t.save()
     with pytest.raises(IntegrityError):
-        Turn.objects.create(agent=a, origin=Turn.ORIGIN_BOARD, idempotency_key="k1")
+        Turn.objects.create(agent=a, origin=Turn.ORIGIN_API, idempotency_key="k1")
 
 
 def test_turn_event_seq_unique_per_turn():
-    t = Turn.objects.create(agent=_agent(), origin=Turn.ORIGIN_BOARD, idempotency_key="k1")
+    t = Turn.objects.create(agent=_agent(), origin=Turn.ORIGIN_API, idempotency_key="k1")
     TurnEvent.objects.create(turn=t, seq=1, kind="status", payload={"s": "claimed"})
     with pytest.raises(IntegrityError):
         TurnEvent.objects.create(turn=t, seq=1, kind="status", payload={})
@@ -71,7 +71,7 @@ def test_finish_turn_accepts_missed():
     """MISSED is a terminal status distinct from LOST (infra failure)."""
     agent = Agent.objects.create(slug="eva", name="Eva", workspace=a_workspace())
     turn = Turn.objects.create(
-        agent=agent, origin=Turn.ORIGIN_CRON, idempotency_key="k1", status=Turn.RUNNING
+        agent=agent, origin=Turn.ORIGIN_CANOPY_SCHEDULER, idempotency_key="k1", status=Turn.RUNNING
     )
     out = services.finish_turn(turn, status=Turn.MISSED, result_note="superseded")
 

--- a/tests/test_harness_project_turns.py
+++ b/tests/test_harness_project_turns.py
@@ -33,19 +33,19 @@ def test_a_turn_cannot_target_both_an_agent_and_a_project():
     with pytest.raises(IntegrityError):
         Turn.objects.create(
             agent=_agent(), project="canopy-web",
-            origin=Turn.ORIGIN_MANUAL, idempotency_key="both",
+            origin=Turn.ORIGIN_API, idempotency_key="both",
         )
 
 
 def test_a_turn_must_target_something():
     with pytest.raises(IntegrityError):
-        Turn.objects.create(origin=Turn.ORIGIN_MANUAL, idempotency_key="neither")
+        Turn.objects.create(origin=Turn.ORIGIN_API, idempotency_key="neither")
 
 
 def test_a_project_turn_needs_no_agent():
     t = Turn.objects.create(
         project="canopy-web", workspace=_ws(),
-        origin=Turn.ORIGIN_MANUAL, idempotency_key="p1", prompt="fix the header",
+        origin=Turn.ORIGIN_API, idempotency_key="p1", prompt="fix the header",
     )
     assert t.agent_id is None
     assert t.target == "canopy-web"
@@ -63,11 +63,11 @@ def test_two_project_turns_for_the_same_repo_both_execute():
     """
     ws = _ws()
     Turn.objects.create(
-        project="canopy-web", workspace=ws, origin=Turn.ORIGIN_MANUAL,
+        project="canopy-web", workspace=ws, origin=Turn.ORIGIN_API,
         idempotency_key="p1", status=Turn.RUNNING,
     )
     Turn.objects.create(  # must not raise
-        project="canopy-web", workspace=ws, origin=Turn.ORIGIN_MANUAL,
+        project="canopy-web", workspace=ws, origin=Turn.ORIGIN_API,
         idempotency_key="p2", status=Turn.RUNNING,
     )
     assert Turn.objects.filter(project="canopy-web", status=Turn.RUNNING).count() == 2
@@ -78,18 +78,18 @@ def test_one_executing_turn_per_agent_still_holds_for_agents():
     loosened the agent invariant it was protecting."""
     a = _agent()
     Turn.objects.create(
-        agent=a, origin=Turn.ORIGIN_BOARD, idempotency_key="a1", status=Turn.RUNNING
+        agent=a, origin=Turn.ORIGIN_API, idempotency_key="a1", status=Turn.RUNNING
     )
     with pytest.raises(IntegrityError):
         Turn.objects.create(
-            agent=a, origin=Turn.ORIGIN_BOARD, idempotency_key="a2", status=Turn.RUNNING
+            agent=a, origin=Turn.ORIGIN_API, idempotency_key="a2", status=Turn.RUNNING
         )
 
 
 def test_str_does_not_crash_on_a_project_turn():
     """__str__ read self.agent.slug unconditionally before agent could be NULL."""
     t = Turn.objects.create(
-        project="canopy-web", workspace=_ws(), origin=Turn.ORIGIN_MANUAL,
+        project="canopy-web", workspace=_ws(), origin=Turn.ORIGIN_API,
         idempotency_key="p1",
     )
     assert "canopy-web" in str(t)
@@ -97,7 +97,7 @@ def test_str_does_not_crash_on_a_project_turn():
 
 def test_target_prefers_the_agent_for_agent_turns():
     t = Turn.objects.create(
-        agent=_agent("hal"), origin=Turn.ORIGIN_BOARD, idempotency_key="a1"
+        agent=_agent("hal"), origin=Turn.ORIGIN_API, idempotency_key="a1"
     )
     assert t.target == "hal"
 
@@ -108,7 +108,7 @@ def test_turn_out_serializes_a_project_turn_without_dereferencing_a_null_agent()
     from apps.harness.schemas import TurnOut
 
     t = Turn.objects.create(
-        project="canopy-web", workspace=_ws(), origin=Turn.ORIGIN_MANUAL,
+        project="canopy-web", workspace=_ws(), origin=Turn.ORIGIN_API,
         idempotency_key="p1", prompt="fix the header",
     )
     out = TurnOut.from_orm(t)
@@ -121,7 +121,7 @@ def test_turn_out_still_serializes_an_agent_turn():
     from apps.harness.schemas import TurnOut
 
     out = TurnOut.from_orm(
-        Turn.objects.create(agent=_agent("hal"), origin=Turn.ORIGIN_BOARD, idempotency_key="a1")
+        Turn.objects.create(agent=_agent("hal"), origin=Turn.ORIGIN_API, idempotency_key="a1")
     )
     assert out.agent_slug == "hal"
     assert out.project == ""

--- a/tests/test_harness_turn_transcript.py
+++ b/tests/test_harness_turn_transcript.py
@@ -27,7 +27,7 @@ pytestmark = pytest.mark.django_db
 def _turn(idempotency_key: str = "k1") -> Turn:
     agent = Agent.objects.create(slug="echo", name="Echo", workspace=a_workspace())
     return Turn.objects.create(
-        agent=agent, origin=Turn.ORIGIN_BOARD, idempotency_key=idempotency_key
+        agent=agent, origin=Turn.ORIGIN_API, idempotency_key=idempotency_key
     )
 
 

--- a/tests/test_origin_vocabulary.py
+++ b/tests/test_origin_vocabulary.py
@@ -1,0 +1,78 @@
+"""The source vocabulary: six values, legacy aliases normalized at the boundary.
+
+`origin` is now a ROUTING input (spec 2026-07-27), so the set of values a caller
+may supply is deliberately narrower than the set the column holds.
+"""
+from __future__ import annotations
+
+import pytest
+
+from apps.agents.models import Agent
+from apps.harness import services
+from apps.harness.models import Item, Turn
+from apps.harness.schemas import ItemIn, TurnIn
+from apps.workspaces.testing import a_workspace
+
+pytestmark = pytest.mark.django_db
+
+
+def test_the_vocabulary_is_exactly_six_values():
+    assert {v for v, _label in Turn.ORIGIN_CHOICES} == {
+        "api", "ace_web", "canopy_web_chat", "canopy_scheduler", "email", "slack",
+    }
+
+
+def test_server_only_origins_are_not_postable():
+    assert Turn.POSTABLE_ORIGINS == {"api", "ace_web", "email", "slack"}
+    for server_only in ("canopy_web_chat", "canopy_scheduler"):
+        with pytest.raises(ValueError):
+            TurnIn(agent_slug="echo", origin=server_only, idempotency_key="k")
+
+
+def test_a_caller_may_post_a_source_value():
+    assert TurnIn(agent_slug="echo", origin="ace_web", idempotency_key="k").origin == "ace_web"
+
+
+@pytest.mark.parametrize(
+    "legacy,expected",
+    [("board", "api"), ("manual", "api"), ("drill", "api"), ("cron", "canopy_scheduler")],
+)
+def test_legacy_origins_normalize_rather_than_422(legacy, expected):
+    """The live fleet posts these today. Rejecting them would 422 Echo/Ada mid-flight,
+    so they normalize to their migration target for one release."""
+    assert TurnIn(agent_slug="echo", origin=legacy, idempotency_key="k").origin == expected
+    assert ItemIn(title="t", origin=legacy, idempotency_key="k").origin == expected
+
+
+def test_an_unknown_origin_is_still_rejected():
+    with pytest.raises(ValueError):
+        TurnIn(agent_slug="echo", origin="wat", idempotency_key="k")
+
+
+def test_routable_sources_exclude_nothing_produced_and_include_the_real_cases():
+    assert set(Turn.ROUTABLE_ORIGINS) == {
+        "ace_web", "email", "canopy_scheduler", "canopy_web_chat", "slack", "api",
+    }
+
+
+def test_both_origin_columns_hold_the_longest_value():
+    """`canopy_scheduler` is 16 chars; the column was max_length=10."""
+    agent = Agent.objects.create(slug="echo", name="Echo", workspace=a_workspace())
+    turn = Turn.objects.create(
+        agent=agent, origin=Turn.ORIGIN_CANOPY_SCHEDULER, idempotency_key="k1"
+    )
+    item = Item.objects.create(
+        agent=agent, origin=Turn.ORIGIN_CANOPY_SCHEDULER, title="t", idempotency_key="i1"
+    )
+    turn.refresh_from_db()
+    item.refresh_from_db()
+    assert turn.origin == item.origin == "canopy_scheduler"
+
+
+def test_a_stored_dispatch_spec_with_a_retired_origin_still_enqueues_a_valid_one():
+    """Items raised before this deploy carry origin="manual" in their dispatch JSON,
+    and TurnSpec.from_dict hands it straight to enqueue_turn without a schema in the
+    path. A turn born with a retired origin matches no rule and no log filter."""
+    agent = Agent.objects.create(slug="echo", name="Echo", workspace=a_workspace())
+    turn, _ = services.enqueue_turn(agent=agent, origin="manual", idempotency_key="legacy-1")
+    assert turn.origin == Turn.ORIGIN_API

--- a/tests/test_realtime_fanout.py
+++ b/tests/test_realtime_fanout.py
@@ -33,7 +33,7 @@ def _fixtures():
 
 def test_turn_event_fanout():
     _user, _ws, agent = _fixtures()
-    turn = Turn.objects.create(agent=agent, origin=Turn.ORIGIN_BOARD, idempotency_key="k1")
+    turn = Turn.objects.create(agent=agent, origin=Turn.ORIGIN_API, idempotency_key="k1")
     layer = get_channel_layer()
     async_to_sync(layer.group_add)(groups.turn_group(turn.id), "turn-chan")
 

--- a/tests/test_realtime_groups.py
+++ b/tests/test_realtime_groups.py
@@ -30,7 +30,7 @@ def test_user_can_read_turn_by_workspace_membership():
     ws = Workspace.objects.create(slug="canopy", display_name="Canopy", created_by=owner)
     WorkspaceMembership.objects.create(user=owner, workspace=ws, role=WorkspaceMembership.OWNER)
     agent = Agent.objects.create(slug="echo", name="Echo", workspace=ws, owner=owner)
-    turn = Turn.objects.create(agent=agent, origin=Turn.ORIGIN_BOARD, idempotency_key="k1")
+    turn = Turn.objects.create(agent=agent, origin=Turn.ORIGIN_API, idempotency_key="k1")
 
     assert groups.user_can_read_turn(owner, turn) is True
     outsider = User.objects.create_user("no", "no@dimagi.com", "pw")
@@ -47,7 +47,7 @@ def test_user_cannot_read_workspaceless_turn():
     user_can_read_turn still has to hold for the kinds that can be NULL."""
     user = User.objects.create_user("jj", "jj@dimagi.com", "pw")
     turn = Turn.objects.create(
-        project="canopy-web", origin=Turn.ORIGIN_MANUAL, idempotency_key="k1"
+        project="canopy-web", origin=Turn.ORIGIN_API, idempotency_key="k1"
     )
     assert turn.workspace_id is None
     assert groups.user_can_read_turn(user, turn) is False
@@ -57,7 +57,7 @@ def test_user_cannot_read_workspaceless_turn():
 def test_superuser_can_read_any_turn():
     su = User.objects.create_superuser("admin", "admin@dimagi.com", "pw")
     agent = Agent.objects.create(slug="loner", name="Loner", workspace=a_workspace())
-    turn = Turn.objects.create(agent=agent, origin=Turn.ORIGIN_BOARD, idempotency_key="k1")
+    turn = Turn.objects.create(agent=agent, origin=Turn.ORIGIN_API, idempotency_key="k1")
     assert groups.user_can_read_turn(su, turn) is True
 
 

--- a/tests/test_realtime_integration.py
+++ b/tests/test_realtime_integration.py
@@ -75,7 +75,7 @@ async def test_authenticated_supervisor_connect_and_snapshot():
 async def test_authenticated_turn_tail_replay_then_live():
     def setup():
         user, agent = _seed()
-        turn = Turn.objects.create(agent=agent, origin=Turn.ORIGIN_BOARD, idempotency_key="k1")
+        turn = Turn.objects.create(agent=agent, origin=Turn.ORIGIN_API, idempotency_key="k1")
         services.append_events(turn, [{"kind": "assistant", "payload": {"text": "old"}}])
         return turn, _make_session(user)
 

--- a/tests/test_realtime_runner_consumer.py
+++ b/tests/test_realtime_runner_consumer.py
@@ -73,7 +73,7 @@ async def test_enqueue_wakes_the_runner():
 
     @database_sync_to_async
     def _enqueue():
-        services.enqueue_turn(agent=agent, origin=Turn.ORIGIN_MANUAL,
+        services.enqueue_turn(agent=agent, origin=Turn.ORIGIN_API,
                               idempotency_key="w1", prompt="hi")
 
     await _enqueue()
@@ -88,7 +88,7 @@ async def test_claim_over_ws_returns_a_turn():
 
     @database_sync_to_async
     def _enqueue():
-        services.enqueue_turn(agent=agent, origin=Turn.ORIGIN_MANUAL,
+        services.enqueue_turn(agent=agent, origin=Turn.ORIGIN_API,
                               idempotency_key="c1", prompt="do the thing")
 
     await _enqueue()  # queued before connect — so no wake reaches this socket
@@ -119,7 +119,7 @@ async def test_run_turn_end_to_end_over_ws():
 
     @database_sync_to_async
     def _enqueue():
-        t, _ = services.enqueue_turn(agent=agent, origin=Turn.ORIGIN_MANUAL,
+        t, _ = services.enqueue_turn(agent=agent, origin=Turn.ORIGIN_API,
                                      idempotency_key="run1", prompt="go")
         return t
 
@@ -158,7 +158,7 @@ async def test_cannot_touch_a_turn_it_did_not_claim():
 
     @database_sync_to_async
     def _foreign_turn():
-        t, _ = services.enqueue_turn(agent=agent, origin=Turn.ORIGIN_MANUAL,
+        t, _ = services.enqueue_turn(agent=agent, origin=Turn.ORIGIN_API,
                                      idempotency_key="foreign", prompt="x")
         return str(t.id)
 

--- a/tests/test_realtime_turn_consumer.py
+++ b/tests/test_realtime_turn_consumer.py
@@ -25,7 +25,7 @@ def _member_turn():
     ws = Workspace.objects.create(slug="canopy", display_name="Canopy", created_by=user)
     WorkspaceMembership.objects.create(user=user, workspace=ws, role=WorkspaceMembership.OWNER)
     agent = Agent.objects.create(slug="echo", name="Echo", workspace=ws, owner=user)
-    turn = Turn.objects.create(agent=agent, origin=Turn.ORIGIN_BOARD, idempotency_key="k1")
+    turn = Turn.objects.create(agent=agent, origin=Turn.ORIGIN_API, idempotency_key="k1")
     return user, turn
 
 

--- a/tests/test_runner_assignments.py
+++ b/tests/test_runner_assignments.py
@@ -38,10 +38,13 @@ def test_drill_unique_per_pair_and_defaults_pending():
         RunnerDrill.objects.create(runner=r1, agent=a)
 
 
-def test_turn_pinned_runner_nullable_and_origin_drill():
+def test_turn_pinned_runner_degrades_to_normal_routing_on_delete():
+    # Was named "…_and_origin_drill": a drill USED to be an origin value. It is
+    # now an ordinary `api` turn that names its runner, identified by its
+    # RunnerDrill FK — the pin is the only part this test was ever exercising.
     a, r1 = _agent(), _runner()
     t = Turn.objects.create(
-        agent=a, origin=Turn.ORIGIN_DRILL, idempotency_key="k1", pinned_runner=r1
+        agent=a, origin=Turn.ORIGIN_API, idempotency_key="k1", pinned_runner=r1
     )
     r1.delete()
     t.refresh_from_db()

--- a/tests/test_runner_drills.py
+++ b/tests/test_runner_drills.py
@@ -59,7 +59,7 @@ def test_start_drill_fans_out_pinned_pending_turns(django_user_model):
         RunnerAssignment.objects.create(agent=a, runner=r, rank=i)
     drills = services.start_drill(r, [a1, a2])
     assert {d.outcome for d in drills} == {RunnerDrill.OUTCOME_PENDING}
-    turns = Turn.objects.filter(origin=Turn.ORIGIN_DRILL)
+    turns = Turn.objects.filter(origin=Turn.ORIGIN_API)
     assert turns.count() == 2
     assert all(t.pinned_runner_id == r.id for t in turns)
     assert "read-only" in turns.first().prompt.lower()
@@ -82,7 +82,7 @@ def test_failed_drill_turn_marks_drill_fail(django_user_model):
     a = Agent.objects.create(slug="echo", name="Echo", workspace=a_workspace())
     RunnerAssignment.objects.create(agent=a, runner=r, rank=0)
     [d] = services.start_drill(r, [a])
-    turn = Turn.objects.get(origin=Turn.ORIGIN_DRILL)
+    turn = Turn.objects.get(origin=Turn.ORIGIN_API)
     Turn.objects.filter(pk=turn.pk).update(status=Turn.CLAIMED, claimed_by=r)
     turn.refresh_from_db()
     services.finish_turn(turn, status=Turn.FAILED, result_note="claude auth expired")
@@ -102,7 +102,7 @@ def test_lost_drill_turn_marks_drill_fail(django_user_model):
     a = Agent.objects.create(slug="echo5", name="Echo5", workspace=a_workspace())
     RunnerAssignment.objects.create(agent=a, runner=r, rank=0)
     [d] = services.start_drill(r, [a])
-    turn = Turn.objects.get(origin=Turn.ORIGIN_DRILL)
+    turn = Turn.objects.get(origin=Turn.ORIGIN_API)
     Turn.objects.filter(pk=turn.pk).update(
         status=Turn.CLAIMED, claimed_by=r,
         lease_expires_at=timezone.now() - timezone.timedelta(minutes=5),

--- a/tests/test_runner_routing.py
+++ b/tests/test_runner_routing.py
@@ -85,7 +85,7 @@ def test_pinned_turn_invisible_to_other_runners():
     RunnerAssignment.objects.create(agent=a, runner=r2, rank=0)
 
     turn, _ = services.enqueue_turn(
-        agent=a, origin=Turn.ORIGIN_DRILL, idempotency_key="p1", pinned_runner=r1,
+        agent=a, origin=Turn.ORIGIN_API, idempotency_key="p1", pinned_runner=r1,
     )
 
     assert services.claim_next_turn(r2) is None  # pinned elsewhere -> invisible
@@ -108,7 +108,7 @@ def test_pin_bypasses_assignments_but_not_tenancy():
     r_stranger = _runner("evil", stranger)
 
     turn, _ = services.enqueue_turn(
-        agent=a, origin=Turn.ORIGIN_DRILL, idempotency_key="p2", pinned_runner=r_stranger,
+        agent=a, origin=Turn.ORIGIN_API, idempotency_key="p2", pinned_runner=r_stranger,
     )
 
     assert services.claim_next_turn(r_stranger) is None  # tenant gate holds even when pinned

--- a/tests/test_schedule_api.py
+++ b/tests/test_schedule_api.py
@@ -134,7 +134,7 @@ def test_delete_supersedes_open_occurrences_so_the_agent_is_not_wedged(client, a
     # The real proof: the executing-turn index now admits a new turn for the
     # agent. If the old turn were still executing, this insert would raise.
     Turn.objects.create(
-        agent=agent, origin=Turn.ORIGIN_MANUAL, idempotency_key="probe",
+        agent=agent, origin=Turn.ORIGIN_API, idempotency_key="probe",
         status=Turn.RUNNING,
     )
 
@@ -185,7 +185,8 @@ def test_run_now_enqueues_a_manual_turn(client, agent):
     resp = client.post(f"/api/agents/echo/schedules/{sid}/run-now")
     assert resp.status_code == 202, resp.content
     turn = Turn.objects.get()
-    assert turn.origin == Turn.ORIGIN_MANUAL
+    assert turn.origin == Turn.ORIGIN_CANOPY_SCHEDULER
+    assert turn.origin_ref["manual"] is True  # off-cycle, but the same SOURCE
     assert turn.prompt == "/echo:manager-report"
 
 

--- a/tests/test_schedule_authz.py
+++ b/tests/test_schedule_authz.py
@@ -202,4 +202,4 @@ def test_same_tenant_runner_syncs_and_fires(victim_ws, victim_schedule):
         content_type="application/json",
     )
     assert fired.status_code == 201, fired.content
-    assert Turn.objects.get().origin == Turn.ORIGIN_CRON
+    assert Turn.objects.get().origin == Turn.ORIGIN_CANOPY_SCHEDULER

--- a/tests/test_schedule_services.py
+++ b/tests/test_schedule_services.py
@@ -34,7 +34,7 @@ def test_fire_creates_a_cron_turn_and_advances_last_slot(schedule):
     turn, created = services.fire_schedule(schedule, SLOT_A)
 
     assert created is True
-    assert turn.origin == Turn.ORIGIN_CRON
+    assert turn.origin == Turn.ORIGIN_CANOPY_SCHEDULER
     assert turn.status == Turn.QUEUED
     assert turn.prompt == "/echo:manager-report"
     assert turn.origin_ref == {"schedule_id": schedule.id, "slot": SLOT_A.isoformat()}
@@ -51,7 +51,7 @@ def test_fire_is_idempotent_two_runners_one_turn(schedule):
     assert created_1 is True
     assert created_2 is False
     assert first.id == second.id
-    assert Turn.objects.filter(origin=Turn.ORIGIN_CRON).count() == 1
+    assert Turn.objects.filter(origin=Turn.ORIGIN_CANOPY_SCHEDULER).count() == 1
 
 
 def test_fire_supersedes_the_prior_unfinished_turn(schedule):
@@ -98,7 +98,7 @@ def test_release_stale_unwedges_the_agent(schedule, agent):
     assert turn.status == Turn.MISSED
     # Proof it is unwedged: a new executing turn is now insertable.
     Turn.objects.create(
-        agent=agent, origin=Turn.ORIGIN_BOARD, idempotency_key="board-1", status=Turn.RUNNING
+        agent=agent, origin=Turn.ORIGIN_API, idempotency_key="board-1", status=Turn.RUNNING
     )
 
 
@@ -152,7 +152,7 @@ def test_release_all_unwedges_on_the_claim_tick(schedule, agent):
         status=Turn.RUNNING, claimed_at=timezone.now() - dt.timedelta(minutes=200)
     )
     queued = Turn.objects.create(
-        agent=agent, origin=Turn.ORIGIN_BOARD, idempotency_key="board-1"
+        agent=agent, origin=Turn.ORIGIN_API, idempotency_key="board-1"
     )
     runner = Runner.objects.create(
         name="mac-a", kind=Runner.EMDASH, host="mac-a", status=Runner.ONLINE,
@@ -236,7 +236,7 @@ def test_run_now_does_not_advance_the_cadence(schedule):
     never does is consume a slot."""
     manual = services.run_schedule_now(schedule)
 
-    assert manual.origin == Turn.ORIGIN_MANUAL
+    assert manual.origin == Turn.ORIGIN_CANOPY_SCHEDULER
     assert manual.idempotency_key.startswith(f"sched:{schedule.id}:manual:")
     schedule.refresh_from_db()
     assert schedule.last_slot is None  # a manual run does not consume a slot

--- a/tests/test_schedule_services_crud.py
+++ b/tests/test_schedule_services_crud.py
@@ -121,14 +121,14 @@ def test_delete_supersedes_open_turns_then_removes(owner, agent):
     assert not AgentSchedule.objects.filter(pk=s.id).exists()
     # Proof it is unwedged: a new executing turn for the agent is insertable.
     Turn.objects.create(
-        agent=agent, origin=Turn.ORIGIN_BOARD, idempotency_key="b1", status=Turn.RUNNING
+        agent=agent, origin=Turn.ORIGIN_API, idempotency_key="b1", status=Turn.RUNNING
     )
 
 
 def test_run_now_enqueues_manual_turn(owner, agent):
     s = ss.create_schedule(owner, "eva", _fields())
     ss.run_schedule_now(owner, "eva", s.id)
-    assert Turn.objects.filter(origin=Turn.ORIGIN_MANUAL).count() == 1
+    assert Turn.objects.filter(origin=Turn.ORIGIN_CANOPY_SCHEDULER).count() == 1
 
 
 def test_preview_cron_returns_three(owner, agent):


### PR DESCRIPTION
First slice of source-aware runner routing. Nothing routes differently yet — this
makes the **record** honest so the later slices have something to key on.

- `Turn.origin` becomes the source vocabulary: `api` · `ace_web` ·
  `canopy_web_chat` · `canopy_scheduler` · `email` · `slack`. ace-web work and
  chat sends stop hiding inside the `api` catch-all; `cron` becomes
  `canopy_scheduler` (one-shot schedules are coming, and they are not cron);
  `manual`, `board` and `drill` retire into `api`.
- Drill turns are identified by their `RunnerDrill` FK — always their real
  identity — so the three `origin == "drill"` pre-filters are gone.
- Both `origin` columns widen 10 → 32 (metadata-only in Postgres) and migration
  `0030` remaps existing rows.
- Retired spellings **normalize rather than 422**: the live fleet posts `cron`
  and `manual` today, so rejecting them would break Echo and Ada on deploy. A
  one-release shim, marked for removal.

Two things worth a reviewer's eye:

**Normalization runs in `enqueue_turn`, not only at the request boundary.**
`TurnSpec.from_dict` parses stored Item JSON with no schema in the path, and
`_raise_schedule_nag` writes an origin into that JSON. Every schedule nag open
across the deploy would otherwise enqueue a turn carrying a dead value — matching
no routing rule and no turn-log filter.

**`run_schedule_now` is scheduler work now, not `manual`.** Who fired a schedule
is not a different *source*; both route the same way, which is the point of
naming sources. The off-cycle distinction stays in `origin_ref["manual"]`, and
the turn log reads it ("canopy_scheduler · run now").

Verified: `uv run pytest -q` → 1772 passed, 1 skipped. `npx vitest run` → 402
passed. `npm run build` clean. `generated.ts` regenerated.

Plan: `docs/superpowers/plans/2026-07-27-source-aware-runner-routing.md`
(this PR also folds a review pass into that plan — see its Self-Review section)
Spec: `docs/superpowers/specs/2026-07-27-source-aware-runner-routing-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)