### PR TITLE
feat(chat): answer a blocked agent's permission dialog from the phone

### DIFF
--- a/apps/canopy_sessions/api.py
+++ b/apps/canopy_sessions/api.py
@@ -30,6 +30,7 @@ from .schemas import (
     AttachmentOut,
     BackfillStateOut,
     MessageOut,
+    MenuAnswerIn,
     MessagePageOut,
     PlaceIn,
     SendIn,
@@ -341,6 +342,23 @@ def place(request: HttpRequest, session_id: uuid.UUID, payload: PlaceIn):
     except ValueError as exc:
         raise HttpError(422, str(exc))
     return turn
+
+
+@router.post(
+    "/{session_id}/answer-menu", response=dict,
+    summary="Answer the dialog an agent is blocked on",
+)
+def answer_menu(request: HttpRequest, session_id: uuid.UUID, payload: MenuAnswerIn):
+    """Approve or refuse a permission prompt from the web.
+
+    A refusal is a 200 with `ok:false` and a stable reason, not a 4xx: the dialog
+    can go stale between the phone rendering it and a thumb reaching it, and the
+    runner can go offline in between — both ordinary, neither a client error.
+    Same shape `reset` uses for the same reason.
+    """
+    session = _session_or_404(request, session_id)
+    outcome = services.answer_menu(session=session, option=payload.option)
+    return {"ok": outcome == "sent", "reason": "" if outcome == "sent" else outcome}
 
 
 @router.post("/{session_id}/stop", response=dict, summary="Cancel every non-terminal turn on this session")

--- a/apps/canopy_sessions/schemas.py
+++ b/apps/canopy_sessions/schemas.py
@@ -153,3 +153,13 @@ class ResetSummaryOut(Schema):
     skipped: list[ResetOut]
     pruned: list[dict]
     rows_dropped: int
+
+
+class MenuAnswerIn(Schema):
+    """Which option to press on a blocked agent's dialog.
+
+    `None` means refuse — sent as Escape. Deliberately nullable rather than a
+    magic number: every dialog offers Esc, and it is the only answer that is
+    safe when the option numbering is not what the client thought it was.
+    """
+    option: int | None = None

--- a/apps/canopy_sessions/services.py
+++ b/apps/canopy_sessions/services.py
@@ -875,3 +875,35 @@ def project_events(turn: Turn, rows) -> int:
             index += 1
             created += 1
     return created
+
+
+def answer_menu(*, session: Session, option: int | None) -> str:
+    """Answer the dialog an agent is blocked on, from the web.
+
+    Returns "sent" | "unavailable" | "unbound", mirroring `request_backfill`'s
+    refusal shape rather than raising: a menu can go stale between the phone
+    rendering it and a thumb reaching it, and that is ordinary, not an error.
+
+    `option=None` means refuse, which the runner sends as Escape. Escape is the
+    one answer that is safe when the dialog is not what we think it is — a NUMBER
+    typed at a session that is no longer showing a menu lands in its prompt.
+
+    The keystroke itself is the runner's job: the server knows nothing about
+    terminals, and emdash (not canopy) owns the session.
+    """
+    from apps.harness.models import Runner  # framework->framework; lazy, import cycle
+
+    binding = getattr(session, "runner_binding", None)
+    if binding is None or binding.runner_id is None or not binding.session_key:
+        return "unbound"
+    reachable = {Runner.ONLINE, Runner.DEGRADED}
+    if binding.runner.live_status not in reachable:
+        return "unavailable"
+    from apps.realtime import groups
+    groups.publish(groups.runner_group(binding.runner_id), {
+        "type": "runner.menu_answer",
+        "session_id": str(session.id),
+        "session_key": binding.session_key,
+        "option": option,
+    })
+    return "sent"

--- a/apps/canopy_sessions/stream_map.py
+++ b/apps/canopy_sessions/stream_map.py
@@ -25,8 +25,15 @@ def turn_event_to_frames(evt: dict, resolve_message_id: Callable[[int], str]) ->
         # now" — which nothing else could: between a prompt and the first tool
         # call Claude is thinking and emits no content at all, so the session read
         # as idle for the most interesting part of a turn.
-        return [{"event": "session.activity",
-                 "data": {"state": kind.split(":", 1)[1]}}]
+        data = {"state": kind.split(":", 1)[1]}
+        # A "blocked" event may carry the dialog the agent is waiting on. The
+        # runner reads it off the session's screen, because a hook can say
+        # somebody is wanted but never what is being asked — and without the
+        # question and its options, "blocked" is not answerable from a phone.
+        menu = payload.get("menu")
+        if isinstance(menu, dict) and menu:
+            data["menu"] = menu
+        return [{"event": "session.activity", "data": data}]
     if kind == "user":
         # Text a human typed straight into emdash. It reaches no web client any
         # other way — there was no optimistic echo, because no web client sent

--- a/apps/realtime/consumers.py
+++ b/apps/realtime/consumers.py
@@ -214,6 +214,17 @@ class RunnerConsumer(AsyncJsonWebsocketConsumer):
             "desired": message.get("desired"),
         })
 
+    async def runner_menu_answer(self, message):
+        # runner.{id} group_send type="runner.menu_answer" — a human answered, from
+        # the web, the dialog an agent is blocked on. The runner presses the key in
+        # the session's terminal; the server never touches a terminal itself.
+        await self.send_json({
+            "type": "menu_answer",
+            "session_id": message.get("session_id"),
+            "session_key": message.get("session_key"),
+            "option": message.get("option"),
+        })
+
     async def receive_json(self, content, **kwargs):
         action = content.get("action")
         if action == "claim":

