### PR TITLE
chore(deploy): drop CANOPY_PLUGIN_TOKEN, fix the OIDC subject note

### DIFF
--- a/.github/workflows/deploy-labs.yml
+++ b/.github/workflows/deploy-labs.yml
@@ -19,12 +19,18 @@ name: Deploy to Labs (AWS)
 # rolls the service.
 #
 # Required GitHub secrets (see deploy/aws + Phase 2 of the labs migration):
-#   AWS_ROLE_ARN         — the shared github-actions-labs-deploy OIDC role
-#                          (trust policy must allow repo:dimagi-internal/canopy-web:*)
+#   AWS_ROLE_ARN         — the shared github-actions-labs-deploy OIDC role.
+#                          Since this repo was transferred into the org (2026-07-28)
+#                          GitHub mints its OIDC token with an IMMUTABLE subject —
+#                          repo:dimagi-internal@272902307/canopy-web@1193139337:* —
+#                          NOT the name-based repo:dimagi-internal/canopy-web:*.
+#                          The trust policy must allow the immutable form; the
+#                          name-based one silently fails with "Not authorized to
+#                          perform sts:AssumeRoleWithWebIdentity". Check the live
+#                          value with:
+#                            gh api repos/dimagi-internal/canopy-web/actions/oidc/customization/sub
 #   LABS_SUBNET          — a labs VPC subnet id (for the one-off migration task)
 #   LABS_SECURITY_GROUP  — the labs security group id
-#   CANOPY_PLUGIN_TOKEN  — read-only token for the private dimagi-internal/canopy plugin
-#                          (optional; absent → /system shows an empty catalog)
 
 on:
   workflow_dispatch:
@@ -96,24 +102,20 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      # Vendor the private canopy plugin into the build context so apps.system
-      # can render the /system catalog. Absent → /system degrades to an empty
-      # catalog (the build still succeeds). Mirrors the retired deploy.sh step;
-      # the ./canopy dir is picked up by the Dockerfile's `COPY . .`.
+      # Vendor the canopy plugin into the build context so apps.system can
+      # render the /system catalog. canopy is PUBLIC (dimagi-internal/canopy), so
+      # this needs no credentials — it used to clone via a CANOPY_PLUGIN_TOKEN PAT
+      # back when the repo was private. Clone failure → /system degrades to an
+      # empty catalog (the build still succeeds). Mirrors the retired deploy.sh
+      # step; the ./canopy dir is picked up by the Dockerfile's `COPY . .`.
       - name: Vendor canopy plugin
-        env:
-          CANOPY_PLUGIN_TOKEN: ${{ secrets.CANOPY_PLUGIN_TOKEN }}
         run: |
           rm -rf canopy
-          if [ -n "$CANOPY_PLUGIN_TOKEN" ]; then
-            if git clone --depth 1 "https://x-access-token:${CANOPY_PLUGIN_TOKEN}@github.com/dimagi-internal/canopy.git" canopy; then
-              rm -rf canopy/.git
-              echo "Vendored canopy plugin into build context."
-            else
-              echo "::warning::canopy plugin clone failed — /system will show an empty catalog."
-            fi
+          if git clone --depth 1 https://github.com/dimagi-internal/canopy.git canopy; then
+            rm -rf canopy/.git
+            echo "Vendored canopy plugin into build context."
           else
-            echo "::warning::CANOPY_PLUGIN_TOKEN not set — /system will show an empty catalog."
+            echo "::warning::canopy plugin clone failed — /system will show an empty catalog."
           fi
 
       - uses: aws-actions/configure-aws-credentials@v6


### PR DESCRIPTION
## Drop `CANOPY_PLUGIN_TOKEN`

The `Vendor canopy plugin` step cloned `dimagi-internal/canopy` through a read-only PAT because canopy used to be private. **canopy went public on 2026-07-28**, so the credential is dead weight — an unnecessary secret sitting in the repo with no purpose.

The step simplifies to a plain `git clone`, and the `[ -n "$TOKEN" ]` branch disappears with it. Verified an anonymous clone of `dimagi-internal/canopy` succeeds.

The secret gets deleted from repo settings once this merges.

## Fix the AWS_ROLE_ARN header note

The header documented the trust policy as needing `repo:dimagi-internal/canopy-web:*`. That is **wrong and cost a failed deploy today**.

Since the transfer, GitHub mints this repo's OIDC token with an **immutable subject**:

| repo | subject prefix |
|---|---|
| canopy-web (transferred) | `repo:dimagi-internal@272902307/canopy-web@1193139337` |
| ace-web (not transferred) | `repo:dimagi-internal/ace-web` |

The name-based pattern never matches, and the failure surfaces only as `Not authorized to perform sts:AssumeRoleWithWebIdentity` with no hint about subject format. The note now records the real value and the `gh api …/oidc/customization/sub` call to check it.

Workflow re-parsed with `yaml.safe_load`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)