### PR TITLE
fix(runner): canopy_transcript was never importable on the box, so sessions lost their record

### DIFF
--- a/apps/realtime/consumers.py
+++ b/apps/realtime/consumers.py
@@ -22,14 +22,56 @@ from . import groups
 
 
 def _serialize_turn(turn: Turn) -> dict:
-    """The fields a runner needs to run a claimed turn, over the WS."""
+    """The fields a runner needs to run a claimed turn, over the WS.
+
+    Deliberately a subset of `schemas.TurnOut` (the REST claim's shape) — a
+    runner does not need a turn's timestamps or lease — but every field it DOES
+    carry must AGREE with TurnOut, and be derived the same way. This function
+    previously re-implemented that derivation from the columns alone:
+
+        target = turn.agent.slug if turn.agent_id else turn.project
+
+    A SESSION turn has `agent_id` NULL and `project` "" — its agent and repo
+    hang off `chat_session` (see Turn.target, which already handles all three
+    shapes). So every session turn claimed over the socket reported `target=""`
+    and carried no `origin_ref` at all. Downstream, in the cloud runner:
+
+      * `_chat_session_id()` returned "" -> `_turn_cwd` fell through to a
+        PER-TURN scratch dir. Claude Code resolves a session id by cwd path, so
+        every turn of a conversation cold-started — the exact amnesia
+        `--resume` continuity exists to remove.
+      * `_ship_transcript_rows()` returned early -> the conversation was never
+        written as durable Message rows. Observed live 2026-07-28: a turn ran to
+        `done`, retained its raw transcript, and left a session with zero
+        messages.
+
+    The REST claim path was always correct because it serializes TurnOut, which
+    is why only the WS-preferring cloud runner hit this. Read the values off the
+    model's own properties rather than restating the rules a third time.
+    """
+    cs = turn.chat_session if turn.chat_session_id else None
     return {
         "id": str(turn.id),
         "prompt": turn.prompt,
-        "target": turn.agent.slug if turn.agent_id else turn.project,
-        "agent_slug": turn.agent.slug if turn.agent_id else None,
-        "project": turn.project,
+        # Turn.target is THE definition — agent slug, else session's agent slug,
+        # else session's project, else the repo. Never restate it here.
+        "target": turn.target,
+        "agent_slug": (
+            turn.agent.slug if turn.agent_id
+            else (cs.agent.slug if cs is not None and cs.agent_id else None)
+        ),
+        "project": turn.project or (cs.project if cs is not None else ""),
         "routing": turn.routing,
+        # The routing source (spec 2026-07-27) — a runner that logs or reports
+        # what it claimed should be able to say what KIND of work it was.
+        "origin": turn.origin,
+        # THE identity of a conversation: origin_ref.chat_session_id. Its absence
+        # is what made a session turn unrecognizable as one. Never drop it.
+        "origin_ref": turn.origin_ref or {},
+        "workspace_slug": (
+            turn.agent.workspace_id if turn.agent_id
+            else (cs.workspace_id if cs is not None else turn.workspace_id)
+        ),
     }
 
 

--- a/deploy/ec2-runner/cloud_runner.py
+++ b/deploy/ec2-runner/cloud_runner.py
@@ -90,22 +90,29 @@ if _csv("RUNNER_PROJECTS"):
     RUNNER_CAPS["projects"] = _csv("RUNNER_PROJECTS")
 if _csv("RUNNER_AGENTS"):
     RUNNER_CAPS["agents"] = _csv("RUNNER_AGENTS")