--- a/frontend/packages/canopy-ui/src/chat/MenuPrompt.tsx
+++ b/frontend/packages/canopy-ui/src/chat/MenuPrompt.tsx
@@ -1,0 +1,58 @@
+import type { SessionMenu } from "./protocol";
+
+export interface MenuPromptProps {
+  menu: SessionMenu;
+  busy?: boolean;
+  error?: string;
+  onAnswer: (option: number | null) => void;
+}
+
+/**
+ * The dialog a blocked agent is waiting on, answerable from here.
+ *
+ * Shows the SUBJECT, not just the question: "Do you want to proceed?" tells you
+ * nothing away from the keyboard — the command is the whole decision, so it is
+ * rendered verbatim and monospaced rather than summarised.
+ *
+ * Refusing is always offered separately from the numbered options. Every dialog
+ * accepts Escape, and it is the only answer that stays correct if the dialog on
+ * screen is not the one rendered here.
+ */
+export function MenuPrompt({ menu, busy = false, error, onAnswer }: MenuPromptProps) {
+  return (
+    <div className="rounded-md border border-warning/30 bg-warning/10 px-3 py-2.5 text-sm">
+      <div className="flex items-center gap-1.5 font-medium text-warning">
+        <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-warning" />
+        {menu.title || "Waiting on you"}
+      </div>
+      {menu.body ? (
+        <pre className="mt-1.5 max-h-32 overflow-auto whitespace-pre-wrap break-all rounded bg-muted px-2 py-1.5 font-mono text-[12px] text-foreground-secondary">
+          {menu.body}
+        </pre>
+      ) : null}
+      <div className="mt-2 text-foreground">{menu.question}</div>
+      <div className="mt-2 flex flex-wrap gap-1.5">
+        {menu.options.map((option) => (
+          <button
+            key={option.number}
+            type="button"
+            disabled={busy}
+            onClick={() => onAnswer(option.number)}
+            className="rounded border border-input bg-card px-2 py-1 text-[13px] text-foreground hover:bg-muted disabled:opacity-50"
+          >
+            {option.label}
+          </button>
+        ))}
+        <button
+          type="button"
+          disabled={busy}
+          onClick={() => onAnswer(null)}
+          className="rounded px-2 py-1 text-[13px] text-muted-foreground hover:text-foreground disabled:opacity-50"
+        >
+          Cancel (Esc)
+        </button>
+      </div>
+      {error ? <div className="mt-1.5 text-[12px] text-destructive">{error}</div> : null}
+    </div>
+  );
+}

