### PR TITLE
fix(runner): String.raw the CDP evaluate source — a template ate the escapes

### DIFF
--- a/packages/canopy_runner/canopy_runner/cdp/emdash_control.mjs
+++ b/packages/canopy_runner/canopy_runner/cdp/emdash_control.mjs
@@ -40,7 +40,15 @@ import { chromium } from 'playwright-core';
 // evaluates ONE EXPRESSION, so prefixing a function DECLARATION produced
 // `function(){}(...)()` — a call on a function expression — and every call failed
 // with "(intermediate value) is not a function".
-const ACTIVE_TERM_FN = `
+// String.raw on every one of these, and it is load-bearing. A plain template
+// literal PROCESSES escapes before Playwright ever sees the source: `\n` became a
+// real newline (so `.join('\n')` produced an unterminated string —
+// "SyntaxError: Invalid or unexpected token" at runtime, nowhere near this file)
+// and `\s` collapsed to a literal `s`, silently turning every `\s*` in these
+// regexes into "zero or more letter s". The file still parsed; only the evaluated
+// string was wrong, which is why `node --check` was clean and the collision guard
+// quietly never matched.
+const ACTIVE_TERM_FN = String.raw`
 function activeTerm() {
   const real = [...document.querySelectorAll('.xterm')].filter(t => {
     if (t.offsetParent === null) return false;
@@ -133,7 +141,7 @@ const openTask = async (task) => {
   // `.xterm-helper-textarea`, so a Playwright .click() fails its viewport check — we
   // focus it via JS (viewport-agnostic) instead, picking the visible xterm (the active
   // task's pane) when several are mounted.
-  const focused = await page.evaluate(`(() => { ${ACTIVE_TERM_FN}; return (() => {
+  const focused = await page.evaluate(String.raw`(() => { ${ACTIVE_TERM_FN}; return (() => {
     const term = activeTerm();
     const ta = (term && term.querySelector('.xterm-helper-textarea'))
       || document.querySelector('textarea[aria-label="Terminal input"]');
@@ -238,7 +246,7 @@ try {
     //
     // Now: the same activeTerm() everything else uses, and the composer read whole
     // (a long unsent line wraps across rows), stripped of marker and box drawing.
-    const readLine = () => page.evaluate(`(() => { ${ACTIVE_TERM_FN}; return (() => {
+    const readLine = () => page.evaluate(String.raw`(() => { ${ACTIVE_TERM_FN}; return (() => {
       const term = activeTerm();
       if (!term) return '';
       const rows = [...term.querySelectorAll('.xterm-rows > div')]
@@ -310,7 +318,7 @@ try {
     // Claude Code draws spaces as ESC[nC.
     const { task } = args;
     await openTask(task);
-    const text = await page.evaluate(`(() => { ${ACTIVE_TERM_FN}; return (() => {
+    const text = await page.evaluate(String.raw`(() => { ${ACTIVE_TERM_FN}; return (() => {
       const term = activeTerm();
       const rows = term && term.querySelector('.xterm-rows');
       if (!rows) return null;
@@ -331,7 +339,7 @@ try {
     // Enter there RUNS something. Reading the wrong pane costs a menu; typing
     // into it is the one outcome worth failing for, so this command alone
     // requires a positive identification instead of falling back.
-    const isClaude = await page.evaluate(`(() => { ${ACTIVE_TERM_FN}; return (() => {
+    const isClaude = await page.evaluate(String.raw`(() => { ${ACTIVE_TERM_FN}; return (() => {
       const term = activeTerm();
       const rows = term && term.querySelector('.xterm-rows');
       const text = rows ? rows.textContent || '' : '';

--- a/packages/canopy_runner/tests/test_cdp_control.py
+++ b/packages/canopy_runner/tests/test_cdp_control.py
@@ -262,3 +262,51 @@ def test_ensure_sidecar_deps_fails_when_npm_claims_success_but_installs_nothing(
                         lambda *a, **k: SimpleNamespace(stdout="", stderr="", returncode=0))
     with pytest.raises(cdp_control.CDPError):
         cdp_control.ensure_sidecar_deps()
+
+
+# -- the evaluated JS must be valid, which node --check cannot tell us ---------
+
+def _evaluate_bodies():
+    """Every string this sidecar hands to page.evaluate, as Playwright sees it."""
+    import re
+    from pathlib import Path
+    src = (Path(__file__).resolve().parents[1] / "canopy_runner" / "cdp"
+           / "emdash_control.mjs").read_text()
+    helper = re.search(r"const ACTIVE_TERM_FN = String\.raw`([\s\S]*?)`;", src)
+    helper_src = helper.group(1) if helper else ""
+    return [m.replace("${ACTIVE_TERM_FN}", helper_src)
+            for m in re.findall(r"page\.evaluate\(String\.raw`([\s\S]*?)`\)", src)]
+
+
+def test_every_evaluate_string_is_valid_javascript():
+    """`node --check` passes on a file whose TEMPLATE contents are broken, because
+    the template is a valid string literal either way. What Playwright receives is
+    the PROCESSED text — and a plain template ate the escapes: `\\n` became a real
+    newline (unterminated string -> "SyntaxError: Invalid or unexpected token" at
+    runtime) and `\\s` collapsed to a literal `s`, turning every `\\s*` into "zero
+    or more letter s". The collision guard silently stopped matching and nothing
+    in CI noticed. String.raw is what prevents it; this test is what catches a
+    regression.
+    """
+    import shutil
+    import subprocess
+    node = shutil.which("node")
+    if node is None:                       # CI without node: nothing to assert
+        return
+    bodies = _evaluate_bodies()
+    assert bodies, "no page.evaluate(String.raw`…`) sites found — did the shape change?"
+    for i, body in enumerate(bodies, start=1):
+        check = subprocess.run(
+            [node, "-e", "new Function('return ' + require('fs').readFileSync(0, 'utf8'))"],
+            input=body, capture_output=True, text=True, timeout=30)
+        assert check.returncode == 0, f"evaluate #{i} is invalid JS: {check.stderr[:300]}"
+
+
+def test_the_evaluate_sites_use_string_raw():
+    """A plain backtick here reintroduces the escape-eating bug."""
+    import re
+    from pathlib import Path
+    src = (Path(__file__).resolve().parents[1] / "canopy_runner" / "cdp"
+           / "emdash_control.mjs").read_text()
+    assert "page.evaluate(`" not in src, "use String.raw` for evaluate source"
+    assert len(re.findall(r"page\.evaluate\(String\.raw`", src)) >= 4


### PR DESCRIPTION
The collision guard *still* never fired after #511, and the reason was invisible to every check we had: **the JS handed to `page.evaluate` was mangled before Playwright saw it.**

Wrapping the evaluate source in a plain template literal means JS processes its escapes first:

- `\n` became a **real newline**, so `.join('\n')` produced an unterminated string — surfacing as `page.evaluate: SyntaxError: Invalid or unexpected token` at runtime, nowhere near this file
- `\s` collapsed to a literal `s`, silently turning every `\s*` in the prompt regexes into *"zero or more letter s"*

**`node --check` was clean throughout**, because the file is valid either way — only the evaluated *string* was wrong. So `read-term` threw and the collision check quietly stopped matching, which is exactly what kept being reported: a chat message appended straight onto a half-typed line.

## Fix

`String.raw` at all four evaluate sites and on `ACTIVE_TERM_FN`.

Two tests, because the existing ones could not see this:
1. extract every evaluate body (with the helper interpolated) and parse it with node — the check that would have caught it
2. fail if a plain backtick reappears at an evaluate site

🤖 Generated with [Claude Code](https://claude.com/claude-code)