### PR TITLE
fix(harness): a session turn claimed over the socket lost the identity that makes it a session

### DIFF
--- a/apps/realtime/consumers.py
+++ b/apps/realtime/consumers.py
@@ -22,14 +22,56 @@ from . import groups
 
 
 def _serialize_turn(turn: Turn) -> dict:
-    """The fields a runner needs to run a claimed turn, over the WS."""
+    """The fields a runner needs to run a claimed turn, over the WS.
+
+    Deliberately a subset of `schemas.TurnOut` (the REST claim's shape) — a
+    runner does not need a turn's timestamps or lease — but every field it DOES
+    carry must AGREE with TurnOut, and be derived the same way. This function
+    previously re-implemented that derivation from the columns alone:
+
+        target = turn.agent.slug if turn.agent_id else turn.project
+
+    A SESSION turn has `agent_id` NULL and `project` "" — its agent and repo
+    hang off `chat_session` (see Turn.target, which already handles all three
+    shapes). So every session turn claimed over the socket reported `target=""`
+    and carried no `origin_ref` at all. Downstream, in the cloud runner:
+
+      * `_chat_session_id()` returned "" -> `_turn_cwd` fell through to a
+        PER-TURN scratch dir. Claude Code resolves a session id by cwd path, so
+        every turn of a conversation cold-started — the exact amnesia
+        `--resume` continuity exists to remove.
+      * `_ship_transcript_rows()` returned early -> the conversation was never
+        written as durable Message rows. Observed live 2026-07-28: a turn ran to
+        `done`, retained its raw transcript, and left a session with zero
+        messages.
+
+    The REST claim path was always correct because it serializes TurnOut, which
+    is why only the WS-preferring cloud runner hit this. Read the values off the
+    model's own properties rather than restating the rules a third time.
+    """
+    cs = turn.chat_session if turn.chat_session_id else None
     return {
         "id": str(turn.id),
         "prompt": turn.prompt,
-        "target": turn.agent.slug if turn.agent_id else turn.project,
-        "agent_slug": turn.agent.slug if turn.agent_id else None,
-        "project": turn.project,
+        # Turn.target is THE definition — agent slug, else session's agent slug,
+        # else session's project, else the repo. Never restate it here.
+        "target": turn.target,
+        "agent_slug": (
+            turn.agent.slug if turn.agent_id
+            else (cs.agent.slug if cs is not None and cs.agent_id else None)
+        ),
+        "project": turn.project or (cs.project if cs is not None else ""),
         "routing": turn.routing,
+        # The routing source (spec 2026-07-27) — a runner that logs or reports
+        # what it claimed should be able to say what KIND of work it was.
+        "origin": turn.origin,
+        # THE identity of a conversation: origin_ref.chat_session_id. Its absence
+        # is what made a session turn unrecognizable as one. Never drop it.
+        "origin_ref": turn.origin_ref or {},
+        "workspace_slug": (
+            turn.agent.workspace_id if turn.agent_id
+            else (cs.workspace_id if cs is not None else turn.workspace_id)
+        ),
     }
 
 

--- a/tests/test_realtime_runner_consumer.py
+++ b/tests/test_realtime_runner_consumer.py
@@ -248,3 +248,75 @@ async def test_send_message_interjects_the_running_runner():
     assert interject["message"] == "actually, stop and do X"
     assert interject["turn_id"] == str(running.id)
     await comm.disconnect()
