### PR TITLE
A caller may name the runner on POST /turns/ (source-aware routing, 5/8)

### DIFF
--- a/apps/harness/api.py
+++ b/apps/harness/api.py
@@ -684,6 +684,21 @@ def enqueue_turn(request: HttpRequest, payload: TurnIn):
                     )
                 raise HttpError(404, "workspace not found")
 
+    pinned = None
+    if payload.runner_id is not None:
+        # Same visibility predicate _runner_or_404 / list_runners gate on: a runner
+        # the caller cannot see must 422 as unknown, never be attachable because
+        # its UUID was guessed. Retired runners are excluded too — pinning to one
+        # strands the turn forever, since nothing can claim it.
+        pinned = (
+            Runner.objects.exclude(status=Runner.RETIRED)
+            .filter(_runner_visibility_q(request))
+            .filter(id=payload.runner_id)
+            .first()
+        )
+        if pinned is None:
+            raise HttpError(422, f"unknown or retired runner id: {payload.runner_id}")
+
     turn, created = services.enqueue_turn(
         agent=agent,
         project=payload.project,
@@ -694,6 +709,7 @@ def enqueue_turn(request: HttpRequest, payload: TurnIn):
         origin_ref=payload.origin_ref,
         routing=payload.routing,
         enqueued_by=request.user,  # the human launching a manual / composer turn
+        pinned_runner=pinned,
     )
     return Status(201 if created else 200, turn)
 

--- a/apps/harness/schemas.py
+++ b/apps/harness/schemas.py
@@ -226,6 +226,11 @@ class TurnIn(Schema):
     prompt: str = ""
     origin_ref: dict = {}
     routing: Routing = "prefer_local"
+    # Name the box explicitly. A pin bypasses assignments and source rules — never
+    # the tenant gate, never one_executing_turn_per_agent. This is what retired the
+    # `drill` origin: a drill is an api turn that names its runner, identified by
+    # its RunnerDrill row rather than by a magic origin value.
+    runner_id: uuid.UUID | None = None
 
     _norm_origin = field_validator("origin")(staticmethod(normalize_origin))
 

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -7636,6 +7636,8 @@ export interface components {
              * @enum {string}
              */
             readonly routing: "prefer_local" | "local_only" | "any";
+            /** Runner Id */
+            readonly runner_id?: string | null;
         };
         /** EmdashSessionOut */
         readonly EmdashSessionOut: {

--- a/tests/test_turn_runner_id.py
+++ b/tests/test_turn_runner_id.py
@@ -1,0 +1,93 @@
+"""POST /api/harness/turns/ may name the runner (spec 2026-07-27).
+
+Pinning bypasses assignments and source rules — never the tenant gate, and never
+a runner the caller cannot see. That last part is the whole security surface of
+this field, so it is tested from the outside via the API.
+"""
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+
+from apps.agents.models import Agent
+from apps.harness.models import Runner, Turn
+from apps.workspaces.models import Workspace, WorkspaceMembership
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def setup(client):
+    jj = get_user_model().objects.create_user(username="jj", email="jj@dimagi.com")
+    ws = Workspace.objects.create(slug="connect", display_name="Connect", created_by=jj)
+    WorkspaceMembership.objects.create(workspace=ws, user=jj, role=WorkspaceMembership.OWNER)
+    agent = Agent.objects.create(slug="echo", name="Echo", workspace=ws)
+    runner = Runner.objects.create(
+        name="cloud-1", kind=Runner.CLOUD, paired_by=jj, status=Runner.ONLINE,
+        last_heartbeat_at=timezone.now(), capabilities={},
+    )
+    client.force_login(jj)
+    return {"client": client, "user": jj, "agent": agent, "runner": runner}
+
+
+def _post(client, body):
+    return client.post("/api/harness/turns/", data=body, content_type="application/json")
+
+
+def test_runner_id_pins_the_turn(setup):
+    res = _post(setup["client"], {
+        "agent_slug": "echo", "origin": "api", "idempotency_key": "k1",
+        "runner_id": str(setup["runner"].id),
+    })
+
+    assert res.status_code == 201, res.content
+    assert Turn.objects.get(idempotency_key="k1").pinned_runner_id == setup["runner"].id
+
+
+def test_omitting_runner_id_leaves_the_turn_unpinned(setup):
+    res = _post(setup["client"], {
+        "agent_slug": "echo", "origin": "api", "idempotency_key": "k2",
+    })
+
+    assert res.status_code == 201, res.content
+    assert Turn.objects.get(idempotency_key="k2").pinned_runner is None
+
+
+def test_a_runner_the_caller_cannot_see_is_rejected(setup):
+    outsider = get_user_model().objects.create_user(username="mal", email="mal@evil.com")
+    theirs = Runner.objects.create(
+        name="mal-box", kind=Runner.CLOUD, paired_by=outsider, status=Runner.ONLINE,
+        last_heartbeat_at=timezone.now(), capabilities={},
+    )
+
+    res = _post(setup["client"], {
+        "agent_slug": "echo", "origin": "api", "idempotency_key": "k3",
+        "runner_id": str(theirs.id),
+    })
+
+    assert res.status_code == 422
+    # Rejected, not silently enqueued unpinned: a caller that asked for a specific
+    # box and got "anywhere" would look like it worked.
+    assert not Turn.objects.filter(idempotency_key="k3").exists()
+
+
+def test_a_retired_runner_is_rejected(setup):
+    """Pinning to a retired runner strands the turn forever — nothing can claim it."""
+    Runner.objects.filter(pk=setup["runner"].pk).update(status=Runner.RETIRED)
+
+    res = _post(setup["client"], {
+        "agent_slug": "echo", "origin": "api", "idempotency_key": "k4",
+        "runner_id": str(setup["runner"].id),
+    })
+
+    assert res.status_code == 422
+
+
+def test_an_unknown_runner_id_is_rejected(setup):
+    res = _post(setup["client"], {
+        "agent_slug": "echo", "origin": "api", "idempotency_key": "k5",
+        "runner_id": "00000000-0000-0000-0000-000000000000",
+    })
+
+    assert res.status_code == 422


### PR DESCRIPTION
`TurnIn.runner_id` sets `pinned_runner` — the field that let the `drill` origin
retire in slice 1, since a drill is just an `api` turn that names its box and is
identified by its `RunnerDrill` row.

Gated by `_runner_visibility_q`, the same predicate `_runner_or_404` and
`list_runners` use, plus a retired-runner exclusion (pinning to a retired runner
strands the turn forever — nothing can claim it). Unknown, retired, or not-yours
all **422 rather than silently enqueuing unpinned**: a caller that asked for a
specific box and got "anywhere" would look like it worked.

The existing pin guarantees are unchanged — a pin bypasses assignments and source
rules, never the tenant gate and never `one_executing_turn_per_agent`.

Verified: `uv run pytest -q` → 1801 passed, 1 skipped; ruff clean; types
regenerated (`runner_id` on the enqueue body).

Plan: `docs/superpowers/plans/2026-07-27-source-aware-runner-routing.md` (Task 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)