### PR TITLE
chore(canopy-ui): 0.6.2 — realign with npm, restore OIDC publish

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14244,7 +14244,7 @@
       }
     },
     "packages/canopy-ui": {
-      "version": "0.5.0",
+      "version": "0.6.2",
       "devDependencies": {
         "sonner": "^2.0.7"
       },

--- a/frontend/packages/canopy-ui/package.json
+++ b/frontend/packages/canopy-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "canopy-ui",
-  "version": "0.5.0",
+  "version": "0.6.2",
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bumps `canopy-ui` 0.5.0 → 0.6.2 in `package.json` + `package-lock.json`.

## Why 0.6.2 and not 0.5.1

The repo and npm had drifted apart:

| | version | provenance |
|---|---|---|
| `main` declared | 0.5.0 | never published |
| npm `latest` | **0.6.1** | ❌ none |
| npm 0.6.0 | | ❌ none |
| npm 0.4.0 (last workflow run, Jul 25) | | ✅ SLSA |

`0.6.0` and `0.6.1` were published by hand on 2026-07-28 with plain `npm publish`, bypassing `publish-canopy-ui.yml`. So the supply-chain guarantee the OIDC setup exists to provide has been absent for the last two releases, and tagging `0.5.0` would have failed as lower than npm's `latest`.

0.6.2 clears 0.6.1 and lets the workflow publish again.

## Verification plan

After merge, tag `canopy-ui-v0.6.2` from `main`. Success is `npm view canopy-ui@0.6.2 dist.attestations` returning a `slsa.dev/provenance/v1` predicate — that proves both that Trusted Publishing is correctly repointed to `dimagi-internal/canopy-web` after today's transfer, and that provenance is restored.

Also the first PR through the new merge queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)