### PR TITLE
fix(chat): ace-web work is ace-web work, whoever typed it

### DIFF
--- a/apps/canopy_sessions/services.py
+++ b/apps/canopy_sessions/services.py
@@ -642,6 +642,42 @@ def claim_pending_attachments(session, message=None) -> list[dict]:
         for a in pending
     ]
 
+# Which product a session BELONGS to, keyed off the marker its creator stamped.
+# `metadata.source` is already the canonical "who made this" marker — canopy's
+# own session LIST filters on it (`?source=ace-web`).
+SOURCE_ORIGINS = {"ace-web": Turn.ORIGIN_ACE_WEB}
+
+
+def default_origin(session) -> str:
+    """The source a turn on this session is, when the caller didn't name one.
+
+    A session ace-web created is ace-web work — whoever typed it, over whatever
+    transport. That is the rule, and getting it wrong is what shipped in #496:
+    origin was threaded only through ace-web's SERVER-side run dispatcher, on
+    the reasoning that a human typing "IS a human typing" and therefore chat. So
+    a person typing into ace-web's own chat produced `canopy_web_chat`,
+    indistinguishable from canopy's chat UI, and routed to whatever runs canopy
+    chat rather than to the box that runs ace-web's work. Observed directly:
+    "testing", typed into an ace-web session, went to a laptop runner.
+
+    The distinction that matters is not human-vs-programmatic, it is WHICH
+    PRODUCT the work belongs to. Deriving it here rather than asking each caller
+    to pass it means every ace-web surface is covered by construction — the chat
+    UI over the WS, the workbench's discuss-this-step pane, and the run
+    dispatcher — with no client change and no way for one of them to be missed.
+
+    Not tamper-proof, and deliberately not sold as such: `metadata` is
+    caller-supplied on the generic session-create endpoint, so a caller could
+    stamp `source: ace-web` itself. That is no weaker than what already exists —
+    `ace_web` is a POSTABLE origin any caller may name outright — and the blast
+    radius is the one the routing spec already accepted: you can only enqueue
+    into your own workspace, and a rule only redirects that agent's work among
+    runners you can see.
+    """
+    source = (getattr(session, "metadata", None) or {}).get("source")
+    return SOURCE_ORIGINS.get(source, Turn.ORIGIN_CANOPY_WEB_CHAT)
+
+
 def send_message(
     *, session: Session, text: str, user, client_id: str = "", placement: str | None = None,
     origin: str | None = None,
@@ -673,7 +709,7 @@ def send_message(
     send, so this path writes no row — the frontend already echoes the message
     optimistically (draft.committed), and a transient Message keeps the contract.
     """
-    origin = origin or Turn.ORIGIN_CANOPY_WEB_CHAT
+    origin = origin or default_origin(session)
     if transcript_sourced(session):
         return _send_transcript_sourced_message(
             session=session, text=text, client_id=client_id, placement=placement,

--- a/tests/test_chat_send.py
+++ b/tests/test_chat_send.py
@@ -327,3 +327,60 @@ def test_transcript_sourced_send_carries_the_origin_too():
     assert chat.transcript_sourced(session)
     _msg, turn = chat.send_message(session=session, text="hi", user=user, origin=Turn.ORIGIN_ACE_WEB)
     assert turn.origin == Turn.ORIGIN_ACE_WEB
+
+
+# ---- origin derived from the session's owning product ----
+# #496 threaded origin only through ace-web's SERVER-side run dispatcher, so a
+# human typing into ace-web's OWN chat produced canopy_web_chat and routed like
+# canopy chat. Observed live: "testing" typed into an ace-web session went to a
+# laptop runner instead of the box that runs ace-web's work. The distinction
+# that matters is which PRODUCT the session belongs to, not who typed.
+
+
+def _ace_web_session(**meta):
+    user = User.objects.create_user("aw", "aw@dimagi.com", "pw")
+    ws = Workspace.objects.create(slug="aw-ws", display_name="W", created_by=user)
+    agent = Agent.objects.create(slug="ace", name="ACE", workspace=ws, owner=user)
+    session = chat.create_session(workspace=ws, created_by=user, agent=agent)
+    session.metadata = {**(session.metadata or {}), "source": "ace-web", **meta}
+    session.save(update_fields=["metadata"])
+    return user, session
+
+
+def test_a_human_typing_in_an_ace_web_session_is_ace_web_work():
+    user, session = _ace_web_session(origin_key="ace-web:dimagi-team")
+    _msg, turn = chat.send_message(session=session, text="testing", user=user)
+    assert turn.origin == Turn.ORIGIN_ACE_WEB
+
+
+def test_a_canopy_session_is_still_chat():
+    user, _ws, _agent, session = _ctx()
+    _msg, turn = chat.send_message(session=session, text="hi", user=user)
+    assert turn.origin == Turn.ORIGIN_CANOPY_WEB_CHAT
+
+
+def test_transcript_sourced_ace_web_session_also_derives_ace_web():
+    # The path labs actually takes — every session is transcript_sourced at
+    # creation, so deriving on the durable path only would be a no-op in prod.
+    user, session = _ace_web_session()
+    session.metadata = {**(session.metadata or {}), chat.TRANSCRIPT_SOURCED: True}
+    session.save(update_fields=["metadata"])
+    assert chat.transcript_sourced(session)
+    _msg, turn = chat.send_message(session=session, text="testing", user=user)
+    assert turn.origin == Turn.ORIGIN_ACE_WEB
+
+
+def test_an_explicit_origin_still_wins():
+    # The run dispatcher names ace_web outright; derivation must not fight it,
+    # and a caller naming something else must not be silently overridden.
+    user, session = _ace_web_session()
+    _msg, turn = chat.send_message(session=session, text="x", user=user,
+                                   origin=Turn.ORIGIN_EMAIL)
+    assert turn.origin == Turn.ORIGIN_EMAIL
+
+
+def test_unknown_or_missing_source_falls_back_to_chat():
+    user, _ws, _agent, session = _ctx()
+    for meta in ({}, {"source": "something-else"}, {"source": None}):
+        session.metadata = meta
+        assert chat.default_origin(session) == Turn.ORIGIN_CANOPY_WEB_CHAT, meta

--- a/tests/test_chat_session_consumer.py
+++ b/tests/test_chat_session_consumer.py
@@ -359,3 +359,49 @@ async def test_snapshot_falls_back_to_the_binding_tail():
     assert [m["turn_index"] for m in msgs] == [-2, -1]   # never collides with real rows
     assert [m["id"] for m in msgs] == ["tail:-2", "tail:-1"]
     await comm.disconnect()
+
+
+# ── origin derived from the session's owning product ────────────────────────
+# THE path a human actually uses: canopy-ui's chat kit sends `chat.send` and the
+# consumer calls send_message with no origin. #496 threaded origin only through
+# ace-web's SERVER-side run dispatcher, so typing into ace-web's own chat still
+# produced canopy_web_chat and routed like canopy chat — observed live, a
+# "testing" message on an ace-web session went to a laptop runner. Deriving in
+# the REST view alone would have left this path exactly as broken.
+async def test_ws_send_on_an_ace_web_session_is_ace_web_work():
+    def _seed_ace_web():
+        owner, _teammate, session = _seed()
+        session.metadata = {**(session.metadata or {}), "source": "ace-web",
+                            "origin_key": "ace-web:dimagi-team"}
+        session.save(update_fields=["metadata"])
+        return owner, session
+
+    owner, session = await database_sync_to_async(_seed_ace_web)()
+    comm = await _connect(session, owner)
+    assert (await comm.connect())[0]
+    await comm.send_json_to({"action": "draft.update", "data": {"version": 0, "body": "testing"}})
+    await _recv_match(comm, lambda f: f.get("event") == "draft.updated")
+    await comm.send_json_to({"action": "chat.send", "data": {}})
+    await _recv_match(comm, lambda f: f.get("event") == "chat.stream_complete")
+
+    origin = await database_sync_to_async(
+        lambda: Turn.objects.filter(chat_session_id=session.id).first().origin
+    )()
+    assert origin == Turn.ORIGIN_ACE_WEB
+    await comm.disconnect()
+
+
+async def test_ws_send_on_a_canopy_session_is_still_chat():
+    owner, _teammate, session = await database_sync_to_async(_seed)()
+    comm = await _connect(session, owner)
+    assert (await comm.connect())[0]
+    await comm.send_json_to({"action": "draft.update", "data": {"version": 0, "body": "hi"}})
+    await _recv_match(comm, lambda f: f.get("event") == "draft.updated")
+    await comm.send_json_to({"action": "chat.send", "data": {}})
+    await _recv_match(comm, lambda f: f.get("event") == "chat.stream_complete")
+
+    origin = await database_sync_to_async(
+        lambda: Turn.objects.filter(chat_session_id=session.id).first().origin
+    )()
+    assert origin == Turn.ORIGIN_CANOPY_WEB_CHAT
+    await comm.disconnect()


### PR DESCRIPTION
## What happened

Typing `testing` into a session ace-web created routed to a **laptop** runner:

```
origin: "canopy_web_chat"   claimed_by_name: "jj-mbp-cdp"
```

## Why #496 was wrong

I threaded `origin=ace_web` only through ace-web's **server-side run dispatcher**, reasoning that a human typing "IS a human typing" and therefore chat. That's the wrong axis.

And it wasn't a matter of using the wrong URL: **neither** browser path could have produced `ace_web`. canopy's WS consumer calls `send_message(...)` with no origin, and ace-web's SPA talks to canopy directly through the same chat kit and the same frame. So an ace-web chat URL would have routed to the laptop identically.

The distinction that matters is **which product the work belongs to**, not who typed it.

## The fix

Derive it from the session. ace-web already stamps `metadata.source = "ace-web"` server-side on **both** creation paths — the browser chat endpoint (`apps/canopy/api.py`, from a membership-checked path param) and the run dispatcher (`run_dispatch._run_metadata`) — and canopy's own session LIST already treats that as the canonical "who made this" marker (`?source=ace-web`).

```python
SOURCE_ORIGINS = {"ace-web": Turn.ORIGIN_ACE_WEB}

def default_origin(session) -> str:
    source = (getattr(session, "metadata", None) or {}).get("source")
    return SOURCE_ORIGINS.get(source, Turn.ORIGIN_CANOPY_WEB_CHAT)
```

Deriving server-side rather than asking each caller to pass it means every ace-web surface is covered **by construction** — chat over the WS, the workbench's discuss-this-step pane, programmatic runs — with no client change and no way for one to be missed. An explicit origin still wins, so the run dispatcher naming `ace_web` outright is unaffected.

**Requires no ace-web change.** It already stamps everything needed.

## Honest limit

Not tamper-proof: `metadata` is caller-supplied on the generic create endpoint, so a caller could stamp the marker itself. That's no weaker than what exists — `ace_web` is a POSTABLE origin any caller may name outright — and the blast radius is the one the routing spec already accepted (you can only enqueue into your own workspace; a rule only redirects that agent's work among runners you can see). Stated in the docstring rather than implied away.

## Tests

5 service-level + **2 over the actual WebSocket** — that's the path a human uses, and deriving in the REST view alone would have left the observed bug exactly as it was. Covers: human typing in an ace-web session → `ace_web`; a canopy session → still `canopy_web_chat`; the transcript-sourced path (what labs actually takes); explicit origin wins; unknown/missing source falls back.

Verified all three `ace_web` tests go red when reverted to #496's behaviour.

`1872 passed, 1 skipped`, `ruff` clean.

## Note on the session that caught this

That session is now **bound** to the laptop, and binding stickiness beats source rules — so it stays there regardless. A fresh ace-web session is needed to see this route to the cloud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)