### PR TITLE
fix(runner): the auto-updater advertised itself as a stray shell script

### DIFF
--- a/packages/canopy_runner/README.md
+++ b/packages/canopy_runner/README.md
@@ -120,6 +120,12 @@ them together would make the two modules import each other.
      within 30 minutes. `launchctl bootout gui/$(id -u)/com.canopy.runner.updater`
      first, or install with `--no-auto-update`.
 
+   The timer runs `~/.canopy/canopy-runner-update` (a copy of this script placed
+   there by the install) rather than the script in your checkout — macOS names
+   background items after the executable, so pointing at the repo made canopy's
+   updater show up in System Settings › Login Items as `install-runner.sh` from
+   an "unidentified developer".
+
    Its log is `~/.canopy/updater.log`. Ask any box what it thinks with
    `canopy-runner update-check --config ~/.canopy/runner.json`, which prints
    `current|stale|busy|unknown <expected-sha>` and never writes anything.

--- a/packages/canopy_runner/launchd/com.canopy.runner.updater.plist.template
+++ b/packages/canopy_runner/launchd/com.canopy.runner.updater.plist.template
@@ -12,10 +12,16 @@
 
   It runs the INSTALLER, not the runner: `uv tool install --force` replaces the
   runner's venv, and a process cannot safely have its own interpreter and modules
-  swapped out from under it mid-run. The shell script lives in the repo checkout,
-  which this job therefore depends on — but note it can only ever install what
-  `--if-stale` resolves from the control plane, so a stray branch checked out in
-  that repo still cannot change WHAT gets installed.
+  swapped out from under it mid-run.
+
+  __INSTALLER__ is a COPY of install-runner.sh placed at ~/.canopy/canopy-runner-update
+  by the install. Two reasons, both about being legible: macOS names background
+  items after this executable's basename, so pointing at the repo made canopy's
+  updater appear in System Settings as `install-runner.sh` from an "unidentified
+  developer"; and copying from the installed snapshot means a stray `git checkout`
+  in the repo cannot change the script this timer runs. The repo is still the
+  source of the BUILD (--repo, for `git archive`), and `--if-stale` still resolves
+  WHAT to install from the control plane.
 -->
 <plist version="1.0">
 <dict>

--- a/packages/canopy_runner/scripts/install-runner.sh
+++ b/packages/canopy_runner/scripts/install-runner.sh
@@ -209,10 +209,23 @@ if [ "$DO_LAUNCHD" -eq 1 ]; then
   install_job "$LABEL" "$TMP/runner.plist" || exit 1
 
   if [ "$DO_AUTO_UPDATE" -eq 1 ]; then
-    # The timer job runs the installer FROM THE REPO — the script is not part of
-    # the wheel, and a copy frozen at install time could never fix itself.
-    INSTALLER="$REPO/packages/canopy_runner/scripts/install-runner.sh"
-    if [ -x "$INSTALLER" ]; then
+    # Install THIS script to a stable, self-describing path and point the timer
+    # job at that — not at the copy in the repo.
+    #
+    # macOS names every entry in System Settings › Login Items › "App Background
+    # Activity" after the basename of ProgramArguments[0]. Pointing at the repo
+    # made canopy's updater show up as `install-runner.sh` — "Item from
+    # unidentified developer" — a bare shell script running from a git checkout,
+    # indistinguishable at a glance from something you would want to kill, and
+    # with nothing tying it to canopy. It now reads `canopy-runner-update`.
+    #
+    # Copied from the SNAPSHOT ($TMP), not the working tree, for the same reason
+    # everything else here is: what gets installed is the ref, never whatever
+    # happens to be checked out. That also means a `git checkout` in the repo can
+    # no longer change the script the timer executes — only an install can.
+    INSTALLER="$HOME/.canopy/canopy-runner-update"
+    mkdir -p "$HOME/.canopy"
+    if install -m 755 "$TMP/packages/canopy_runner/scripts/install-runner.sh" "$INSTALLER"; then
       sed -e "s|__INSTALLER__|$INSTALLER|g" -e "s|__REPO__|$REPO|g" -e "s|__HOME__|$HOME|g" \
         "$TMP/packages/canopy_runner/launchd/$UPDATER_LABEL.plist.template" > "$TMP/updater.plist"
       # A failed updater is NOT fatal: the runner itself is installed and running,
@@ -220,7 +233,7 @@ if [ "$DO_LAUNCHD" -eq 1 ]; then
       install_job "$UPDATER_LABEL" "$TMP/updater.plist" \
         || echo "WARNING: auto-update job not installed; updates stay manual." >&2
     else
-      echo "WARNING: $INSTALLER not found/executable — auto-update job not installed." >&2
+      echo "WARNING: could not install $INSTALLER — auto-update job not installed." >&2
     fi
   fi
 fi


### PR DESCRIPTION
Spotted by looking at System Settings › Login Items › "App Background Activity", not by anything in the code.

## The problem

macOS names background items after the basename of `ProgramArguments[0]`. The updater job (#518) pointed at the installer inside the git checkout, so canopy's auto-updater presented itself as:

> **install-runner.sh** — *Item from unidentified developer.*

A bare shell script running out of a repo, with nothing tying it to canopy and nothing to distinguish it from something you'd want to switch off. The three canopy entries read `Canopy Runner`, `canopy-runner`, and… `install-runner.sh`.

## The fix

The install places a copy at `~/.canopy/canopy-runner-update` and points the timer there. The entry now reads `canopy-runner-update`, beside its siblings.

Copied from the **snapshot**, not the working tree — matching the rest of this design: what gets installed is the ref, never whatever happens to be checked out. Side effect worth having: a stray `git checkout` in the repo can no longer change the script the timer executes; only an install can. The repo remains the *build* source (`--repo`, for `git archive`), and `--if-stale` still resolves *what* to install from the control plane.

## Verified on the live box

```
$ plutil -extract ProgramArguments json -o - ~/Library/LaunchAgents/com.canopy.runner.updater.plist
["/Users/jjackson/.canopy/canopy-runner-update","--if-stale","--repo","/Users/jjackson/emdash-projects/canopy-web"]

$ launchctl kickstart gui/501/com.canopy.runner.updater
2026-07-29T12:14:15Z --if-stale: current — nothing to do.
```

289 runner tests, ruff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)