### PR TITLE
feat(runner): the laptop runner auto-updates itself

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -359,6 +359,21 @@ restarts the daemon, so not mid-turn. `--ref <branch>` installs something else d
 the previously committed literal named one source directory while the runner imports three
 packages, so it could not actually start the runner and the live copy had been hand-patched.
 
+**The laptop runner AUTO-UPDATES itself** via a second launchd job
+(`com.canopy.runner.updater`, `StartInterval` 1800), installed by the same script
+(`--no-auto-update` to skip). Three rules make it safe: it tracks the **deployed**
+`expected_code_sha`, never `origin/main` (so it only installs what has been through
+CI + the merge queue + a deploy, and can't leave the box permanently mismatched
+against the server); it **defers while a turn is in flight** (the daemon publishes
+an in-flight count to `~/.canopy/in-flight` each tick, because a chat turn is
+bridged ACROSS ticks and a restart would strand the reply); and it is a **separate
+job**, because a self-updating runner that shipped a crash-looping version could
+never update again — an independent timer means shipping a fix rescues every box.
+`canopy-runner update-check` answers `current|stale|busy|unknown` and is READ-ONLY
+(it must never heartbeat — that would forge liveness for a daemon that may be dead).
+Log: `~/.canopy/updater.log`. Testing a branch on a box? Bootout the updater first,
+or it reverts you to the deployed sha within 30 minutes.
+
 **Runner code provenance.** The heartbeat carries `code_version` (the package's
 `__version__`, legible) and `code_sha` — **the sha of the last commit touching
 `packages/canopy_runner/canopy_runner/`**, NOT the repo HEAD. The server holds the same

--- a/packages/canopy_runner/README.md
+++ b/packages/canopy_runner/README.md
@@ -71,6 +71,29 @@ for the schema drift that causes such a failure.
 
    It restarts the daemon, so avoid running it mid-turn.
 
