### PR TITLE
feat(runner): read a permission dialog off the terminal, and answer it

### DIFF
--- a/packages/canopy_runner/canopy_runner/menu.py
+++ b/packages/canopy_runner/canopy_runner/menu.py
@@ -1,0 +1,193 @@
+"""Read a Claude Code dialog out of a rendered terminal, and answer it.
+
+**Why this exists.** A hook cannot describe a menu. `Notification` fires when
+Claude Code wants a human and carries a message string — not the options, not
+the command being approved, and no way to reply. ACP *does* carry all of it
+(`session/request_permission` gives labelled options plus the toolCall), but
+that is the cloud path: on a laptop emdash owns the session, so the only place
+the menu exists is the terminal it is drawn in.
+
+**Why a rendered grid, not the PTY stream.** Claude Code draws spaces as
+cursor-forward escapes (`ESC[1C`), so stripping ANSI from the raw stream welds
+words together (`Accessingworkspace:`). xterm resolves those into cells, and the
+runner reads the resulting text out of emdash's DOM over CDP — so this parser
+takes the grid, which is what a terminal shows.
+
+Verified end to end on 2026-07-28: a real dialog was captured from a live
+`claude`, parsed by this module, answered with `answer_keys`, and the file it
+asked about was actually deleted.
+
+**It fails closed.** `find_menu` returns None unless it sees consecutively
+numbered options AND a footer offering a way out. A false positive tells a phone
+an agent is blocked when it is working, and after a few of those nobody trusts
+the signal.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+# The pointer marking the highlighted row. Cosmetic for answering (we send the
+# NUMBER) but shown to the user, so it must be stripped from labels.
+CURSOR = "❯"
+
+# "1. Yes" / "❯ 2. Yes, and always allow …" — leading indent varies with the box.
+_OPTION = re.compile(rf"^\s*(?:{CURSOR}\s*)?(\d+)\.\s+(\S.*)$")
+
+# Every dialog observed ends its prose with a question. Requiring one is what
+# keeps a numbered LIST an agent wrote from parsing as a menu.
+_QUESTION = re.compile(r"^\s*(.*\?)\s*$")
+
+# Footer hints, never options or subject.
+_FOOTER = re.compile(r"(Esc to cancel|Enter to confirm|Tab to amend|ctrl\+e to explain)")
+
+# The rule drawn above a dialog. Marks where the subject block starts.
+_RULE = re.compile(r"^[─━-]{10,}$")
+
+
+@dataclass
+class Option:
+    number: int
+    label: str
+
+
+@dataclass
+class Menu:
+    question: str
+    options: list[Option]
+    title: str = ""
+    body: str = ""
+    selected: int | None = None
+    raw: str = field(default="", repr=False)
+
+    def allows(self, number: int | None) -> bool:
+        """Whether `number` is actually on this menu.
+
+        A client can post any integer. Typing '9' at a three-option dialog
+        answers nothing, leaves the prompt open and wedges the turn — so the
+        runner checks before pressing a key.
+        """
+        if number is None:
+            return True          # refusing (Esc) is always available
+        return any(o.number == number for o in self.options)
+
+
+def _join_wrapped(lines: list[str]) -> str:
+    """Rejoin a command the TUI hard-wrapped across grid lines.
+
+    It wraps mid-token (`…canopy-web-emd` / `ash-acp-runner…`), so joining with
+    a space or newline corrupts the very string a human is reading in order to
+    decide. Continuation lines are concatenated with nothing; a line that starts
+    a new sentence-ish fragment keeps its space.
+    """
+    out = ""
+    for line in lines:
+        piece = line.strip()
+        if not piece:
+            continue
+        if not out:
+            out = piece
+        elif out.endswith(("&&", "|", "&", ";")) or piece.startswith(("&&", "|", "-")):
+            out += " " + piece
+        elif out[-1:].isspace():
+            out += piece
+        else:
+            # Mid-token wrap: the grid split a path or flag, so no separator.
+            out += piece
+    return out
+
+
+def find_menu(text: str) -> Menu | None:
+    """The dialog on this screen, or None.
+
+    Deliberately strict — see the module docstring on failing closed.
+    """
+    if not text:
+        return None
+    lines = text.splitlines()
+
+    # Options first: they are the least ambiguous thing on the screen.
+    options: list[Option] = []
+    selected: int | None = None
+    first_option_line = None
+    for i, line in enumerate(lines):
+        m = _OPTION.match(line)
+        if not m:
+            continue
+        number, label = int(m.group(1)), m.group(2).strip()
+        if _FOOTER.search(label):
+            continue
+        # Options are consecutive from 1; anything else is prose that happens to
+        # be numbered.
+        if not options and number != 1:
+            continue
+        if options and number != options[-1].number + 1:
+            continue
+        if not options:
+            first_option_line = i
+        options.append(Option(number, label))
+        if CURSOR in line:
+            selected = number
+
+    if len(options) < 2 or first_option_line is None:
+        return None
+
+    # A dialog always offers a way out, and prose never does. Requiring that
+    # footer BELOW the options is what separates a real menu from an agent
+    # writing "1. Read the file / 2. Change the thing" — which parsed as a menu
+    # until this check existed. Numbered lines are simply not evidence: they are
+    # the most common shape in an agent's own output.
+    #
+    # Fails closed on purpose. A dialog with no footer would be missed (the
+    # phone shows "needs you" with no buttons, which the terminal can still
+    # answer); a false positive tells you an agent is blocked while it works,
+    # and a few of those and the signal is worthless.
+    if not any(_FOOTER.search(line) for line in lines[first_option_line:]):
+        return None
+
+    # The question is the last line ending in '?' ABOVE the options.
+    question = ""
+    question_line = None
+    for i in range(first_option_line - 1, -1, -1):
+        m = _QUESTION.match(lines[i])
+        if m and m.group(1).strip():
+            question, question_line = m.group(1).strip(), i
+            break
+    if not question:
+        # The trust gate states rather than asks on its final line, so fall back
+        # to the nearest prose line above the options.
+        for i in range(first_option_line - 1, -1, -1):
+            if lines[i].strip() and not _RULE.match(lines[i].strip()):
+                question, question_line = lines[i].strip(), i
+                break
+    if not question:
+        return None
+
+    # Subject: everything between the rule above and the question. First line is
+    # the title ("Bash command"), the rest is the body (the command itself).
+    start = 0
+    for i in range(question_line - 1, -1, -1):
+        if _RULE.match(lines[i].strip()):
+            start = i + 1
+            break
+    block = [l for l in lines[start:question_line] if l.strip()]
+    title = block[0].strip() if block else ""
+    body = _join_wrapped(block[1:]) if len(block) > 1 else ""
+
+    return Menu(question=question, options=options, title=title, body=body,
+                selected=selected, raw=text)
+
+
+def answer_keys(option: int | None) -> list[str]:
+    """The keystrokes that answer a dialog.
+
+    `None` means refuse, and sends Escape rather than a number — the one answer
+    that is safe when the numbering is not what we think it is. Every dialog
+    observed offers Esc.
+
+    Roundtrip-verified: '1' + Enter on a real Bash-permission dialog ran the
+    command.
+    """
+    if option is None:
+        return ["\x1b"]
+    return [str(option), "\r"]

--- a/packages/canopy_runner/tests/test_menu.py
+++ b/packages/canopy_runner/tests/test_menu.py
@@ -1,0 +1,152 @@
+"""Parsing a Claude Code permission dialog out of a rendered terminal.
+
+Every fixture here was CAPTURED, not written: `claude` driven in a real PTY and
+rendered through a terminal emulator, which is the same character grid xterm
+produces for emdash — so what the runner reads over CDP is what these strings
+contain. Verified by roundtrip on 2026-07-28: the dialog below was detected,
+answered with a keystroke, and the file it asked about was actually deleted.
+"""
+from canopy_runner.menu import answer_keys, find_menu
+
+# Verbatim, as a terminal renders it. Note the leading spaces, the box rule, and
+# that option 2's text wraps concerns beyond the tool itself.
+PERMISSION = """\
+❯ Delete the file target.txt using the Bash tool (rm).
+  Read 1 file, listed 1 directory (ctrl+o to expand)
+⏺ Bash(rm /private/tmp/claude-501/-Users-jjackson-emdash-worktrees-canopy-web-em
+      dash-acp-runner-730f0/be9ee2f2-4712-40ce-9f0d-17846ae7a65f/scratchpad/rt2/
+      target.txt &&…)
+  ⎿  Waiting…
+────────────────────────────────────────────────────────────────────────────────
+ Bash command
+   rm /private/tmp/claude-501/-Users-jjackson-emdash-worktrees-canopy-web-emd
+   ash-acp-runner-730f0/be9ee2f2-4712-40ce-9f0d-17846ae7a65f/scratchpad/rt2/t
+   arget.txt && ls -la
+   /private/tmp/claude-501/-Users-jjackson-emdash-worktrees-canopy-web-emdash
+   -acp-runner-730f0/be9ee2f2-4712-40ce-9f0d-17846ae7a65f/scratchpad/rt2
+   Delete target.txt and verify
+ Do you want to proceed?
+ ❯ 1. Yes
+   2. Yes, and always allow access to rt2/ from this project
+   3. No
+ Esc to cancel · Tab to amend · ctrl+e to explain
+"""
+
+# The gate a fresh worktree hits first. A different dialog, same grammar — which
+# is the point: one parser, or the runner grows a special case per dialog.
+TRUST = """\
+────────────────────────────────────────────────────────────────────────────────
+ Accessing workspace:
+ /private/tmp/scratchpad/menu-work
+ Quick safety check: Is this a project you created or one you trust?
+ Claude Code'll be able to read, edit, and execute files here.
+ Security guide
+ ❯ 1. Yes, I trust this folder
+   2. No, exit
+ Enter to confirm · Esc to cancel
+"""
+
+# A working session. The single most important negative case: mistaking this for
+# a menu would tell the phone an agent is blocked when it is busy, and every
+# "needs you" after that is noise.
+BUSY = """\
+❯ Delete the file target.txt using the Bash tool (rm).
+⏺ Bash(rm target.txt && ls -la)
+  ⎿  Waiting…
+✻ Sautéed for 6s
+────────────────────────────────────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────────────────────────────────────
+  ⏵⏵ auto mode on (shift+tab to cycle)
+"""
+
+
+def test_a_permission_dialog_is_found():
+    menu = find_menu(PERMISSION)
+    assert menu is not None
+    assert menu.question == "Do you want to proceed?"
+
+
+def test_every_option_is_extracted_in_order():
+    menu = find_menu(PERMISSION)
+    assert [(o.number, o.label) for o in menu.options] == [
+        (1, "Yes"),
+        (2, "Yes, and always allow access to rt2/ from this project"),
+        (3, "No"),
+    ]
+
+
+def test_the_selected_option_is_known():
+    """The ❯ marker is which choice is highlighted. Answering by NUMBER makes it
+    cosmetic — but showing the wrong default on a phone is its own bug."""
+    assert find_menu(PERMISSION).selected == 1
+
+
+def test_the_subject_is_carried_so_the_phone_can_show_WHAT_it_is_asking():
+    """A menu with no subject is unanswerable away from the keyboard: "Do you
+    want to proceed?" tells you nothing about what you are approving."""
+    menu = find_menu(PERMISSION)
+    assert menu.title == "Bash command"
+    assert "rm " in menu.body
+    assert "target.txt" in menu.body
+
+
+def test_a_wrapped_command_is_rejoined():
+    """The TUI hard-wraps the command across grid lines mid-token
+    ('…canopy-web-emd' / 'ash-acp-runner…'). Joining with a space or a newline
+    corrupts the command being approved — which is the one string a human is
+    reading to decide."""
+    body = find_menu(PERMISSION).body
+    assert "canopy-web-emdash-acp-runner-730f0" in body
+    assert "canopy-web-emd ash" not in body
+
+
+def test_the_trust_gate_parses_with_the_same_grammar():
+    menu = find_menu(TRUST)
+    assert menu is not None
+    assert [(o.number, o.label) for o in menu.options] == [
+        (1, "Yes, I trust this folder"),
+        (2, "No, exit"),
+    ]
+
+
+def test_a_busy_session_is_not_a_menu():
+    assert find_menu(BUSY) is None
+
+
+def test_empty_and_garbage_are_not_menus():
+    assert find_menu("") is None
+    assert find_menu("just some output\nand more") is None
+
+
+def test_numbered_prose_is_not_a_menu():
+    """An agent writing a numbered list must not read as a dialog."""
+    prose = """\
+⏺ Here is the plan:
+   1. Read the file
+   2. Change the thing
+   3. Run the tests
+"""
+    assert find_menu(prose) is None
+
+
+def test_answering_is_the_number_then_enter():
+    """Roundtrip-verified 2026-07-28: '1' + Enter on the dialog above ran the
+    command and deleted the file."""
+    assert answer_keys(1) == ["1", "\r"]
+    assert answer_keys(3) == ["3", "\r"]
+
+
+def test_refusing_is_escape_not_a_number():
+    """Every dialog offers Esc, and it is the only answer that is safe when the
+    option numbering is not what we think it is."""
+    assert answer_keys(None) == ["\x1b"]
+
+
+def test_an_option_outside_the_menu_is_refused():
+    """A client could post any number; approving option 9 of a 3-option dialog
+    by typing '9' would leave the prompt open and the turn wedged."""
+    menu = find_menu(PERMISSION)
+    assert menu.allows(1) and menu.allows(3)
+    assert not menu.allows(4)
+    assert not menu.allows(0)


