### PR TITLE
fix(runner): a spawned claude must not inherit our own session identity

### DIFF
--- a/deploy/ec2-runner/cloud_runner.py
+++ b/deploy/ec2-runner/cloud_runner.py
@@ -298,6 +298,46 @@ def pair_or_load() -> str:
     return rid
 
 
+# Session-identity markers Claude Code exports into its own child processes.
+# They must NOT reach a `claude` this runner spawns.
+#
+# Measured 2026-07-28 by spawning `claude` from inside a Claude Code session: the
+# child came up in the PARENT'S permission mode (`auto`, self-approving) and
+# announced "Transcript saving is off — inherited CLAUDE_CODE_CHILD_SESSION
+# marker". Transcript saving being off is the serious half — the transcript is
+# canopy's DURABLE RECORD, so a turn would run, finish, report success, and
+# leave nothing to persist or reset from.
+#
+# Normally the runner is a service and has none of these. It inherits them the
+# moment someone starts it from inside an agent session — exactly the debugging
+# situation where you would least suspect the record.
+#
+# CLAUDE_CODE_OAUTH_TOKEN IS DELIBERATELY NOT HERE: it is how the box
+# authenticates (see the module docstring). A blanket CLAUDE_CODE* strip is the
+# obvious-looking version of this fix and it silently breaks every turn.
+INHERITED_SESSION_MARKERS = (
+    "CLAUDECODE",
+    "CLAUDE_CODE_ENTRYPOINT",
+    "CLAUDE_CODE_EXECPATH",
+    "CLAUDE_CODE_SESSION_ID",
+    "CLAUDE_CODE_CHILD_SESSION",
+    "CLAUDE_PID",
+    "CLAUDE_EFFORT",
+)
+
+
+def _child_safe_env() -> dict:
+    """`os.environ` with the parent's Claude session identity removed.
+
+    Credentials are preserved; only the markers that make a spawned agent behave
+    as a CHILD of this process are dropped.
+    """
+    env = os.environ.copy()
+    for marker in INHERITED_SESSION_MARKERS:
+        env.pop(marker, None)
+    return env
+
+
 def _agent_env(slug: str | None) -> dict:
     """The turn environment, with the agent's OWN `~/.<slug>/.env` layered on top.
 
@@ -316,7 +356,7 @@ def _agent_env(slug: str | None) -> dict:
     prefixes, shell interpolation) is not part of the format and is skipped
     rather than guessed at.
     """
-    env = os.environ.copy()
+    env = _child_safe_env()
     if not slug:
         return env
     env_file = pathlib.Path.home() / f".{slug}" / ".env"

--- a/deploy/ec2-runner/tests/test_cloud_runner.py
+++ b/deploy/ec2-runner/tests/test_cloud_runner.py
@@ -1183,3 +1183,51 @@ def test_a_missing_transcript_core_never_fails_the_turn(cloud_runner, monkeypatc
     monkeypatch.setattr(cloud_runner, "_transcript_core", lambda: None)
     monkeypatch.setattr(cloud_runner, "_chat_session_id", lambda turn: "sess-1")
     cloud_runner._ship_transcript_rows("r1", {"id": "t1"}, "/tmp", "sess")  # must not raise
+
+
+class TestInheritedSessionMarkers:
+    """A `claude` this runner spawns must not think it is a CHILD of a Claude
+    session that happens to have started the runner.
+
+    Measured 2026-07-28: a claude spawned from inside a Claude Code session came
+    up in the parent's permission mode (`auto`, self-approving) and reported
+    "Transcript saving is off — inherited CLAUDE_CODE_CHILD_SESSION marker".
+    The transcript is canopy's durable record, so that turn would have run,
+    finished, reported success, and left nothing behind.
+    """
+
+    def test_session_markers_are_stripped(self, cloud_runner, monkeypatch):
+        for marker in cloud_runner.INHERITED_SESSION_MARKERS:
+            monkeypatch.setenv(marker, "inherited")
+        env = cloud_runner._agent_env(None)
+        for marker in cloud_runner.INHERITED_SESSION_MARKERS:
+            assert marker not in env, marker
+
+    def test_the_oauth_token_survives(self, cloud_runner, monkeypatch):
+        """The one that must NOT be stripped. `claude` authenticates with it, so
+        a blanket CLAUDE_CODE* strip — the obvious-looking version of this fix —
+        silently breaks every turn on the box."""
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "secret-token")
+        monkeypatch.setenv("CLAUDECODE", "1")
+        env = cloud_runner._agent_env(None)
+        assert env["CLAUDE_CODE_OAUTH_TOKEN"] == "secret-token"
+        assert "CLAUDECODE" not in env
+
+    def test_ordinary_environment_is_untouched(self, cloud_runner, monkeypatch):
+        monkeypatch.setenv("PATH", "/usr/bin")
+        monkeypatch.setenv("CANOPY_TOKEN", "pat")
+        env = cloud_runner._agent_env(None)
+        assert env["PATH"] == "/usr/bin"
+        assert env["CANOPY_TOKEN"] == "pat"
+
+    def test_an_agents_own_env_still_layers_on_top(self, cloud_runner, monkeypatch, tmp_path):
+        """Stripping must not disturb the per-agent identity load — that file is
+        what makes an agent use its OWN PAT instead of the runner's."""
+        monkeypatch.setenv("CLAUDECODE", "1")
+        monkeypatch.setattr(cloud_runner.pathlib.Path, "home", classmethod(lambda cls: tmp_path))
+        agent_dir = tmp_path / ".echo"
+        agent_dir.mkdir()
+        (agent_dir / ".env").write_text("CANOPY_WEB_PAT=agent-pat\n")
+        env = cloud_runner._agent_env("echo")
+        assert env["CANOPY_WEB_PAT"] == "agent-pat"
+        assert "CLAUDECODE" not in env


### PR DESCRIPTION
Measured, not theorised. Spawning `claude` from inside a Claude Code session produced a child that came up in the **parent's permission mode** (`auto` — so it self-approved its own Bash call and never prompted) and announced:

```
⚠ Transcript saving is off — inherited CLAUDE_CODE_CHILD_SESSION marker
```

**Transcript saving being off is the serious half.** The transcript is canopy's durable record — `_ship_transcript_rows` reads it, reset re-derives from it. Such a turn runs, finishes, reports success, and leaves nothing to persist. The failure is invisible at exactly the moment you'd trust the result.

## Exposure

`_agent_env` did `os.environ.copy()`, so the runner passed through whatever it was started with. Normally it's a service and has none of these markers — it inherits them the moment someone starts it by hand from inside an agent session, which is the debugging situation where you'd least suspect the record.

## The trap in the obvious fix

`CLAUDE_CODE_OAUTH_TOKEN` is **how the box authenticates**. A blanket `CLAUDE_CODE*` strip — which is exactly what my own capture script used — would silently break every turn on the box. So the deny-list is explicit, and a test pins the token's survival alongside the per-agent `.env` layering that gives an agent its own PAT.

Found while capturing a permission dialog for the menu parser: three earlier capture attempts saw no dialog at all, and this was why.

4 new tests, cloud-runner suite 58 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)