### PR TITLE
chore: repoint at dimagi-internal after repo transfers

### DIFF
--- a/.github/workflows/deploy-labs.yml
+++ b/.github/workflows/deploy-labs.yml
@@ -20,10 +20,10 @@ name: Deploy to Labs (AWS)
 #
 # Required GitHub secrets (see deploy/aws + Phase 2 of the labs migration):
 #   AWS_ROLE_ARN         — the shared github-actions-labs-deploy OIDC role
-#                          (trust policy must allow repo:jjackson/canopy-web:*)
+#                          (trust policy must allow repo:dimagi-internal/canopy-web:*)
 #   LABS_SUBNET          — a labs VPC subnet id (for the one-off migration task)
 #   LABS_SECURITY_GROUP  — the labs security group id
-#   CANOPY_PLUGIN_TOKEN  — read-only token for the private jjackson/canopy plugin
+#   CANOPY_PLUGIN_TOKEN  — read-only token for the private dimagi-internal/canopy plugin
 #                          (optional; absent → /system shows an empty catalog)
 
 on:
@@ -106,7 +106,7 @@ jobs:
         run: |
           rm -rf canopy
           if [ -n "$CANOPY_PLUGIN_TOKEN" ]; then
-            if git clone --depth 1 "https://x-access-token:${CANOPY_PLUGIN_TOKEN}@github.com/jjackson/canopy.git" canopy; then
+            if git clone --depth 1 "https://x-access-token:${CANOPY_PLUGIN_TOKEN}@github.com/dimagi-internal/canopy.git" canopy; then
               rm -rf canopy/.git
               echo "Vendored canopy plugin into build context."
             else

--- a/.github/workflows/publish-canopy-ui.yml
+++ b/.github/workflows/publish-canopy-ui.yml
@@ -6,7 +6,7 @@ name: Publish canopy-ui
 # Auth is OIDC Trusted Publishing — NO stored token. GitHub Actions mints a
 # short-lived OIDC token that npm trusts, so there's no NPM_TOKEN secret to leak.
 # One-time setup on npmjs: the canopy-ui package → Settings → Trusted Publisher →
-# GitHub Actions → repo `jjackson/canopy-web`, workflow `publish-canopy-ui.yml`.
+# GitHub Actions → repo `dimagi-internal/canopy-web`, workflow `publish-canopy-ui.yml`.
 #
 # Trigger by pushing a tag like `canopy-ui-v0.3.0`, or manually via the Actions
 # tab (workflow_dispatch). Bump the version in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,21 +73,21 @@ being opened. With auto-merge on, GitHub brings the branch up to date, re-runs C
 the merged result, and lands it — no human rebase loop. Without it you will hand-rebase
 the same PR several times (observed: three times in one afternoon).
 