-# Default OFF (opt-in, RUNNER_SESSIONS=1): this runner has no durable-record path
-# for a chat session yet. On labs (CHAT_STUB_EXECUTOR=False) every session is
-# stamped transcript_sourced at creation (apps/canopy_sessions/services.py
-# create_session), which means the reduced TurnEvents this runner posts to
-# /turns/{id}/events NEVER become durable Message rows (project_events short-
-# circuits to 0 for such a session) and the user's own line is never durably
-# written either (_send_transcript_sourced_message deliberately authors none).
-# The only durable path is POST /runners/{id}/session-stream with per-line
-# transcript ordinals -> services.persist_transcript_rows, which today has
-# exactly one caller: packages/canopy_runner/canopy_runner/client.py (the
-# laptop runner). Until THIS runner implements that same call (plus honoring
-# /runners/{id}/streams + /backfills), declaring sessions:true would make it
-# eligible to claim a real chat turn, stream a perfect-looking live reply, and
-# then silently lose the entire conversation the moment the user reloads the
-# page — worse than not claiming it at all. Flip this default only once
-# persist_transcript_rows (via session-stream/streams/backfills) is wired here.
+# The durable-record precondition below is now SATISFIED, and verified end to end
+# on cloud-ec2-1 (2026-07-28): a session turn ships its transcript rows via
+# POST /runners/{id}/session-stream -> services.persist_transcript_rows
+# (`_ship_transcript_rows`), lands ordinal-keyed Message rows, and resumes its
+# CLI session on the next turn. RUNNER_SESSIONS therefore defaults ON in
+# runner.cfn.yaml; this env default stays OFF so a runner started by hand,
+# outside the template, opts in deliberately.
+#
+# It took longer to be true than it looked, and both causes were invisible from
+# here — worth recording, because the original note blamed the wrong layer:
+#   * the WS claim frame (apps/realtime/consumers._serialize_turn) omitted
+#     origin_ref, so `_chat_session_id` came back "" and BOTH the stable
+#     per-session cwd and `_ship_transcript_rows` silently no-opped;
+#   * `canopy_transcript` was installed by a method Ubuntu 24.04 refuses
+#     (PEP 668 + no pip), so `_transcript_core()` returned None regardless.
+# The original risk was real: a runner that streams a perfect-looking live reply
+# and then loses the conversation is worse than one that never claims. That was
+# the OBSERVED behaviour here until both were fixed.
+#
+# Still not implemented: /runners/{id}/streams + /backfills. A viewer attached
+# mid-turn sees the reduced TurnEvent stream rather than a live transcript tail,
+# and a server-requested backfill is ignored. Neither loses history — the
+# transcript ships at turn end either way.
 RUNNER_SESSIONS = _bool_env("RUNNER_SESSIONS", False)
 if RUNNER_SESSIONS:
     RUNNER_CAPS["sessions"] = True
@@ -1096,42 +1103,57 @@ def clone_or_pull_canopy_web() -> bool:
         return False
 
 
-def _install_repo_package(repo_dir: pathlib.Path, name: str, purpose: str) -> None:
-    """Install one in-repo package from the freshly-cloned repo.
+def _expose_repo_package(repo_dir: pathlib.Path, name: str, purpose: str) -> None:
+    """Put one in-repo package on `sys.path`, straight from the freshly-cloned repo.
 
