### PR TITLE
feat(runner): the cloud runner serves attached viewers, not just the record

### DIFF
--- a/deploy/ec2-runner/cloud_runner.py
+++ b/deploy/ec2-runner/cloud_runner.py
@@ -109,10 +109,11 @@ if _csv("RUNNER_AGENTS"):
 # and then loses the conversation is worse than one that never claims. That was
 # the OBSERVED behaviour here until both were fixed.
 #
-# Still not implemented: /runners/{id}/streams + /backfills. A viewer attached
-# mid-turn sees the reduced TurnEvent stream rather than a live transcript tail,
-# and a server-requested backfill is ignored. Neither loses history — the
-# transcript ships at turn end either way.
+# /runners/{id}/streams + /backfills are implemented too, as of 2026-07-28
+# (_sync_session_streams / _drain_backfills), so an attached viewer gets a live
+# transcript tail rather than the reduced TurnEvent stream, and a
+# server-requested backfill rebuilds history. That closes the last gap against
+# packages/canopy_runner for session work.
 RUNNER_SESSIONS = _bool_env("RUNNER_SESSIONS", False)
 if RUNNER_SESSIONS:
     RUNNER_CAPS["sessions"] = True
@@ -139,6 +140,11 @@ HEARTBEAT_SECONDS = int(os.environ.get("HEARTBEAT_SECONDS", "20"))
 # heartbeat gated on recv() timing out would never fire and the runner would go
 # stale while still connected.
 WS_POLL_TIMEOUT = float(os.environ.get("WS_POLL_TIMEOUT", "3"))
+# How often to tail the transcripts of sessions a viewer is attached to. This is
+# the live view's latency floor, so it is deliberately far tighter than
+# POLL_SECONDS (the turn-claim clock): at 15s a watcher sees a streaming reply
+# arrive in 15-second lumps. Costs one small GET /streams per tick when idle.
+STREAM_POLL_SECONDS = float(os.environ.get("STREAM_POLL_SECONDS", "3"))
 # How often the lease-renewal thread heartbeats WHILE a turn is executing (both
 # loops block inside run_claude() for the whole turn, so nothing else heartbeats
 # during that window). Must stay comfortably under DEFAULT_LEASE_SECONDS (900s,
@@ -1471,6 +1477,153 @@ def _ship_transcript_rows(runner_id: str, turn: dict, cwd, cli_session_id: str) 
     _log(f"turn {turn['id'][:8]}: shipped {len(events)} transcript rows -> {status}")
 
 