-**Merge queue is NOT available here — do not retry it.** GitHub requires an
-ORGANISATION-owned repository; `jjackson/canopy-web` is user-owned, so adding a
-`merge_queue` rule to the ruleset returns `422 Invalid rule 'merge_queue':` with
-no field named — because the rule TYPE is rejected, not any parameter. Tried
-2026-07-26 across three parameter shapes before that was clear; don't spend the
-same twenty minutes. Transferring the repo to `dimagi-internal` (jjackson is a
-member) would unlock it, but that moves URLs and every runner PAT,
-`CANOPY_PLUGIN_TOKEN`, and workflow reference wants re-checking first — a real
-decision, not a side effect of wanting a queue. The `merge_group` CI trigger is
-already in place for the day it happens.
+**Merge queue is now UNBLOCKED — but not yet enabled.** It requires an
+ORGANISATION-owned repository. That was the blocker while this repo was
+`jjackson/canopy-web` (adding a `merge_queue` rule returned `422 Invalid rule
+'merge_queue':` with no field named — the rule TYPE was rejected, not any
+parameter; established 2026-07-26 across three parameter shapes, don't re-spend
+that twenty minutes). The repo moved to `dimagi-internal/canopy-web` on
+2026-07-28, so the plan-level blocker is gone and the `merge_group` CI trigger
+is already in place. Enabling it is still a deliberate step, not automatic —
+add the `merge_queue` rule to the `main protection` ruleset when someone wants
+to own the rollout.
 
 **Known gap, accepted:** with `strict: true` and no queue, a PR whose base moved
 can sit `BEHIND` indefinitely — auto-merge USUALLY updates it, but not always
 (#413 stalled until nudged). The fix is one call:
-`gh api -X PUT repos/jjackson/canopy-web/pulls/<n>/update-branch`. Deliberately
+`gh api -X PUT repos/dimagi-internal/canopy-web/pulls/<n>/update-branch`. Deliberately
 not automated yet: it has bitten once.
 
 Branch protection lives in ONE place: the `main protection` **ruleset** (requires a PR,

--- a/apps/projects/management/commands/seed_projects.py
+++ b/apps/projects/management/commands/seed_projects.py
@@ -2,17 +2,17 @@ from django.core.management.base import BaseCommand
 from apps.projects.models import Project
 
 PROJECTS = [
-    {"name": "canopy-web", "slug": "canopy-web", "repo_url": "https://github.com/jjackson/canopy-web", "deploy_url": "https://canopy-web-502453377792.us-central1.run.app", "visibility": "public", "status": "active"},
+    {"name": "canopy-web", "slug": "canopy-web", "repo_url": "https://github.com/dimagi-internal/canopy-web", "deploy_url": "https://canopy-web-502453377792.us-central1.run.app", "visibility": "public", "status": "active"},
     {"name": "ace", "slug": "ace", "repo_url": "https://github.com/jjackson/ace", "visibility": "public", "status": "active"},
     {"name": "ace-web", "slug": "ace-web", "repo_url": "https://github.com/jjackson/ace-web", "deploy_url": "https://labs.connect.dimagi.com/ace", "visibility": "public", "status": "active"},
     {"name": "commcare-ios", "slug": "commcare-ios", "repo_url": "https://github.com/jjackson/commcare-ios", "visibility": "public", "status": "active"},
     {"name": "connect-search", "slug": "connect-search", "repo_url": "https://github.com/jjackson/connect-search", "deploy_url": "https://connect-search-frontend-502453377792.us-central1.run.app", "visibility": "private", "status": "active"},
     {"name": "connect-website", "slug": "connect-website", "repo_url": "https://github.com/jjackson/connect-website", "deploy_url": "https://jjackson.github.io/connect-website/overview/", "visibility": "public", "status": "active"},
-    {"name": "canopy", "slug": "canopy", "repo_url": "https://github.com/jjackson/canopy", "visibility": "private", "status": "active"},
+    {"name": "canopy", "slug": "canopy", "repo_url": "https://github.com/dimagi-internal/canopy", "visibility": "private", "status": "active"},
     {"name": "connect-labs", "slug": "connect-labs", "repo_url": "https://github.com/jjackson/connect-labs", "deploy_url": "https://labs.connect.dimagi.com", "visibility": "public", "status": "active"},
     {"name": "chrome-sales", "slug": "chrome-sales", "repo_url": "https://github.com/jjackson/chrome-sales", "visibility": "private", "status": "active"},
     {"name": "scout", "slug": "scout", "repo_url": "https://github.com/jjackson/scout", "visibility": "public", "status": "active"},
-    {"name": "canopy-skills", "slug": "canopy-skills", "repo_url": "https://github.com/jjackson/canopy-skills", "visibility": "public", "status": "active"},
+    {"name": "canopy-skills", "slug": "canopy-skills", "repo_url": "https://github.com/dimagi-internal/canopy-skills", "visibility": "public", "status": "active"},
     {"name": "reef", "slug": "reef", "repo_url": "https://github.com/jjackson/reef", "visibility": "public", "status": "archived"},
     {"name": "commcare-connect", "slug": "commcare-connect", "repo_url": "https://github.com/jjackson/commcare-connect", "visibility": "public", "status": "active"},
 ]

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -44,12 +44,12 @@ ALLOWED_HOSTS = env("ALLOWED_HOSTS")
 
 # Path to the canopy plugin source (skills/ agents/ commands/) read by
 # apps.system to render the capability catalog at /system. In production the
-# Docker build clones jjackson/canopy into CANOPY_DIR; for local dev, point this
+# Docker build clones dimagi-internal/canopy into CANOPY_DIR; for local dev, point this
 # at your installed plugin cache, e.g.
 #   CANOPY_PLUGIN_PATH=~/.claude/plugins/cache/canopy/canopy/<version>
 # When the path is absent the catalog renders empty with a warning (never 500s).
 #
-# The jjackson/canopy marketplace repo NESTS the plugin under plugins/canopy/;
+# The dimagi-internal/canopy marketplace repo NESTS the plugin under plugins/canopy/;
 # a bare plugin checkout (the cache) has skills/ at its root. Auto-detect both.
 def _resolve_canopy_plugin_path() -> str:
     explicit = env.str("CANOPY_PLUGIN_PATH", default="")

--- a/deploy/ec2-runner/bootstrap_agents.sh
+++ b/deploy/ec2-runner/bootstrap_agents.sh
@@ -24,7 +24,7 @@ set -uo pipefail
 AGENT_SLUGS="${AGENT_SLUGS:-ace,ada,echo,eva,hal}"
 AGENT_ROOT="${AGENT_ROOT:-/opt/agents}"
 AGENT_REPO_ORG="${AGENT_REPO_ORG:-dimagi-internal}"
-CANOPY_PLUGIN_URL="${CANOPY_PLUGIN_URL:-https://github.com/jjackson/canopy.git}"
+CANOPY_PLUGIN_URL="${CANOPY_PLUGIN_URL:-https://github.com/dimagi-internal/canopy.git}"
 
 log()  { printf '[bootstrap-agents] %s\n' "$*"; }
 ok()   { printf '[bootstrap-agents] OK: %s\n' "$*"; }

--- a/deploy/ec2-runner/cloud_runner.py
+++ b/deploy/ec2-runner/cloud_runner.py
@@ -122,7 +122,7 @@ WORK_DIR = os.environ.get("WORK_DIR", "/tmp/canopy-runner-work")
 # bootstrap_agent_fleet() below for why this runs from here and not cloud-init.
 AGENT_ROOT = os.environ.get("AGENT_ROOT", "/opt/agents")
 CANOPY_WEB_REPO_DIR = os.environ.get("CANOPY_WEB_REPO_DIR", "/opt/canopy-web")
-CANOPY_WEB_REPO_URL = os.environ.get("CANOPY_WEB_REPO_URL", "https://github.com/jjackson/canopy-web.git")
+CANOPY_WEB_REPO_URL = os.environ.get("CANOPY_WEB_REPO_URL", "https://github.com/dimagi-internal/canopy-web.git")
 POLL_SECONDS = int(os.environ.get("POLL_SECONDS", "15"))
 # App-level heartbeat cadence (keeps the lease + status fresh).
 HEARTBEAT_SECONDS = int(os.environ.get("HEARTBEAT_SECONDS", "20"))
@@ -1075,7 +1075,7 @@ def _turn_cwd(turn: dict, turn_id: str) -> pathlib.Path:
 
 
 def clone_or_pull_canopy_web() -> bool:
-    """canopy-web is PUBLIC (github.com/jjackson/canopy-web) — this needs no
+    """canopy-web is PUBLIC (github.com/dimagi-internal/canopy-web) — this needs no
     credential, but it still runs from bootstrap_agent_fleet (after credential
     staging), not cloud-init, purely to keep the whole bootstrap sequence in
     one place with one log stream."""

--- a/frontend/packages/canopy-ui/package.json
+++ b/frontend/packages/canopy-ui/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jjackson/canopy-web.git",
+    "url": "git+https://github.com/dimagi-internal/canopy-web.git",
     "directory": "frontend/packages/canopy-ui"
   },
   "exports": {


### PR DESCRIPTION
Both `canopy` and `canopy-web` moved into the `dimagi-internal` org today, joining `ace` / `ace-web` on the shared labs platform.

## Functional changes

- **`deploy-labs.yml`** — clones `dimagi-internal/canopy`. This was **already stale before this PR**: canopy moved earlier today, so the existing URL only resolved via GitHub's redirect.
- **`bootstrap_agents.sh`** `CANOPY_PLUGIN_URL` and **`cloud_runner.py`** `CANOPY_WEB_REPO_URL` defaults
- **`canopy-ui/package.json`** repository url
- **`seed_projects.py`** repo_url seeds

## CLAUDE.md — rewritten, not string-swapped

The merge-queue note asserted merge queue was unavailable *because* the repo was user-owned. The transfer inverts that premise, so the paragraph is rewritten to record that the blocker is gone (and that enabling it is still a deliberate act).

## Deliberately unchanged

`docs/superpowers/` specs, `.canopy/pm/` run logs, the `jjackson/canopy#400` issue citation, and the `apps/issues` test fixtures — historical record and generic fixture data, all still resolving via redirect.

## Infra done alongside (outside this diff)

- AWS `github-actions-labs-deploy` trust policy widened to accept **both** `repo:jjackson/canopy-web:*` and `repo:dimagi-internal/canopy-web:*`, so deploys never broke during the cutover. The stale entry gets dropped once a deploy is verified green from the new path.
- All four repo secrets confirmed intact post-transfer; `main protection` ruleset survived.

## Still outstanding

npm Trusted Publishing for `canopy-ui` is bound to `jjackson/canopy-web` and is web-UI-only — it must be repointed on npmjs.com before the next `canopy-ui-v*` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)