### PR TITLE
feat(chat): a mic in the composer — dictate instead of typing on a phone

### DIFF
--- a/frontend/packages/canopy-ui/src/chat/SendBox.tsx
+++ b/frontend/packages/canopy-ui/src/chat/SendBox.tsx
@@ -1,4 +1,5 @@
 import {
+  useCallback,
   useEffect,
   useRef,
   useState,
@@ -6,9 +7,11 @@ import {
   type ReactNode,
 } from "react";
 import type React from "react";
+import { Mic, Square } from "lucide-react";
 
 import type { Draft } from "./protocol";
 import { isDraftIdle, msUntilDraftIdle } from "./drafts";
+import { useDictation } from "./useDictation";
 import { Button } from "../ui/button";
 
 /** An attachment the composer is holding, uploaded but not yet sent. */
@@ -120,6 +123,21 @@ export function SendBox({
   }, [canEdit, isHolder]);
 
   const body = localBody;
+  // Mirrors localBody so a caller that writes twice before React re-renders
+  // (SpeechRecognition can finalize two utterances in one tick) reads what the
+  // previous write produced rather than a body from the last paint.
+  const bodyRef = useRef(localBody);
+  bodyRef.current = localBody;
+
+  const commit = useCallback(
+    (value: string) => {
+      bodyRef.current = value;
+      setLocalBody(value);
+      onUpdate(value);
+    },
+    [onUpdate],
+  );
+
   const blocked = Boolean(disabledReason);
   // Sending needs a draft (`chat.send` commits the SERVER's copy, so there must
   // be one) AND a live socket. The socket check is load-bearing now that the
@@ -134,10 +152,29 @@ export function SendBox({
     !isStreaming &&
     !blocked;
 
-  const handleChange = (value: string) => {
-    setLocalBody(value);
-    onUpdate(value);
-  };
+  const handleChange = (value: string) => commit(value);
+
+  // Dictation writes into the same local-first draft the keyboard writes into,
+  // so a spoken message and a typed one are the same message. Only FINALIZED
+  // utterances land here — interim text is displayed beside the mic and never
+  // enters the draft, which syncs to the server on every change.
+  const appendDictated = useCallback(
+    (text: string) => {
+      const prev = bodyRef.current.trimEnd();
+      commit(prev ? `${prev} ${text}` : text);
+    },
+    [commit],
+  );
+  const dictation = useDictation(appendDictated);
+  const canDictate = dictation.supported && canEdit && !blocked;
+
+  // The mic can lose its right to write mid-utterance — a teammate takes the
+  // draft, or the host blocks the composer. Hiding the button would otherwise
+  // leave recognition running with no visible way to end it.
+  const dictationStop = dictation.stop;
+  useEffect(() => {
+    if (!canDictate) dictationStop();
+  }, [canDictate, dictationStop]);
 
   const canAttach = typeof onAttach === "function" && canEdit && !blocked;
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -159,9 +196,14 @@ export function SendBox({
   };
 
   const handleSend = () => {
+    // A message that has been sent is finished being dictated. Leaving the mic
+    // hot would drop the next sentence into an empty composer with nothing on
+    // screen saying why it was still listening.
+    dictation.stop();
     // Clear locally rather than waiting for the server's cleared draft to
     // echo back: that echo carries last_editor === us, which the adopt rule
     // above (correctly) ignores, so nothing else would empty the box.
+    bodyRef.current = "";
     setLocalBody("");
     onSend();
   };
@@ -251,36 +293,62 @@ export function SendBox({
           className="w-full resize-none rounded-md border border-input bg-transparent p-2 text-sm text-foreground shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:bg-muted disabled:text-muted-foreground"
         />
         <div className="mt-1 flex items-center justify-end gap-2">
-          {canAttach && (
-            <>
-              <input
-                ref={fileInputRef}
-                type="file"
-                multiple
-                accept="image/*"
-                className="hidden"
-                data-testid="attachment-input"
-                onChange={(e) => {
-                  take(e.target.files);
-                  e.target.value = "";  // same file twice in a row must re-fire
-                }}
-              />
+          <div className="mr-auto flex min-w-0 items-center gap-2">
+            {canAttach && (
+              <>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  multiple
+                  accept="image/*"
+                  className="hidden"
+                  data-testid="attachment-input"
+                  onChange={(e) => {
+                    take(e.target.files);
+                    e.target.value = "";  // same file twice in a row must re-fire
+                  }}
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => fileInputRef.current?.click()}
+                >
+                  attach
+                </Button>
+              </>
+            )}
+            {canDictate && (
               <Button
                 type="button"
-                variant="outline"
-                size="sm"
-                className="mr-auto"
-                onClick={() => fileInputRef.current?.click()}
+                variant={dictation.listening ? "destructive" : "outline"}
+                size="icon-sm"
+                aria-label={
+                  dictation.listening ? "Stop dictation" : "Start dictation"
+                }
+                aria-pressed={dictation.listening}
+                onClick={dictation.toggle}
               >
-                attach
+                {dictation.listening ? (
+                  <Square className="size-3 fill-current" aria-hidden />
+                ) : (
+                  <Mic aria-hidden />
+                )}
               </Button>
-            </>
-          )}
-          {blocked && (
-            <span className="mr-auto text-xs text-muted-foreground">
-              {disabledReason}
-            </span>
-          )}
+            )}
+            {dictation.listening && (
+              // Italic because these words are provisional — the recognizer
+              // rewrites them until it finalizes the phrase.
+              <span className="min-w-0 truncate text-xs text-muted-foreground italic">
+                {dictation.interim || "Listening…"}
+              </span>
+            )}
+            {blocked && (
+              <span className="text-xs text-muted-foreground">
+                {disabledReason}
+              </span>
+            )}
+          </div>
           {isStreaming ? (
             <Button
               type="button"

--- a/frontend/packages/canopy-ui/src/chat/index.ts
+++ b/frontend/packages/canopy-ui/src/chat/index.ts
@@ -28,6 +28,7 @@ export {
   type UseSessionSocketResult,
 } from "./useSessionSocket";
 export { useStickyBottom } from "./useStickyBottom";
+export { useDictation, type DictationHandle } from "./useDictation";
 
 // Draft idle helpers
 export { IDLE_THRESHOLD_MS, isDraftIdle, msUntilDraftIdle } from "./drafts";

--- a/frontend/packages/canopy-ui/src/chat/useDictation.test.tsx
+++ b/frontend/packages/canopy-ui/src/chat/useDictation.test.tsx
@@ -1,0 +1,261 @@
+/**
+ * Dictation is the composer's answer to "let me talk instead of type".
+ *
+ * A web page cannot put the Android keyboard into its mic mode — no such API
+ * exists — so the mic button drives SpeechRecognition directly and writes into
+ * the same local-first draft the keyboard writes into. Two properties matter
+ * and are pinned here:
+ *
+ *   * FINAL text goes into the draft; INTERIM text never does. The draft syncs
+ *     to the server on every change, and streaming provisional recognition
+ *     through it would churn the draft version on words about to be rewritten.
+ *   * Where the API is absent (most desktop Firefox, older iOS) the hook says
+ *     unsupported and the button is not rendered at all — no dead control.
+ */
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, render, screen, fireEvent } from "@testing-library/react";
+
+import { SendBox } from "./SendBox";
+import type { Draft } from "./protocol";
+
+const ME = 1;
+
+interface FakeResult {
+  transcript: string;
+  isFinal: boolean;
+}
+
+/** Stands in for the browser's SpeechRecognition, which jsdom has none of. */
+class FakeRecognition {
+  static instances: FakeRecognition[] = [];
+  continuous = false;
+  interimResults = false;
+  lang = "";
+  onresult: ((event: unknown) => void) | null = null;
+  onend: (() => void) | null = null;
+  started = false;
+  aborted = false;
+
+  constructor() {
+    FakeRecognition.instances.push(this);
+  }
+
+  start() {
+    if (this.started) throw new Error("InvalidStateError");
+    this.started = true;
+  }
+
+  stop() {
+    // The real API funnels every stop through onend, including this one.
+    this.onend?.();
+  }
+
+  abort() {
+    this.aborted = true;
+  }
+
+  emit(results: FakeResult[], resultIndex = 0) {
+    const list = results.map((r) => ({
+      isFinal: r.isFinal,
+      0: { transcript: r.transcript },
+      length: 1,
+    }));
+    act(() => {
+      this.onresult?.({ resultIndex, results: list });
+    });
+  }
+
+  static latest(): FakeRecognition {
+    const rec = FakeRecognition.instances.at(-1);
+    if (!rec) throw new Error("no recognition was constructed");
+    return rec;
+  }
+}
+
+function installSpeechRecognition() {
+  FakeRecognition.instances = [];
+  (window as unknown as Record<string, unknown>).SpeechRecognition =
+    FakeRecognition;
+}
+
+afterEach(() => {
+  cleanup();
+  delete (window as unknown as Record<string, unknown>).SpeechRecognition;
+  delete (window as unknown as Record<string, unknown>).webkitSpeechRecognition;
+  FakeRecognition.instances = [];
+});
+
+function draft(overrides: Partial<Draft> = {}): Draft {
+  return {
+    id: "d1",
+    body: "",
+    version: 1,
+    last_editor: ME,
+    last_edit_at: new Date().toISOString(),
+    ...overrides,
+  } as Draft;
+}
+
+function setup(props: Partial<Parameters<typeof SendBox>[0]> = {}) {
+  const onUpdate = vi.fn();
+  const onSend = vi.fn();
+  render(
+    <SendBox
+      draft={draft()}
+      connected
+      currentUserId={ME}
+      holderIsPresent={false}
+      isStreaming={false}
+      streamingMessageId={null}
+      onUpdate={onUpdate}
+      onSend={onSend}
+      onStop={vi.fn()}
+      onTakeOver={vi.fn()}
+      {...props}
+    />,
+  );
+  const textarea = () => screen.getByRole("textbox") as HTMLTextAreaElement;
+  const mic = () => screen.queryByRole("button", { name: /dictat/i });
+  return { textarea, mic, onUpdate, onSend };
+}
+
+describe("SendBox — dictation", () => {
+  it("renders no mic where the browser has no SpeechRecognition", () => {
+    const { mic } = setup();
+    expect(mic()).toBeNull();
+  });
+
+  it("finds the webkit-prefixed constructor (iOS Safari)", () => {
+    FakeRecognition.instances = [];
+    (window as unknown as Record<string, unknown>).webkitSpeechRecognition =
+      FakeRecognition;
+    const { mic } = setup();
+    expect(mic()).not.toBeNull();
+  });
+
+  it("starts recognition on click and stops it on a second click", () => {
+    installSpeechRecognition();
+    const { mic } = setup();
+
+    fireEvent.click(mic()!);
+    const rec = FakeRecognition.latest();
+    expect(rec.started).toBe(true);
+    expect(rec.continuous).toBe(true);
+    expect(rec.interimResults).toBe(true);
+    // The label flips so the control says what the next tap does.
+    expect(screen.getByRole("button", { name: /stop dictation/i })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: /stop dictation/i }));
+    expect(screen.getByRole("button", { name: /start dictation/i })).toBeTruthy();
+  });
+
+  it("writes a finalized utterance into the draft and syncs it", () => {
+    installSpeechRecognition();
+    const { mic, textarea, onUpdate } = setup();
+
+    fireEvent.click(mic()!);
+    FakeRecognition.latest().emit([
+      { transcript: "ship the runner fix", isFinal: true },
+    ]);
+
+    expect(textarea().value).toBe("ship the runner fix");
+    expect(onUpdate).toHaveBeenLastCalledWith("ship the runner fix");
+  });
+
+  it("shows interim text without putting it in the draft", () => {
+    installSpeechRecognition();
+    const { mic, textarea, onUpdate } = setup();
+
+    fireEvent.click(mic()!);
+    FakeRecognition.latest().emit([
+      { transcript: "half a thought", isFinal: false },
+    ]);
+
+    expect(textarea().value).toBe("");
+    expect(onUpdate).not.toHaveBeenCalled();
+    expect(screen.getByText(/half a thought/)).toBeTruthy();
+  });
+
+  it("appends to what is already typed, with one space between", () => {
+    installSpeechRecognition();
+    const { mic, textarea } = setup();
+
+    fireEvent.change(textarea(), { target: { value: "hey " } });
+    fireEvent.click(mic()!);
+    FakeRecognition.latest().emit([{ transcript: "there", isFinal: true }]);
+
+    expect(textarea().value).toBe("hey there");
+  });
+
+  it("keeps both utterances when two finals land before a re-render", () => {
+    installSpeechRecognition();
+    const { mic, textarea } = setup();
+
+    fireEvent.click(mic()!);
+    const rec = FakeRecognition.latest();
+    // Two separate onresult events in one tick — the second must not read a
+    // stale body and clobber the first.
+    rec.emit([{ transcript: "one", isFinal: true }]);
+    rec.emit([{ transcript: "two", isFinal: true }]);
+
+    expect(textarea().value).toBe("one two");
+  });
+
+  it("only reads results from resultIndex forward", () => {
+    installSpeechRecognition();
+    const { mic, textarea } = setup();
+
+    fireEvent.click(mic()!);
+    // The API hands back the whole session's results each time; everything
+    // before resultIndex was already consumed.
+    FakeRecognition.latest().emit(
+      [
+        { transcript: "already used", isFinal: true },
+        { transcript: "new", isFinal: true },
+      ],
+      1,
+    );
+
+    expect(textarea().value).toBe("new");
+  });
+
+  it("stops listening when the message is sent", () => {
+    installSpeechRecognition();
+    const { mic, textarea, onSend } = setup();
+
+    fireEvent.click(mic()!);
+    FakeRecognition.latest().emit([{ transcript: "send it", isFinal: true }]);
+    fireEvent.click(screen.getByRole("button", { name: /^send$/i }));
+
+    expect(onSend).toHaveBeenCalled();
+    expect(textarea().value).toBe("");
+    expect(screen.getByRole("button", { name: /start dictation/i })).toBeTruthy();
+  });
+
+  it("hides the mic when the composer is blocked", () => {
+    installSpeechRecognition();
+    const { mic } = setup({ disabledReason: "Runner offline" });
+    expect(mic()).toBeNull();
+  });
+
+  it("hides the mic while a teammate holds the draft", () => {
+    installSpeechRecognition();
+    const { mic } = setup({
+      holderIsPresent: true,
+      draft: draft({ last_editor: 2, last_edit_at: new Date().toISOString() }),
+    });
+    expect(mic()).toBeNull();
+  });
+
+  it("aborts recognition on unmount so the mic light goes out", () => {
+    installSpeechRecognition();
+    const { mic } = setup();
+
+    fireEvent.click(mic()!);
+    const rec = FakeRecognition.latest();
+    cleanup();
+
+    expect(rec.aborted).toBe(true);
+  });
+});

--- a/frontend/packages/canopy-ui/src/chat/useDictation.ts
+++ b/frontend/packages/canopy-ui/src/chat/useDictation.ts
@@ -1,0 +1,125 @@
+// Voice dictation for the composer, via the Web Speech API.
+//
+// A web page cannot switch the OS keyboard into its mic mode (there is no API
+// for that on Android or iOS), so the mic button does the better thing:
+// SpeechRecognition transcribes directly into the draft, no keyboard involved.
+// Where the API doesn't exist the hook reports unsupported and the button
+// simply isn't rendered — nothing else degrades.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+// lib.dom ships no SpeechRecognition types (the API is prefixed in every
+// browser that has it), so we carry the minimal shape we touch.
+interface RecognitionAlternativeLike {
+  transcript: string;
+}
+interface RecognitionResultLike {
+  isFinal: boolean;
+  0: RecognitionAlternativeLike;
+  length: number;
+}
+interface RecognitionResultEventLike {
+  resultIndex: number;
+  results: ArrayLike<RecognitionResultLike>;
+}
+interface SpeechRecognitionLike {
+  continuous: boolean;
+  interimResults: boolean;
+  lang: string;
+  onresult: ((event: RecognitionResultEventLike) => void) | null;
+  onend: (() => void) | null;
+  start(): void;
+  stop(): void;
+  abort(): void;
+}
+type RecognitionCtor = new () => SpeechRecognitionLike;
+
+function recognitionCtor(): RecognitionCtor | null {
+  if (typeof window === "undefined") return null;
+  const w = window as unknown as {
+    SpeechRecognition?: RecognitionCtor;
+    webkitSpeechRecognition?: RecognitionCtor;
+  };
+  return w.SpeechRecognition ?? w.webkitSpeechRecognition ?? null;
+}
+
+export interface DictationHandle {
+  /** False where the browser has no SpeechRecognition — hide the mic. */
+  supported: boolean;
+  listening: boolean;
+  /** The not-yet-final transcript of the phrase being spoken right now. */
+  interim: string;
+  toggle: () => void;
+  stop: () => void;
+}
+
+/**
+ * `onFinal` receives each finalized utterance (already trimmed); the caller
+ * appends it to the draft. Interim text is exposed for display only and never
+ * written into the draft — the co-edited draft syncs every keystroke to the
+ * server, and streaming provisional recognition through it would churn the
+ * draft version on text that is about to be rewritten.
+ */
+export function useDictation(onFinal: (text: string) => void): DictationHandle {
+  const supported = recognitionCtor() != null;
+  const [listening, setListening] = useState(false);
+  const [interim, setInterim] = useState("");
+  const recRef = useRef<SpeechRecognitionLike | null>(null);
+  const onFinalRef = useRef(onFinal);
+  onFinalRef.current = onFinal;
+
+  const stop = useCallback(() => {
+    recRef.current?.stop();
+  }, []);
+
+  const start = useCallback(() => {
+    const Ctor = recognitionCtor();
+    if (!Ctor || recRef.current) return;
+    const rec = new Ctor();
+    rec.continuous = true;
+    rec.interimResults = true;
+    rec.lang =
+      typeof navigator !== "undefined" && navigator.language
+        ? navigator.language
+        : "en-US";
+    rec.onresult = (event) => {
+      const finals: string[] = [];
+      let interimText = "";
+      for (let i = event.resultIndex; i < event.results.length; i++) {
+        const result = event.results[i];
+        const transcript = result[0]?.transcript ?? "";
+        if (result.isFinal) finals.push(transcript.trim());
+        else interimText += transcript;
+      }
+      const finalText = finals.filter(Boolean).join(" ");
+      if (finalText) onFinalRef.current(finalText);
+      setInterim(interimText.trim());
+    };
+    // onend is the single funnel for every way a run stops: our stop(), a
+    // recognition error (the browser fires end after error), or Chrome ending
+    // the run itself after sustained silence.
+    rec.onend = () => {
+      recRef.current = null;
+      setListening(false);
+      setInterim("");
+    };
+    try {
+      rec.start();
+    } catch {
+      return; // double-start race → InvalidStateError; already listening
+    }
+    recRef.current = rec;
+    setListening(true);
+  }, []);
+
+  const toggle = useCallback(() => {
+    if (recRef.current) stop();
+    else start();
+  }, [start, stop]);
+
+  useEffect(() => {
+    return () => recRef.current?.abort();
+  }, []);
+
+  return { supported, listening, interim, toggle, stop };
+}


### PR DESCRIPTION
> *"I'm curious if there is an ability to have a microphone icon visible in the chat such that I can click on it and it automatically opens the Android keyboard with the microphone enabled… I keep forgetting the mic it's possible to use."*

## The ask, and why it's built differently

A web page **cannot** put the Android keyboard into its mic mode — there is no API for that on Android or iOS. So the literal request isn't buildable. `SpeechRecognition` (Web Speech API) is the better version of it: it skips the keyboard entirely and transcribes straight into the draft. One tap instead of two, and the same behaviour on Android Chrome and iOS Safari.

Tap the mic → speak → the words land in the composer → tap send. The mic sits beside `attach`.

| idle | listening |
|---|---|
| mic button, outline | red stop square + the provisional phrase, italic |

## Two rules that hold the seam together

**FINAL utterances enter the draft; INTERIM ones never do.** The draft is co-edited and syncs to the server on every change, so streaming provisional recognition through it would churn the draft version on words the recognizer is about to rewrite. Interim text renders *beside* the mic instead — italic, because it isn't committed yet.

**Unsupported means absent, not broken.** Where there's no `SpeechRecognition` (most desktop Firefox, older iOS) the hook reports unsupported and the button isn't rendered. No dead control; nothing else about the composer degrades.

## Notes on the wiring

- The composer is local-first, and dictation now shares that path with the keyboard through one `commit()`. It keeps a ref alongside the state because recognition can finalize **two utterances inside one tick** — the second must not read a body from the last paint and clobber the first. Pinned by a test.
- The mic stops on send, and when the composer loses the right to write mid-utterance (a teammate takes the draft, the host blocks it). Hiding the button while recognition ran would leave the mic hot with no visible way to end it.
- `onend` is the single funnel for every way a run stops — our `stop()`, a recognition error, or Chrome ending the run after sustained silence — so the button can never be left claiming to listen when it isn't.
- Entirely inside `SendBox`; `ChatPanel` needed no prop plumbing. `useDictation` is exported from `canopy-ui/chat` so ace-web gets it from the shared kit.

## Caveat worth knowing

Chrome implements this by **sending audio to Google's servers**. It's speech-to-text over the network, not on-device. Nothing about that is unusual for the platform, but it's a fact about the feature rather than an implementation detail.

## Verification

- 13 new tests covering the whole surface: unsupported → no button, webkit-prefixed constructor, start/stop toggle, final→draft, interim→display-only, append-with-one-space, two-finals-in-a-tick, `resultIndex` windowing, stop-on-send, hidden when blocked / when a teammate holds the draft, abort on unmount.
- Full frontend suite: **496 passed (54 files)**.
- `npm run build` clean (type check + build).
- Rendered in a throwaway harness and screenshotted in both states to check layout; harness deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)