+# ── live streaming: /streams + /backfills ────────────────────────────────────
+# The observable half of attach/detach. `_ship_transcript_rows` above makes a
+# session's record DURABLE at turn end, which is enough for a conversation
+# nobody is watching. It is not enough for someone watching one: they would see
+# the reduced TurnEvent stream during the turn and the real rows only after it
+# finished. These two syncs close that, and bring this runner to parity with
+# packages/canopy_runner (whose _sync_session_streams / _drain_backfills this
+# mirrors deliberately — same server contract, same ordinal semantics).
+#
+# Resolution differs from the laptop's and that is the whole trick: a laptop
+# session is found by (project, emdash task), a cloud session by (cwd, CLI
+# session id). Both are known here without asking anyone — the cwd is
+# deterministic from the canopy session id (see _turn_cwd), and the CLI session
+# id is what `record_session` stored in RunnerBinding.session_key, which is
+# exactly what the stream descriptor hands back.
+_STREAM_READERS: dict[str, dict] = {}
+
+
+def _session_transcript_path(session_id: str, session_key: str):
+    """The CLI transcript backing a canopy session, or None if not resolvable yet."""
+    ct = _transcript_core()
+    if ct is None or not (session_id and session_key):
+        return None
+    cwd = pathlib.Path(WORK_DIR) / "sessions" / _safe_session_dirname(session_id)
+    return ct.resolve_cli_transcript(cwd, session_key, claude_home=CLAUDE_PROJECTS_HOME)
+
+
+def _post_stream_rows(runner_id: str, session_id: str, rows: list) -> bool:
+    """Ship conversational rows as live events. `seq == index` (the composite
+    transcript ordinal): monotonic per session forever, so WS-derived `seq:<n>`
+    message ids cannot collide across detaches, restarts or failovers."""
+    ct = _transcript_core()
+    if ct is None:
+        return False
+    events = [
+        {"kind": r["role"], "seq": r["index"], "index": r["index"],
+         "payload": ct.row_payload(r)}
+        for r in rows
+    ]
+    status, _ = _api("POST", f"/runners/{runner_id}/session-stream",
+                     {"session_id": session_id, "events": events})
+    return status == 200
+
+
+def _sync_session_streams(runner_id: str) -> None:
+    """Tail every session a viewer is attached to and ship new rows.
+
+    The resume point is SERVER-side (`last_index`, the max persisted turn_index),
+    refreshed every tick as our own posts land. There is deliberately no local
+    offset checkpoint: a failed post drops the tailer, so the next tick
+    re-attaches from the server marker and a restart recovers identically.
+    Best-effort throughout — a hiccup here costs live latency, never history,
+    because the turn-end ship and the backfill both still run.
+    """
+    ct = _transcript_core()
+    if ct is None:
+        return
+    status, payload = _api("GET", f"/runners/{runner_id}/streams")
+    if status != 200 or not isinstance(payload, dict):
+        return
+    desired = {s["session_id"]: s for s in (payload.get("streams") or []) if s.get("session_id")}
+
+    for sid in list(_STREAM_READERS):  # drop tailers for sessions nobody watches
+        if sid not in desired:
+            _STREAM_READERS.pop(sid, None)
+
+    for sid, descriptor in desired.items():
+        st = _STREAM_READERS.setdefault(sid, {"reader": None, "count": 0})
+        st["session_key"] = descriptor.get("session_key") or ""
+        st["last_index"] = descriptor.get("last_index")
+        try:
+            if st["reader"] is None:
+                path = _session_transcript_path(sid, st["session_key"])
+                if path is None:
+                    continue  # not spawned yet, or a different box owns it
+                reader = ct.TailReader(str(path))
+                records = reader.read_new()
+                last = st["last_index"]
+                # No marker yet -> stream forward only; history is the backfill's job.
+                since = ct.end_index(len(records)) if last is None else int(last)
+                rows = ct.conversational_messages(records, since)
+                if rows and not _post_stream_rows(runner_id, sid, rows):
+                    continue  # nothing consumed — re-attach next tick
+                st["reader"], st["count"] = reader, len(records)
+                _log(f"stream {sid[:8]}: attached ({len(rows)} rows caught up)")
+                continue
+            new_records = st["reader"].read_new()
+            if not new_records:
+                continue
+            base = st["count"]
+            # The offset applies to the RECORD ordinal inside compose_index, never
+            # to the composite index — adding it there would shift a row into
+            # another record's slots.
+            rows = ct.conversational_messages(new_records, -1, record_offset=base)
+            if rows and not _post_stream_rows(runner_id, sid, rows):
+                st["reader"], st["count"] = None, 0  # don't advance past unshipped records
+                continue
+            st["count"] = base + len(new_records)
+        except Exception as exc:  # noqa: BLE001 — one bad session must not stop the rest
+            _log(f"stream {sid[:8]}: {exc}; will re-attach")
+            st["reader"], st["count"] = None, 0
+
+
+def _drain_backfills(runner_id: str) -> None:
+    """Ship a session's FULL history when the server asks for it, with ordinals,
+    so it upsert-fills the older rows around anything the live stream already
+    persisted."""
+    ct = _transcript_core()
+    if ct is None:
+        return
+    status, payload = _api("GET", f"/runners/{runner_id}/backfills")
+    if status != 200 or not isinstance(payload, dict):
+        return
+    for b in payload.get("backfills") or []:
+        sid = b.get("session_id") or ""
+        path = _session_transcript_path(sid, b.get("session_key") or "")
+        if not (sid and path):
+            continue  # unresolvable -> leave the request standing, server keeps the tail
+        try:
+            messages = ct.conversational_messages(ct.read_records(path), -1)
+            st, _ = _api("POST", f"/runners/{runner_id}/session-backfill",
+                         {"session_id": sid, "messages": messages})
+            _log(f"backfill {sid[:8]}: shipped {len(messages)} rows -> {st}")
+        except Exception as exc:  # noqa: BLE001
+            # A backfill that keeps failing never rebuilds history and never stops
+            # trying — exactly the case that must not be silent.
+            _log(f"backfill {sid[:8]} FAILED: {exc}")
+
+
+def _sync_session_views(runner_id: str, *, with_backfills: bool = True) -> None:
+    """Both session-view syncs, in the order that minimises duplicate work: a
+    backfill rewrites the whole history, so run it before the incremental tail
+    advances its marker.
+
+    Streams run on their own fast clock (STREAM_POLL_SECONDS) because they ARE
+    the live view — at the turn-claim cadence a viewer would watch the reply
+    arrive in POLL_SECONDS-sized lumps. Backfills are request-driven and rare,
+    so they ride the slower clock and one cheap GET is all an idle tick costs.
+    """
+    try:
+        if with_backfills:
+            _drain_backfills(runner_id)
+        _sync_session_streams(runner_id)
+    except Exception as exc:  # noqa: BLE001 — never take the main loop down
+        _log(f"session view sync error: {exc}")
+
+
 def _run_turn(runner_id: str, turn: dict) -> None:
     """Execute one claimed turn to completion. Runs on its own thread."""
     turn_id = turn["id"]