+   It also installs a second launchd job, `com.canopy.runner.updater`, which
+   **auto-updates this box** every 30 minutes (`--no-auto-update` to skip).
+   What it does and does not do:
+
+   - It tracks the **deployed** runner sha (`expected_code_sha` off this
+     runner's own row), never `origin/main` — so it only ever installs code
+     that has been through CI, the merge queue and a deploy. A merged runner
+     change reaches the fleet when canopy-web is deployed, not at merge.
+   - It **never restarts mid-turn**: the daemon publishes an in-flight count
+     each tick and the updater defers while anything is in flight.
+   - It is a **separate** job on purpose. A runner that updated itself could
+     ship a version that crash-loops on startup and then never update again —
+     it would never heartbeat, never learn it was behind, and stay bricked.
+     An independent timer keeps checking whatever state the runner is in, so
+     shipping a fix is enough to rescue every box.
+   - Testing a branch on a box? The updater will revert it to the deployed sha
+     within 30 minutes. `launchctl bootout gui/$(id -u)/com.canopy.runner.updater`
+     first, or install with `--no-auto-update`.
+
+   Its log is `~/.canopy/updater.log`. Ask any box what it thinks with
+   `canopy-runner update-check --config ~/.canopy/runner.json`, which prints
+   `current|stale|busy|unknown <expected-sha>` and never writes anything.
+
    The `realtime` extra (the WebSocket wake listener — instant claims instead of
    up to a 5s poll delay) is installed as part of this, into the tool venv's own
    interpreter. It used to be a hand-run `pip install --user` against whichever

--- a/packages/canopy_runner/canopy_runner/client.py
+++ b/packages/canopy_runner/canopy_runner/client.py
@@ -93,6 +93,14 @@ class Client:
         _, payload = self._call("POST", f"/runners/{runner_id}/heartbeat", body)
         return payload or {}
 
+    def list_runners(self) -> list[dict]:
+        """The fleet this token can see. READ-ONLY, and the only call the updater
+        makes: it needs `expected_code_sha` off its own row, and must never
+        heartbeat (that would stamp the runner ONLINE and overwrite the provenance
+        the real daemon reports — forging liveness for a daemon that may be dead)."""
+        _, payload = self._call("GET", "/runners/")
+        return payload if isinstance(payload, list) else []
+
     def resolve_session(self, runner_id: str, agent_slug: str, thread_key: str, *,
                         project: str = "", workspace: str = "") -> dict:
         """Ask the control plane whether THIS runner can reuse an existing emdash

--- a/packages/canopy_runner/canopy_runner/main.py
+++ b/packages/canopy_runner/canopy_runner/main.py
@@ -144,6 +144,18 @@ def _fire_due_schedules(cfg: Config, client: Client, paused: set[str] | None = N
         logger.warning("scheduling unavailable this tick (claiming + inbox continue): %s", exc)
 
 
+def _mark_in_flight(cfg: Config, *, extra: int = 0) -> None:
+    """Publish how much work this runner is carrying, for the auto-updater.
+
+    Chat turns are bridged ACROSS ticks (chat_bridge.IN_FLIGHT), so the count is
+    not derivable from anything the updater can see from outside the process —
+    hence a marker file rather than, say, asking the server which turns it thinks
+    are executing (that answer lags, and is wrong in exactly the crash cases)."""
+    from . import update as update_mod
+
+    update_mod.mark_busy(cfg, len(chat_bridge.IN_FLIGHT) + extra)
+
+
 def _claim_and_execute(cfg: Config, client: Client, paused: set) -> str:
     """Claim at most one eligible turn and route it to an emdash session. The shared
     core of both the loop's iteration and the single-turn primitive, so they can't
@@ -157,6 +169,11 @@ def _claim_and_execute(cfg: Config, client: Client, paused: set) -> str:
         return "idle"
     if turn is None:
         return "idle"
+    # Hold the in-flight marker across the WHOLE claim→execute window, not just the
+    # per-tick count: the auto-updater restarts this daemon, and an agent turn is
+    # routed synchronously inside this call. Restarting here would leave the turn
+    # EXECUTING with nothing to finish it, waiting out the lease sweep.
+    _mark_in_flight(cfg, extra=1)
     try:
         return execute.execute_turn(
             cfg, client, cfg.runner_id, turn,
@@ -179,6 +196,7 @@ def _claim_and_execute(cfg: Config, client: Client, paused: set) -> str:
         # way — and it just keeps a module-level set growing unbounded for the life
         # of the process).
         CANCELLED_TURNS.discard(turn["id"])
+        _mark_in_flight(cfg)
 
 
 # Per-session incremental tail readers, keyed by emdash_task — the byte-offset change
@@ -939,6 +957,21 @@ def verify_emdash(cfg_path: Path) -> int:
     return 0
 
 
+def update_check(cfg_path: Path) -> int:
+    """Print `<status> <expected_sha>` for install-runner.sh --if-stale.
+
+    One line, machine-first, so the shell can branch without parsing prose.
+    Always exits 0: this runs on a timer, and a non-zero exit for the ordinary
+    "nothing to do" case would make launchd's log a wall of false failures."""
+    from . import update as update_mod
+
+    cfg = Config.load(cfg_path)
+    client = Client(cfg.base_url, cfg.token)
+    status, expected = update_mod.update_status(cfg, client)
+    print(f"{status} {expected or '-'}")
+    return 0
+
+
 def install_sidecar() -> int:
     """Provision the CDP sidecar's node deps. Exit code, for the CLI."""
     from . import cdp_control as cdp
@@ -995,6 +1028,13 @@ def _build_parser() -> argparse.ArgumentParser:
     run_parser.add_argument("--drain-one", action="store_true",
                             help="claim + run exactly ONE queued turn, then exit")
 
+    update_parser = subparsers.add_parser(
+        "update-check",
+        help="print '<current|stale|busy|unknown> <expected_sha>' — whether this box "
+             "should install a newer runner right now (read-only; never heartbeats)",
+    )
+    update_parser.add_argument("--config", required=True)
+
     subparsers.add_parser(
         "install-sidecar",
         help="install the CDP sidecar's node deps next to the installed sidecar "
@@ -1017,6 +1057,9 @@ def main() -> None:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 
     command = args.command or "run"
+
+    if command == "update-check":
+        raise SystemExit(update_check(Path(args.config)))
 
     if command == "install-sidecar":
         raise SystemExit(install_sidecar())
@@ -1075,6 +1118,9 @@ def main() -> None:
             hb_file.write_text(str(time.time()))
         except OSError:
             pass
+        # Separate file, not a richer heartbeat: the menu-bar app parses that one
+        # as a bare float, so changing its shape would break a shipped Swift binary.
+        _mark_in_flight(cfg)
 
     # RC3: a WS wake-listener lets the loop claim the INSTANT a turn is enqueued
     # instead of waiting out poll_seconds. Additive + best-effort — polling stays the

--- a/packages/canopy_runner/canopy_runner/update.py
+++ b/packages/canopy_runner/canopy_runner/update.py
@@ -1,0 +1,114 @@
+"""Should this box install a newer runner right now?
+
+The question has three parts, and each is answered by whoever actually knows:
+
+- **What is installed** — `provenance.code_sha()`, locally. Deliberately NOT the
+  server's record of `code_sha`: that is only as fresh as the last heartbeat, and
+  a runner that is crash-looping (the case where auto-update matters MOST) has not
+  sent one.
+- **What should be installed** — `expected_code_sha` off the runner's own row.
+  This is the sha of the runner source in the DEPLOYED image, so it has already
+  been through CI, the merge queue and a deploy. Tracking `origin/main` instead
+  would install code nothing has deployed AND leave the box permanently
+  mismatched against the server, i.e. the staleness banner would fire forever on
+  exactly the boxes that are auto-updating correctly.
+- **Whether now is a safe moment** — the local in-flight marker the running
+  daemon writes each tick. An update restarts the daemon, and a chat turn is
+  bridged across ticks, so restarting mid-turn strands a reply.
+
+Read-only by construction: this asks the control plane via GET, and must never
+heartbeat. A heartbeat from this second process would stamp the runner ONLINE and
+overwrite the provenance the real daemon reports — the updater would be forging
+liveness for a daemon that might be dead.
+
+See docs/superpowers/specs/2026-07-28-runner-as-installed-package-design.md.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import time
+from pathlib import Path
+
+logger = logging.getLogger("canopy_runner.update")
+
+CURRENT = "current"
+STALE = "stale"
+BUSY = "busy"
+UNKNOWN = "unknown"
+
+# How old the in-flight marker may be before we stop believing it. The loop
+# rewrites it every tick (poll_seconds defaults to 5), so a marker older than
+# this means the daemon is not running its loop at all — stopped, wedged, or
+# crash-looping. That is NOT "busy": it is the case auto-update exists to
+# rescue, so it must not be allowed to block the update forever.
+BUSY_MARKER_MAX_AGE = 120.0
+
+
+def _busy_path(cfg) -> Path:
+    base = Path(cfg.state_path).parent if getattr(cfg, "state_path", "") else Path.home() / ".canopy"
+    return base / "in-flight"
+
+
+def mark_busy(cfg, count: int) -> None:
+    """Record how many turns this runner is carrying. Best-effort — a failure here
+    must never affect the turn itself."""
+    try:
+        p = _busy_path(cfg)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps({"count": int(count), "at": time.time()}))
+    except OSError:
+        pass
+
+
+def in_flight(cfg, *, now: float | None = None) -> int | None:
+    """Turns in flight per the marker, or None when the marker can't be trusted
+    (missing, unreadable, or stale — see BUSY_MARKER_MAX_AGE)."""
+    now = time.time() if now is None else now
+    try:
+        raw = json.loads(_busy_path(cfg).read_text())
+        if now - float(raw["at"]) > BUSY_MARKER_MAX_AGE:
+            return None
+        return int(raw["count"])
+    except (OSError, ValueError, KeyError, TypeError):
+        return None
+
+
+def update_status(cfg, client, *, installed_sha: str | None = None,
+                  now: float | None = None) -> tuple[str, str]:
+    """(status, expected_sha).
+
+    - `current` — installed matches what the deployed server expects.
+    - `stale`   — they differ and nothing is in flight: install `expected_sha`.
+    - `busy`    — they differ but a turn is in flight: try again next cycle.
+    - `unknown` — either side can't be determined. Do nothing. Empty means
+                  UNKNOWN, never "different": a dev server bakes in no
+                  expectation, and auto-installing an empty sha would be a
+                  reinstall loop against a target that does not exist.
+    """
+    from . import provenance
+
+    installed = provenance.code_sha() if installed_sha is None else installed_sha
+    try:
+        rows = client.list_runners()
+    except Exception as exc:  # noqa: BLE001 — a flaky network is not a reason to update
+        logger.warning("update check: could not reach the control plane: %s", exc)
+        return UNKNOWN, ""
+
+    mine = next((r for r in rows if str(r.get("id")) == str(cfg.runner_id)), None)
+    if mine is None:
+        # Retired, or not visible to this token. Either way we have no expectation
+        # to compare against — and reinstalling would not fix it.
+        logger.warning("update check: runner %s is not in the fleet list", cfg.runner_id)
+        return UNKNOWN, ""
+
+    expected = (mine.get("expected_code_sha") or "").strip()
+    if not expected or not installed:
+        return UNKNOWN, expected
+    if expected == installed:
+        return CURRENT, expected
+
+    carrying = in_flight(cfg, now=now)
+    if carrying:  # a positive count; None (unknown/dead) deliberately does NOT block
+        return BUSY, expected
+    return STALE, expected

--- a/packages/canopy_runner/launchd/com.canopy.runner.updater.plist.template
+++ b/packages/canopy_runner/launchd/com.canopy.runner.updater.plist.template
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  TEMPLATE — rendered to ~/Library/LaunchAgents/com.canopy.runner.updater.plist by
+  scripts/install-runner.sh. Do not load this file directly.
+
+  A SEPARATE job from the runner, and that is the whole design. If the runner
+  updated itself, a version that crash-loops on startup could never update again:
+  it never heartbeats, never learns it is behind, and the box stays bricked until
+  a human notices. An independent timer keeps checking regardless of what state
+  the runner is in, so shipping a fix is enough to rescue every box automatically.
+
+  It runs the INSTALLER, not the runner: `uv tool install --force` replaces the
+  runner's venv, and a process cannot safely have its own interpreter and modules
+  swapped out from under it mid-run. The shell script lives in the repo checkout,
+  which this job therefore depends on — but note it can only ever install what
+  `--if-stale` resolves from the control plane, so a stray branch checked out in
+  that repo still cannot change WHAT gets installed.
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>com.canopy.runner.updater</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>__INSTALLER__</string>
+    <string>--if-stale</string>
+    <string>--repo</string>
+    <string>__REPO__</string>
+  </array>
+  <!-- Not RunAtLoad: the installer restarts the runner, and load happens at login
+       and on every re-install — neither is a moment to bounce a working daemon. -->
+  <key>StartInterval</key><integer>1800</integer>
+  <key>StandardOutPath</key><string>__HOME__/.canopy/updater.log</string>
+  <key>StandardErrorPath</key><string>__HOME__/.canopy/updater.log</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <!-- launchd's default PATH has neither uv (~/.local/bin) nor git/node
+         (Homebrew), and this job needs all three. -->
+    <key>PATH</key>
+    <string>__HOME__/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+  </dict>
+</dict>
+</plist>

--- a/packages/canopy_runner/scripts/install-runner.sh
+++ b/packages/canopy_runner/scripts/install-runner.sh
@@ -5,6 +5,8 @@
 #   packages/canopy_runner/scripts/install-runner.sh                 # origin/main
 #   packages/canopy_runner/scripts/install-runner.sh --ref my-branch # deliberately, a branch
 #   packages/canopy_runner/scripts/install-runner.sh --no-launchd    # install only, don't touch the daemon
+#   packages/canopy_runner/scripts/install-runner.sh --if-stale      # auto-update mode (the timer job)
+#   packages/canopy_runner/scripts/install-runner.sh --no-auto-update # skip installing the timer job
 #
 # Why a snapshot and not the working tree: the daemon used to execute from
 # ~/emdash-projects/canopy-web via PYTHONPATH, so any `git checkout` in that
@@ -24,15 +26,22 @@ set -euo pipefail
 REPO="${CANOPY_WEB_REPO:-$HOME/emdash-projects/canopy-web}"
 REF="origin/main"
 DO_LAUNCHD=1
+DO_AUTO_UPDATE=1
+IF_STALE=0
 RUNNER_SRC="packages/canopy_runner/canopy_runner"
 LABEL="com.canopy.runner"
+UPDATER_LABEL="com.canopy.runner.updater"
+CONFIG="$HOME/.canopy/runner.json"
 
 while [ $# -gt 0 ]; do
   case "$1" in
     --ref) REF="${2:?--ref needs a git ref}"; shift 2 ;;
     --repo) REPO="${2:?--repo needs a path}"; shift 2 ;;
+    --config) CONFIG="${2:?--config needs a path}"; shift 2 ;;
     --no-launchd) DO_LAUNCHD=0; shift ;;
-    -h|--help) sed -n '2,20p' "$0"; exit 0 ;;
+    --no-auto-update) DO_AUTO_UPDATE=0; shift ;;
+    --if-stale) IF_STALE=1; shift ;;
+    -h|--help) sed -n '2,24p' "$0"; exit 0 ;;
     *) echo "unknown argument: $1" >&2; exit 2 ;;
   esac
 done
@@ -43,10 +52,58 @@ command -v uv >/dev/null || { echo "uv not found — https://docs.astral.sh/uv/"
 git -C "$REPO" rev-parse --git-dir >/dev/null 2>&1 \
   || { echo "not a git checkout: $REPO (set CANOPY_WEB_REPO)" >&2; exit 1; }
 
+# --- auto-update mode -------------------------------------------------------
+# Ask the INSTALLED runner whether this box should update right now, and pin the
+# install to the sha the control plane expects.
+#
+# Pinning matters: this must NOT track origin/main. The expected sha is the runner
+# source in the DEPLOYED image — already through CI, the merge queue and a deploy.
+# Installing main instead would run code nothing has deployed, and would leave
+# code_sha != expected_code_sha permanently, so the staleness banner would fire
+# forever on exactly the boxes auto-updating correctly.
+if [ "$IF_STALE" -eq 1 ]; then
+  CHECK_BIN="$(uv tool dir --bin 2>/dev/null)/canopy-runner"
+  [ -x "$CHECK_BIN" ] || CHECK_BIN="$(command -v canopy-runner || true)"
+  if [ -z "$CHECK_BIN" ] || [ ! -x "$CHECK_BIN" ]; then
+    echo "$(date -u +%FT%TZ) --if-stale: no installed runner to check; nothing to do."
+    exit 0
+  fi
+  [ -f "$CONFIG" ] || { echo "$(date -u +%FT%TZ) --if-stale: no config at $CONFIG."; exit 0; }
+  read -r STATUS EXPECTED <<<"$("$CHECK_BIN" update-check --config "$CONFIG" 2>&1 | tail -1)"
+  case "$STATUS" in
+    stale)
+      echo "$(date -u +%FT%TZ) --if-stale: behind — installing ${EXPECTED:0:12}"
+      REF="$EXPECTED"
+      ;;
+    current|busy|unknown)
+      # All "do nothing", and all exit 0: this runs on a timer, so a non-zero
+      # exit for the ordinary case would fill launchd's log with false failures
+      # and train everyone to ignore it.
+      echo "$(date -u +%FT%TZ) --if-stale: $STATUS — nothing to do."
+      exit 0
+      ;;
+    *)
+      # Anything else is the installed runner not understanding `update-check` —
+      # i.e. it predates auto-update. Fail CLOSED (an unparseable answer is not
+      # evidence of anything) but say why, because "nothing to do" forever would
+      # otherwise look exactly like a healthy up-to-date box.
+      echo "$(date -u +%FT%TZ) --if-stale: update-check unavailable from $CHECK_BIN" >&2
+      echo "    (it answered: ${STATUS:-<nothing>}). This runner predates auto-update;" >&2
+      echo "    run install-runner.sh once by hand to pick it up." >&2
+      exit 0
+      ;;
+  esac
+fi
+
 echo "==> fetching $REPO"
 git -C "$REPO" fetch --quiet origin || echo "    (fetch failed — using local refs)"
-git -C "$REPO" rev-parse --verify --quiet "$REF^{commit}" >/dev/null \
-  || { echo "no such ref: $REF" >&2; exit 1; }
+if ! git -C "$REPO" rev-parse --verify --quiet "$REF^{commit}" >/dev/null; then
+  # In auto-update mode this is survivable and self-correcting (the sha may not
+  # have reached this clone yet), so log and wait for the next cycle rather than
+  # failing loudly every 30 minutes.
+  [ "$IF_STALE" -eq 1 ] && { echo "    ref $REF not in this clone yet; will retry."; exit 0; }
+  echo "no such ref: $REF" >&2; exit 1
+fi
 
 # The provenance the runner reports and the server compares against: the last
 # commit that touched the runner's OWN source, NOT the repo HEAD (which moves on
@@ -100,52 +157,71 @@ BIN="$(uv tool dir --bin 2>/dev/null)/canopy-runner"
 echo "==> provisioning the CDP sidecar's node deps"
 "$BIN" install-sidecar
 
-if [ "$DO_LAUNCHD" -eq 1 ]; then
-  PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
-  echo "==> rendering $PLIST"
-  mkdir -p "$HOME/Library/LaunchAgents"
-  # Render to a staging file and VALIDATE before going anywhere near the running
-  # job. Writing straight to $PLIST and then booting out means a malformed
-  # render leaves the daemon stopped with nothing to bootstrap — an "update"
-  # that silently kills the fleet's laptop. Validate first, swap last.
-  sed -e "s|__CANOPY_RUNNER_BIN__|$BIN|g" -e "s|__HOME__|$HOME|g" \
-    "$TMP/packages/canopy_runner/launchd/$LABEL.plist.template" > "$TMP/rendered.plist"
-  plutil -lint "$TMP/rendered.plist" >/dev/null \
-    || { echo "rendered plist is not valid — leaving the running daemon alone" >&2; exit 1; }
-  cp "$TMP/rendered.plist" "$PLIST"
+# Render a plist template, validate it, then reload the job. Shared by the runner
+# and the updater so their failure handling can't drift.
+#
+# Render to a staging file and VALIDATE before going anywhere near the running
+# job: writing straight to the live path and then booting out means a malformed
+# render leaves the job stopped with nothing to bootstrap — an "update" that
+# silently kills the fleet's laptop. Validate first, swap last.
+#
+# `bootout` returns BEFORE launchd has finished tearing the job down, and a
+# bootstrap issued into a domain still holding the old job fails with
+# `Bootstrap failed: 5: Input/output error`, leaving it STOPPED. Hit on the very
+# first real install (2026-07-29); a hand-run retry seconds later succeeded with
+# no other change — the signature of a race, not a bad plist. So wait for the
+# domain to clear, then retry anyway, because the print check races too.
+install_job() {
+  local label="$1" src="$2" dest="$HOME/Library/LaunchAgents/$1.plist"
+  local uid_n booted=0 err="" attempt
+  uid_n="$(id -u)"
 
-  # bootout+bootstrap rather than kickstart: ProgramArguments changed, and
-  # launchd keeps the OLD definition until the job is reloaded.
-  #
-  # `bootout` returns BEFORE launchd has finished tearing the job down, and a
-  # bootstrap issued into a domain still holding the old job fails with
-  # `Bootstrap failed: 5: Input/output error` — leaving the daemon STOPPED.
-  # Hit on the very first real install (2026-07-29); a hand-run retry seconds
-  # later succeeded with no other change, which is the signature of a race
-  # rather than a bad plist. So: wait for the domain to actually clear, then
-  # retry anyway, because the print check races too.
-  UID_N="$(id -u)"
-  launchctl bootout "gui/$UID_N/$LABEL" 2>/dev/null || true
+  echo "==> rendering $dest"
+  mkdir -p "$HOME/Library/LaunchAgents"
+  plutil -lint "$src" >/dev/null \
+    || { echo "rendered plist for $label is not valid — leaving the running job alone" >&2; return 1; }
+  cp "$src" "$dest"
+
+  launchctl bootout "gui/$uid_n/$label" 2>/dev/null || true
   for _ in $(seq 1 20); do
-    launchctl print "gui/$UID_N/$LABEL" >/dev/null 2>&1 || break
+    launchctl print "gui/$uid_n/$label" >/dev/null 2>&1 || break
     sleep 0.5
   done
-
-  booted=0
-  err=""
   for attempt in $(seq 1 5); do
-    if err="$(launchctl bootstrap "gui/$UID_N" "$PLIST" 2>&1)"; then booted=1; break; fi
+    if err="$(launchctl bootstrap "gui/$uid_n" "$dest" 2>&1)"; then booted=1; break; fi
     [ "$attempt" -lt 5 ] && sleep 1
   done
   if [ "$booted" -eq 1 ]; then
-    echo "==> restarted $LABEL"
-  else
-    # Loud, and non-zero: the daemon is now STOPPED, which is the one outcome
-    # nobody would notice on their own until turns stopped being claimed.
-    echo "ERROR: launchctl bootstrap failed after 5 attempts — the runner is NOT running." >&2
-    echo "       launchd said: $err" >&2
-    echo "       Retry with: launchctl bootstrap gui/$UID_N $PLIST" >&2
-    exit 1
+    echo "==> (re)started $label"
+    return 0
+  fi
+  # Loud, and non-zero: the job is now STOPPED, which is the one outcome nobody
+  # notices on their own until turns stop being claimed.
+  echo "ERROR: launchctl bootstrap failed after 5 attempts — $label is NOT running." >&2
+  echo "       launchd said: $err" >&2
+  echo "       Retry with: launchctl bootstrap gui/$uid_n $dest" >&2
+  return 1
+}
+
+if [ "$DO_LAUNCHD" -eq 1 ]; then
+  sed -e "s|__CANOPY_RUNNER_BIN__|$BIN|g" -e "s|__HOME__|$HOME|g" \
+    "$TMP/packages/canopy_runner/launchd/$LABEL.plist.template" > "$TMP/runner.plist"
+  install_job "$LABEL" "$TMP/runner.plist" || exit 1
+
+  if [ "$DO_AUTO_UPDATE" -eq 1 ]; then
+    # The timer job runs the installer FROM THE REPO — the script is not part of
+    # the wheel, and a copy frozen at install time could never fix itself.
+    INSTALLER="$REPO/packages/canopy_runner/scripts/install-runner.sh"
+    if [ -x "$INSTALLER" ]; then
+      sed -e "s|__INSTALLER__|$INSTALLER|g" -e "s|__REPO__|$REPO|g" -e "s|__HOME__|$HOME|g" \
+        "$TMP/packages/canopy_runner/launchd/$UPDATER_LABEL.plist.template" > "$TMP/updater.plist"
+      # A failed updater is NOT fatal: the runner itself is installed and running,
+      # and losing auto-update is strictly less bad than aborting the install.
+      install_job "$UPDATER_LABEL" "$TMP/updater.plist" \
+        || echo "WARNING: auto-update job not installed; updates stay manual." >&2
+    else
+      echo "WARNING: $INSTALLER not found/executable — auto-update job not installed." >&2
+    fi
   fi
 fi
 

--- a/packages/canopy_runner/tests/test_update.py
+++ b/packages/canopy_runner/tests/test_update.py
@@ -1,0 +1,139 @@
+"""Auto-update: should this box install a newer runner right now?
+
+Spec: docs/superpowers/specs/2026-07-28-runner-as-installed-package-design.md
+"""
+import json
+
+import pytest
+
+from canopy_runner import update
+from canopy_runner.config import Config
+
+SHIPPED = "a" * 40
+OLD = "b" * 40
+
+
+@pytest.fixture()
+def cfg(tmp_path):
+    return Config(base_url="http://x", token="t", runner_id="r-1",
+                  emdash_db=str(tmp_path / "e.db"),
+                  state_path=str(tmp_path / "state.json"))
+
+
+class FakeClient:
+    def __init__(self, rows=None, boom=None):
+        self._rows = rows if rows is not None else []
+        self._boom = boom
+        self.calls = []
+
+    def list_runners(self):
+        self.calls.append("list_runners")
+        if self._boom:
+            raise self._boom
+        return self._rows
+
+    def heartbeat(self, *a, **k):
+        pytest.fail("the updater must NEVER heartbeat — it would forge liveness "
+                    "for a daemon that may be dead, and clobber its provenance")
+
+
+def _row(**kw):
+    base = {"id": "r-1", "name": "mbp", "expected_code_sha": SHIPPED}
+    base.update(kw)
+    return base
+
+
+# --- the comparison ---------------------------------------------------------
+
+
+def test_current_when_installed_matches_what_shipped(cfg):
+    status, expected = update.update_status(cfg, FakeClient([_row()]), installed_sha=SHIPPED)
+    assert status == update.CURRENT and expected == SHIPPED
+
+
+def test_stale_when_they_differ_and_nothing_is_in_flight(cfg):
+    status, expected = update.update_status(cfg, FakeClient([_row()]), installed_sha=OLD)
+    assert status == update.STALE and expected == SHIPPED
+
+
+def test_unknown_when_the_server_has_no_expectation(cfg):
+    """A dev server bakes in no RUNNER_CODE_SHA. Empty means UNKNOWN, never
+    "different" — auto-installing an empty sha would be a reinstall loop against
+    a target that does not exist."""
+    status, _ = update.update_status(cfg, FakeClient([_row(expected_code_sha="")]),
+                                     installed_sha=OLD)
+    assert status == update.UNKNOWN
+
+
+def test_unknown_when_this_box_cannot_say_what_it_is_running(cfg):
+    status, _ = update.update_status(cfg, FakeClient([_row()]), installed_sha="")
+    assert status == update.UNKNOWN
+
+
+def test_unknown_when_the_runner_is_not_in_the_fleet_list(cfg):
+    """Retired, or invisible to this token. Reinstalling would not fix either."""
+    status, _ = update.update_status(cfg, FakeClient([_row(id="someone-else")]),
+                                     installed_sha=OLD)
+    assert status == update.UNKNOWN
+
+
+def test_a_flaky_network_never_triggers_an_update(cfg):
+    """The timer fires every 30 min; a blip must not be read as "you're behind"."""
+    status, _ = update.update_status(cfg, FakeClient(boom=RuntimeError("no route")),
+                                     installed_sha=OLD)
+    assert status == update.UNKNOWN
+
+
+# --- the idle gate ----------------------------------------------------------
+
+
+def test_busy_defers_the_update(cfg):
+    """An update restarts the daemon, and a chat turn is bridged across ticks —
+    restarting mid-turn strands the reply."""
+    update.mark_busy(cfg, 2)
+    status, _ = update.update_status(cfg, FakeClient([_row()]), installed_sha=OLD)
+    assert status == update.BUSY
+
+
+def test_idle_marker_allows_the_update(cfg):
+    update.mark_busy(cfg, 0)
+    status, _ = update.update_status(cfg, FakeClient([_row()]), installed_sha=OLD)
+    assert status == update.STALE
+
+
+def test_a_stale_marker_does_not_block_forever(cfg):
+    """The loop rewrites the marker every tick, so an OLD marker means the daemon
+    is not looping — stopped, wedged or crash-looping. That is precisely the case
+    auto-update exists to rescue, so it must not read as "busy" and block the fix."""
+    update.mark_busy(cfg, 5)
+    later = update.BUSY_MARKER_MAX_AGE + 60
+    import time as _t
+    status, _ = update.update_status(cfg, FakeClient([_row()]), installed_sha=OLD,
+                                     now=_t.time() + later)
+    assert status == update.STALE
+
+
+def test_a_missing_marker_does_not_block(cfg):
+    """A runner that has never run has no marker; so does one whose disk write
+    failed. Neither is evidence of work in flight."""
+    assert update.in_flight(cfg) is None
+    status, _ = update.update_status(cfg, FakeClient([_row()]), installed_sha=OLD)
+    assert status == update.STALE
+
+
+def test_a_corrupt_marker_is_treated_as_unknown_not_busy(cfg, tmp_path):
+    (tmp_path / "in-flight").write_text("{not json")
+    assert update.in_flight(cfg) is None
+
+
+def test_mark_busy_survives_an_unwritable_state_dir(tmp_path):
+    bad = Config(base_url="http://x", token="t", runner_id="r-1", emdash_db="x",
+                 state_path="/proc/nope/state.json")
+    update.mark_busy(bad, 1)  # must not raise — a marker failure can't break a turn
+
+
+def test_the_marker_round_trips(cfg):
+    update.mark_busy(cfg, 3)
+    assert update.in_flight(cfg) == 3
+    raw = json.loads((__import__("pathlib").Path(cfg.state_path).parent / "in-flight").read_text())
+    assert raw["count"] == 3 and raw["at"] > 0


### PR DESCRIPTION
Follow-on to #512/#515. A box now fixes its own staleness instead of waiting for someone to notice the banner.

**Observed live while building this:** #513 shipped runner changes and deployed, so `jj-mbp-cdp` sat on the previous sha with the out-of-date banner lit and nothing to act on it. That is the gap this closes.

## Three rules, each load-bearing

**It tracks the DEPLOYED sha, never `origin/main`.** The target is `expected_code_sha` off the runner's own row — the runner source in the deployed image, already through CI + the merge queue + a deploy. Tracking main would install code nothing has deployed *and* leave `code_sha != expected_code_sha` permanently, so the staleness banner would fire forever on exactly the boxes updating correctly. Consequence worth knowing: a merged runner change reaches the fleet when canopy-web is deployed, not at merge.

**It never restarts mid-turn.** A chat turn is bridged *across* ticks, so a restart strands the reply; an agent turn is routed synchronously inside `_claim_and_execute`, so a restart there leaves it EXECUTING with nothing to finish it. The daemon publishes an in-flight count each tick and holds it across the whole claim→execute window; the updater defers on it.

**It is a separate launchd job.** A self-updating runner could ship a version that crash-loops on startup and then never update again — it never heartbeats, never learns it is behind, and stays bricked until a human notices. An independent timer keeps checking whatever state the runner is in, so shipping a fix rescues every box automatically.

## Fail-safe throughout

- **Read-only.** The check asks `GET /runners/` and must never heartbeat — that would stamp the runner ONLINE and overwrite the provenance the real daemon reports, forging liveness for a daemon that may be dead. A test fails if the fake client's `heartbeat` is ever called.
- **Empty means unknown**, never "different" — auto-installing an empty sha would be a reinstall loop against a target that doesn't exist.
- **A flaky network reads as unknown**, not "you're behind".
- **A marker older than 120s does NOT count as busy** — that means the daemon isn't looping (stopped/wedged/crash-looping), which is the case auto-update exists to rescue.
- A failed *updater* install is a warning, not a failed *runner* install.

## Verified against the live control plane

From an isolated install (real tool dir untouched):

```
stale 26d08989c47d     # branch install vs what labs expects
busy  26d08989c47d     # with the in-flight marker set
current …              # when matched
--if-stale: update-check unavailable … predates auto-update   # old installed runner, fails closed with a reason
```

Plus 288 runner tests, 1900 backend, ruff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)