### PR TITLE
GET|PUT /api/agents/{slug}/runner-rules (source-aware routing, 6/8)

### DIFF
--- a/apps/agents/api.py
+++ b/apps/agents/api.py
@@ -18,6 +18,8 @@ from .schemas import (
     AgentIn,
     AgentOut,
     AgentRunnerOut,
+    AgentRunnerRuleOut,
+    AgentRunnerRulesIn,
     AgentRunnerRowIn,
     AgentRunnersIn,
     AgentRuntimeOut,
@@ -193,7 +195,10 @@ def list_agent_runners(request: HttpRequest, slug: str) -> list[AgentRunnerOut]:
             ready=a.runner.ready,
             enabled=a.enabled,
         )
-        for a in agent.runner_assignments.select_related("runner")
+        # source="" ONLY: this endpoint is the DEFAULT ordered list. A source
+        # rule lives in the same table and would otherwise render as a phantom
+        # chip in the order row.
+        for a in agent.runner_assignments.filter(source="").select_related("runner")
     ]
 
 
@@ -240,12 +245,105 @@ def replace_agent_runners(request: HttpRequest, slug: str, payload: AgentRunners
     if missing:
         raise HttpError(422, f"unknown or retired runner id(s): {', '.join(missing)}")
     with transaction.atomic():
-        RunnerAssignment.objects.filter(agent=agent).delete()
+        # source="" ONLY. Source rules live in this table too, and an unscoped
+        # delete here would destroy every one of them each time the default
+        # order was saved.
+        RunnerAssignment.objects.filter(agent=agent, source="").delete()
         RunnerAssignment.objects.bulk_create([
             RunnerAssignment(agent=agent, runner=by_id[row.runner_id], rank=i, enabled=row.enabled)
             for i, row in enumerate(rows_in)
         ])
     return list_agent_runners(request, slug)
+
+
+# ---- per-source routing rules (the exceptions to the ordered list above) ----
+@router.get("/{slug}/runner-rules", response=list[AgentRunnerRuleOut],
+            summary="List the agent's per-source routing rules")
+def list_agent_runner_rules(request: HttpRequest, slug: str) -> list[AgentRunnerRuleOut]:
+    """The per-source overrides on top of the default ordered list (spec
+    2026-07-27). One rule per source, max — the priority runner, and whether it is
+    the only one allowed to take that source's work."""
+    from django.db.models import Count
+
+    from apps.harness.models import Runner, RunnerAssignment, Turn
+
+    agent = _get_agent_or_404(request, slug)
+    # Per-source queued depth in one query — what the UI's "N turns are parked"
+    # warning renders next to a strict rule whose runner is offline.
+    queued = dict(
+        Turn.objects.filter(agent=agent, status=Turn.QUEUED)
+        .values_list("origin").annotate(n=Count("id"))
+    )
+    rows = (
+        RunnerAssignment.objects.filter(agent=agent).exclude(source="")
+        .select_related("runner").order_by("source")
+    )
+    return [
+        AgentRunnerRuleOut(
+            source=row.source,
+            runner_id=row.runner.id,
+            runner_name=row.runner.name,
+            kind=row.runner.kind,
+            strict=row.strict,
+            # Derived, like AgentRunnerOut: the stored status lies once a runner
+            # goes quiet (heartbeat writes ONLINE and nothing demotes it).
+            online=row.runner.live_status == Runner.ONLINE,
+            ready=row.runner.ready,
+            enabled=row.enabled,
+            queued_count=queued.get(row.source, 0),
+        )
+        for row in rows
+    ]
+
+
+@router.put("/{slug}/runner-rules", response=list[AgentRunnerRuleOut],
+            summary="Replace the agent's per-source routing rules")
+def replace_agent_runner_rules(
+    request: HttpRequest, slug: str, payload: AgentRunnerRulesIn
+) -> list[AgentRunnerRuleOut]:
+    """Wholesale replace, scoped to non-empty-source rows — the default ordered
+    list belongs to PUT /runners and is left alone.
+
+    A separate endpoint rather than a combined body so neither write can clobber
+    the other's rows (they share one table), and so the existing GET response
+    shape stays what the frontend already consumes.
+    """
+    from apps.harness.api import _runner_visibility_q
+    from apps.harness.models import Runner, RunnerAssignment
+
+    agent = _get_agent_or_404(request, slug)
+
+    # One rule per source. Caught here rather than left to the DB constraint so
+    # the caller gets a named reason instead of an IntegrityError 500.
+    sources = [r.source for r in payload.rules]
+    if len(sources) != len(set(sources)):
+        raise HttpError(422, "one rule per source: duplicate source in list")
+
+    # Same visibility predicate the default-list PUT gates on — a runner the
+    # caller can't see must 422 as unknown, never be attachable by guessed UUID.
+    ids = [r.runner_id for r in payload.rules]
+    runners = list(
+        Runner.objects.filter(id__in=ids)
+        .exclude(status=Runner.RETIRED)
+        .filter(_runner_visibility_q(request))
+    )
+    by_id = {r.id: r for r in runners}
+    missing = [str(rid) for rid in ids if rid not in by_id]
+    if missing:
+        raise HttpError(422, f"unknown or retired runner id(s): {', '.join(missing)}")
+
+    with transaction.atomic():
+        RunnerAssignment.objects.filter(agent=agent).exclude(source="").delete()
+        RunnerAssignment.objects.bulk_create([
+            # rank=0: meaningless on a source row (the constraint allows exactly
+            # one per source), and the composition helper renumbers anyway.
+            RunnerAssignment(
+                agent=agent, runner=by_id[r.runner_id], rank=0,
+                source=r.source, strict=r.strict, enabled=r.enabled,
+            )
+            for r in payload.rules
+        ])
+    return list_agent_runner_rules(request, slug)
 
 
 # ---- syncs (Google-Doc backed) ----

--- a/apps/agents/schemas.py
+++ b/apps/agents/schemas.py
@@ -8,6 +8,9 @@ from typing import Literal
 from pydantic import Field
 
 from apps.common.schemas import StrictModel
+# framework→framework: agents and harness are both framework tier, and the
+# source vocabulary has ONE definition (harness owns Turn.origin).
+from apps.harness.schemas import RoutableSource
 
 
 # ---- Agent ----
@@ -75,6 +78,45 @@ class AgentRunnersIn(StrictModel):
 
     runner_ids: list[uuid.UUID] | None = None
     runners: list[AgentRunnerRowIn] | None = None
+
+
+class AgentRunnerRuleOut(StrictModel):
+    """One per-source routing rule: the priority runner for a source, and whether
+    it is the ONLY runner allowed to take that source's work.
+
+    `source` stays a plain `str` here (not the literal) by the same rule the rest
+    of the API follows — an output schema serializes what the DB already holds, and
+    a Literal would break on a value retired later. `queued_count` is the agent's
+    queued turns from this source, which is what the UI's parked warning reads."""
+
+    source: str
+    runner_id: uuid.UUID
+    runner_name: str
+    kind: str
+    strict: bool
+    online: bool
+    ready: bool
+    enabled: bool = True
+    queued_count: int = 0
+
+
+class AgentRunnerRuleIn(StrictModel):
+    """One rule of the wholesale-replace body. `source` is typed as the routable
+    literal so an unknown source is a 422 here rather than a rule that silently
+    never matches anything — and so the generated TypeScript carries the union."""
+
+    source: RoutableSource
+    runner_id: uuid.UUID
+    strict: bool = False
+    enabled: bool = True
+
+
+class AgentRunnerRulesIn(StrictModel):
+    """Wholesale replace of an agent's source rules. Scoped to non-empty-source
+    rows: the default ordered list is the sibling endpoint's business, and neither
+    write may clobber the other's rows."""
+
+    rules: list[AgentRunnerRuleIn] = Field(default_factory=list)
 
 
 class AgentRuntimeOut(StrictModel):

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -1290,6 +1290,37 @@ export interface paths {
         readonly patch?: never;
         readonly trace?: never;
     };
+    readonly "/api/agents/{slug}/runner-rules": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        /**
+         * List the agent's per-source routing rules
+         * @description The per-source overrides on top of the default ordered list (spec
+         *     2026-07-27). One rule per source, max — the priority runner, and whether it is
+         *     the only one allowed to take that source's work.
+         */
+        readonly get: operations["apps_agents_api_list_agent_runner_rules"];
+        /**
+         * Replace the agent's per-source routing rules
+         * @description Wholesale replace, scoped to non-empty-source rows — the default ordered
+         *     list belongs to PUT /runners and is left alone.
+         *
+         *     A separate endpoint rather than a combined body so neither write can clobber
+         *     the other's rows (they share one table), and so the existing GET response
+         *     shape stays what the frontend already consumes.
+         */
+        readonly put: operations["apps_agents_api_replace_agent_runner_rules"];
+        readonly post?: never;
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
     readonly "/api/agents/{slug}/syncs/": {
         readonly parameters: {
             readonly query?: never;
@@ -5571,6 +5602,83 @@ export interface components {
             readonly runner_ids?: readonly string[] | null;
             /** Runners */
             readonly runners?: readonly components["schemas"]["AgentRunnerRowIn"][] | null;
+        };
+        /**
+         * AgentRunnerRuleOut
+         * @description One per-source routing rule: the priority runner for a source, and whether
+         *     it is the ONLY runner allowed to take that source's work.
+         *
+         *     `source` stays a plain `str` here (not the literal) by the same rule the rest
+         *     of the API follows — an output schema serializes what the DB already holds, and
+         *     a Literal would break on a value retired later. `queued_count` is the agent's
+         *     queued turns from this source, which is what the UI's parked warning reads.
+         */
+        readonly AgentRunnerRuleOut: {
+            /** Source */
+            readonly source: string;
+            /**
+             * Runner Id
+             * Format: uuid
+             */
+            readonly runner_id: string;
+            /** Runner Name */
+            readonly runner_name: string;
+            /** Kind */
+            readonly kind: string;
+            /** Strict */
+            readonly strict: boolean;
+            /** Online */
+            readonly online: boolean;
+            /** Ready */
+            readonly ready: boolean;
+            /**
+             * Enabled
+             * @default true
+             */
+            readonly enabled: boolean;
+            /**
+             * Queued Count
+             * @default 0
+             */
+            readonly queued_count: number;
+        };
+        /**
+         * AgentRunnerRuleIn
+         * @description One rule of the wholesale-replace body. `source` is typed as the routable
+         *     literal so an unknown source is a 422 here rather than a rule that silently
+         *     never matches anything — and so the generated TypeScript carries the union.
+         */
+        readonly AgentRunnerRuleIn: {
+            /**
+             * Source
+             * @enum {string}
+             */
+            readonly source: "ace_web" | "email" | "canopy_scheduler" | "canopy_web_chat" | "slack" | "api";
+            /**
+             * Runner Id
+             * Format: uuid
+             */
+            readonly runner_id: string;
+            /**
+             * Strict
+             * @default false
+             */
+            readonly strict: boolean;
+            /**
+             * Enabled
+             * @default true
+             */
+            readonly enabled: boolean;
+        };
+        /**
+         * AgentRunnerRulesIn
+         * @description Wholesale replace of an agent's source rules. Scoped to non-empty-source
+         *     rows: the default ordered list is the sibling endpoint's business, and neither
+         *     write may clobber the other's rows.
+         */
+        readonly AgentRunnerRulesIn: {
+            /** Rules */
+            readonly rules?: readonly components["schemas"]["AgentRunnerRuleIn"][];
         };
         /** AgentSyncOut */
         readonly AgentSyncOut: {
@@ -10211,6 +10319,54 @@ export interface operations {
                 };
                 content: {
                     readonly "application/json": readonly components["schemas"]["AgentRunnerOut"][];
+                };
+            };
+        };
+    };
+    readonly apps_agents_api_list_agent_runner_rules: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path: {
+                readonly slug: string;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description OK */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": readonly components["schemas"]["AgentRunnerRuleOut"][];
+                };
+            };
+        };
+    };
+    readonly apps_agents_api_replace_agent_runner_rules: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path: {
+                readonly slug: string;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody: {
+            readonly content: {
+                readonly "application/json": components["schemas"]["AgentRunnerRulesIn"];
+            };
+        };
+        readonly responses: {
+            /** @description OK */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": readonly components["schemas"]["AgentRunnerRuleOut"][];
                 };
             };
         };

