### PR TITLE
ci: stop running cloud_runner's suite twice, and stop sleeping 2s in it

### DIFF
--- a/deploy/ec2-runner/tests/test_cloud_runner.py
+++ b/deploy/ec2-runner/tests/test_cloud_runner.py
@@ -597,6 +597,11 @@ def test_run_claude_transcript_failure_does_not_fail_turn(cloud_runner, monkeypa
         raise RuntimeError("network is down")
 
     monkeypatch.setattr(cloud_runner, "_api", boom)
+    # A raising _api lands in the retry loop, which sleeps
+    # TRANSCRIPT_POST_RETRY_SLEEP_SECONDS (1.0s) between each of its 3 attempts.
+    # Nothing here asserts on elapsed time, so that was 2s of dead wall-clock —
+    # the slowest single test in the repo. Same idiom as the retry tests above.
+    monkeypatch.setattr(cloud_runner.time, "sleep", lambda *_a: None)
     ok, text, cli_session_id = cloud_runner.run_claude(
         "hi", "turn-xyz", lambda batch: None, cwd=tmp_path,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,4 +99,12 @@ asyncio_mode = "auto"
 # The standalone packages/canopy_agent_runs has its OWN plain-pytest suite (no Django,
 # no DB); it is run from its own dir, not as part of the Django suite. Ignore it
 # here so the Django runner doesn't try to collect it under DJANGO_SETTINGS.
-addopts = "--ignore=packages"
+#
+# deploy/ec2-runner is ignored for the same reason, and one more: cloud_runner.py is
+# deliberately stdlib-only, and CI runs its suite from its own dir in a BARE env
+# (`uv run --with pytest`). That bare run is the only thing proving the file hasn't
+# grown a dependency on canopy-web's environment — an accidental `import django`
+# would sail through here (Django is installed) and fail on the EC2 box. Collecting
+# it here therefore doesn't just re-run 58 tests we already run, it re-runs them in
+# the one environment that cannot check the invariant they exist to protect.
+addopts = "--ignore=packages --ignore=deploy"


### PR DESCRIPTION
Backend CI is the critical path (73s vs the frontend job's 49s). Two pieces of pure waste on it. **No test removed, no assertion weakened.**

### 1. `deploy/ec2-runner`'s 58 tests ran twice per CI run

`addopts` ignored `packages` but not `deploy`, so the root pytest collected them — and CI *also* runs them from their own dir.

The dedicated step is the one worth keeping. `cloud_runner.py` is deliberately stdlib-only, and that step runs it in a **bare env** (`uv run --with pytest`), which is the only thing proving the file hasn't grown a dependency on canopy-web's environment. An accidental `import django` would sail through the root run (Django is installed there) and fail on the EC2 box.

So the root run wasn't just duplicating 58 tests — it was duplicating them in the one environment that *cannot* check the invariant they exist to protect.

### 2. The slowest test in the repo was 2s of `sleep`

`test_run_claude_transcript_failure_does_not_fail_turn` patches `_api` to raise, which lands in `_post_transcript_batch`'s retry loop and sleeps `TRANSCRIPT_POST_RETRY_SLEEP_SECONDS` (1.0s) between 3 attempts. Nothing in it asserts on elapsed time.

The two retry tests ~200 lines above already patch `time.sleep` for exactly this reason — this one just missed it. Same idiom, one line.

### Measured

| | before | after |
|---|---|---|
| root suite | 20.3s | 16.1s |
| cloud_runner step | 3.28s | 1.33s |
| root suite test count | 1820 | 1762 (58 dups gone) |
| cloud_runner test count | 58 | 58 |

On CI (~2.2× slower than local) that's roughly **73s → 55s on the backend job**. Worth having before the merge queue goes on, since the queue re-runs this per batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)