### PR TITLE
fix(runner): stop stealing emdash's focus to read a menu

### DIFF
--- a/packages/canopy_runner/canopy_runner/main.py
+++ b/packages/canopy_runner/canopy_runner/main.py
@@ -626,11 +626,27 @@ def _start_hook_listener(cfg: Config, client: Client):
     from .hook_listener import HookListener
 
     nonce = uuid.uuid4().hex
+    # NO read_menu here, deliberately. Reading a session's screen means driving
+    # emdash over CDP, and `openTask` CLICKS the task in the sidebar and focuses
+    # its terminal — so wiring it to a hook meant every Notification yanked
+    # emdash to whatever agent had just asked for input, mid-typing.
+    #
+    # Reported 2026-07-28, twice: focus taken, a few characters typed into the
+    # newly-focused prompt, then the message that was meant for that task never
+    # arrived. The second half is the collision guard working exactly as designed
+    # — `open_and_send` found unsent text, refused to clobber it, and defaulted to
+    # a fresh session — so this bug MANUFACTURED the leaked-keystroke case that
+    # guard exists to catch.
+    #
+    # A menu can still be read on demand (`cdp_control.read_terminal`), where the
+    # task switch is something a human just asked for. It cannot be read on a
+    # signal, because there is no way to read a NON-active task: emdash marks no
+    # task as current in the DOM (checked — no aria-current, no data-state), so
+    # identifying whose screen you are looking at requires activating it first.
     listener = HookListener(
         port=cfg.hook_port, nonce=nonce,
         resolve_session=_resolve_hook_session,
         forward=lambda: cfg.forward_sessions,
-        read_menu=lambda cwd: _read_hook_menu(cwd, cdp_port=cfg.cdp_port),
     )
     listener.bind_sender(
         lambda session_id, events: client.post_session_stream(

--- a/packages/canopy_runner/tests/test_main.py
+++ b/packages/canopy_runner/tests/test_main.py
@@ -651,3 +651,37 @@ def test_an_option_not_on_the_dialog_is_dropped(monkeypatch):
     monkeypatch.setattr(main_mod, "cdp_control", fake)
     main_mod._answer_menu("agent-task", 7)
     assert fake.sent == []
+
+
+def test_the_hook_listener_never_reads_the_screen_by_itself(monkeypatch, tmp_path):
+    """Reading a session's screen drives emdash over CDP, and `openTask` CLICKS
+    the task and focuses its terminal. Wired to a hook, that yanked emdash to
+    whatever agent had just asked for input — mid-typing, twice, reported
+    2026-07-28. Nothing on the hook path may steal focus.
+    """
+    cfg = Config(base_url="http://x", token="t", runner_id="r",
+                 emdash_db=str(tmp_path / "emdash.db"),
+                 hook_port=8799, forward_sessions=True)
+    captured = {}
+
+    class _Listener:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        def bind_sender(self, _s):
+            pass
+
+        def start(self):
+            pass
+
+    import canopy_runner.hook_listener as hl
+    monkeypatch.setattr(hl, "HookListener", _Listener)
+    monkeypatch.setattr(main_mod.hook_install, "install", lambda *a, **k: True)
+    monkeypatch.setattr(main_mod.Path, "home", classmethod(lambda cls: tmp_path))
+
+    class _Client:
+        def post_session_stream(self, *a, **k):
+            pass
+
+    main_mod._start_hook_listener(cfg, _Client())
+    assert "read_menu" not in captured or captured["read_menu"] is None


### PR DESCRIPTION
Reported twice today: emdash jumps to another task, a few typed characters land in the newly-focused prompt, and the message meant for that task never appears.

**I caused it.** #495 wired a menu read onto the `Notification` hook. Reading a session's screen means driving emdash over CDP — and `openTask` **clicks the task in the sidebar and focuses its terminal**. So every time any agent asked for input, canopy yanked emdash to that agent, mid-typing.

## The missing paste was the collision guard working

`open_and_send` found unsent text in the prompt, refused to clobber it, and fell back to a fresh session — exactly as designed. This bug **manufactured** the leaked-keystroke case that guard exists to catch: the human's keystrokes really had leaked into a task they never chose.

## Why the fix is removal, not a smarter read

A menu can still be read **on demand**, where the task switch is something a human just asked for. It cannot be read **on a signal**, because reading a non-active task isn't possible: emdash marks no task as current in the DOM (checked — no `aria-current`, no `aria-selected`, no `data-state`), so identifying whose screen you're looking at requires activating it first. Any "just peek without switching" version of this is unsound, not merely unimplemented.

**Cost:** a phone shows "needs you" without buttons until the read is triggered deliberately. That's the right trade — the state was always the load-bearing half, and no observability feature may interrupt the human it's reporting to.

A test pins that the hook path is constructed without a screen reader at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)