--- a/tests/test_agent_runner_rules_api.py
+++ b/tests/test_agent_runner_rules_api.py
@@ -1,0 +1,171 @@
+"""GET|PUT /api/agents/{slug}/runner-rules.
+
+The wipe tests are the important ones: both writes live in the same table, and a
+default-list save that silently deleted every rule is exactly the bug this
+endpoint split exists to prevent.
+"""
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+
+from apps.agents.models import Agent
+from apps.harness.models import Runner, RunnerAssignment, Turn
+from apps.workspaces.models import Workspace, WorkspaceMembership
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def setup(client):
+    jj = get_user_model().objects.create_user(username="jj", email="jj@dimagi.com")
+    ws = Workspace.objects.create(slug="connect", display_name="Connect", created_by=jj)
+    WorkspaceMembership.objects.create(workspace=ws, user=jj, role=WorkspaceMembership.OWNER)
+    agent = Agent.objects.create(slug="echo", name="Echo", workspace=ws)
+    laptop = Runner.objects.create(
+        name="jj-mbp", kind=Runner.EMDASH, paired_by=jj, status=Runner.ONLINE,
+        last_heartbeat_at=timezone.now(), capabilities={},
+    )
+    cloud = Runner.objects.create(
+        name="cloud-1", kind=Runner.CLOUD, paired_by=jj, status=Runner.ONLINE,
+        last_heartbeat_at=timezone.now(), capabilities={},
+    )
+    client.force_login(jj)
+    return {"client": client, "agent": agent, "laptop": laptop, "cloud": cloud}
+
+
+def _put_rules(client, rules):
+    return client.put(
+        "/api/agents/echo/runner-rules",
+        data={"rules": rules}, content_type="application/json",
+    )
+
+
+def _put_default(client, runner):
+    return client.put(
+        "/api/agents/echo/runners",
+        data={"runners": [{"runner_id": str(runner.id), "enabled": True}]},
+        content_type="application/json",
+    )
+
+
+def test_put_then_get_round_trips_a_rule(setup):
+    res = _put_rules(setup["client"], [
+        {"source": "ace_web", "runner_id": str(setup["cloud"].id), "strict": True},
+    ])
+    assert res.status_code == 200, res.content
+
+    got = setup["client"].get("/api/agents/echo/runner-rules").json()
+    assert len(got) == 1
+    assert got[0]["source"] == "ace_web"
+    assert got[0]["runner_name"] == "cloud-1"
+    assert got[0]["strict"] is True
+    assert got[0]["online"] is True
+
+
+def test_saving_the_default_list_does_not_wipe_the_rules(setup):
+    """RunnerAssignment holds both; PUT /runners must scope its delete to source=''."""
+    _put_rules(setup["client"], [
+        {"source": "email", "runner_id": str(setup["laptop"].id), "strict": True},
+    ])
+
+    assert _put_default(setup["client"], setup["cloud"]).status_code == 200
+
+    assert RunnerAssignment.objects.filter(agent=setup["agent"], source="email").exists()
+
+
+def test_saving_the_rules_does_not_wipe_the_default_list(setup):
+    _put_default(setup["client"], setup["cloud"])
+
+    _put_rules(setup["client"], [
+        {"source": "email", "runner_id": str(setup["laptop"].id), "strict": True},
+    ])
+
+    assert RunnerAssignment.objects.filter(agent=setup["agent"], source="").count() == 1
+
+
+def test_the_default_list_read_excludes_rule_rows(setup):
+    """Otherwise a rule would show up as a phantom chip in the Default order row."""
+    _put_default(setup["client"], setup["cloud"])
+    _put_rules(setup["client"], [
+        {"source": "email", "runner_id": str(setup["laptop"].id)},
+    ])
+
+    got = setup["client"].get("/api/agents/echo/runners").json()
+
+    assert [r["runner_name"] for r in got] == ["cloud-1"]
+
+
+def test_put_replaces_wholesale(setup):
+    _put_rules(setup["client"], [
+        {"source": "email", "runner_id": str(setup["laptop"].id), "strict": True},
+    ])
+    _put_rules(setup["client"], [
+        {"source": "ace_web", "runner_id": str(setup["cloud"].id), "strict": False},
+    ])
+
+    rows = RunnerAssignment.objects.filter(agent=setup["agent"]).exclude(source="")
+    assert [r.source for r in rows] == ["ace_web"]
+
+
+def test_a_duplicate_source_is_rejected(setup):
+    res = _put_rules(setup["client"], [
+        {"source": "email", "runner_id": str(setup["laptop"].id)},
+        {"source": "email", "runner_id": str(setup["cloud"].id)},
+    ])
+    assert res.status_code == 422
+
+
+def test_a_non_routable_source_is_rejected(setup):
+    res = _put_rules(setup["client"], [
+        {"source": "not_a_source", "runner_id": str(setup["laptop"].id)},
+    ])
+    assert res.status_code == 422
+
+
+def test_a_runner_the_caller_cannot_see_is_rejected(setup):
+    outsider = get_user_model().objects.create_user(username="mal", email="mal@evil.com")
+    theirs = Runner.objects.create(
+        name="mal-box", kind=Runner.CLOUD, paired_by=outsider, status=Runner.ONLINE,
+        last_heartbeat_at=timezone.now(), capabilities={},
+    )
+
+    res = _put_rules(setup["client"], [
+        {"source": "email", "runner_id": str(theirs.id)},
+    ])
+
+    assert res.status_code == 422
+    # …and the rejected batch left nothing behind: the delete is inside the same
+    # transaction as the insert, so a bad row can't wipe the existing rules.
+    assert not RunnerAssignment.objects.filter(agent=setup["agent"]).exclude(source="").exists()
+
+
+def test_queued_count_reports_the_parked_work(setup):
+    """The UI's 'N turns are parked' warning reads this."""
+    _put_rules(setup["client"], [
+        {"source": "email", "runner_id": str(setup["laptop"].id), "strict": True},
+    ])
+    Turn.objects.create(agent=setup["agent"], origin=Turn.ORIGIN_EMAIL, idempotency_key="q1")
+    Turn.objects.create(agent=setup["agent"], origin=Turn.ORIGIN_EMAIL, idempotency_key="q2")
+    Turn.objects.create(agent=setup["agent"], origin=Turn.ORIGIN_API, idempotency_key="q3")
+
+    got = setup["client"].get("/api/agents/echo/runner-rules").json()
+
+    assert got[0]["queued_count"] == 2
+
+
+def test_a_non_member_cannot_read_or_write_the_rules(client):
+    """Same 404-not-403 discipline as the rest of the agents surface."""
+    owner = get_user_model().objects.create_user(username="own", email="own@dimagi.com")
+    ws = Workspace.objects.create(slug="private", display_name="Private", created_by=owner)
+    WorkspaceMembership.objects.create(workspace=ws, user=owner, role=WorkspaceMembership.OWNER)
+    Agent.objects.create(slug="secret", name="Secret", workspace=ws)
+    outsider = get_user_model().objects.create_user(username="mal", email="mal@dimagi.com")
+    client.force_login(outsider)
+
+    assert client.get("/api/agents/secret/runner-rules").status_code == 404
+    assert client.put(
+        "/api/agents/secret/runner-rules",
+        data={"rules": []}, content_type="application/json",
+    ).status_code == 404


