### PR TITLE
feat(chat): the ace_web origin producer, so source routing has something to match

### DIFF
--- a/apps/canopy_sessions/api.py
+++ b/apps/canopy_sessions/api.py
@@ -318,6 +318,7 @@ def send(request: HttpRequest, session_id: uuid.UUID, payload: SendIn):
         message, turn = services.send_message(
             session=session, text=payload.text, user=request.user,
             client_id=payload.client_id, placement=payload.placement,
+            origin=payload.origin,
         )
     except ValueError as exc:
         raise HttpError(422, str(exc))

--- a/apps/canopy_sessions/schemas.py
+++ b/apps/canopy_sessions/schemas.py
@@ -5,6 +5,9 @@ import datetime as dt
 import uuid
 
 from ninja import Schema
+from pydantic import field_validator
+
+from apps.harness.schemas import Origin, normalize_origin
 
 
 class SessionCreateIn(Schema):
@@ -29,6 +32,15 @@ class SendIn(Schema):
     # session's currently bound runner, or a runner UUID string pins to that
     # runner outright. None leaves normal routing/stickiness in charge.
     placement: str | None = None
+    # What KIND of work this send is, for source-aware routing (spec 2026-07-27).
+    # None = the default `canopy_web_chat` (a human typing in the web UI), which
+    # a caller cannot spell for itself: `Origin` admits only the POSTABLE values,
+    # so the server-only sources keep exactly one producer each. ace-web sets
+    # `ace_web` here — without it, a delegated run enqueues as `canopy_web_chat`
+    # and an `ace_web` routing rule has nothing to match.
+    origin: Origin | None = None
+
+    _norm_origin = field_validator("origin")(staticmethod(normalize_origin))
 
 
 class PlaceIn(Schema):

--- a/apps/canopy_sessions/services.py
+++ b/apps/canopy_sessions/services.py
@@ -643,7 +643,8 @@ def claim_pending_attachments(session, message=None) -> list[dict]:
     ]
 
 def send_message(
-    *, session: Session, text: str, user, client_id: str = "", placement: str | None = None
+    *, session: Session, text: str, user, client_id: str = "", placement: str | None = None,
+    origin: str | None = None,
 ) -> tuple[Message, Turn]:
     """Record the human's message and enqueue the session Turn that answers it.
 
@@ -659,6 +660,12 @@ def send_message(
     new chat, the `requested_runner_id` stashed at create time). See
     `_resolve_placement`.
 
+    `origin`: which SOURCE of work this send is, the key source-aware routing
+    composes a runner list on (spec 2026-07-27). None means the default — a
+    human typing in canopy's own chat UI. ace-web passes `ace_web` so its
+    delegated runs can be routed (and read) as what they are rather than
+    disappearing into the chat source.
+
     For an origin=runner session the TRANSCRIPT is the sole durable source
     (spec 2026-07-24): the user's words reach the DB when the runner ships the
     transcript record they became, keyed on its ordinal. Persisting a second
@@ -666,9 +673,11 @@ def send_message(
     send, so this path writes no row — the frontend already echoes the message
     optimistically (draft.committed), and a transient Message keeps the contract.
     """
+    origin = origin or Turn.ORIGIN_CANOPY_WEB_CHAT
     if transcript_sourced(session):
         return _send_transcript_sourced_message(
-            session=session, text=text, client_id=client_id, placement=placement
+            session=session, text=text, client_id=client_id, placement=placement,
+            origin=origin,
         )
     with transaction.atomic():
         Session.objects.select_for_update().get(pk=session.pk)