-    The runner is otherwise stdlib-only and ships as a single file, so these are
-    the only packages it needs on the box. Installed from the clone rather than
-    an index so they are always the same commit as the rest of this deploy.
+    Taken from the clone rather than an index so it is always the same commit as
+    the rest of this deploy.
+
+    This used to `uv pip install --system` (falling back to `python3 -m pip`).
+    Both are dead on this AMI, and silently so — the failure was swallowed into
+    one `warn:` line while every dependent feature turned itself off:
+
+      * Ubuntu 24.04's system Python is PEP 668 externally-managed, so
+        `uv pip install --system` REFUSES ("hint: Virtual environments were not
+        considered due to the `--system` flag").
+      * `python3 -m pip` does not exist — the AMI ships no pip, and cloud-init's
+        apt list never adds python3-pip.
+
+    Observed 2026-07-28: `canopy_transcript` had never been importable on
+    cloud-ec2-1, so every session turn it ran wrote no durable rows at all.
+
+    `sys.path` rather than a venv or `--target` because these packages are
+    stdlib-only BY CONTRACT — canopy_transcript declares `dependencies = []`
+    with a comment explaining that this box has to resolve every dep it adds at
+    boot, and canopy_acp depends on nothing but canopy_transcript. So there is
+    nothing to resolve, and an installer is machinery in front of a path append.
+    A package here that grows a third-party dependency needs a deliberate
+    install strategy, and will announce itself as an ImportError in the named
+    degradation below rather than failing quietly.
 
     Best-effort by design: every caller degrades to a named disabled feature if
     the import later fails, and the turn still runs and still finishes. A
     bootstrap step that could brick execution is worse than a missing feature.
     """
     pkg = repo_dir / "packages" / name
-    if not pkg.is_dir():
+    if not (pkg / name).is_dir():
         _log(f"warn: {pkg} not in the clone; {purpose} disabled")
         return
-    for installer in (["uv", "pip", "install", "--system", str(pkg)],
-                      [sys.executable, "-m", "pip", "install", str(pkg)]):
-        try:
-            subprocess.run(installer, check=True, timeout=180,
-                           stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-            _log(f"installed {name} from {pkg} via {installer[0]}")
-            return
-        except Exception:  # noqa: BLE001 — try the next installer
-            continue
-    _log(f"warn: could not install {name}; {purpose} disabled")
+    entry = str(pkg)
+    if entry not in sys.path:
+        sys.path.insert(0, entry)
+    _log(f"exposed {name} from {pkg}")
 
 
 def _install_transcript_core(repo_dir: pathlib.Path) -> None:
     """The packages this runner imports off the clone.
 
-    `canopy_acp` is installed unconditionally rather than only when
+    `canopy_acp` is exposed unconditionally rather than only when
     RUNNER_EXECUTOR=acp, so flipping the executor is an env change and a restart
     rather than a redeploy — the point of a switch you can actually use.
     """
-    _install_repo_package(repo_dir, "canopy_transcript", "transcript rows")
-    _install_repo_package(repo_dir, "canopy_acp", "the ACP executor")
+    _expose_repo_package(repo_dir, "canopy_transcript", "transcript rows")
+    _expose_repo_package(repo_dir, "canopy_acp", "the ACP executor")
     _install_acp_adapter()
 
 

--- a/deploy/ec2-runner/runner.cfn.yaml
+++ b/deploy/ec2-runner/runner.cfn.yaml
@@ -28,6 +28,28 @@ Parameters:
     Type: String
     Default: ''
     Description: Comma-separated agent slugs this runner may drive.
+  RunnerSessions:
+    Type: String
+    AllowedValues: ['0', '1']
+    Default: '1'
+    Description: >
+      Whether this runner declares capabilities.sessions and may therefore claim
+      chat/session-targeted turns — including the ace-web runs delegated to
+      canopy's harness, which are session-targeted by construction and are the
+      reason this box exists (spec 2026-07-27 source-aware runner routing).
+
+      Default ON as of 2026-07-28, once the durable-record path was verified end
+      to end on this box: a session turn now ships its transcript rows via
+      /runners/{id}/session-stream and lands ordinal-keyed Message rows, and
+      resumes its CLI session across turns. Two server-side defects had to be
+      fixed first — the WS claim frame dropped origin_ref (so the runner could
+      not tell a session turn was one), and the in-repo packages were installed
+      by a method this AMI cannot run, so canopy_transcript was never importable.
+
+      Still NOT implemented here: /runners/{id}/streams + /backfills, so a
+      viewer attached mid-turn sees the reduced TurnEvent stream rather than a
+      live transcript tail, and a server-requested backfill is ignored. History
+      is not lost by either — the transcript ships at turn end regardless.
   AgentSlugs:
     Type: String
     Default: 'ace,ada,echo,eva,hal'
@@ -186,6 +208,7 @@ Resources:
                 CLAUDE_CODE_OAUTH_TOKEN=$(secret ${ClaudeTokenSecret})
                 RUNNER_PROJECTS=${RunnerProjects}
                 RUNNER_AGENTS=${RunnerAgents}
+                RUNNER_SESSIONS=${RunnerSessions}
                 RUNNER_WORKSPACE=${RunnerWorkspace}
                 RUNNER_NAME=${RunnerName}
                 AGENT_SLUGS=${AgentSlugs}

--- a/deploy/ec2-runner/tests/test_cloud_runner.py
+++ b/deploy/ec2-runner/tests/test_cloud_runner.py
@@ -1236,3 +1236,69 @@ class TestInheritedSessionMarkers:
         env = cloud_runner._agent_env("echo")
         assert env["CANOPY_WEB_PAT"] == "agent-pat"
         assert "CLAUDECODE" not in env
+
+
+# --- exposing the in-repo packages (canopy_transcript / canopy_acp) ----------
+# These used to be `uv pip install --system`'d, which cannot work on this AMI:
+# Ubuntu 24.04's system Python is PEP 668 externally-managed (uv refuses) and
+# the box has no pip for the fallback. The failure was swallowed, so
+# canopy_transcript was simply never importable and every session turn the
+# cloud runner executed wrote zero durable rows. Observed live 2026-07-28.
+
+
+def _fake_pkg(tmp_path, name):
+    pkg = tmp_path / "packages" / name
+    (pkg / name).mkdir(parents=True)
+    (pkg / name / "__init__.py").write_text("")
+    return pkg
+
+
+def test_expose_repo_package_puts_the_clone_on_sys_path(cloud_runner, tmp_path, monkeypatch):
+    pkg = _fake_pkg(tmp_path, "canopy_transcript")
+    monkeypatch.setattr(cloud_runner.sys, "path", list(cloud_runner.sys.path))
+    cloud_runner._expose_repo_package(tmp_path, "canopy_transcript", "transcript rows")
+    assert str(pkg) in cloud_runner.sys.path
+    # and it must actually be importable from there — the whole point
+    assert (pkg / "canopy_transcript" / "__init__.py").exists()
+
+
+def test_expose_repo_package_never_shells_out(cloud_runner, tmp_path, monkeypatch):
+    # No installer means no PEP 668 to trip over, and no 180s subprocess on a
+    # boot path. If this ever regresses to shelling out, this fails loudly.
+    _fake_pkg(tmp_path, "canopy_transcript")
+    monkeypatch.setattr(cloud_runner.sys, "path", list(cloud_runner.sys.path))
+
+    def _boom(*a, **kw):
+        raise AssertionError("bootstrap must not shell out to an installer")
+
+    monkeypatch.setattr(cloud_runner.subprocess, "run", _boom)
+    cloud_runner._expose_repo_package(tmp_path, "canopy_transcript", "transcript rows")
+
+
+def test_expose_repo_package_is_idempotent(cloud_runner, tmp_path, monkeypatch):
+    # canopy-fetch-env re-runs on every service start; a restart loop must not
+    # grow sys.path without bound.
+    pkg = _fake_pkg(tmp_path, "canopy_acp")
+    monkeypatch.setattr(cloud_runner.sys, "path", list(cloud_runner.sys.path))
+    for _ in range(3):
+        cloud_runner._expose_repo_package(tmp_path, "canopy_acp", "the ACP executor")
+    assert cloud_runner.sys.path.count(str(pkg)) == 1
+
+
+def test_expose_repo_package_missing_from_clone_degrades(cloud_runner, tmp_path, monkeypatch):
+    # A partial clone must disable the named feature, not raise on a boot path.
+    monkeypatch.setattr(cloud_runner.sys, "path", list(cloud_runner.sys.path))
+    before = list(cloud_runner.sys.path)
+    cloud_runner._expose_repo_package(tmp_path, "canopy_transcript", "transcript rows")
+    assert cloud_runner.sys.path == before
+
+
+def test_expose_repo_package_rejects_a_bare_project_dir(cloud_runner, tmp_path, monkeypatch):
+    # packages/<name>/ exists but packages/<name>/<name>/ does not — a checkout
+    # that would put an unimportable path on sys.path and fail later, at import,
+    # far from the cause.
+    (tmp_path / "packages" / "canopy_transcript").mkdir(parents=True)
+    monkeypatch.setattr(cloud_runner.sys, "path", list(cloud_runner.sys.path))
+    before = list(cloud_runner.sys.path)
+    cloud_runner._expose_repo_package(tmp_path, "canopy_transcript", "transcript rows")
+    assert cloud_runner.sys.path == before

--- a/tests/test_realtime_runner_consumer.py
+++ b/tests/test_realtime_runner_consumer.py
@@ -248,3 +248,75 @@ async def test_send_message_interjects_the_running_runner():
     assert interject["message"] == "actually, stop and do X"
     assert interject["turn_id"] == str(running.id)
     await comm.disconnect()
+
+
+# --- a SESSION turn over the socket ------------------------------------------
+# Observed on the live cloud runner 2026-07-28: a session-targeted turn claimed
+# over the WS ran and finished, but wrote ZERO durable Message rows and
+# cold-started in a per-turn scratch dir. Both because `_serialize_turn`
+# reimplemented a subset of TurnOut and lost the two fields a session turn is
+# identified by. The REST claim path (full TurnOut) was always fine, which is
+# why only the WS-preferring cloud runner hit it.
+async def test_claim_over_ws_carries_a_session_turns_identity():
+    user, ws, agent, runner = await database_sync_to_async(_setup)()
+
+    @database_sync_to_async
+    def _enqueue_session_turn():
+        from apps.canopy_sessions import services as chat
+
+        runner.capabilities = {**runner.capabilities, "sessions": True}
+        runner.save(update_fields=["capabilities"])
+        session = chat.create_session(workspace=ws, created_by=user, agent=agent)
+        _msg, turn = chat.send_message(session=session, text="hello", user=user)
+        return session, turn
+
+    session, _turn = await _enqueue_session_turn()
+    comm = await _connect(runner.id, user)
+    await comm.connect()
+
+    await comm.send_json_to({"action": "claim"})
+    frame = await comm.receive_json_from(timeout=2)
+    claimed = frame["turn"]
+    assert claimed is not None, "a session-capable runner must be able to claim a session turn"
+
+    # origin_ref.chat_session_id is THE invariant identity of a conversation. The
+    # runner keys its stable per-session workdir on it (so `claude --resume`
+    # works at all) and ships the transcript back under it (so the conversation
+    # becomes durable rows). Without it both silently no-op.
+    assert claimed["origin_ref"]["chat_session_id"] == str(session.id)
+    # A session turn has agent_id NULL and project "" — its agent hangs off the
+    # session. Deriving target from the columns alone reported "".
+    assert claimed["target"] == "echo"
+    assert claimed["agent_slug"] == "echo"
+    assert claimed["workspace_slug"] == ws.slug
+    await comm.disconnect()
+
+
+async def test_ws_claim_agrees_with_the_rest_claim_payload():
+    # The two claim paths must not disagree about a turn's identity — that
+    # divergence IS this bug. Pin the overlap rather than the WS shape alone.
+    user, ws, agent, runner = await database_sync_to_async(_setup)()
+
+    @database_sync_to_async
+    def _enqueue():
+        services.enqueue_turn(agent=agent, origin=Turn.ORIGIN_ACE_WEB,
+                              idempotency_key="parity-1", prompt="p",
+                              origin_ref={"marker": "keep-me"})
+
+    await _enqueue()
+    comm = await _connect(runner.id, user)
+    await comm.connect()
+    await comm.send_json_to({"action": "claim"})
+    claimed = (await comm.receive_json_from(timeout=2))["turn"]
+
+    @database_sync_to_async
+    def _rest_shape(turn_id):
+        from apps.harness.schemas import TurnOut
+
+        return TurnOut.from_orm(Turn.objects.get(pk=turn_id)).dict()
+
+    rest = await _rest_shape(claimed["id"])
+    for field in ("target", "agent_slug", "project", "routing", "origin", "origin_ref",
+                  "workspace_slug", "prompt"):
+        assert claimed[field] == rest[field], f"{field} disagrees: {claimed[field]!r} vs {rest[field]!r}"
+    await comm.disconnect()


### PR DESCRIPTION
## What I found

Chasing why a cloud-executed session had zero durable messages (the other half of #499), on cloud-ec2-1:

```
$ python3 -c "import canopy_transcript"
ModuleNotFoundError: No module named 'canopy_transcript'
```

It had **never** been importable. `_transcript_core()` returned `None` on every turn, so `_ship_transcript_rows` returned before doing anything, silently.

## Why

`_install_repo_package` tried two installers, both dead on this AMI:

| installer | outcome |
|---|---|
| `uv pip install --system <pkg>` | refuses — Ubuntu 24.04's system Python is PEP 668 externally-managed (`hint: Virtual environments were not considered due to the --system flag`) |
| `python3 -m pip install <pkg>` | `No module named pip` — the AMI ships none, and cloud-init never apt-installs `python3-pip` |

Both swallowed into one `warn:` line, with `stdout`/`stderr` sent to `DEVNULL`.

## The fix

Put the packages on `sys.path` instead of installing them. They're stdlib-only **by contract** — `canopy_transcript` declares `dependencies = []` with a comment noting that this box has to resolve every dep it adds at boot, and `canopy_acp` depends on nothing but `canopy_transcript`. There is nothing to resolve, so the installer was machinery in front of a path append. Also drops a 180s subprocess from a boot path.

A package here that later grows a third-party dependency needs a deliberate install strategy; it'll announce itself as an `ImportError` in the existing named degradation rather than failing quietly.

## Verified end to end on cloud-ec2-1

With this plus #499:

```
claimed turn 903e4ac2 target=ace (WS)
exec: claude -p (turn 903e4ac2) in /tmp/canopy-runner-work/sessions/eaabeb2f-…
turn 903e4ac2: shipped 2 transcript rows -> 200
finished turn 903e4ac2: done
```

- `origin=ace_web` → routed to the cloud runner **by the source rule, unpinned**
- stable per-session cwd (not the per-turn scratch dir)
- 2 ordinal-keyed durable `Message` rows (`128 user` / `448 assistant`)
- retained raw transcript, 7403 bytes
- a **second** turn ran with `--resume 74b145ce-…` and correctly recalled the first turn's content

## RUNNER_SESSIONS

Its durable-record precondition now genuinely holds, so `runner.cfn.yaml` gains a `RunnerSessions` parameter defaulting **ON**. The env default in `cloud_runner.py` stays OFF, so a runner started by hand outside the template opts in deliberately.

I've rewritten the comment that predicted this failure. It was right about the risk and wrong about the cause — it blamed a missing durable path in this runner, when the runner's path (`_ship_transcript_rows`, #449/#488) was fine and was being starved by two defects one layer up.

**Still not implemented here:** `/runners/{id}/streams` + `/backfills`. A viewer attached mid-turn sees the reduced TurnEvent stream rather than a live transcript tail, and a server-requested backfill is ignored. Neither loses history — the transcript ships at turn end regardless. Recorded in both the parameter description and the code comment.

> **Deploy note:** the running box already carries this code (published to `canopy/cloud-runner/runner-code` + restart, the documented path) and a systemd drop-in for `RUNNER_SESSIONS=1`. The template change makes that reproducible; it takes effect on the next stack recycle, since cloud-init only runs `write_files` on first boot.

## Tests

5 new, covering sys.path exposure, idempotence across restarts, a missing package, a bare project dir, and one asserting the boot path **never shells out to an installer**. `63 passed` in the runner suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)