### PR TITLE
fix(runner): find the composer by structure, not by scanning the last 14 rows

### DIFF
--- a/packages/canopy_runner/canopy_runner/cdp/emdash_control.mjs
+++ b/packages/canopy_runner/canopy_runner/cdp/emdash_control.mjs
@@ -40,7 +40,15 @@ import { chromium } from 'playwright-core';
 // evaluates ONE EXPRESSION, so prefixing a function DECLARATION produced
 // `function(){}(...)()` — a call on a function expression — and every call failed
 // with "(intermediate value) is not a function".
-const ACTIVE_TERM_FN = `
+// String.raw on every one of these, and it is load-bearing. A plain template
+// literal PROCESSES escapes before Playwright ever sees the source: `\n` became a
+// real newline (so `.join('\n')` produced an unterminated string —
+// "SyntaxError: Invalid or unexpected token" at runtime, nowhere near this file)
+// and `\s` collapsed to a literal `s`, silently turning every `\s*` in these
+// regexes into "zero or more letter s". The file still parsed; only the evaluated
+// string was wrong, which is why `node --check` was clean and the collision guard
+// quietly never matched.
+const ACTIVE_TERM_FN = String.raw`
 function activeTerm() {
   const real = [...document.querySelectorAll('.xterm')].filter(t => {
     if (t.offsetParent === null) return false;
@@ -59,6 +67,44 @@ function activeTerm() {
     return /[⏺✻⎿]/.test(text) || /esc to interrupt|shift\\+tab to cycle/i.test(text);
   });
   return claudeish || byArea[0];
+}
+`;
+
+// WHERE the composer is, structurally — not "the last rows". The input line is
+// the `❯` row sitting directly UNDER a box rule (with the closing rule below and
+// the status bar under that); historical `❯` user messages in scrollback never
+// have that rule. The scan covers the WHOLE viewport, top-bounded by nothing and
+// bottom-bounded by the status bar when one is rendered, because a FRESH session
+// draws its TUI at the TOP of the pane (measured live, #521: composer at row 13
+// of 38, rows 24–37 all empty) — any "last N rows" window reads exactly those
+// sessions as empty and blind-appends. Returns {found, text}:
+//   found:false  = no composer in the rendered frame (mid-redraw, a menu is up,
+//                  or a clipped stale frame) — the caller must NOT treat this as
+//                  "empty and safe to send"; it cannot see what a send would hit.
+//   found:true   = composer visible; `text` is its content ('' = genuinely empty;
+//                  NBSP — what an empty composer actually holds after ❯ — is
+//                  normalized to space before trimming).
+const COMPOSER_FN = String.raw`
+function composerText(rows) {
+  const norm = rows.map(r => (r || '').replace(/\u00a0/g, ' '));
+  const isRule = (s) => /^\s*[╭╰]?─{8,}[╮╯]?\s*$/.test(s);
+  const isStatus = (s) => /⏵⏵|bypass permissions|shift\+tab to cycle|esc to interrupt/i.test(s);
+  let hi = norm.length - 1;
+  for (let i = norm.length - 1; i >= 0; i--) {
+    if (isStatus(norm[i])) { hi = i - 1; break; }
+  }
+  for (let i = hi; i >= 1; i--) {
+    if (!/^\s*(?:[│|]\s*)?[>❯]/.test(norm[i])) continue;
+    if (!isRule(norm[i - 1])) continue;
+    const strip = (s) => s.replace(/^\s*(?:[│|]\s*)?/, '').replace(/\s*[│|]\s*$/, '');
+    const parts = [strip(norm[i]).replace(/^[>❯]\s?/, '')];
+    for (let j = i + 1; j <= hi; j++) {
+      if (isRule(norm[j])) break;
+      parts.push(strip(norm[j]));
+    }
+    return { found: true, text: parts.join(' ').trim() };
+  }
+  return { found: false, text: '' };
 }
 `;
 
@@ -133,7 +179,7 @@ const openTask = async (task) => {
   // `.xterm-helper-textarea`, so a Playwright .click() fails its viewport check — we
   // focus it via JS (viewport-agnostic) instead, picking the visible xterm (the active
   // task's pane) when several are mounted.
-  const focused = await page.evaluate(`(() => { ${ACTIVE_TERM_FN}; return (() => {
+  const focused = await page.evaluate(String.raw`(() => { ${ACTIVE_TERM_FN}; return (() => {
     const term = activeTerm();
     const ta = (term && term.querySelector('.xterm-helper-textarea'))
       || document.querySelector('textarea[aria-label="Terminal input"]');
@@ -213,51 +259,40 @@ try {
     const { task, text, clearFirst } = args;
     await openTask(task);
 
-    // Read whatever is ALREADY sitting in the prompt. claude's TUI renders its input
-    // inside a bordered box; the input line is the last visible row carrying a '>'
-    // prompt marker. A non-empty line here means the human was typing when emdash
-    // switched to this task and their keystrokes leaked in — a COLLISION we must NOT
-    // clobber blindly. Heuristic + version-fragile: on any ambiguity it returns '',
-    // which takes the fast send path (never worse than the pre-collision behaviour, and
-    // no false-positive dialog).
-    // Is there ANY text sitting in the composer? That is the whole question — not
-    // "parse the prompt line", which is what this used to attempt and why it kept
-    // failing open. Two defects, both silent:
+    // Read whatever is ALREADY sitting in the composer. Non-empty means the human
+    // was typing when emdash switched to this task and their keystrokes leaked in —
+    // a COLLISION we must NOT clobber blindly (insertText APPENDS and Enter submits
+    // the concatenation; verified live 2026-07-28, a half-typed thought and a chat
+    // message reached the agent as ONE line).
     //
-    //   1. it matched '>' as the prompt marker; Claude Code's TUI draws U+276F (❯),
-    //      so every real prompt read as EMPTY;
-    //   2. it picked its own `terms[0]` under the loose width>0 filter, which admits
-    //      the 16x16 ghost terminals emdash keeps mounted for other tasks — so it
-    //      could answer about a different session entirely (observed: it returned
-    //      another agent's prompt).
-    //
-    // Either one makes isEmpty('') true, and the send takes the fast path:
-    // insertText APPENDS to whatever the human half-typed and Enter submits the
-    // concatenation. Verified live 2026-07-28 — "half typed thought" and a chat
-    // message reached the agent as ONE line, with no dialog.
-    //
-    // Now: the same activeTerm() everything else uses, and the composer read whole
-    // (a long unsent line wraps across rows), stripped of marker and box drawing.
-    const readLine = () => page.evaluate(`(() => { ${ACTIVE_TERM_FN}; return (() => {
+    // Detection is structural (COMPOSER_FN: the ❯ row directly under a box rule,
+    // whole viewport, status-bar bounded) — NOT a "last N rows" scan. The previous
+    // window read a FRESH session as empty every time, because a fresh session
+    // draws its composer near the TOP of the pane (measured: row 13 of 38, the
+    // whole scanned window blank) — which is exactly the state every new chat
+    // session is in (#521).
+    const readComposer = () => page.evaluate(String.raw`(() => { ${ACTIVE_TERM_FN}; ${COMPOSER_FN}; return (() => {
       const term = activeTerm();
-      if (!term) return '';
-      const rows = [...term.querySelectorAll('.xterm-rows > div')]
-        .map(r => (r.textContent || '').replace(/\u00a0/g, ' '));
-      for (let i = rows.length - 1; i >= 0 && i >= rows.length - 14; i--) {
-        const m = rows[i].match(/(?:^|[│|])\s*[>❯]\s?(.*)$/);
-        if (!m) continue;
-        const parts = [m[1] || ''];
-        for (let j = i + 1; j < rows.length; j++) {
-          const next = rows[j];
-          if (/^[\s│|─╭╮╰╯]*$/.test(next)) break;         // blank line or a box rule
-          if (/^\s*[>❯]/.test(next)) break;                // a new prompt begins
-          if (/⏵⏵|shift\+tab to cycle/.test(next)) break;  // the status bar
-          parts.push(next);
-        }
-        return parts.join(' ').replace(/[│|─╭╮╰╯]/g, '').trim();
-      }
-      return '';
+      if (!term) return { found: false, text: '' };
+      const rows = [...term.querySelectorAll('.xterm-rows > div')].map(r => r.textContent || '');
+      return composerText(rows);
     })(); })()`);
+    // A frame with no composer is UNREADABLE, not empty: mid-redraw right after the
+    // task click, a menu/dialog covering the input, or a clipped stale frame (all
+    // observed live). Re-read a few times for the transient cases, then fail closed —
+    // a blind send would append into a composer we cannot see. The runner treats a
+    // CDPError as "task exists but undrivable" and retries the turn; it never
+    // duplicates the session.
+    let composer = { found: false, text: '' };
+    for (let attempt = 0; attempt < 4; attempt++) {
+      composer = await readComposer();
+      if (composer.found) break;
+      await page.waitForTimeout(400);
+    }
+    if (!composer.found) {
+      fail(`COMPOSER_NOT_VISIBLE: no input line in the rendered frame for task "${task}" ` +
+           `(mid-redraw, a menu is up, or a stale frame) — refusing a blind send`);
+    }
     // Ghost/placeholder hints claude shows in an EMPTY input — treat as empty so the
     // fast path still fires instead of popping a spurious collision dialog.
     const PLACEHOLDER = /^(Try |Ask |\/ for |\? for )/i;
@@ -270,7 +305,8 @@ try {
       // TUI actually honors). Leaked text is "the last few words", so this is short.
       await page.keyboard.press('Control+U');
       for (let i = 0; i < 6; i++) {
-        const n = Math.min((await readLine()).length, 300);
+        const cur = await readComposer();
+        const n = Math.min(cur.found ? cur.text.length : 0, 300);
         if (n === 0) break;
         await page.keyboard.press('End');
         for (let k = 0; k < n; k++) await page.keyboard.press('Backspace');
@@ -278,16 +314,13 @@ try {
       await page.keyboard.insertText(text);
       await page.keyboard.press('Enter');
       out({ ok: true, action: 'sent-cleared', task });
+    } else if (!isEmpty(composer.text)) {
+      // Don't touch it — hand the collision back to the runner to ask the human.
+      out({ ok: true, action: 'collision', task, line: composer.text });
     } else {
-      const line = await readLine();
-      if (!isEmpty(line)) {
-        // Don't touch it — hand the collision back to the runner to ask the human.
-        out({ ok: true, action: 'collision', task, line });
-      } else {
-        await page.keyboard.insertText(text);   // atomic commit, not char-by-char
-        await page.keyboard.press('Enter');
-        out({ ok: true, action: 'sent', task });
-      }
+      await page.keyboard.insertText(text);   // atomic commit, not char-by-char
+      await page.keyboard.press('Enter');
+      out({ ok: true, action: 'sent', task });
     }
 
   } else if (command === 'interrupt') {
@@ -310,7 +343,7 @@ try {
     // Claude Code draws spaces as ESC[nC.
     const { task } = args;
     await openTask(task);
-    const text = await page.evaluate(`(() => { ${ACTIVE_TERM_FN}; return (() => {
+    const text = await page.evaluate(String.raw`(() => { ${ACTIVE_TERM_FN}; return (() => {
       const term = activeTerm();
       const rows = term && term.querySelector('.xterm-rows');
       if (!rows) return null;
@@ -331,7 +364,7 @@ try {
     // Enter there RUNS something. Reading the wrong pane costs a menu; typing
     // into it is the one outcome worth failing for, so this command alone
     // requires a positive identification instead of falling back.
-    const isClaude = await page.evaluate(`(() => { ${ACTIVE_TERM_FN}; return (() => {
+    const isClaude = await page.evaluate(String.raw`(() => { ${ACTIVE_TERM_FN}; return (() => {
       const term = activeTerm();
       const rows = term && term.querySelector('.xterm-rows');
       const text = rows ? rows.textContent || '' : '';

--- a/packages/canopy_runner/canopy_runner/cdp_control.py
+++ b/packages/canopy_runner/canopy_runner/cdp_control.py
@@ -180,7 +180,10 @@ def open_and_send(task: str, text: str, *, clear_first: bool = False, port: int 
     may re-call with ``clear_first=True`` to kill the current line first, then send
     (``{"action": "sent-cleared"}``).
 
-    Raises CDPError if the task isn't present (caller falls back to create+rehydrate)."""
+    Raises CDPError if the task isn't present (caller falls back to create+rehydrate),
+    or with ``COMPOSER_NOT_VISIBLE`` if the rendered frame shows no input line
+    (mid-redraw, a menu is up, or a stale frame) — the sidecar refuses a blind send
+    it can't verify; the caller fails the turn for retry rather than duplicating."""
     args = {"port": port, "task": task, "text": text}
     if clear_first:
         args["clearFirst"] = True

--- a/packages/canopy_runner/tests/test_cdp_control.py
+++ b/packages/canopy_runner/tests/test_cdp_control.py
@@ -262,3 +262,152 @@ def test_ensure_sidecar_deps_fails_when_npm_claims_success_but_installs_nothing(
                         lambda *a, **k: SimpleNamespace(stdout="", stderr="", returncode=0))
     with pytest.raises(cdp_control.CDPError):
         cdp_control.ensure_sidecar_deps()
+
+
+# -- the evaluated JS must be valid, which node --check cannot tell us ---------
+
+def _evaluate_bodies():
+    """Every string this sidecar hands to page.evaluate, as Playwright sees it."""
+    import re
+    from pathlib import Path
+    src = (Path(__file__).resolve().parents[1] / "canopy_runner" / "cdp"
+           / "emdash_control.mjs").read_text()
+    helpers = {name: (re.search(rf"const {name} = String\.raw`([\s\S]*?)`;", src) or [None, ""])[1]
+               for name in ("ACTIVE_TERM_FN", "COMPOSER_FN")}
+    bodies = []
+    for m in re.findall(r"page\.evaluate\(String\.raw`([\s\S]*?)`\)", src):
+        for name, helper_src in helpers.items():
+            m = m.replace("${" + name + "}", helper_src)
+        bodies.append(m)
+    return bodies
+
+
+def test_every_evaluate_string_is_valid_javascript():
+    """`node --check` passes on a file whose TEMPLATE contents are broken, because
+    the template is a valid string literal either way. What Playwright receives is
+    the PROCESSED text — and a plain template ate the escapes: `\\n` became a real
+    newline (unterminated string -> "SyntaxError: Invalid or unexpected token" at
+    runtime) and `\\s` collapsed to a literal `s`, turning every `\\s*` into "zero
+    or more letter s". The collision guard silently stopped matching and nothing
+    in CI noticed. String.raw is what prevents it; this test is what catches a
+    regression.
+    """
+    import shutil
+    import subprocess
+    node = shutil.which("node")
+    if node is None:                       # CI without node: nothing to assert
+        return
+    bodies = _evaluate_bodies()
+    assert bodies, "no page.evaluate(String.raw`…`) sites found — did the shape change?"
+    for i, body in enumerate(bodies, start=1):
+        check = subprocess.run(
+            [node, "-e", "new Function('return ' + require('fs').readFileSync(0, 'utf8'))"],
+            input=body, capture_output=True, text=True, timeout=30)
+        assert check.returncode == 0, f"evaluate #{i} is invalid JS: {check.stderr[:300]}"
+
+
+def test_the_evaluate_sites_use_string_raw():
+    """A plain backtick here reintroduces the escape-eating bug."""
+    import re
+    from pathlib import Path
+    src = (Path(__file__).resolve().parents[1] / "canopy_runner" / "cdp"
+           / "emdash_control.mjs").read_text()
+    assert "page.evaluate(`" not in src, "use String.raw` for evaluate source"
+    assert len(re.findall(r"page\.evaluate\(String\.raw`", src)) >= 4
+
+
+# -- composer detection: the collision guard's core, exercised under node ------
+#
+# The scan is a pure function over the rendered viewport rows (COMPOSER_FN in
+# emdash_control.mjs), so these fixtures ARE the bug reports: the fresh-session
+# layout below is the measured live state that made readLine() return '' for a
+# composer holding text (canopy-web #521 — composer at row 13 of 38, rows 24-37
+# all empty, and the old scan only looked at the last 14 rows).
+
+def _composer_fn_source():
+    import re
+    from pathlib import Path
+    src = (Path(__file__).resolve().parents[1] / "canopy_runner" / "cdp"
+           / "emdash_control.mjs").read_text()
+    m = re.search(r"const COMPOSER_FN = String\.raw`([\s\S]*?)`;", src)
+    assert m, "COMPOSER_FN not found in emdash_control.mjs"
+    return m.group(1)
+
+
+def _composer(rows):
+    import shutil
+    import subprocess
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("node not installed")
+    script = (_composer_fn_source()
+              + "\nconst rows = JSON.parse(require('fs').readFileSync(0, 'utf8'));"
+              + "\nprocess.stdout.write(JSON.stringify(composerText(rows)));")
+    out = subprocess.run([node, "-e", script], input=json.dumps(rows),
+                         capture_output=True, text=True, timeout=30)
+    assert out.returncode == 0, f"composerText crashed: {out.stderr[:300]}"
+    return json.loads(out.stdout)
+
+
+_RULE = "─" * 90
+_STATUS = "  ⏵⏵ bypass permissions on (shift+tab to cycle)"
+
+
+def _fresh_session(*composer_rows):
+    """Measured live 2026-07-29: a fresh session draws its TUI at the TOP of the
+    pane — composer around row 13 of 38, everything below the status bar empty."""
+    return (["  word: ready. Then do nothing further and wait.", "",
+             "⏺ ready", "", "✻ Worked for 3s", "",
+             _RULE, *composer_rows, _RULE, _STATUS] + [""] * 24)
+
+
+def test_fresh_session_planted_text_is_found():
+    # THE #521 repro: planted text in a fresh session's composer, far above the
+    # bottom of the pane. The old last-14-rows scan returned '' here.
+    r = _composer(_fresh_session("❯ hi "))
+    assert r == {"found": True, "text": "hi"}
+
+
+def test_filled_session_bottom_composer():
+    rows = (["⏺ some transcript"] * 30
+            + [_RULE, "❯ okay so any changes we should do here?", _RULE,
+               _STATUS + " · esc to interrupt", "", ""])
+    r = _composer(rows)
+    assert r == {"found": True, "text": "okay so any changes we should do here?"}
+
+
+def test_empty_composer_reads_empty_not_missing():
+    # An empty composer is '❯' + NBSP + trailing spaces. That is EMPTY (send),
+    # never NOT-VISIBLE (refuse) — conflating them would wedge every send.
+    r = _composer(_fresh_session("❯   "))
+    assert r == {"found": True, "text": ""}
+
+
+def test_wrapped_composer_joins_rows():
+    r = _composer(_fresh_session("❯ a long unsent line that", "  wraps onto more rows"))
+    assert r["found"] is True
+    assert r["text"] == "a long unsent line that wraps onto more rows"
+
+
+def test_scrollback_prompt_without_rule_is_not_the_composer():
+    # Historical user messages also render with a ❯ prefix, but never with a box
+    # rule directly above. A stale frame showing only transcript must read as
+    # NOT VISIBLE, not as a collision with an old message.
+    rows = ["⏺ doing things", "", "❯ an old user message in scrollback",
+            "", "⏺ more output", "✻ Worked for 12m 35s"]
+    r = _composer(rows)
+    assert r == {"found": False, "text": ""}
+
+
+def test_clipped_frame_has_no_composer():
+    # The live state observed on a just-switched-to pane: transcript ends mid-
+    # frame, no composer, no status bar. Must be NOT VISIBLE so open-send fails
+    # closed instead of blind-appending into the off-screen composer.
+    rows = ["⏺ transcript"] * 38
+    r = _composer(rows)
+    assert r == {"found": False, "text": ""}
+
+
+def test_legacy_gt_marker_still_matches():
+    r = _composer(_fresh_session("> typed with the old marker"))
+    assert r == {"found": True, "text": "typed with the old marker"}


### PR DESCRIPTION
Fixes #521 — chat sends appending onto a busy composer.

## Root cause (two of them)

**1. The bug the issue asked for.** `readLine()` scanned only the last 14 viewport rows for the prompt marker, assuming Claude Code's TUI is bottom-anchored. A **fresh session draws its frame at the top of the pane** — measured live: planted text in the composer at row 13 of 38, with rows 24–37 (the entire scanned window) blank. So `readLine()` returned `''` for a composer that visibly held text, and open-send blind-appended. Fresh chat sessions are exactly the sessions chat sends target, which is why this hit chat every time while long, screen-filling sessions read fine.

**2. #520 silently reverted #519.** The refactor merge ("pure movement, no behaviour change") put the `.mjs` back to plain template literals at all five `String.raw` sites *and deleted the 48-line guard-test block that existed to catch precisely that*. The auto-updater (#518) then installed the reverted build 27 minutes after the merge — so the box that verified #519 was un-fixed under it. Both are re-applied here; the guard test now also interpolates `COMPOSER_FN`.

## The fix

- `COMPOSER_FN` — a pure, node-tested function: the composer is the `❯` row **directly under a box rule**, scanned over the whole viewport, bounded below by the status bar. Scrollback `❯` messages never have the rule above, so no window is needed to avoid them (the issue's "anchor between the rules / relative to the status bar" suggestion, implemented).
- Distinguishes **empty** (`found:true, text:''` → send) from **not visible** (`found:false` → retry ×4 over ~1.6s, then fail closed with `COMPOSER_NOT_VISIBLE`). The not-visible state is real and was observed live: a just-switched-to pane rendering a clipped frame with no composer and no status bar. Blind-sending there is exactly the appending bug in another costume. A `CDPError` takes the existing "task exists but undrivable → fail the turn for retry, never duplicate" path in `execute.py`; no new wiring.

## Live verification (throwaway emdash session `collision-debug-521`)

- plant `hi` → open-send → `{"action":"collision","line":"hi"}`, composer left untouched (re-read shows `❯ hi` intact)
- `clearFirst` → `sent-cleared`; agent received **only** the new message and replied `delivered`
- empty composer → `sent`; agent confirmed the message arrived standalone ("no appended text before or after it")

`298` runner tests pass, including 7 new fixture tests for `COMPOSER_FN` (the fresh-session repro layout is the first fixture) and the restored #519 guards.

## Notes

- The open judgment call in the issue — chat's **New session / timeout defers the turn for retry** rather than spawning a fresh session — is deliberately **unchanged**; this PR only fixes detection upstream of that choice.
- The throwaway emdash task `collision-debug-521` can be deleted from the sidebar whenever.
- Worth a thought beyond this PR: #520 reverting #519 was a stale-branch merge artifact that CI couldn't catch *because the same merge deleted the tests*. The queue tested the merged result faithfully — the result just no longer contained the guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)