+
+
+# --- a SESSION turn over the socket ------------------------------------------
+# Observed on the live cloud runner 2026-07-28: a session-targeted turn claimed
+# over the WS ran and finished, but wrote ZERO durable Message rows and
+# cold-started in a per-turn scratch dir. Both because `_serialize_turn`
+# reimplemented a subset of TurnOut and lost the two fields a session turn is
+# identified by. The REST claim path (full TurnOut) was always fine, which is
+# why only the WS-preferring cloud runner hit it.
+async def test_claim_over_ws_carries_a_session_turns_identity():
+    user, ws, agent, runner = await database_sync_to_async(_setup)()
+
+    @database_sync_to_async
+    def _enqueue_session_turn():
+        from apps.canopy_sessions import services as chat
+
+        runner.capabilities = {**runner.capabilities, "sessions": True}
+        runner.save(update_fields=["capabilities"])
+        session = chat.create_session(workspace=ws, created_by=user, agent=agent)
+        _msg, turn = chat.send_message(session=session, text="hello", user=user)
+        return session, turn
+
+    session, _turn = await _enqueue_session_turn()
+    comm = await _connect(runner.id, user)
+    await comm.connect()
+
+    await comm.send_json_to({"action": "claim"})
+    frame = await comm.receive_json_from(timeout=2)
+    claimed = frame["turn"]
+    assert claimed is not None, "a session-capable runner must be able to claim a session turn"
+
+    # origin_ref.chat_session_id is THE invariant identity of a conversation. The
+    # runner keys its stable per-session workdir on it (so `claude --resume`
+    # works at all) and ships the transcript back under it (so the conversation
+    # becomes durable rows). Without it both silently no-op.
+    assert claimed["origin_ref"]["chat_session_id"] == str(session.id)
+    # A session turn has agent_id NULL and project "" — its agent hangs off the
+    # session. Deriving target from the columns alone reported "".
+    assert claimed["target"] == "echo"
+    assert claimed["agent_slug"] == "echo"
+    assert claimed["workspace_slug"] == ws.slug
+    await comm.disconnect()
+
+
+async def test_ws_claim_agrees_with_the_rest_claim_payload():
+    # The two claim paths must not disagree about a turn's identity — that
+    # divergence IS this bug. Pin the overlap rather than the WS shape alone.
+    user, ws, agent, runner = await database_sync_to_async(_setup)()
+
+    @database_sync_to_async
+    def _enqueue():
+        services.enqueue_turn(agent=agent, origin=Turn.ORIGIN_ACE_WEB,
+                              idempotency_key="parity-1", prompt="p",
+                              origin_ref={"marker": "keep-me"})
+
+    await _enqueue()
+    comm = await _connect(runner.id, user)
+    await comm.connect()
+    await comm.send_json_to({"action": "claim"})
+    claimed = (await comm.receive_json_from(timeout=2))["turn"]
+
+    @database_sync_to_async
+    def _rest_shape(turn_id):
+        from apps.harness.schemas import TurnOut
+
+        return TurnOut.from_orm(Turn.objects.get(pk=turn_id)).dict()
+
+    rest = await _rest_shape(claimed["id"])
+    for field in ("target", "agent_slug", "project", "routing", "origin", "origin_ref",
+                  "workspace_slug", "prompt"):
+        assert claimed[field] == rest[field], f"{field} disagrees: {claimed[field]!r} vs {rest[field]!r}"
+    await comm.disconnect()


### PR DESCRIPTION
## What I saw

Pinned a session turn to `cloud-ec2-1` on labs to check whether the cloud runner could execute session work at all. It could:

```
claimed turn 38fbd35c target= (WS)
exec: claude -p (turn 38fbd35c) in /tmp/canopy-runner-work/38fbd35c
finished turn 38fbd35c (WS): done
```

Turn `done`. Raw transcript retained (7319 bytes). And the canopy Session it belonged to had **zero messages**.

Two tells in those three lines: `target=` is empty, and the cwd is a **per-turn** scratch dir rather than the stable per-session one.

## Why

`_serialize_turn` — the WS claim frame — re-derives a turn's identity from the columns:

```python
"target": turn.agent.slug if turn.agent_id else turn.project,
```

A **session** turn has `agent_id` NULL and `project` `""`; both hang off `chat_session`. `Turn.target` already handles all three shapes, and `TurnOut`'s resolvers already do this correctly for the REST claim. This function restated the rule and got it wrong — and, more damagingly, omitted `origin_ref` entirely.

Downstream in `cloud_runner.py`:

| | consequence |
|---|---|
| `_chat_session_id()` → `""` | `_turn_cwd` falls through to a per-turn dir. Claude Code resolves its session id **by cwd path**, so every turn cold-starts — the exact amnesia `--resume` continuity exists to remove. |
| `_ship_transcript_rows()` → early return | the conversation is never written as durable `Message` rows. |

The REST claim path was always fine, which is why only the WS-preferring cloud runner hit this. The laptop runner uses a different client entirely.

This is the failure `cloud_runner.py`'s `RUNNER_SESSIONS` comment predicted — "stream a perfect-looking live reply, and then silently lose the entire conversation" — with a cause one layer up from where that comment went looking. Worth noting for whoever revisits that default: the runner's durable path (`_ship_transcript_rows`, #449/#488) is real; it was being starved of its input.

## The fix

Read identity off the model's own properties instead of restating the rules a third time; add `origin` / `origin_ref` / `workspace_slug`.

## Tests

- one that reproduces the live failure: a session turn claimed over the WS must carry `origin_ref.chat_session_id`, and a real `target`/`agent_slug`/`workspace_slug`
- a **parity** test asserting the WS frame agrees with `TurnOut` field by field, so the two claim paths can't drift again — the divergence *is* the bug

`1764 passed, 1 skipped`. `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)