@@ -708,7 +717,7 @@ def send_message(
             origin_ref["attachments"] = attachments
         turn, _created = harness_services.enqueue_turn(
             session=session,
-            origin=Turn.ORIGIN_CANOPY_WEB_CHAT,
+            origin=origin,
             idempotency_key=f"chat:{session.id.hex}:{client_id or index}",
             prompt=text,
             origin_ref=origin_ref,
@@ -755,7 +764,8 @@ def place_queued_turn(*, session: Session, placement: str) -> Turn:
 
 
 def _send_transcript_sourced_message(
-    *, session: Session, text: str, client_id: str = "", placement: str | None = None
+    *, session: Session, text: str, client_id: str = "", placement: str | None = None,
+    origin: str = Turn.ORIGIN_CANOPY_WEB_CHAT,
 ) -> tuple[Message, Turn]:
     """The transcript-sourced send path: enqueue the Turn, author NO durable user row.
 
@@ -792,7 +802,7 @@ def _send_transcript_sourced_message(
         origin_ref["attachments"] = attachments
     turn, _created = harness_services.enqueue_turn(
         session=session,
-        origin=Turn.ORIGIN_CANOPY_WEB_CHAT,
+        origin=origin,
         idempotency_key=f"chat:{session.id.hex}:{client_id or uuid.uuid4().hex}",
         prompt=text,
         origin_ref=origin_ref,

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -8097,6 +8097,8 @@ export interface components {
             readonly client_id: string;
             /** Placement */
             readonly placement?: string | null;
+            /** Origin */
+            readonly origin?: ("api" | "ace_web" | "email" | "slack" | "board" | "cron" | "manual" | "drill") | null;
         };
         /**
          * TurnOutMinimal

--- a/tests/test_chat_api.py
+++ b/tests/test_chat_api.py
@@ -382,3 +382,38 @@ def test_runner_online_reflects_binding_liveness(client, ctx):
         last_heartbeat_at=timezone.now() - dt.timedelta(hours=2)
     )
     assert client.get(f"/api/canopy-sessions/{session.id}").json()["runner_online"] is False
+
+
+# ---- origin at the request boundary (spec 2026-07-27) ----
+
+
+def test_send_accepts_ace_web_origin(client):
+    sid = client.post("/api/canopy-sessions/", data={"agent_slug": "echo"},
+                      content_type="application/json").json()["id"]
+    r = client.post(f"/api/canopy-sessions/{sid}/send",
+                    data={"text": "run it", "origin": "ace_web"},
+                    content_type="application/json")
+    assert r.status_code == 200, r.content
+    assert Turn.objects.get(pk=r.json()["turn_id"]).origin == Turn.ORIGIN_ACE_WEB
+
+
+def test_send_without_origin_stays_canopy_web_chat(client):
+    sid = client.post("/api/canopy-sessions/", data={"agent_slug": "echo"},
+                      content_type="application/json").json()["id"]
+    r = client.post(f"/api/canopy-sessions/{sid}/send", data={"text": "hi"},
+                    content_type="application/json")
+    assert r.status_code == 200, r.content
+    assert Turn.objects.get(pk=r.json()["turn_id"]).origin == Turn.ORIGIN_CANOPY_WEB_CHAT
+
+
+def test_send_refuses_a_server_only_origin(client):
+    # canopy_web_chat / canopy_scheduler have exactly one in-repo producer each;
+    # a caller spelling one would borrow that source's routing rule. The shared
+    # schemas.Origin literal is what enforces it — not a second gate here.
+    sid = client.post("/api/canopy-sessions/", data={"agent_slug": "echo"},
+                      content_type="application/json").json()["id"]
+    for bad in ("canopy_web_chat", "canopy_scheduler", "nonsense"):
+        r = client.post(f"/api/canopy-sessions/{sid}/send",
+                        data={"text": "hi", "origin": bad},
+                        content_type="application/json")
+        assert r.status_code == 422, f"{bad}: {r.status_code} {r.content}"

--- a/tests/test_chat_send.py
+++ b/tests/test_chat_send.py
@@ -295,3 +295,35 @@ def test_place_queued_turn_foreign_tenant_runner_raises_value_error():
     turn.refresh_from_db()
     assert turn.pinned_runner_id == original_pin
     assert turn.pinned_runner_id != foreign_runner.id
+
+
+# ---- origin: the ace_web producer (spec 2026-07-27 source-aware runner routing) ----
+# ace-web delegates run execution to canopy (spec 2026-07-26). Until it could say
+# so, its turns arrived as `canopy_web_chat` — indistinguishable from a human
+# typing in the web UI — so a routing rule on `ace_web` had nothing to match and
+# the source-aware routing spec shipped with its ace_web PRODUCER missing.
+
+
+def test_send_defaults_to_canopy_web_chat_origin():
+    user, _ws, _agent, session = _ctx()
+    _msg, turn = chat.send_message(session=session, text="hi", user=user)
+    assert turn.origin == Turn.ORIGIN_CANOPY_WEB_CHAT
+
+
+def test_send_carries_an_explicit_origin():
+    user, _ws, _agent, session = _ctx()
+    _msg, turn = chat.send_message(session=session, text="hi", user=user, origin=Turn.ORIGIN_ACE_WEB)
+    assert turn.origin == Turn.ORIGIN_ACE_WEB
+
+
+def test_transcript_sourced_send_carries_the_origin_too():
+    # The path labs actually takes: every session is stamped transcript_sourced at
+    # creation, so a run dispatched by ace-web lands in _send_transcript_sourced_
+    # message. Threading the origin through only the durable path would leave
+    # production exactly as broken as before.
+    user, _ws, _agent, session = _ctx()
+    session.metadata = {**(session.metadata or {}), chat.TRANSCRIPT_SOURCED: True}
+    session.save(update_fields=["metadata"])
+    assert chat.transcript_sourced(session)
+    _msg, turn = chat.send_message(session=session, text="hi", user=user, origin=Turn.ORIGIN_ACE_WEB)
+    assert turn.origin == Turn.ORIGIN_ACE_WEB


### PR DESCRIPTION
## Why

`docs/superpowers/specs/2026-07-27-source-aware-runner-routing-design.md` ships with an explicit hole in its own status line:

> **Status:** Shipped — except the `ace_web` PRODUCER, which lives in ace-web (`turn_driver`) and is not this repo's change. Until it posts `origin=ace_web`, a rule on that source is inert.

Half of that is true and half of it isn't. ace-web does need to ask — but it had no way to. Both session-send paths in `apps/canopy_sessions/services.py` hardcode `origin=Turn.ORIGIN_CANOPY_WEB_CHAT`, and `canopy_web_chat` is a server-only value the request boundary rejects. So a run ace-web delegates to canopy (spec 2026-07-26) arrives indistinguishable from a human typing in the web chat: an `ace_web` routing rule has nothing to match, and the fleet turn log can't tell the two apart either.

This is the canopy half. The ace-web half (passing it) is a separate PR.

## What

`SendIn` gains an optional `origin`, typed as the shared `apps.harness.schemas.Origin` literal. The boundary rule then falls out of the existing type instead of a second, drifting gate:

- `ace_web` / `email` / `slack` / `api` — postable
- `canopy_web_chat` / `canopy_scheduler` — 422 (one in-repo producer each; a caller spelling one would borrow that source's routing rule)
- `board` / `cron` / `manual` / `drill` — normalized via the shared `normalize_origin` validator
- `None` — today's default, unchanged

Threaded through **both** send paths. Only doing the durable one would have been a no-op in production: labs stamps every session `transcript_sourced` at creation, so a delegated run takes `_send_transcript_sourced_message`.

The WS consumer's send deliberately doesn't pass one — that IS a human typing, and the default is what it should be.

## Tests

6 new (3 service-level, 3 boundary), including one that pins the transcript-sourced path specifically, since that's the one production uses. Full suite: **1826 passed, 1 skipped**. `ruff` clean. `generated.ts` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)