@@ -1545,6 +1698,9 @@ def run_over_rest(runner_id: str) -> None:
         # the others expire mid-run.
         _api("POST", f"/runners/{runner_id}/heartbeat",
              {"active_turn_ids": _in_flight_ids(), "host": RUNNER_HOST})
+        # Attached viewers are served on this path too — a runner that fell back
+        # to REST must not also silently stop being watchable.
+        _sync_session_views(runner_id)
         if len(_in_flight_ids()) >= MAX_CONCURRENT_TURNS:
             time.sleep(POLL_SECONDS)
             continue
@@ -1744,6 +1900,7 @@ def run_over_ws(runner_id: str) -> bool:
             last_beat = time.monotonic()
             _drain(ws, runner_id)  # anything already queued gets no wake
             last_poll = time.monotonic()
+            last_stream = 0.0
             while not _stop:
                 try:
                     raw = ws.recv()
@@ -1756,6 +1913,11 @@ def run_over_ws(runner_id: str) -> bool:
                         _drain(ws, runner_id)
                     elif mtype == "interject":
                         _log(f"interject turn={msg.get('turn_id')}: {msg.get('message')!r}")
+                    elif mtype == "stream":
+                        # Latency optimization only — /streams is polled below
+                        # regardless, so a dropped frame costs one tick, never
+                        # a permanently unattached viewer.
+                        _sync_session_views(runner_id)
                 elif raw == "":
                     break  # server closed the socket
                 if time.monotonic() - last_beat >= HEARTBEAT_SECONDS:
@@ -1772,7 +1934,12 @@ def run_over_ws(runner_id: str) -> bool:
                 # the WS path to parity.
                 if time.monotonic() - last_poll >= POLL_SECONDS:
                     _drain(ws, runner_id)
+                    _sync_session_views(runner_id)          # incl. backfills
                     last_poll = time.monotonic()
+                    last_stream = time.monotonic()
+                elif time.monotonic() - last_stream >= STREAM_POLL_SECONDS:
+                    _sync_session_views(runner_id, with_backfills=False)
+                    last_stream = time.monotonic()
         except Exception as exc:
             _log(f"ws loop error: {exc}")
         finally:

--- a/deploy/ec2-runner/tests/test_cloud_runner.py
+++ b/deploy/ec2-runner/tests/test_cloud_runner.py
@@ -1302,3 +1302,280 @@ def test_expose_repo_package_rejects_a_bare_project_dir(cloud_runner, tmp_path, 
     before = list(cloud_runner.sys.path)
     cloud_runner._expose_repo_package(tmp_path, "canopy_transcript", "transcript rows")
     assert cloud_runner.sys.path == before
+
+
+# ── live session views: /streams + /backfills ───────────────────────────────
+# The runner made a session's record durable at TURN END, which serves a
+# conversation nobody is watching. Someone watching one saw the reduced
+# TurnEvent stream during the turn and the real rows only after it finished.
+# These cover the attach/tail/detach cycle that closes that.
+
+
+class _FakeCore:
+    """Stands in for canopy_transcript. Only the surface the runner uses."""
+
+    TRANSCRIPT = "/fake/transcript.jsonl"
+
+    def __init__(self, records=None, resolvable=True):
+        self.records = records if records is not None else ["r0", "r1"]
+        self.resolvable = resolvable
+        self.resolved_with = []
+
+    # -- paths --
+    def resolve_cli_transcript(self, cwd, session_id, claude_home=None):
+        self.resolved_with.append((str(cwd), session_id))
+        return self.TRANSCRIPT if self.resolvable else None
+
+    # -- rows --
+    def end_index(self, n):
+        return 1000 + n
+
+    def conversational_messages(self, records, since, record_offset=0):
+        return [
+            {"role": "assistant", "index": 10 + i + record_offset, "text": str(r)}
+            for i, r in enumerate(records)
+        ]
+
+    def row_payload(self, row):
+        return {"text": row["text"]}
+
+    def read_records(self, path):
+        return self.records
+
+    class TailReader:
+        def __init__(self, path):
+            self.path = path
+            self._batches = [["a", "b"]]
+
+        def read_new(self):
+            return self._batches.pop(0) if self._batches else []
+
+
+def _wire(mod, monkeypatch, core, api):
+    monkeypatch.setattr(mod, "_transcript_core", lambda: core)
+    monkeypatch.setattr(mod, "_api", api)
+    mod._STREAM_READERS.clear()
+
+
+def test_stream_sync_attaches_and_ships_rows(cloud_runner, monkeypatch):
+    core = _FakeCore()
+    posted = []
+
+    def api(method, path, body=None):
+        if method == "GET" and path.endswith("/streams"):
+            return 200, {"streams": [{"session_id": "sess-1", "session_key": "cli-9",
+                                      "project": "", "last_index": 5}]}
+        if method == "POST" and path.endswith("/session-stream"):
+            posted.append(body)
+            return 200, {"count": len(body["events"])}
+        return 200, {}
+
+    _wire(cloud_runner, monkeypatch, core, api)
+    cloud_runner._sync_session_streams("runner-1")
+
+    assert len(posted) == 1
+    assert posted[0]["session_id"] == "sess-1"
+    # seq MUST equal the composite transcript ordinal, or WS-derived seq:<n>
+    # message ids collide across detaches/restarts.
+    assert all(e["seq"] == e["index"] for e in posted[0]["events"])
+    # Resolution is (deterministic cwd from the canopy session id, CLI session id
+    # from the descriptor) — the cloud analogue of the laptop's project+task.
+    cwd, cli = core.resolved_with[0]
+    assert cwd.endswith("sessions/sess-1") and cli == "cli-9"
+
+
+def test_stream_sync_uses_server_marker_not_a_local_checkpoint(cloud_runner, monkeypatch):
+    core = _FakeCore()
+    seen_since = []
+    orig = core.conversational_messages
+
+    def spy(records, since, record_offset=0):
+        seen_since.append(since)
+        return orig(records, since, record_offset=record_offset)
+
+    core.conversational_messages = spy
+
+    def api(method, path, body=None):
+        if method == "GET" and path.endswith("/streams"):
+            return 200, {"streams": [{"session_id": "s", "session_key": "k", "last_index": 42}]}
+        return 200, {}
+
+    _wire(cloud_runner, monkeypatch, core, api)
+    cloud_runner._sync_session_streams("r")
+    assert seen_since[0] == 42
+
+
+def test_stream_sync_with_no_marker_streams_forward_only(cloud_runner, monkeypatch):
+    # last_index None => a fresh attach must NOT replay history; that is the
+    # backfill's job. end_index(len(records)) is the "everything already seen" marker.
+    core = _FakeCore()
+    seen_since = []
+    orig = core.conversational_messages
+    core.conversational_messages = lambda r, s, record_offset=0: (
+        seen_since.append(s) or orig(r, s, record_offset=record_offset))
+
+    def api(method, path, body=None):
+        if method == "GET" and path.endswith("/streams"):
+            return 200, {"streams": [{"session_id": "s", "session_key": "k", "last_index": None}]}
+        return 200, {}
+
+    _wire(cloud_runner, monkeypatch, core, api)
+    cloud_runner._sync_session_streams("r")
+    assert seen_since[0] == core.end_index(2)
+
+
+def test_stream_sync_drops_tailers_for_detached_sessions(cloud_runner, monkeypatch):
+    core = _FakeCore()
+    streams = [{"session_id": "s", "session_key": "k", "last_index": 1}]
+
+    def api(method, path, body=None):
+        if method == "GET" and path.endswith("/streams"):
+            return 200, {"streams": streams}
+        return 200, {}
+
+    _wire(cloud_runner, monkeypatch, core, api)
+    cloud_runner._sync_session_streams("r")
+    assert "s" in cloud_runner._STREAM_READERS
+    streams.clear()  # viewer detached
+    cloud_runner._sync_session_streams("r")
+    assert cloud_runner._STREAM_READERS == {}
+
+
+def test_failed_post_drops_the_reader_so_the_next_tick_recatches(cloud_runner, monkeypatch):
+    # No local offset checkpoint: an unshipped batch must not advance `count`,
+    # or those rows are lost for good.
+    core = _FakeCore()
+
+    def api(method, path, body=None):
+        if method == "GET" and path.endswith("/streams"):
+            return 200, {"streams": [{"session_id": "s", "session_key": "k", "last_index": 1}]}
+        if path.endswith("/session-stream"):
+            return 500, None
+        return 200, {}
+
+    _wire(cloud_runner, monkeypatch, core, api)
+    cloud_runner._sync_session_streams("r")
+    assert cloud_runner._STREAM_READERS["s"]["reader"] is None
+    assert cloud_runner._STREAM_READERS["s"]["count"] == 0
+
+
+def test_stream_sync_skips_an_unresolvable_transcript(cloud_runner, monkeypatch):
+    # Turn not spawned yet, or another box owns it — retry next tick, never crash.
+    core = _FakeCore(resolvable=False)
+
+    def api(method, path, body=None):
+        if method == "GET" and path.endswith("/streams"):
+            return 200, {"streams": [{"session_id": "s", "session_key": "k", "last_index": 1}]}
+        raise AssertionError("must not post without a transcript")
+
+    _wire(cloud_runner, monkeypatch, core, api)
+    cloud_runner._sync_session_streams("r")
+    assert cloud_runner._STREAM_READERS["s"]["reader"] is None
+
+
+def test_backfill_ships_full_history(cloud_runner, monkeypatch):
+    core = _FakeCore(records=["x", "y", "z"])
+    posted = []
+
+    def api(method, path, body=None):
+        if method == "GET" and path.endswith("/backfills"):
+            return 200, {"backfills": [{"session_id": "s", "session_key": "k"}]}
+        if method == "POST" and path.endswith("/session-backfill"):
+            posted.append(body)
+            return 200, {"written": len(body["messages"])}
+        return 200, {}
+
+    _wire(cloud_runner, monkeypatch, core, api)
+    cloud_runner._drain_backfills("r")
+    assert len(posted) == 1 and len(posted[0]["messages"]) == 3
+
+
+def test_a_broken_session_does_not_stop_the_others(cloud_runner, monkeypatch):
+    # One session's exception must not starve every other watcher on the box.
+    core = _FakeCore()
+    calls = {"n": 0}
+    real_resolve = core.resolve_cli_transcript
+
+    def flaky(cwd, session_id, claude_home=None):
+        calls["n"] += 1
+        if session_id == "bad":
+            raise RuntimeError("boom")
+        return real_resolve(cwd, session_id, claude_home=claude_home)
+
+    core.resolve_cli_transcript = flaky
+    posted = []
+
+    def api(method, path, body=None):
+        if method == "GET" and path.endswith("/streams"):
+            return 200, {"streams": [
+                {"session_id": "s1", "session_key": "bad", "last_index": 1},
+                {"session_id": "s2", "session_key": "good", "last_index": 1},
+            ]}
+        if path.endswith("/session-stream"):
+            posted.append(body)
+            return 200, {}
+        return 200, {}
+
+    _wire(cloud_runner, monkeypatch, core, api)
+    cloud_runner._sync_session_streams("r")
+    assert [p["session_id"] for p in posted] == ["s2"]
+
+
+def test_sync_session_views_can_skip_backfills(cloud_runner, monkeypatch):
+    # The fast stream clock must not drag a /backfills GET along with it.
+    core = _FakeCore()
+    paths = []
+
+    def api(method, path, body=None):
+        paths.append(path)
+        if path.endswith("/streams"):
+            return 200, {"streams": []}
+        return 200, {"backfills": []}
+
+    _wire(cloud_runner, monkeypatch, core, api)
+    cloud_runner._sync_session_views("r", with_backfills=False)
+    assert not any(p.endswith("/backfills") for p in paths)
+    paths.clear()
+    cloud_runner._sync_session_views("r")
+    assert any(p.endswith("/backfills") for p in paths)
+
+
+def test_session_views_survive_a_missing_transcript_core(cloud_runner, monkeypatch):
+    # canopy_transcript unavailable => named degradation, not an exception on the
+    # main loop.
+    monkeypatch.setattr(cloud_runner, "_transcript_core", lambda: None)
+    monkeypatch.setattr(cloud_runner, "_api", lambda *a, **k: (_ for _ in ()).throw(
+        AssertionError("must not call the API without the transcript core")))
+    cloud_runner._sync_session_views("r")
+
+
+def test_a_failed_steady_state_post_does_not_advance_the_offset(cloud_runner, monkeypatch):
+    """The row-losing branch. On attach a failure just leaves the reader unset,
+    but in steady state `count` is the ONLY record of how far the tailer got —
+    advancing it past a batch the server never accepted drops those rows for
+    good, and nothing ever re-reads them (TailReader only returns NEW bytes)."""
+    core = _FakeCore()
+    ok = {"v": True}
+
+    def api(method, path, body=None):
+        if method == "GET" and path.endswith("/streams"):
+            return 200, {"streams": [{"session_id": "s", "session_key": "k", "last_index": 1}]}
+        if path.endswith("/session-stream"):
+            return (200, {}) if ok["v"] else (500, None)
+        return 200, {}
+
+    _wire(cloud_runner, monkeypatch, core, api)
+
+    # Tick 1: attach succeeds, tailer is live and has consumed 2 records.
+    cloud_runner._sync_session_streams("r")
+    st = cloud_runner._STREAM_READERS["s"]
+    assert st["reader"] is not None and st["count"] == 2
+
+    # Tick 2: a fresh batch arrives and the post fails.
+    st["reader"]._batches = [["c", "d"]]
+    ok["v"] = False
+    cloud_runner._sync_session_streams("r")
+
+    st = cloud_runner._STREAM_READERS["s"]
+    assert st["reader"] is None, "a failed post must drop the tailer"
+    assert st["count"] == 0, "count must not advance past records the server never took"


### PR DESCRIPTION
## The gap

`_ship_transcript_rows` makes a session's record durable at **turn end**. That serves a conversation nobody is watching. It doesn't serve someone watching one — they saw the reduced `TurnEvent` stream while the turn ran, and the real ordinal-keyed rows only once it finished. A server-requested **backfill** was ignored outright, so a session whose history needed rebuilding never got it.

This was the "still not implemented" caveat on #503/#504, recorded in both the `RUNNER_SESSIONS` comment and the CFN parameter description. This closes it.

## What

`_sync_session_streams` + `_drain_backfills`, mirroring `packages/canopy_runner`'s contract exactly — same endpoints, same server-side resume marker (`last_index`), same `seq == composite transcript ordinal` rule (WS-derived `seq:<n>` message ids collide across detaches and restarts otherwise).

The one real difference is **resolution**, and it needs no new state:

| | laptop | cloud |
|---|---|---|
| find the transcript by | (project, emdash task) | (cwd, CLI session id) |
| where those come from | session report | cwd is deterministic from the canopy session id (`_turn_cwd`); the CLI session id is what `record_session` stored in `RunnerBinding.session_key` — which the stream descriptor hands straight back |

**Cadence.** Streams get their own clock (`STREAM_POLL_SECONDS`, 3s) rather than riding `POLL_SECONDS` — at the 15s turn-claim cadence a watcher sees a streaming reply arrive in 15-second lumps. Backfills are request-driven and rare, so they stay on the slow clock; an idle tick costs one small GET. The WS `stream` frame triggers a sync immediately but is only a latency optimization — a dropped frame costs one tick, never a permanently unattached viewer. The REST fallback syncs too: falling back must not silently stop the runner being watchable.

**No local offset checkpoint**, deliberately. A failed post drops the tailer, so the next tick re-attaches from the server marker; a restart recovers identically.

## Tests

11 new (74 total in the runner suite). Attach, server-marker resume, forward-only on a fresh attach, detach cleanup, unresolvable transcript, per-session error isolation, backfill, the fast-clock skipping `/backfills`, and a missing transcript core degrading rather than throwing.

One is worth calling out: `test_a_failed_steady_state_post_does_not_advance_the_offset`. In steady state `count` is the *only* record of how far the tailer got — advancing it past a batch the server never accepted drops those rows for good, because `TailReader` only ever returns new bytes. I checked the test earns its keep by reintroducing exactly that bug and confirming it goes red (my first attempt at the check was itself wrong — it broke the steady-state branch while the existing test only covered *attach*, so it passed; hence this second, targeted test).

Full suite `1865 passed, 1 skipped`, `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)