### PR DESCRIPTION
The hooks can say an agent is **blocked**. They cannot say *what* it is asking, and they cannot answer — `Notification` carries a message string, not the options, not the command being approved. ACP carries all of it, but that's the cloud path; on a laptop emdash owns the session, so the only place the menu exists is the terminal it's drawn in.

## Verified by roundtrip, not by reading

Captured from a live `claude` in a real PTY, parsed by this module, answered with `answer_keys(1)` — and **the file it asked about was actually deleted**. That last part is the only honest proof the answer landed rather than the dialog merely disappearing.

```
 Bash command
   rm /private/…/target.txt && ls -la /private/…/rt2
   Delete target.txt and verify
 Do you want to proceed?
 ❯ 1. Yes
   2. Yes, and always allow access to rt2/ from this project
   3. No
 Esc to cancel · Tab to amend · ctrl+e to explain
```

## Three things the capture taught that reading couldn't

- **A `claude` spawned from inside a Claude Code session inherits the parent's session env**, comes up in `auto` mode and self-approves. That's why three earlier attempts saw no dialog at all — not flakiness, the prompt was never going to render. The fixture exists only because the spawn strips `CLAUDE_CODE*` and passes `--permission-mode default`. Worth knowing generally: the same capture warned *"Transcript saving is off — inherited CLAUDE_CODE_CHILD_SESSION marker"*, and the transcript is canopy's durable record.
- **The TUI draws spaces as cursor-forward escapes**, so stripping ANSI from the raw stream welds words together (`Accessingworkspace:`). This parser takes a *rendered grid* — what xterm gives emdash's DOM, and what the runner reads over CDP.
- **The command is hard-wrapped mid-token** across grid lines, so rejoining with a space or newline corrupts the one string a human reads in order to decide.

## Fails closed

Numbered lines are not evidence of a dialog — they're the most common shape in an agent's own output, and `1. Read the file / 2. Change the thing` parsed as a menu until a test caught it. A footer offering a way out is now required. Missing a real dialog costs the phone its buttons (the terminal can still answer); a false one says an agent is blocked while it's working, and a few of those make the signal worthless.

`allows()` guards the reply: a client can post any integer, and typing `9` at a three-option dialog answers nothing and wedges the turn. Refusing sends Escape rather than a number.

**Scope:** parser and keystrokes only, 12 tests, runner suite 228 green. Wiring to CDP and the phone is the next slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)