### PR TITLE
Source rules on RunnerAssignment (source-aware routing, 2/8)

### DIFF
--- a/apps/harness/migrations/0031_runnerassignment_source_rules.py
+++ b/apps/harness/migrations/0031_runnerassignment_source_rules.py
@@ -1,0 +1,43 @@
+"""Per-source routing rules on RunnerAssignment (spec 2026-07-27).
+
+Splitting the old unique constraint cannot fail on existing data: every current
+row has source="" and so lands in the first constraint, which is the old one
+plus a condition that all of them satisfy.
+"""
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [("harness", "0030_source_vocabulary")]
+
+    operations = [
+        migrations.AddField(
+            model_name="runnerassignment",
+            name="source",
+            field=models.CharField(blank=True, default="", max_length=32),
+        ),
+        migrations.AddField(
+            model_name="runnerassignment",
+            name="strict",
+            field=models.BooleanField(default=False),
+        ),
+        migrations.RemoveConstraint(
+            model_name="runnerassignment", name="one_assignment_per_agent_runner",
+        ),
+        migrations.AddConstraint(
+            model_name="runnerassignment",
+            constraint=models.UniqueConstraint(
+                fields=("agent", "runner"),
+                condition=models.Q(source=""),
+                name="one_default_assignment_per_agent_runner",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="runnerassignment",
+            constraint=models.UniqueConstraint(
+                fields=("agent", "source"),
+                condition=models.Q(("source", ""), _negated=True),
+                name="one_priority_runner_per_agent_source",
+            ),
+        ),
+    ]

--- a/apps/harness/models.py
+++ b/apps/harness/models.py
@@ -651,11 +651,39 @@ class RunnerAssignment(models.Model):
     # lower rank. Distinct from removal — the operator's "x" toggles this
     # instead of deleting the row, so re-enabling doesn't lose the rank.
     enabled = models.BooleanField(default=True)
+    # THE SOURCE RULE (spec 2026-07-27). "" = this row belongs to the agent's
+    # DEFAULT ordered list (the pre-existing behaviour). Non-empty = this row is
+    # the single priority runner for that source, and `rank` is meaningless on it
+    # (the uniqueness constraint below allows exactly one). The column is kept
+    # rather than dropped so an ordered per-source list needs no second migration.
+    #
+    # Note `enabled` then means two things across the two row kinds: a runner
+    # switched off in the default list is still live for any source that names
+    # it, because the rule is its own row with its own toggle. Pinned by
+    # tests/test_source_rules.py and stated in the Runners-tab UI.
+    source = models.CharField(max_length=32, blank=True, default="")
+    # Only meaningful on a source row. False: the priority runner goes first and
+    # the default list follows beneath it. True: that runner or nothing — the turn
+    # waits rather than degrading, which is the point for a source whose work can
+    # only happen on one box (mailbox credentials, local files).
+    strict = models.BooleanField(default=False)
 
     class Meta:
         ordering = ["agent_id", "rank"]
         constraints = [
-            models.UniqueConstraint(fields=["agent", "runner"], name="one_assignment_per_agent_runner"),
+            # One DEFAULT row per runner (what one_assignment_per_agent_runner
+            # meant before source rules existed) …
+            models.UniqueConstraint(
+                fields=["agent", "runner"],
+                condition=models.Q(source=""),
+                name="one_default_assignment_per_agent_runner",
+            ),
+            # … and exactly one priority runner per (agent, source).
+            models.UniqueConstraint(
+                fields=["agent", "source"],
+                condition=~models.Q(source=""),
+                name="one_priority_runner_per_agent_source",
+            ),
         ]
 
 

--- a/apps/harness/services.py
+++ b/apps/harness/services.py
@@ -172,6 +172,52 @@ def sweep_expired_leases() -> int:
     return count
 
 
+def load_assignment_rows(agent_ids) -> tuple[dict, dict]:
+    """Load every ENABLED assignment row for these agents in one query, split into
+    the two shapes routing needs: the per-agent default list (rank-ordered) and the
+    per-(agent, source) priority row.
+
+    enabled=False is filtered here, once, so a disabled row can neither claim nor
+    count as a better-ranked availability blocker — and a disabled SOURCE row means
+    the rule is simply off, falling back to the default list.
+    """
+    defaults: dict = {}
+    priorities: dict = {}
+    if not agent_ids:
+        return defaults, priorities
+    rows = (
+        RunnerAssignment.objects.filter(agent_id__in=agent_ids, enabled=True)
+        .select_related("runner").order_by("rank")
+    )
+    for row in rows:
+        if row.source:
+            priorities[(row.agent_id, row.source)] = row
+        else:
+            defaults.setdefault(row.agent_id, []).append((row.rank, row.runner))
+    return defaults, priorities
+
+
+def assignment_rows_for(agent_id, origin: str, defaults: dict, priorities: dict) -> list:
+    """THE ordered runner list for one (agent, source) pair — what the availability
+    cascade then walks. Pure: no queries, no clock.
+
+    Ranks are renumbered from 0 because the cascade compares them to decide who
+    blocks whom; a source row's stored rank is meaningless (one row per source) and
+    leaving it would put two runners at rank 0, each apparently blocking the other.
+    """
+    base = defaults.get(agent_id) or []
+    row = priorities.get((agent_id, origin))
+    if row is None:
+        return [(i, r) for i, (_rank, r) in enumerate(base)]
+    if row.strict:
+        # That runner or nothing: the turn waits rather than degrading. Everyone
+        # else is absent from the list, so the wedged-runner grace cannot promote
+        # them either — which is what makes "and nowhere else" actually hold.
+        return [(0, row.runner)]
+    rest = [r for _rank, r in base if r.id != row.runner_id]
+    return [(0, row.runner)] + [(i + 1, r) for i, r in enumerate(rest)]
+
+
 def _kind_allows(runner: Runner, routing: str) -> bool:
     if routing == Turn.LOCAL_ONLY:
         return runner.kind in (Runner.EMDASH, Runner.REMOTE)

--- a/tests/test_source_rules.py
+++ b/tests/test_source_rules.py
@@ -1,0 +1,125 @@
+"""Source rules: one priority runner per (agent, source), plus a strict toggle.
+
+The composition helper is pure — it takes the loaded rows and returns the ordered
+list the existing cascade walks. Everything about ranks, availability and the
+grace stays in claim_next_turn; this only decides WHICH list gets cascaded.
+"""
+from __future__ import annotations
+
+import pytest
+from django.db import IntegrityError
+
+from apps.agents.models import Agent
+from apps.harness import services
+from apps.harness.models import Runner, RunnerAssignment, Turn
+from apps.workspaces.testing import a_workspace
+
+pytestmark = pytest.mark.django_db
+
+
+def _agent(slug="echo"):
+    return Agent.objects.create(slug=slug, name=slug.title(), workspace=a_workspace())
+
+
+def _runner(name):
+    return Runner.objects.create(name=name, kind=Runner.EMDASH, capabilities={})
+
+
+def _rows(agent, origin):
+    defaults, priorities = services.load_assignment_rows([agent.id])
+    return [r for _rank, r in services.assignment_rows_for(agent.id, origin, defaults, priorities)]
+
+
+def test_one_priority_runner_per_agent_and_source():
+    a, r1, r2 = _agent(), _runner("r1"), _runner("r2")
+    RunnerAssignment.objects.create(agent=a, runner=r1, rank=0, source=Turn.ORIGIN_EMAIL)
+    with pytest.raises(IntegrityError):
+        RunnerAssignment.objects.create(agent=a, runner=r2, rank=0, source=Turn.ORIGIN_EMAIL)
+
+
+def test_the_same_runner_may_be_a_default_and_a_priority():
+    """A runner is normally BOTH: rank 2 by default, first for email."""
+    a, r1 = _agent(), _runner("r1")
+    RunnerAssignment.objects.create(agent=a, runner=r1, rank=0)
+    RunnerAssignment.objects.create(agent=a, runner=r1, rank=0, source=Turn.ORIGIN_EMAIL)
+    assert RunnerAssignment.objects.filter(agent=a).count() == 2
+
+
+def test_no_rule_returns_the_default_list_in_rank_order():
+    a, r1, r2 = _agent(), _runner("r1"), _runner("r2")
+    RunnerAssignment.objects.create(agent=a, runner=r1, rank=0)
+    RunnerAssignment.objects.create(agent=a, runner=r2, rank=1)
+    assert _rows(a, Turn.ORIGIN_EMAIL) == [r1, r2]
+
+
+def test_a_non_strict_rule_puts_its_runner_first_then_the_defaults():
+    a, laptop, cloud = _agent(), _runner("jj-mbp"), _runner("cloud-1")
+    RunnerAssignment.objects.create(agent=a, runner=laptop, rank=0)
+    RunnerAssignment.objects.create(agent=a, runner=cloud, rank=0, source=Turn.ORIGIN_ACE_WEB)
+    assert _rows(a, Turn.ORIGIN_ACE_WEB) == [cloud, laptop]
+    assert _rows(a, Turn.ORIGIN_EMAIL) == [laptop]  # other sources untouched
+
+
+def test_a_priority_runner_already_in_the_defaults_is_not_duplicated():
+    a, laptop, cloud = _agent(), _runner("jj-mbp"), _runner("cloud-1")
+    RunnerAssignment.objects.create(agent=a, runner=laptop, rank=0)
+    RunnerAssignment.objects.create(agent=a, runner=cloud, rank=1)
+    RunnerAssignment.objects.create(agent=a, runner=cloud, rank=0, source=Turn.ORIGIN_ACE_WEB)
+    assert _rows(a, Turn.ORIGIN_ACE_WEB) == [cloud, laptop]
+
+
+def test_the_composed_list_is_renumbered_from_zero():
+    """The cascade compares ranks to decide who blocks whom, so a composed list
+    that kept its source rows' rank=0 alongside a default rank=0 would make two
+    runners each other's better rank."""
+    a, laptop, cloud = _agent(), _runner("jj-mbp"), _runner("cloud-1")
+    RunnerAssignment.objects.create(agent=a, runner=laptop, rank=0)
+    RunnerAssignment.objects.create(agent=a, runner=cloud, rank=0, source=Turn.ORIGIN_ACE_WEB)
+    defaults, priorities = services.load_assignment_rows([a.id])
+    composed = services.assignment_rows_for(a.id, Turn.ORIGIN_ACE_WEB, defaults, priorities)
+    assert [rank for rank, _r in composed] == [0, 1]
+
+
+def test_a_strict_rule_returns_only_its_runner():
+    a, laptop, cloud = _agent(), _runner("jj-mbp"), _runner("cloud-1")
+    RunnerAssignment.objects.create(agent=a, runner=cloud, rank=0)
+    RunnerAssignment.objects.create(
+        agent=a, runner=laptop, rank=0, source=Turn.ORIGIN_EMAIL, strict=True
+    )
+    assert _rows(a, Turn.ORIGIN_EMAIL) == [laptop]
+
+
+def test_a_disabled_rule_falls_back_to_the_default_list():
+    a, laptop, cloud = _agent(), _runner("jj-mbp"), _runner("cloud-1")
+    RunnerAssignment.objects.create(agent=a, runner=cloud, rank=0)
+    RunnerAssignment.objects.create(
+        agent=a, runner=laptop, rank=0, source=Turn.ORIGIN_EMAIL, strict=True, enabled=False
+    )
+    assert _rows(a, Turn.ORIGIN_EMAIL) == [cloud]
+
+
+def test_a_disabled_default_row_is_excluded_as_before():
+    a, r1, r2 = _agent(), _runner("r1"), _runner("r2")
+    RunnerAssignment.objects.create(agent=a, runner=r1, rank=0, enabled=False)
+    RunnerAssignment.objects.create(agent=a, runner=r2, rank=1)
+    assert _rows(a, Turn.ORIGIN_API) == [r2]
+
+
+def test_a_rule_routes_to_a_runner_switched_off_in_the_default_list():
+    """The one place `enabled` means two things, pinned deliberately.
+
+    A rule is its OWN row with its own toggle, so switching a runner off in the
+    default order does not switch off the rule that names it. Defensible — the
+    operator edited two separate things — but it means a chip greyed under
+    "Default order" can still be answering email, so the UI says so and this
+    test stops the behaviour changing by accident.
+    """
+    a, laptop = _agent(), _runner("jj-mbp")
+    RunnerAssignment.objects.create(agent=a, runner=laptop, rank=0, enabled=False)
+    RunnerAssignment.objects.create(agent=a, runner=laptop, rank=0, source=Turn.ORIGIN_EMAIL)
+    assert _rows(a, Turn.ORIGIN_EMAIL) == [laptop]
+    assert _rows(a, Turn.ORIGIN_API) == []  # …and the default list stays empty
+
+
+def test_no_agents_loads_nothing():
+    assert services.load_assignment_rows([]) == ({}, {})


### PR DESCRIPTION
The unit-tested core of per-source routing. **Nothing calls it yet** — claim
wiring is the next slice, so this lands with no behaviour change.

- `RunnerAssignment` gains `source` and `strict`. `source=""` is a row of the
  agent's default ordered list, exactly as today; a non-empty `source` is that
  source's single priority runner.
- The old `one_assignment_per_agent_runner` constraint splits into two
  conditional ones: one default row per runner, and one priority runner per
  `(agent, source)`. It cannot fail on existing data — every current row has
  `source=""`, so it lands in the first constraint, which is the old one plus a
  condition all of them already satisfy.
- `load_assignment_rows` (one query, enabled rows only) and `assignment_rows_for`
  (pure — no queries, no clock) compose the ordered list the existing cascade
  will walk.

**Ranks are renumbered from zero on composition.** The cascade compares ranks to
decide who blocks whom, and a source row's stored rank is meaningless (the
constraint allows exactly one). Leaving it would put two runners at rank 0, each
apparently blocking the other. Pinned by `test_the_composed_list_is_renumbered_from_zero`.

**`enabled` now means two things, deliberately.** A runner switched off in the
default list is still live for any source that names it — the rule is its own row
with its own toggle. That is the right behaviour (the operator edited two separate
things) but it means a chip greyed under "Default order" can still be answering
email, so it gets a test here and a sentence in the Runners-tab UI in slice 7.

Verified: `uv run pytest -q` → 1783 passed, 1 skipped;
`manage.py makemigrations --check` → no changes detected.

Stacked on #480. Plan:
`docs/superpowers/plans/2026-07-27-source-aware-runner-routing.md` (Task 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)