--- a/frontend/packages/canopy-ui/src/chat/index.ts
+++ b/frontend/packages/canopy-ui/src/chat/index.ts
@@ -11,6 +11,7 @@ export type {
   MessageStatus,
   Draft,
   Participant,
+  SessionMenu,
   SessionState,
   WsAction,
   WsEvent,
@@ -43,6 +44,7 @@ export {
 
 // Presentational components
 export { ChatPanel, type ChatPanelProps } from "./ChatPanel";
+export { MenuPrompt, type MenuPromptProps } from "./MenuPrompt";
 export { MessageList } from "./MessageList";
 export { MessageItem, type RenderMarkdown } from "./MessageItem";
 export { ToolCallPair } from "./ToolCallPair";

--- a/frontend/packages/canopy-ui/src/chat/protocol.ts
+++ b/frontend/packages/canopy-ui/src/chat/protocol.ts
@@ -60,6 +60,18 @@ export interface Participant {
   last_seen_at: string | null;
 }
 
+/** A dialog an agent is blocked on, read off its terminal.
+ *
+ *  `title` and `body` are what makes it answerable away from the keyboard:
+ *  "Do you want to proceed?" tells you nothing without the command it means. */
+export interface SessionMenu {
+  question: string;
+  title?: string;
+  body?: string;
+  selected?: number | null;
+  options: { number: number; label: string }[];
+}
+
 export interface SessionState {
   messages: Message[];
   /** Live agent activity, from the runner's turn-boundary hooks. Undefined when
@@ -71,6 +83,10 @@ export interface SessionState {
    *  those apart — but it is the difference between "still thinking, wait" and
    *  "it is waiting on YOU", which previously rendered identically. */
   activity?: "working" | "idle" | "blocked";
+  /** The dialog the agent is waiting on, when one could be read off its screen.
+   *  Absent when the agent is not blocked, or when the runner has no way to look
+   *  (no CDP) — "blocked" still arrives, it just has no buttons. */
+  menu?: SessionMenu;
   active_draft: Draft | null;
   participants: Participant[];
   presence_user_ids: number[];
@@ -96,7 +112,7 @@ export type WsEvent =
   | { event: "chat.stream_start"; data: { message_id: string; turn_index: number } }
   // The agent started or finished a turn. Distinct from tool events: it fires
   // while Claude is THINKING, before any content exists to show.
-  | { event: "session.activity"; data: { state: "working" | "idle" | "blocked" } }
+  | { event: "session.activity"; data: { state: "working" | "idle" | "blocked"; menu?: SessionMenu } }
   // A human typed into emdash rather than into this page. No client echoed it,
   // so this is the only way it reaches the browser before a reload.
   | { event: "chat.user_message"; data: { message_id: string; turn_index: number; plaintext: string } }

--- a/frontend/packages/canopy-ui/src/chat/sessionReducer.test.ts
+++ b/frontend/packages/canopy-ui/src/chat/sessionReducer.test.ts
@@ -584,3 +584,45 @@ describe("blocked — the agent is waiting on YOU", () => {
     expect(after.activity).toBe("blocked");
   });
 });
+
+describe("the dialog an agent is blocked on", () => {
+  const MENU = {
+    question: "Do you want to proceed?",
+    title: "Bash command",
+    body: "rm target.txt",
+    options: [{ number: 1, label: "Yes" }, { number: 2, label: "No" }],
+  };
+
+  it("is carried with the blocked state", () => {
+    const state = sessionReducer(makeState(), {
+      event: "session.activity",
+      data: { state: "blocked", menu: MENU },
+    });
+    expect(state.menu?.options).toHaveLength(2);
+    expect(state.menu?.body).toBe("rm target.txt");
+  });
+
+  it("is dropped when the agent starts producing again", () => {
+    // Buttons that answer a dialog no longer on screen send a stray keystroke
+    // into the prompt — worse than showing nothing.
+    const blocked = sessionReducer(makeState(), {
+      event: "session.activity",
+      data: { state: "blocked", menu: MENU },
+    });
+    const after = sessionReducer(blocked, {
+      event: "chat.tool_use",
+      data: { parent_message_id: null, tool_message_id: "m1", turn_index: 3, block: { id: "t1" } },
+    });
+    expect(after.activity).toBe("working");
+    expect(after.menu).toBeUndefined();
+  });
+
+  it("is cleared by a later activity frame that has no menu", () => {
+    const blocked = sessionReducer(makeState(), {
+      event: "session.activity",
+      data: { state: "blocked", menu: MENU },
+    });
+    const idle = sessionReducer(blocked, { event: "session.activity", data: { state: "idle" } });
+    expect(idle.menu).toBeUndefined();
+  });
+});

--- a/frontend/packages/canopy-ui/src/chat/sessionReducer.ts
+++ b/frontend/packages/canopy-ui/src/chat/sessionReducer.ts
@@ -29,7 +29,10 @@ const UNBLOCKING_FRAMES = new Set([
 
 export function sessionReducer(prev: SessionState, frame: WsEvent): SessionState {
   if (prev.activity === "blocked" && UNBLOCKING_FRAMES.has(frame.event)) {
-    prev = { ...prev, activity: "working" };
+    // Dropping the menu with the state matters as much as the state itself —
+    // the dialog is gone, and buttons that answer a gone dialog send a stray
+    // keystroke into the prompt.
+    prev = { ...prev, activity: "working", menu: undefined };
   }
   switch (frame.event) {
     case "session.state":
@@ -68,7 +71,10 @@ export function sessionReducer(prev: SessionState, frame: WsEvent): SessionState
     }
 
     case "session.activity":
-      return { ...prev, activity: frame.data.state };
+      // The menu is cleared unless this frame carries one: a stale dialog is
+      // worse than none, because its buttons would answer a prompt that is no
+      // longer on screen.
+      return { ...prev, activity: frame.data.state, menu: frame.data.menu };
 
     case "chat.user_message": {
       // Someone typed into emdash, OR into this page. Both reach here, and that

--- a/frontend/src/api/chat.ts
+++ b/frontend/src/api/chat.ts
@@ -246,3 +246,25 @@ export async function deleteAttachment(attachmentId: string): Promise<void> {
 export function attachmentUrl(attachmentId: string): string {
   return apiUrl(`/api/canopy-sessions/attachments/${attachmentId}/content`);
 }
+
+/**
+ * Answer the dialog a blocked agent is waiting on.
+ *
+ * `option = null` refuses (the runner sends Escape). A refusal comes back as a
+ * 200 with `ok:false` and a reason rather than a 4xx: the dialog can go stale
+ * between the phone rendering it and a thumb reaching it, and the runner can go
+ * offline in between — both ordinary, neither a client error.
+ */
+export function answerMenu(
+  id: string,
+  option: number | null,
+): Promise<{ ok: boolean; reason: string }> {
+  return request<{ ok: boolean; reason: string }>(
+    `/api/canopy-sessions/${encodeURIComponent(id)}/answer-menu`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ option }),
+    },
+  );
+}

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -2942,6 +2942,31 @@ export interface paths {
         readonly patch?: never;
         readonly trace?: never;
     };
+    readonly "/api/canopy-sessions/{session_id}/answer-menu": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly get?: never;
+        readonly put?: never;
+        /**
+         * Answer the dialog an agent is blocked on
+         * @description Approve or refuse a permission prompt from the web.
+         *
+         *     A refusal is a 200 with `ok:false` and a stable reason, not a 4xx: the dialog
+         *     can go stale between the phone rendering it and a thumb reaching it, and the
+         *     runner can go offline in between — both ordinary, neither a client error.
+         *     Same shape `reset` uses for the same reason.
+         */
+        readonly post: operations["apps_canopy_sessions_api_answer_menu"];
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
     readonly "/api/canopy-sessions/{session_id}/stop": {
         readonly parameters: {
             readonly query?: never;
@@ -8124,6 +8149,18 @@ export interface components {
             readonly placement: string;
         };
         /**
+         * MenuAnswerIn
+         * @description Which option to press on a blocked agent's dialog.
+         *
+         *     `None` means refuse — sent as Escape. Deliberately nullable rather than a
+         *     magic number: every dialog offers Esc, and it is the only answer that is
+         *     safe when the option numbering is not what the client thought it was.
+         */
+        readonly MenuAnswerIn: {
+            /** Option */
+            readonly option?: number | null;
+        };
+        /**
          * StreamStateOut
          * @description Whether the bound runner is being asked to stream this session live.
          */
@@ -12714,6 +12751,34 @@ export interface operations {
                 };
                 content: {
                     readonly "application/json": components["schemas"]["TurnOutMinimal"];
+                };
+            };
+        };
+    };
+    readonly apps_canopy_sessions_api_answer_menu: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path: {
+                readonly session_id: string;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody: {
+            readonly content: {
+                readonly "application/json": components["schemas"]["MenuAnswerIn"];
+            };
+        };
+        readonly responses: {
+            /** @description OK */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": {
+                        readonly [key: string]: unknown;
+                    };
                 };
             };
         };

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom'
 import {
   ChatPanel,
   PlacementBanner,
+  MenuPrompt,
   useSessionSocket,
   type PendingAttachment,
   type PlacementRunner,
@@ -17,6 +18,7 @@ import {
   requestBackfill,
   resetSession,
   placeTurn,
+  answerMenu,
   ChatApiError,
   type ChatSessionDetail,
   uploadAttachment,
@@ -408,6 +410,37 @@ export function ChatPage() {
     </div>
   )
 
+  // Answering the dialog a blocked agent is waiting on. The optimistic clear is
+  // deliberate: the runner re-reads the screen and refuses a stale answer, so the
+  // worst case is a menu that reappears — better than buttons that stay live
+  // against a dialog that is already gone.
+  const [answering, setAnswering] = useState(false)
+  const [answerError, setAnswerError] = useState('')
+  const onAnswerMenu = useCallback(
+    async (option: number | null) => {
+      if (!id) return
+      setAnswering(true)
+      setAnswerError('')
+      try {
+        const res = await answerMenu(id, option)
+        if (!res.ok) {
+          setAnswerError(
+            res.reason === 'unavailable'
+              ? 'That runner is offline — answer it in emdash.'
+              : res.reason === 'unbound'
+                ? 'This session has no runner to answer on.'
+                : 'Could not answer.',
+          )
+        }
+      } catch {
+        setAnswerError('Could not answer.')
+      } finally {
+        setAnswering(false)
+      }
+    },
+    [id],
+  )
+
   // undefined = no hook has reported for this session yet, so defer to the
   // server's coarser flag rather than asserting idle.
   const liveWorking =
@@ -503,7 +536,14 @@ export function ChatPage() {
           emptyState={emptyState}
           historySlot={historySlot}
           banner={
-            boundOffline ? (
+            socket.state.menu ? (
+              <MenuPrompt
+                menu={socket.state.menu}
+                busy={answering}
+                error={answerError}
+                onAnswer={onAnswerMenu}
+              />
+            ) : boundOffline ? (
               <PlacementBanner
                 runnerName={meta?.runner_name ?? ''}
                 eligibleRunners={placementRunners}

--- a/packages/canopy_runner/canopy_runner/cdp/emdash_control.mjs
+++ b/packages/canopy_runner/canopy_runner/cdp/emdash_control.mjs
@@ -234,6 +234,41 @@ try {
     await page.keyboard.press('Escape');   // Claude Code: Esc interrupts the running turn
     out({ ok: true, task });
 
+  } else if (command === 'read-term') {
+    // The rendered terminal, as TEXT. This is how canopy sees a dialog that only
+    // exists on screen: a hook can say an agent is blocked but never what it is
+    // asking, and emdash (not canopy) owns the session, so the menu lives here.
+    //
+    // Read the DOM rather than the PTY on purpose — emdash's xterm uses the DOM
+    // renderer, so it has already resolved the TUI's cursor-movement escapes into
+    // real cells. Parsing the raw stream instead welds words together, because
+    // Claude Code draws spaces as ESC[nC.
+    const { task } = args;
+    await openTask(task);
+    const text = await page.evaluate(() => {
+      const terms = [...document.querySelectorAll('.xterm')]
+        .filter(t => t.offsetParent !== null && t.getBoundingClientRect().width > 0);
+      const rows = terms[0] && terms[0].querySelector('.xterm-rows');
+      if (!rows) return null;
+      return [...rows.children].map(r => r.textContent).join('\n');
+    });
+    if (text === null) fail(`could not read the terminal for task "${task}"`);
+    out({ ok: true, task, text });
+
+  } else if (command === 'send-keys') {
+    // Answer a dialog. Keys are sent one at a time so a menu answer is exactly
+    // "3" then Enter, never a pasted string — insertText would put the digit in
+    // the prompt of a session that is NOT showing a menu.
+    const { task, keys } = args;
+    await openTask(task);
+    for (const key of keys) {
+      if (key === '\r') await page.keyboard.press('Enter');
+      else if (key === '\u001b') await page.keyboard.press('Escape');
+      else await page.keyboard.press(key);
+      await page.waitForTimeout(120);
+    }
+    out({ ok: true, task, sent: keys.length });
+
   } else {
     fail(`unknown command: ${command}`);
   }

--- a/packages/canopy_runner/canopy_runner/cdp_control.py
+++ b/packages/canopy_runner/canopy_runner/cdp_control.py
@@ -137,6 +137,31 @@ def open_and_send(task: str, text: str, *, clear_first: bool = False, port: int 
     return _run("open-send", args)
 
 
+def read_terminal(task: str, *, port: int = 9222) -> str:
+    """The task's rendered terminal, as text.
+
+    This is how canopy sees a dialog that exists only on screen. A hook can say
+    an agent is blocked but never WHAT it is asking, and emdash owns the session,
+    so the menu is only in the terminal.
+
+    Reads the DOM, not the PTY: emdash's xterm uses the DOM renderer, so it has
+    already resolved the TUI's cursor-movement escapes into real cells. The raw
+    stream would need re-rendering (Claude Code draws spaces as ESC[nC, so
+    stripping ANSI welds words together).
+    """
+    return _run("read-term", {"task": task, "port": port}).get("text") or ""
+
+
+def send_keys(task: str, keys: list[str], *, port: int = 9222) -> dict:
+    """Press `keys` in the task's terminal, one at a time.
+
+    One at a time, not as inserted text: a menu answer must be exactly "3" then
+    Enter. Inserting a string would type the digit into the PROMPT of a session
+    that turned out not to be showing a menu.
+    """
+    return _run("send-keys", {"task": task, "keys": keys, "port": port})
+
+
 def interrupt(task: str, *, port: int = 9222) -> dict:
     """Press Escape in the task's emdash session — interrupts the running turn.
 

--- a/packages/canopy_runner/canopy_runner/hook_listener.py
+++ b/packages/canopy_runner/canopy_runner/hook_listener.py
@@ -48,11 +48,17 @@ class HookListener:
     testable without the runner's client, binding cache, or a live server.
     """
 
-    def __init__(self, *, port: int, nonce: str, resolve_session, forward):
+    def __init__(self, *, port: int, nonce: str, resolve_session, forward,
+                 read_menu=None):
         self.port = port
         self.nonce = nonce
         self._resolve_session = resolve_session
         self._forward = forward
+        # Injected: given a cwd, return the dialog on that session's screen (or
+        # None). Injected rather than imported so this module stays testable
+        # without CDP, emdash, or a live terminal — and so a runner with no CDP
+        # simply reports "blocked" with no menu instead of failing.
+        self._read_menu = read_menu
         self._server: ThreadingHTTPServer | None = None
         self.received = 0
         self.forwarded = 0
@@ -77,8 +83,20 @@ class HookListener:
                 # A state transition, not a chat row: index -1 so it is never
                 # persisted, and a dedicated kind the server maps to a status
                 # frame rather than a message.
+                #
+                # "blocked" alone is not actionable away from the keyboard — it
+                # says somebody is wanted, not what is being asked. Only on
+                # `blocked` do we go and LOOK at the screen, because that read
+                # costs a CDP round trip and this is the one state where the
+                # agent has stopped and is waiting.
+                payload_out: dict = {}
+                if activity == "blocked" and self._read_menu is not None:
+                    menu = self._safe_read_menu(cwd)
+                    if menu is not None:
+                        payload_out["menu"] = menu
                 self._send(session_id, [{"kind": f"activity:{activity}",
-                                         "seq": -1, "index": -1, "payload": {}}])
+                                         "seq": -1, "index": -1,
+                                         "payload": payload_out}])
                 self.forwarded += 1
                 return f"activity:{activity}"
             events = events_for_hook(payload)
@@ -101,6 +119,20 @@ class HookListener:
         except Exception:  # noqa: BLE001 — a hook must never see a failure
             logger.debug("hook handling failed (non-fatal)", exc_info=True)
             return "error"
+
+    def _safe_read_menu(self, cwd: str):
+        """The dialog on this session's screen, or None.
+
+        Never raises and never blocks the report: reading the screen means
+        driving emdash over CDP, which can be slow, wedged, or looking at
+        another task. A menu we fail to read costs the phone its buttons — the
+        "blocked" state still ships, and the terminal can still answer.
+        """
+        try:
+            return self._read_menu(cwd)
+        except Exception:  # noqa: BLE001 — observability may never cost a turn
+            logger.debug("could not read the menu for %s", cwd, exc_info=True)
+            return None
 
     def _send(self, session_id: str, events: list[dict]) -> None:
         raise NotImplementedError  # set by `bind_sender`

--- a/packages/canopy_runner/canopy_runner/main.py
+++ b/packages/canopy_runner/canopy_runner/main.py
@@ -29,7 +29,7 @@ import time
 import uuid
 from pathlib import Path
 
-from . import chat_bridge, emdash, hook_install, transcript
+from . import cdp_control, chat_bridge, emdash, hook_install, menu, transcript
 from .client import Client, ClientError
 import canopy_transcript as transcript_core
 
@@ -532,6 +532,79 @@ def _resolve_hook_session(cwd: str) -> str:
     return ""
 
 
+def _hook_task_name(cwd: str) -> str:
+    """The emdash task backing this cwd, or "" — the handle CDP drives by."""
+    if not cwd:
+        return ""
+    parsed = transcript_core.parse_emdash_worktree(cwd, home=Path.home())
+    if parsed is None:
+        return ""
+    project, task = parsed
+    for candidate in transcript_core.emdash_task_candidates(task):
+        if _hook_sessions.get((project, candidate)):
+            return candidate
+    return ""
+
+
+# The two functions below take the CDP module as an argument so the whole
+# chain — screen in, keystrokes out — is testable against a captured terminal
+# with no emdash, no browser and no Playwright. The `cdp_control`-bound wrappers
+# under them are what the runner actually calls.
+
+
+def _read_hook_menu_from(cdp, task: str, *, cdp_port: int = 9222):
+    """The dialog on `task`'s screen as a plain dict, or None."""
+    if not task:
+        return None
+    found = menu.find_menu(cdp.read_terminal(task, port=cdp_port))
+    if found is None:
+        return None
+    return {
+        "question": found.question,
+        "title": found.title,
+        "body": found.body,
+        "selected": found.selected,
+        "options": [{"number": o.number, "label": o.label} for o in found.options],
+    }
+
+
+def _answer_menu_with(cdp, session_key: str, option, *, cdp_port: int = 9222) -> None:
+    """Press a human's answer into `session_key`'s terminal.
+
+    Re-reads the screen FIRST and refuses an option that is not on it. A menu can
+    go stale between the phone rendering it and a thumb reaching it — and a
+    NUMBER typed at a session no longer showing a dialog lands in its prompt,
+    where the agent reads a bare "1" as an instruction. Double-taps and two
+    people answering at once both land here.
+    """
+    current = menu.find_menu(cdp.read_terminal(session_key, port=cdp_port))
+    if current is None:
+        logger.info("menu answer for %s ignored — no dialog on screen now", session_key)
+        return
+    number = None if option is None else int(option)
+    if not current.allows(number):
+        logger.warning("menu answer %r for %s is not on the dialog now showing (%d options)",
+                       number, session_key, len(current.options))
+        return
+    cdp.send_keys(session_key, menu.answer_keys(number), port=cdp_port)
+    logger.info("answered the dialog on %s with %s", session_key,
+                "Esc" if number is None else f"option {number}")
+
+
+def _read_hook_menu(cwd: str, *, cdp_port: int):
+    """The dialog on this session's screen, or None.
+
+    Only called when a session reports BLOCKED: a hook can say an agent wants a
+    human but never what it is asking, and emdash owns the session, so the
+    question and its options exist only on the terminal.
+    """
+    return _read_hook_menu_from(cdp_control, _hook_task_name(cwd), cdp_port=cdp_port)
+
+
+def _answer_menu(session_key: str, option, *, cdp_port: int = 9222) -> None:
+    _answer_menu_with(cdp_control, session_key, option, cdp_port=cdp_port)
+
+
 def _start_hook_listener(cfg: Config, client: Client):
     """Install the user-level hook and start the loopback listener.
 
@@ -553,6 +626,7 @@ def _start_hook_listener(cfg: Config, client: Client):
         port=cfg.hook_port, nonce=nonce,
         resolve_session=_resolve_hook_session,
         forward=lambda: cfg.forward_sessions,
+        read_menu=lambda cwd: _read_hook_menu(cwd, cdp_port=cfg.cdp_port),
     )
     listener.bind_sender(
         lambda session_id, events: client.post_session_stream(
@@ -928,6 +1002,17 @@ def main() -> None:
     def _on_control(msg: dict) -> None:
         if msg.get("type") == "cancel" and msg.get("turn_id"):
             CANCELLED_TURNS.add(str(msg["turn_id"]))
+        elif msg.get("type") == "menu_answer" and msg.get("session_key"):
+            # A human answered, from the web, the dialog an agent is blocked on.
+            # Runs on the wake-listener thread and must never raise: this socket
+            # also carries cancel and wake, and losing it would cost the runner
+            # its liveness for a keystroke.
+            try:
+                _answer_menu(str(msg["session_key"]), msg.get("option"),
+                             cdp_port=cfg.cdp_port)
+            except Exception:  # noqa: BLE001
+                logger.warning("menu answer failed for %s", msg.get("session_key"),
+                               exc_info=True)
 
     waker = WakeListener(cfg.base_url, cfg.token, cfg.runner_id, on_control=_on_control)
     wake_on = waker.start()

--- a/packages/canopy_runner/tests/test_cdp_control.py
+++ b/packages/canopy_runner/tests/test_cdp_control.py
@@ -177,3 +177,34 @@ def test_host_id_ignores_a_blank_pin(monkeypatch, tmp_path):
     monkeypatch.setattr(cdp_control.socket, "gethostname", lambda: "H2")
     monkeypatch.setattr(cdp_control.getpass, "getuser", lambda: "u2")
     assert cdp_control.host_id() == "u2@H2"
+
+
+def test_read_terminal_returns_the_rendered_text(monkeypatch):
+    """The screen is the only place an emdash session's dialog exists."""
+    calls = {}
+
+    def fake_run(command, args, **kw):
+        calls["command"], calls["args"] = command, args
+        return {"ok": True, "task": args["task"], "text": " Do you want to proceed?\n ❯ 1. Yes\n   2. No"}
+
+    monkeypatch.setattr(cdp_control, "_run", fake_run)
+    text = cdp_control.read_terminal("agent-x")
+    assert calls["command"] == "read-term"
+    assert calls["args"]["task"] == "agent-x"
+    assert "Do you want to proceed?" in text
+
+
+def test_read_terminal_tolerates_an_empty_screen(monkeypatch):
+    monkeypatch.setattr(cdp_control, "_run", lambda *a, **k: {"ok": True})
+    assert cdp_control.read_terminal("agent-x") == ""
+
+
+def test_send_keys_passes_each_key_separately(monkeypatch):
+    """Not insertText: a stray digit typed into the PROMPT of a session that is
+    not showing a menu is worse than a failed answer."""
+    calls = {}
+    monkeypatch.setattr(cdp_control, "_run",
+                        lambda c, a, **k: (calls.update(command=c, args=a), {"ok": True})[1])
+    cdp_control.send_keys("agent-x", ["3", "\r"])
+    assert calls["command"] == "send-keys"
+    assert calls["args"]["keys"] == ["3", "\r"]

--- a/packages/canopy_runner/tests/test_hook_listener.py
+++ b/packages/canopy_runner/tests/test_hook_listener.py
@@ -282,3 +282,57 @@ def test_remove_clears_both_events_and_spares_foreign_hooks(tmp_path):
     assert [h["command"] for e in hooks["PreToolUse"] for h in e["hooks"]] == ["someone-elses-pre"]
     assert "PostToolUse" not in hooks   # ours was the only entry there
     assert hook_install.remove(p) is False
+
+
+# -- the menu a "blocked" state cannot describe on its own -------------------
+
+def _listener_with_menu(menu=None, boom=False):
+    sent = []
+    def read_menu(cwd):
+        if boom:
+            raise RuntimeError("CDP is wedged")
+        return menu
+    lis = HookListener(
+        port=0, nonce="n", resolve_session=lambda cwd: "sess-1",
+        forward=lambda: True, read_menu=read_menu)
+    lis.bind_sender(lambda sid, events: sent.append((sid, events)))
+    return lis, sent
+
+
+MENU = {"question": "Do you want to proceed?", "title": "Bash command",
+        "body": "rm target.txt", "options": [{"number": 1, "label": "Yes"},
+                                             {"number": 2, "label": "No"}]}
+
+
+def test_a_blocked_state_carries_the_menu_so_the_phone_can_show_it():
+    lis, sent = _listener_with_menu(MENU)
+    assert lis.handle_payload(_payload(hook_event_name="Notification")) == "activity:blocked"
+    assert sent[0][1][0]["payload"]["menu"]["question"] == "Do you want to proceed?"
+
+
+def test_working_and_idle_never_read_the_screen():
+    """Reading costs a CDP round trip. Only `blocked` means the agent has
+    stopped and is waiting, so only `blocked` pays for it."""
+    lis, sent = _listener_with_menu(MENU)
+    lis.handle_payload(_payload(hook_event_name="UserPromptSubmit"))
+    lis.handle_payload(_payload(hook_event_name="Stop"))
+    assert all(e[1][0]["payload"] == {} for e in sent)
+
+
+def test_a_failed_read_still_reports_blocked():
+    """Driving emdash over CDP can be slow, wedged, or looking elsewhere. Losing
+    the menu costs the phone its buttons; losing the STATE would leave you
+    waiting on an agent that is waiting on you."""
+    lis, sent = _listener_with_menu(boom=True)
+    assert lis.handle_payload(_payload(hook_event_name="Notification")) == "activity:blocked"
+    assert sent[0][1][0]["payload"] == {}
+
+
+def test_no_menu_reader_configured_is_not_an_error():
+    """A runner without CDP still reports the state."""
+    sent = []
+    lis = HookListener(port=0, nonce="n", resolve_session=lambda c: "s",
+                                     forward=lambda: True)
+    lis.bind_sender(lambda sid, ev: sent.append((sid, ev)))
+    assert lis.handle_payload(_payload(hook_event_name="Notification")) == "activity:blocked"
+    assert sent[0][1][0]["payload"] == {}

--- a/packages/canopy_runner/tests/test_main.py
+++ b/packages/canopy_runner/tests/test_main.py
@@ -585,3 +585,69 @@ def test_success_with_no_prior_failure_is_silent(caplog):
     with caplog.at_level(logging.INFO, logger="canopy_runner"):
         main_mod._note_success("stream:s1")
     assert caplog.text == ""
+
+
+# -- answering a blocked agent's dialog from the web -------------------------
+
+class _FakeMenuCDP:
+    """Stands in for emdash over CDP."""
+
+    def __init__(self, screen):
+        self.screen = screen
+        self.sent = []
+
+    def read_terminal(self, task, *, port=9222):
+        return self.screen
+
+    def send_keys(self, task, keys, *, port=9222):
+        self.sent.append((task, keys))
+        return {"ok": True}
+
+
+DIALOG = """\
+ Bash command
+   rm target.txt
+ Do you want to proceed?
+ ❯ 1. Yes
+   2. No
+ Esc to cancel · Tab to amend
+"""
+
+NO_DIALOG = """\
+⏺ Bash(rm target.txt)
+  ⎿  Waiting…
+❯
+  ⏵⏵ auto mode on
+"""
+
+
+def test_answering_presses_the_option(monkeypatch):
+    fake = _FakeMenuCDP(DIALOG)
+    monkeypatch.setattr(main_mod, "cdp_control", fake)
+    main_mod._answer_menu("agent-task", 1)
+    assert fake.sent == [("agent-task", ["1", "\r"])]
+
+
+def test_refusing_sends_escape(monkeypatch):
+    fake = _FakeMenuCDP(DIALOG)
+    monkeypatch.setattr(main_mod, "cdp_control", fake)
+    main_mod._answer_menu("agent-task", None)
+    assert fake.sent == [("agent-task", ["\x1b"])]
+
+
+def test_a_stale_answer_is_dropped_rather_than_typed(monkeypatch):
+    """The dialog can vanish between the phone rendering it and a thumb reaching
+    it. A NUMBER typed at a session no longer showing a menu lands in its PROMPT,
+    where the agent reads it as an instruction."""
+    fake = _FakeMenuCDP(NO_DIALOG)
+    monkeypatch.setattr(main_mod, "cdp_control", fake)
+    main_mod._answer_menu("agent-task", 1)
+    assert fake.sent == []
+
+
+def test_an_option_not_on_the_dialog_is_dropped(monkeypatch):
+    """The menu on screen may have changed shape since it was rendered."""
+    fake = _FakeMenuCDP(DIALOG)
+    monkeypatch.setattr(main_mod, "cdp_control", fake)
+    main_mod._answer_menu("agent-task", 7)
+    assert fake.sent == []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,14 @@ dev = [
     # hang into a normal failed-test report.
     "pytest-timeout>=2.3,<3.0",
     "ruff>=0.4,<1.0",
+    # TEST-ONLY, and only for one suite: tests/test_menu_roundtrip_e2e.py runs
+    # the blocked-agent dialog across every seam — runner reads a screen, server
+    # maps the event, answer becomes keystrokes. Neither package can import the
+    # other by design (the runner is Django-free; the server does not depend on
+    # the runner), so the one test that spans both needs the runner present.
+    # Deliberately in `dev` and nowhere near the runtime dependency list: this
+    # must never become a way for apps/* to import canopy_runner.
+    "canopy-runner",
     "schemathesis>=3.30,<4.0",
     # dev-only: channels.testing.WebsocketCommunicator imports daphne's live
     # test harness at package import time. Prod serves WS via uvicorn, not daphne.
@@ -80,6 +88,8 @@ canopy-cron = { path = "packages/canopy_cron", editable = true }
 # The transcript core: in-repo, standalone, installable. Both runners depend on it
 # directly; the server uses it for the ordinal scheme.
 canopy-transcript = { path = "packages/canopy_transcript", editable = true }
+# Test-only (see the dev extra): the cross-seam menu test imports it.
+canopy-runner = { path = "packages/canopy_runner", editable = true }
 
 [tool.setuptools.packages.find]
 include = ["apps*", "config*"]

--- a/tests/test_chat_stream_map.py
+++ b/tests/test_chat_stream_map.py
@@ -104,3 +104,22 @@ def test_an_activity_event_becomes_a_status_frame():
         frames = stream_map.turn_event_to_frames(
             {"kind": kind, "seq": -1, "payload": {}}, lambda seq: f"seq:{seq}")
         assert frames == [{"event": "session.activity", "data": {"state": state}}]
+
+
+def test_a_blocked_activity_carries_its_menu():
+    """"blocked" alone says somebody is wanted, not what is being asked — and
+    without the question and its options there is nothing a phone can answer."""
+    menu = {"question": "Do you want to proceed?", "title": "Bash command",
+            "body": "rm target.txt",
+            "options": [{"number": 1, "label": "Yes"}, {"number": 2, "label": "No"}]}
+    frames = turn_event_to_frames(
+        {"kind": "activity:blocked", "seq": -1, "payload": {"menu": menu}}, _rid)
+    assert frames == [{"event": "session.activity",
+                       "data": {"state": "blocked", "menu": menu}}]
+
+
+def test_an_activity_without_a_menu_is_unchanged():
+    """A runner with no CDP, or one whose read failed, still reports the state —
+    the frame must not grow a null menu the client has to special-case."""
+    frames = turn_event_to_frames({"kind": "activity:blocked", "seq": -1, "payload": {}}, _rid)
+    assert frames == [{"event": "session.activity", "data": {"state": "blocked"}}]

--- a/tests/test_menu_roundtrip_e2e.py
+++ b/tests/test_menu_roundtrip_e2e.py
@@ -1,0 +1,143 @@
+"""The blocked-agent dialog, end to end across every seam.
+
+The unit suites cover each hop on its own. This one runs the whole chain with
+only the two ENDS faked — a real captured terminal screen going in, a real
+keystroke list coming out — because every bug this feature can have lives in a
+seam: the runner reading a screen, the hook payload shape, the server frame, the
+client-visible data, and the answer travelling back to a keystroke.
+
+The screen below was captured from a live `claude` on 2026-07-28 and answered
+for real (the file it asked about was deleted), so what enters here is what a
+terminal actually renders.
+"""
+from __future__ import annotations
+
+import pytest
+
+from canopy_runner import main as runner_main
+from canopy_runner.hook_listener import HookListener
+from apps.canopy_sessions.stream_map import turn_event_to_frames
+
+pytestmark = pytest.mark.django_db
+
+
+# Verbatim from the live capture.
+SCREEN = """\
+❯ Delete the file target.txt using the Bash tool (rm).
+  Read 1 file, listed 1 directory (ctrl+o to expand)
+⏺ Bash(rm /private/tmp/scratchpad/rt2/target.txt &&…)
+  ⎿  Waiting…
+────────────────────────────────────────────────────────────────────────────────
+ Bash command
+   rm /private/tmp/scratchpad/rt2/target.txt && ls -la
+   /private/tmp/scratchpad/rt2
+   Delete target.txt and verify
+ Do you want to proceed?
+ ❯ 1. Yes
+   2. Yes, and always allow access to rt2/ from this project
+   3. No
+ Esc to cancel · Tab to amend · ctrl+e to explain
+"""
+
+AFTER_ANSWER = """\
+⏺ Bash(rm /private/tmp/scratchpad/rt2/target.txt &&…)
+  ⎿  total 0
+⏺ Deleted. target.txt is gone.
+❯
+  ⏸ manual mode on · ? for shortcuts
+"""
+
+
+class FakeEmdash:
+    """emdash over CDP: a screen to read, and keystrokes we can assert on."""
+
+    def __init__(self, screen):
+        self.screen = screen
+        self.sent = []
+
+    def read_terminal(self, task, *, port=9222):
+        return self.screen
+
+    def send_keys(self, task, keys, *, port=9222):
+        self.sent.append((task, keys))
+        self.screen = AFTER_ANSWER      # the dialog is gone once answered
+        return {"ok": True}
+
+
+def _run_hook_to_frames(screen):
+    """Notification hook -> what a browser receives. Every hop, no shortcuts."""
+    emdash = FakeEmdash(screen)
+    published: list = []
+
+    listener = HookListener(
+        port=0, nonce="n",
+        resolve_session=lambda cwd: "session-1",
+        forward=lambda: True,
+        read_menu=lambda cwd: runner_main._read_hook_menu_from(emdash, "agent-task"),
+    )
+    listener.bind_sender(lambda sid, events: published.append((sid, events)))
+    listener.handle_payload({"hook_event_name": "Notification", "cwd": "/w/x",
+                             "message": "Claude needs your permission"})
+
+    frames = []
+    for _sid, events in published:
+        for event in events:
+            frames.extend(turn_event_to_frames(event, lambda seq: f"m:{seq}"))
+    return emdash, frames
+
+
+def test_a_dialog_reaches_the_browser_with_everything_needed_to_answer():
+    _emdash, frames = _run_hook_to_frames(SCREEN)
+    assert len(frames) == 1
+    frame = frames[0]
+    assert frame["event"] == "session.activity"
+    assert frame["data"]["state"] == "blocked"
+
+    menu = frame["data"]["menu"]
+    assert menu["question"] == "Do you want to proceed?"
+    # The subject is what makes it answerable away from the keyboard.
+    assert menu["title"] == "Bash command"
+    assert "rm /private/tmp/scratchpad/rt2/target.txt" in menu["body"]
+    assert [o["label"] for o in menu["options"]] == [
+        "Yes",
+        "Yes, and always allow access to rt2/ from this project",
+        "No",
+    ]
+
+
+def test_a_busy_screen_reports_blocked_without_a_menu():
+    """The state must survive even when there is nothing to render: losing the
+    menu costs buttons, losing the state leaves you waiting on an agent that is
+    waiting on you."""
+    _emdash, frames = _run_hook_to_frames(AFTER_ANSWER)
+    assert frames[0]["data"]["state"] == "blocked"
+    assert "menu" not in frames[0]["data"]
+
+
+def test_the_answer_becomes_the_keystrokes_that_dialog_expects():
+    emdash, frames = _run_hook_to_frames(SCREEN)
+    chosen = frames[0]["data"]["menu"]["options"][0]["number"]
+    runner_main._answer_menu_with(emdash, "agent-task", chosen)
+    assert emdash.sent == [("agent-task", ["1", "\r"])]
+
+
+def test_refusing_sends_escape():
+    emdash, _frames = _run_hook_to_frames(SCREEN)
+    runner_main._answer_menu_with(emdash, "agent-task", None)
+    assert emdash.sent == [("agent-task", ["\x1b"])]
+
+
+def test_answering_twice_does_not_press_a_second_time():
+    """The phone can double-tap, or two people can answer at once. The second
+    answer finds no dialog on screen and must not type into the prompt — where
+    the agent would read a bare '1' as an instruction."""
+    emdash, frames = _run_hook_to_frames(SCREEN)
+    runner_main._answer_menu_with(emdash, "agent-task", 1)
+    runner_main._answer_menu_with(emdash, "agent-task", 1)
+    assert emdash.sent == [("agent-task", ["1", "\r"])]
+
+
+def test_an_option_the_dialog_does_not_offer_is_never_pressed():
+    emdash, _frames = _run_hook_to_frames(SCREEN)
+    runner_main._answer_menu_with(emdash, "agent-task", 9)
+    assert emdash.sent == []

--- a/uv.lock
+++ b/uv.lock
@@ -428,6 +428,23 @@ dependencies = [
 requires-dist = [{ name = "croniter", specifier = ">=6.0,<7.0" }]
 
 [[package]]
+name = "canopy-runner"
+version = "0.1.0"
+source = { editable = "packages/canopy_runner" }
+dependencies = [
+    { name = "canopy-cron" },
+    { name = "canopy-transcript" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "canopy-cron", editable = "packages/canopy_cron" },
+    { name = "canopy-transcript", editable = "packages/canopy_transcript" },
+    { name = "websocket-client", marker = "extra == 'realtime'", specifier = ">=1.8,<2" },
+]
+provides-extras = ["realtime"]
+
+[[package]]
 name = "canopy-transcript"
 version = "0.1.0"
 source = { editable = "packages/canopy_transcript" }
@@ -462,6 +479,7 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "canopy-runner" },
     { name = "daphne" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -477,6 +495,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.34,<2.0" },
     { name = "canopy-agent-runs", editable = "packages/canopy_agent_runs" },
     { name = "canopy-cron", editable = "packages/canopy_cron" },
+    { name = "canopy-runner", marker = "extra == 'dev'", editable = "packages/canopy_runner" },
     { name = "canopy-transcript", editable = "packages/canopy_transcript" },
     { name = "channels", specifier = ">=4.1,<5.0" },
     { name = "channels-redis", specifier = ">=4.2,<5.0" },


### PR DESCRIPTION
"needs you" said somebody was wanted. It couldn't say **what** was being asked, and it couldn't be answered — so unblocking an agent meant walking to the laptop. This closes that loop.

## The chain

```
hook Notification → read screen (CDP) → find_menu → activity:blocked{menu}
  → session.activity frame → buttons → POST answer-menu
  → runner.menu_answer → re-read screen → send_keys
```

A hook cannot describe a menu — `Notification` carries a message string, not the options and not the command. ACP carries all of it, but that's the cloud path; on a laptop emdash owns the session, so the dialog exists only on its terminal. So the runner goes and **looks**: on `blocked` (and only then, because it costs a CDP round trip) it reads the rendered screen, parses the dialog, and ships it with the state.

**The DOM, not the PTY.** emdash's xterm uses the DOM renderer, so it has already resolved the TUI's cursor-movement escapes into cells. Parsing the raw stream welds words together, because Claude Code draws spaces as `ESC[nC`.

## Every failure mode here types a stray key into a live agent's prompt

So each is closed deliberately:

- **The runner re-reads the screen before pressing anything** and drops an answer whose dialog is gone, or whose option the dialog doesn't offer. A menu goes stale between the phone rendering it and a thumb reaching it; a bare `1` typed at a session with no dialog lands in the prompt, where the agent reads it as an instruction. Double-taps and two people answering at once both land here.
- **Keys go one at a time**, never `insertText`, for the same reason.
- **Refusing sends Escape**, not a number — the only answer that stays correct if the dialog isn't what we thought.
- **A failed screen read still reports `blocked`.** Losing the menu costs buttons; losing the state leaves you waiting on an agent that's waiting on you.
- **The client drops the menu** the moment the agent produces anything, so buttons never outlive their dialog.
- **A refusal is a 200 with a reason**, not a 4xx: staleness is ordinary here.

## Tests

**6 cross-seam**, driving a *real captured screen* in and asserting the keystrokes out — the same dialog verified by roundtrip on 2026-07-28, where answering it actually deleted the file. Plus unit coverage at each hop. Backend **1205**, runner **239**, canopy-ui **114**, OpenAPI types regenerated.

`canopy-runner` is added as a **test-only** dev dependency: neither package can import the other by design, and the one test that spans both needs it present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)