### PR TITLE
Claim routing keys on the turn's source (source-aware routing, 3/8)

### DIFF
--- a/apps/harness/services.py
+++ b/apps/harness/services.py
@@ -232,11 +232,17 @@ def _kind_allows(runner: Runner, routing: str) -> bool:
 CASCADE_GRACE_SECONDS = 60
 
 
-def _assignment_allows_for_agent(runner: Runner, agent_id, turn: Turn, assignment_map: dict, now) -> bool:
-    """assignment_map: {agent_id: [(rank, Runner), ...] ordered by rank}. False when
-    this runner is not in the agent's list; True when it is and either every
-    better-ranked runner is unavailable or the turn has aged past the grace."""
-    rows = assignment_map.get(agent_id) or []
+def _assignment_allows_for_agent(runner: Runner, agent_id, turn: Turn,
+                                 defaults: dict, priorities: dict, now) -> bool:
+    """False when this runner is not in the agent's list FOR THIS TURN'S SOURCE;
+    True when it is and either every better rank is unavailable or the turn has
+    aged past the grace.
+
+    The list is composed per (agent, origin) — a strict source rule yields a
+    single-entry list, so every other runner reads as "not in the list" and the
+    grace has nobody to promote.
+    """
+    rows = assignment_rows_for(agent_id, turn.origin, defaults, priorities)
     mine = next((rank for rank, r in rows if r.id == runner.id), None)
     if mine is None:
         return False