### PR DESCRIPTION
The read/write surface for source rules, plus the one-line fix that stops the
default-list save from destroying them.

- `GET|PUT /api/agents/{slug}/runner-rules` — wholesale replace, scoped to
  non-empty-source rows. Same visibility gate as the default-list PUT
  (`_runner_visibility_q`, retired excluded), a named 422 on a duplicate source
  rather than an IntegrityError 500, and `source` typed as the routable literal
  so the union reaches the generated TypeScript instead of being hand-copied.
- `queued_count` per rule — the agent's queued turns from that source, which is
  what the UI's "N turns are parked" warning renders.

**Both sibling writes are now scoped, and so is the default-list read.**
`RunnerAssignment` holds the ordered list and the rules in one table. `PUT
/runners` deleted *every* row for the agent, so saving the default order would
have silently wiped every rule; and `GET /runners` would have rendered each rule
as a phantom chip in the order row. Three tests pin the pair — save one, assert
the other survives.

The rejected-batch test is the other one worth a look: the delete and the insert
share a transaction, so a bad runner id can't wipe the existing rules on its way
to a 422.

Verified: `uv run pytest -q` → 1811 passed, 1 skipped (incl.
`test_architecture_boundary.py` — `agents`→`harness` is framework→framework);
ruff clean; types regenerated.

Plan: `docs/superpowers/plans/2026-07-27-source-aware-runner-routing.md` (Task 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)