@@ -245,8 +251,8 @@ def _assignment_allows_for_agent(runner: Runner, agent_id, turn: Turn, assignmen
     return not any(r.is_available for rank, r in rows if rank < mine)
 
 
-def _assignment_allows(runner: Runner, turn: Turn, assignment_map: dict, now) -> bool:
-    return _assignment_allows_for_agent(runner, turn.agent_id, turn, assignment_map, now)
+def _assignment_allows(runner: Runner, turn: Turn, defaults: dict, priorities: dict, now) -> bool:
+    return _assignment_allows_for_agent(runner, turn.agent_id, turn, defaults, priorities, now)
 
 
 EXECUTING = [Turn.CLAIMED, Turn.RUNNING, Turn.NEEDS_HUMAN]
@@ -557,17 +563,12 @@ def claim_next_turn(runner: Runner, *, lease_seconds: int = DEFAULT_LEASE_SECOND
     agent_ids = {t.agent_id for t in candidates if t.agent_id} | {
         t.chat_session.agent_id for t in candidates if t.chat_session_id and t.chat_session.agent_id
     }
-    assignment_map: dict = {}
-    if agent_ids:
-        # enabled=True only: a disabled row must neither claim (it's excluded from
-        # `rows`, so `mine` in _assignment_allows_for_agent comes back None) nor
-        # count as a better-ranked availability blocker for a lower enabled rank.
-        rows = (
-            RunnerAssignment.objects.filter(agent_id__in=agent_ids, enabled=True)
-            .select_related("runner").order_by("rank")
-        )
-        for row in rows:
-            assignment_map.setdefault(row.agent_id, []).append((row.rank, row.runner))
+    # One query for every candidate agent's rows, split into the default list and
+    # the per-source priorities; the per-turn composition below is in-memory.
+    # enabled=True only, filtered inside the loader: a disabled row must neither
+    # claim (it is absent from the composed list, so `mine` comes back None) nor
+    # count as a better-ranked availability blocker for a lower enabled rank.
+    defaults, priorities = load_assignment_rows(agent_ids)
     now = timezone.now()
     for turn in candidates:
         pinned_here = turn.pinned_runner_id == runner.id
@@ -575,14 +576,16 @@ def claim_next_turn(runner: Runner, *, lease_seconds: int = DEFAULT_LEASE_SECOND
             if not _kind_allows(runner, turn.routing):
                 continue
             if turn.agent_id:
-                if not _assignment_allows(runner, turn, assignment_map, now):
+                if not _assignment_allows(runner, turn, defaults, priorities, now):
                     continue
             if turn.chat_session_id:
                 sess = turn.chat_session
                 binding = getattr(sess, "runner_binding", None)
                 bound_to_me = binding is not None and binding.runner_id == runner.id
                 if not bound_to_me and sess.agent_id:
-                    if not _assignment_allows_for_agent(runner, sess.agent_id, turn, assignment_map, now):
+                    if not _assignment_allows_for_agent(
+                        runner, sess.agent_id, turn, defaults, priorities, now
+                    ):
                         continue
         try:
             # Own atomic block per attempt: an IntegrityError from the

--- a/tests/test_claim_source_routing.py
+++ b/tests/test_claim_source_routing.py
@@ -1,0 +1,165 @@
+"""Claim routing keyed on Turn.origin (spec 2026-07-27).
+
+Tenancy here is deliberately real rather than stubbed: runner_tenant_slugs derives
+from runner.paired_by, and a runner whose pairer is not in the agent's workspace
+claims nothing regardless of any rule.
+"""
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+
+from apps.agents.models import Agent
+from apps.harness import services
+from apps.harness.models import Runner, RunnerAssignment, Turn
+from apps.workspaces.models import Workspace, WorkspaceMembership
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def fleet():
+    jj = get_user_model().objects.create_user(username="jj", email="jj@dimagi.com")
+    ws = Workspace.objects.create(slug="connect", display_name="Connect", created_by=jj)
+    WorkspaceMembership.objects.create(workspace=ws, user=jj, role=WorkspaceMembership.OWNER)
+    echo = Agent.objects.create(slug="echo", name="Echo", workspace=ws)
+    now = timezone.now()
+    laptop = Runner.objects.create(
+        name="jj-mbp", kind=Runner.EMDASH, paired_by=jj, status=Runner.ONLINE,
+        last_heartbeat_at=now, capabilities={},
+    )
+    cloud = Runner.objects.create(
+        name="cloud-1", kind=Runner.CLOUD, paired_by=jj, status=Runner.ONLINE,
+        last_heartbeat_at=now, capabilities={},
+    )
+    return {"user": jj, "ws": ws, "agent": echo, "laptop": laptop, "cloud": cloud}
+
+
+def _turn(agent, origin, key, *, age_seconds=0):
+    turn = Turn.objects.create(
+        agent=agent, origin=origin, idempotency_key=key, routing=Turn.ANY
+    )
+    if age_seconds:
+        Turn.objects.filter(pk=turn.pk).update(
+            created_at=timezone.now() - dt.timedelta(seconds=age_seconds)
+        )
+        turn.refresh_from_db()
+    return turn
+
+
+def test_a_source_rule_sends_its_work_to_the_priority_runner(fleet):
+    """ace_web work goes to the cloud box even though the laptop is rank 0."""
+    a, laptop, cloud = fleet["agent"], fleet["laptop"], fleet["cloud"]
+    RunnerAssignment.objects.create(agent=a, runner=laptop, rank=0)
+    RunnerAssignment.objects.create(agent=a, runner=cloud, rank=1)
+    RunnerAssignment.objects.create(agent=a, runner=cloud, rank=0, source=Turn.ORIGIN_ACE_WEB)
+
+    _turn(a, Turn.ORIGIN_ACE_WEB, "k-ace")
+
+    assert services.claim_next_turn(laptop) is None
+    claimed = services.claim_next_turn(cloud)
+    assert claimed is not None and claimed.origin == Turn.ORIGIN_ACE_WEB
+
+
+def test_other_sources_still_follow_the_default_order(fleet):
+    a, laptop, cloud = fleet["agent"], fleet["laptop"], fleet["cloud"]
+    RunnerAssignment.objects.create(agent=a, runner=laptop, rank=0)
+    RunnerAssignment.objects.create(agent=a, runner=cloud, rank=1)
+    RunnerAssignment.objects.create(agent=a, runner=cloud, rank=0, source=Turn.ORIGIN_ACE_WEB)
+
+    _turn(a, Turn.ORIGIN_EMAIL, "k-mail")
+
+    assert services.claim_next_turn(cloud) is None
+    assert services.claim_next_turn(laptop) is not None
+
+
+def test_a_non_strict_rule_degrades_when_its_runner_is_gone(fleet):
+    a, laptop, cloud = fleet["agent"], fleet["laptop"], fleet["cloud"]
+    RunnerAssignment.objects.create(agent=a, runner=laptop, rank=0)
+    RunnerAssignment.objects.create(agent=a, runner=cloud, rank=0, source=Turn.ORIGIN_ACE_WEB)
+    Runner.objects.filter(pk=cloud.pk).update(
+        last_heartbeat_at=timezone.now() - dt.timedelta(hours=1)
+    )
+
+    _turn(a, Turn.ORIGIN_ACE_WEB, "k-ace")
+
+    assert services.claim_next_turn(laptop) is not None
+
+
+def test_a_strict_rule_parks_the_turn_rather_than_degrading(fleet):
+    a, laptop, cloud = fleet["agent"], fleet["laptop"], fleet["cloud"]
+    RunnerAssignment.objects.create(agent=a, runner=cloud, rank=0)
+    RunnerAssignment.objects.create(
+        agent=a, runner=laptop, rank=0, source=Turn.ORIGIN_EMAIL, strict=True
+    )
+    Runner.objects.filter(pk=laptop.pk).update(
+        last_heartbeat_at=timezone.now() - dt.timedelta(hours=1)
+    )
+
+    turn = _turn(a, Turn.ORIGIN_EMAIL, "k-mail")
+
+    assert services.claim_next_turn(cloud) is None
+    turn.refresh_from_db()
+    assert turn.status == Turn.QUEUED
+
+
+def test_strictness_survives_the_cascade_grace(fleet):
+    """A turn queued past CASCADE_GRACE_SECONDS opens to lower ranks — but a strict
+    rule has no lower ranks, so there is nobody for the grace to promote."""
+    a, laptop, cloud = fleet["agent"], fleet["laptop"], fleet["cloud"]
+    RunnerAssignment.objects.create(agent=a, runner=cloud, rank=0)
+    RunnerAssignment.objects.create(
+        agent=a, runner=laptop, rank=0, source=Turn.ORIGIN_EMAIL, strict=True
+    )
+    Runner.objects.filter(pk=laptop.pk).update(
+        last_heartbeat_at=timezone.now() - dt.timedelta(hours=1)
+    )
+
+    _turn(a, Turn.ORIGIN_EMAIL, "k-mail", age_seconds=services.CASCADE_GRACE_SECONDS + 30)
+
+    assert services.claim_next_turn(cloud) is None
+
+
+def test_a_pin_beats_a_contradicting_rule(fleet):
+    """Precedence: explicit runner > source rule."""
+    a, laptop, cloud = fleet["agent"], fleet["laptop"], fleet["cloud"]
+    RunnerAssignment.objects.create(agent=a, runner=laptop, rank=0)
+    RunnerAssignment.objects.create(
+        agent=a, runner=cloud, rank=0, source=Turn.ORIGIN_ACE_WEB, strict=True
+    )
+    Turn.objects.create(
+        agent=a, origin=Turn.ORIGIN_ACE_WEB, idempotency_key="k-pin",
+        pinned_runner=laptop, routing=Turn.ANY,
+    )
+
+    assert services.claim_next_turn(laptop) is not None
+
+
+def test_a_runner_named_only_by_a_rule_can_claim_that_source(fleet):
+    """The cloud box is in no default list at all — the rule alone routes to it."""
+    a, cloud = fleet["agent"], fleet["cloud"]
+    RunnerAssignment.objects.create(agent=a, runner=fleet["laptop"], rank=0)
+    RunnerAssignment.objects.create(agent=a, runner=cloud, rank=0, source=Turn.ORIGIN_ACE_WEB)
+
+    _turn(a, Turn.ORIGIN_ACE_WEB, "k-ace")
+
+    assert services.claim_next_turn(cloud) is not None
+
+
+def test_a_rule_never_crosses_the_tenant_boundary(fleet):
+    """An outsider's runner named by a rule still claims nothing: the rule composes
+    the list, the workspace gate decides who may act at all."""
+    a, cloud = fleet["agent"], fleet["cloud"]
+    outsider = get_user_model().objects.create_user(username="mal", email="mal@evil.com")
+    theirs = Runner.objects.create(
+        name="mal-box", kind=Runner.CLOUD, paired_by=outsider, status=Runner.ONLINE,
+        last_heartbeat_at=timezone.now(), capabilities={},
+    )
+    RunnerAssignment.objects.create(agent=a, runner=theirs, rank=0, source=Turn.ORIGIN_ACE_WEB)
+
+    _turn(a, Turn.ORIGIN_ACE_WEB, "k-ace")
+
+    assert services.claim_next_turn(theirs) is None

--- a/tests/test_claim_source_routing.py
+++ b/tests/test_claim_source_routing.py
@@ -152,7 +152,7 @@ def test_a_runner_named_only_by_a_rule_can_claim_that_source(fleet):
 def test_a_rule_never_crosses_the_tenant_boundary(fleet):
     """An outsider's runner named by a rule still claims nothing: the rule composes
     the list, the workspace gate decides who may act at all."""
-    a, cloud = fleet["agent"], fleet["cloud"]
+    a = fleet["agent"]
     outsider = get_user_model().objects.create_user(username="mal", email="mal@evil.com")
     theirs = Runner.objects.create(
         name="mal-box", kind=Runner.CLOUD, paired_by=outsider, status=Runner.ONLINE,


### PR DESCRIPTION
The slice that makes routing actually source-aware. `claim_next_turn` walks the
list composed for `(agent, turn.origin)` instead of the agent's single default
list — everything else about the cascade is untouched.

- `_assignment_allows{,_for_agent}` take the loaded rows and compose per turn.
- The batch `assignment_map` build becomes `load_assignment_rows` (same single
  query, split into defaults + per-source priorities).

**Strictness holds past the grace, which is the load-bearing part.** The
wedged-runner grace opens a stale turn to lower ranks so an online-but-stuck box
can't stall a queue forever. Under a strict rule there ARE no lower ranks — the
composed list has one entry, so every other runner reads as "not in the list" and
there is nobody to promote. Without that, "and nowhere else" would quietly stop
holding after 60 seconds. Pinned by `test_strictness_survives_the_cascade_grace`.

Unchanged and asserted so: a pin still beats a contradicting rule; session
binding stickiness is untouched; project turns have no agent and so no rules; and
a rule never crosses the tenant boundary — the rule composes the list,
`runner_tenant_slugs` still decides who may act at all.

Verified: `uv run pytest -q` → 1791 passed, 1 skipped (includes the existing
cascade, session-claim, project-claim and claim/schedule parity suites).

Stacked on #481. Plan:
`docs/superpowers/plans/2026-07-27-source-aware-runner-routing.md` (Task 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)