### PR TITLE
fix(chat): say the agent is working, in the place you are looking

### DIFF
--- a/frontend/packages/canopy-ui/src/chat/ChatPanel.pending.test.tsx
+++ b/frontend/packages/canopy-ui/src/chat/ChatPanel.pending.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * Pressing send must change the TRANSCRIPT, not just the header.
+ *
+ * The gap this closes: no assistant row exists until `chat.stream_start`, and
+ * the server emits that together with `stream_complete` from one `assistant`
+ * ledger event (apps/canopy_sessions/stream_map.py) — i.e. only once the reply's
+ * first text exists, which on a laptop runner is a claim poll plus an emdash
+ * drive plus however long the agent thinks. So the conversation sat visibly
+ * unchanged for seconds-to-minutes after a send, which reads as the app having
+ * ignored you. Reported on a phone, twice, after the header-chip fix (#490)
+ * had supposedly addressed it.
+ */
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import { ChatPanel } from "./ChatPanel";
+import type { Message, SessionState } from "./protocol";
+
+afterEach(cleanup);
+
+const ME = 1;
+
+function message(overrides: Partial<Message> = {}): Message {
+  return {
+    id: "m1",
+    turn_index: 1,
+    role: "user",
+    content: { text: "hi" },
+    plaintext: "hi",
+    status: "complete",
+    error_detail: null,
+    started_at: null,
+    completed_at: null,
+    created_at: "2026-07-30T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function state(overrides: Partial<SessionState> = {}): SessionState {
+  return {
+    messages: [message()],
+    active_draft: {
+      id: "d1",
+      body: "",
+      version: 1,
+      last_editor: ME,
+      last_edit_at: "2026-07-30T00:00:00Z",
+      slot: "next",
+      status: "open",
+    },
+    participants: [],
+    presence_user_ids: [ME],
+    current_user_id: ME,
+    ...overrides,
+  };
+}
+
+function panel(props: Partial<Parameters<typeof ChatPanel>[0]> = {}) {
+  return render(
+    <ChatPanel
+      state={state()}
+      connected
+      currentUserId={ME}
+      onSend={vi.fn()}
+      onStop={vi.fn()}
+      onUpdateDraft={vi.fn()}
+      onTakeOver={vi.fn()}
+      onDiscard={vi.fn()}
+      {...props}
+    />,
+  );
+}
+
+describe("the pending-reply row", () => {
+  it("is absent while nothing is outstanding", () => {
+    panel();
+    expect(screen.queryByTestId("pending-reply")).toBeNull();
+  });
+
+  it("appears the instant a send goes out, with no server round trip", () => {
+    // `awaitingReply` is set synchronously by sendChat. NOTHING server-side can
+    // answer sooner: the turn has to be enqueued, claimed, and driven into the
+    // agent before any report could exist.
+    panel({ awaitingReply: true });
+    expect(screen.getByTestId("pending-reply")).not.toBeNull();
+    expect(screen.getByText("Queued…")).not.toBeNull();
+  });
+
+  it("says the agent is thinking once the hook reports it started", () => {
+    // The distinction is the useful part: queued means canopy has not started
+    // your turn, thinking means the agent has it. Folding them together hides
+    // where the delay actually is.
+    panel({ state: state({ activity: "working" }), awaitingReply: false });
+    expect(screen.getByText("Thinking…")).not.toBeNull();
+  });
+
+  it("survives the first reply block, because the turn has not ended", () => {
+    // `awaitingReply` clears on the FIRST stream_complete, but the bridge posts
+    // each assistant block as its own event — so a turn that says one sentence
+    // and then works for another minute would otherwise go silent again.
+    panel({ state: state({ activity: "working" }), awaitingReply: false });
+    expect(screen.getByTestId("pending-reply")).not.toBeNull();
+  });
+
+  it("withdraws when the agent is BLOCKED on you", () => {
+    // The worst way to get this wrong: waiting on an agent that is waiting on
+    // you. `blocked` must never render as work in progress.
+    panel({ state: state({ activity: "blocked" }), awaitingReply: true });
+    expect(screen.queryByTestId("pending-reply")).toBeNull();
+  });
+
+  it("yields to a real assistant row once one exists", () => {
+    // Otherwise the reply and the placeholder are both on screen at once.
+    panel({
+      state: state({
+        messages: [
+          message(),
+          message({ id: "m2", turn_index: 2, role: "assistant", plaintext: "", content: {}, status: "streaming" }),
+        ],
+      }),
+      awaitingReply: true,
+    });
+    expect(screen.queryByTestId("pending-reply")).toBeNull();
+  });
+
+  it("shows on a first-ever send, when the empty state would otherwise win", () => {
+    panel({
+      state: state({ messages: [] }),
+      awaitingReply: true,
+      emptyState: <div>no messages yet</div>,
+    });
+    expect(screen.getByTestId("pending-reply")).not.toBeNull();
+    expect(screen.queryByText("no messages yet")).toBeNull();
+  });
+});

--- a/frontend/packages/canopy-ui/src/chat/ChatPanel.tsx
+++ b/frontend/packages/canopy-ui/src/chat/ChatPanel.tsx
@@ -96,13 +96,37 @@ export function ChatPanel({
     [state.messages],
   );
 
+  // Feedback where the eye actually is. Pressing send used to change NOTHING in
+  // the transcript: no assistant row exists until `chat.stream_start`, which the
+  // server emits together with `stream_complete` from a single `assistant`
+  // ledger event — i.e. only once the reply's first TEXT exists, seconds to
+  // minutes later. So MessageItem's own "Thinking…" treatment was unreachable on
+  // the real runner path, and the only signal was a 12px chip in the header,
+  // which on a phone is the far corner of the screen from your thumb.
+  //
+  // Two sources, deliberately: `awaitingReply` is client-side and answers
+  // INSTANTLY with no round trip (nothing server-side can — the turn has to be
+  // enqueued, claimed and driven into the agent before anything could report),
+  // and `activity === "working"` keeps it up for the rest of the turn, across
+  // the gaps between the assistant's separate text blocks. `blocked` withdraws
+  // it: an agent waiting on YOU must never render as an agent working.
+  const agentHasFloor =
+    state.activity !== "blocked" &&
+    (awaitingReply || state.activity === "working");
+  const showPendingReply = inFlightMessage == null && agentHasFloor;
+  // "Queued" until something reports the agent actually started — the useful
+  // distinction is where the delay is, not that there is one.
+  const pendingLabel = state.activity === "working" ? "Thinking…" : "Queued…";
+
   // Sticky-bottom scroll: dep changes on (a) new message arrival and (b)
   // streaming text growth on the last message. length-only (cheap) instead
   // of the full string so the effect doesn't re-run on equal characters.
+  // `showPendingReply` is in the dep too — the bubble is a new row at the
+  // bottom, and appearing below the fold would defeat the whole point of it.
   const messages = state.messages;
   const lastMessageLen =
     messages.length > 0 ? messages[messages.length - 1].plaintext.length : 0;
-  const scrollDep = `${messages.length}:${lastMessageLen}`;
+  const scrollDep = `${messages.length}:${lastMessageLen}:${showPendingReply}`;
   const { containerRef, onScroll } = useStickyBottom(scrollDep);
 
   return (
@@ -131,6 +155,8 @@ export function ChatPanel({
           messages={state.messages}
           emptyState={emptyState}
           renderMarkdown={renderMarkdown}
+          pendingReply={showPendingReply}
+          pendingLabel={pendingLabel}
         />
       </div>
       <SendBox

--- a/frontend/packages/canopy-ui/src/chat/MessageItem.tsx
+++ b/frontend/packages/canopy-ui/src/chat/MessageItem.tsx
@@ -44,6 +44,26 @@ function classifyError(detail: string | null) {
   };
 }
 
+/**
+ * The animated "the agent has the floor" treatment.
+ *
+ * Exported because it is rendered from two places that must not drift: inside a
+ * real assistant row that has started but has no text yet, and as MessageList's
+ * TRAILING row while no assistant row exists at all (see `pendingReply` there).
+ */
+export function ThinkingIndicator({ label = "Thinking…" }: { label?: string }) {
+  return (
+    <span className="inline-flex items-center gap-1.5 text-muted-foreground">
+      <span className="inline-flex gap-0.5" aria-label="thinking">
+        <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-current [animation-delay:-0.3s]" />
+        <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-current [animation-delay:-0.15s]" />
+        <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-current" />
+      </span>
+      <span className="text-xs italic">{label}</span>
+    </span>
+  );
+}
+
 export function MessageItem({
   message,
   forceToolOpen,
@@ -104,14 +124,7 @@ export function MessageItem({
       aria-live={isStreaming || isPending ? "polite" : undefined}
     >
       {showThinking ? (
-        <span className="inline-flex items-center gap-1.5 text-muted-foreground">
-          <span className="inline-flex gap-0.5" aria-label="thinking">
-            <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-current [animation-delay:-0.3s]" />
-            <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-current [animation-delay:-0.15s]" />
-            <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-current" />
-          </span>
-          <span className="text-xs italic">Thinking…</span>
-        </span>
+        <ThinkingIndicator />
       ) : message.role === "assistant" ? (
         renderMarkdown(text)
       ) : (

--- a/frontend/packages/canopy-ui/src/chat/MessageList.tsx
+++ b/frontend/packages/canopy-ui/src/chat/MessageList.tsx
@@ -4,7 +4,7 @@ import { ChevronRight, ChevronsDownUp, ChevronsUpDown, Loader2 } from "lucide-re
 import type { Message } from "./protocol";
 import { Button } from "../ui/button";
 import type { RenderMarkdown } from "./MessageItem";
-import { MessageItem } from "./MessageItem";
+import { MessageItem, ThinkingIndicator } from "./MessageItem";
 import { ToolCallPair } from "./ToolCallPair";
 import { pairToolMessages } from "./pairToolMessages";
 import { groupToolRuns, runHasError, runIsActive, summariseRun } from "./groupToolRuns";
@@ -14,6 +14,20 @@ interface Props {
   /** Rendered when there are no messages yet (replaces ace's WelcomePanel). */
   emptyState?: ReactNode;
   renderMarkdown?: RenderMarkdown;
+  /**
+   * The agent has the floor but has produced no row yet — render a trailing
+   * "thinking" bubble at the bottom of the conversation.
+   *
+   * A trailing ELEMENT, not a row spliced into `messages`: the message array is
+   * a projection of the durable record and must keep exactly one writer, and a
+   * placeholder with a made-up id would need upsert/eviction rules against every
+   * frame that can follow it. This has none — it is on screen while the flag is
+   * true and gone when it isn't.
+   */
+  pendingReply?: boolean;
+  /** Wording for that bubble — the caller knows whether the turn is still
+   *  queued for a runner or the agent is actually working. */
+  pendingLabel?: string;
 }
 
 // Show the bulk expand/collapse toolbar once a session has more than this
@@ -22,7 +36,13 @@ const TOOLBAR_THRESHOLD = 5;
 
 type BulkState = "default" | "all" | "none";
 
-export function MessageList({ messages, emptyState, renderMarkdown }: Props) {
+export function MessageList({
+  messages,
+  emptyState,
+  renderMarkdown,
+  pendingReply = false,
+  pendingLabel,
+}: Props) {
   const paired = useMemo(() => pairToolMessages(messages), [messages]);
   // Collapse back-to-back tool calls into one row. An agent mid-task emits long
   // stretches of them, and one row each pushes the prose you actually read off
@@ -38,7 +58,7 @@ export function MessageList({ messages, emptyState, renderMarkdown }: Props) {
   // control back to per-row state.
   const [bulkState, setBulkState] = useState<BulkState>("default");
 
-  if (messages.length === 0) {
+  if (messages.length === 0 && !pendingReply) {
     return <>{emptyState ?? null}</>;
   }
   const forceToolOpen =
@@ -139,6 +159,15 @@ export function MessageList({ messages, emptyState, renderMarkdown }: Props) {
             />
           );
         })}
+        {pendingReply && (
+          <div
+            data-testid="pending-reply"
+            aria-live="polite"
+            className="my-2 mr-auto max-w-[80%] rounded-2xl bg-muted px-4 py-2 text-foreground"
+          >
+            <ThinkingIndicator label={pendingLabel} />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -507,6 +507,15 @@ export function ChatPage() {
   // useful part: queued means canopy has not started your turn yet, running
   // means the agent is thinking. Confusing the two hides where the delay is.
   const liveQueued = socket.awaitingReply;
+  // `meta` is fetched ONCE per session id and never refreshed, and `running`
+  // derives from a 120s window on the runner's last report — so this is a
+  // PAGE-LOAD SNAPSHOT that can only decay. It used to outrank everything below
+  // `blocked`, which quietly cost #490 its whole point: open a chat you were
+  // just using and the header already said "running", so pressing send changed
+  // nothing on screen and the "queued" branch was unreachable. Demoted to the
+  // last resort — consulted only while nothing live has spoken, and dropped for
+  // good once anything has.
+  const staleRunning = liveWorking === undefined && Boolean(meta?.running);
   const title = meta?.title?.trim() || 'Chat'
 
   return (
@@ -525,7 +534,7 @@ export function ChatPage() {
             <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-warning" />
             needs you{meta?.runner_name ? ` · ${meta.runner_name}` : ''}
           </span>
-        ) : (liveWorking ?? meta?.running) ? (
+        ) : liveWorking ? (
           <span className="flex shrink-0 items-center gap-1 text-[12px] font-medium text-success">
             <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-success" />
             running{meta?.runner_name ? ` · ${meta.runner_name}` : ''}
@@ -534,6 +543,11 @@ export function ChatPage() {
           <span className="flex shrink-0 items-center gap-1 text-[12px] font-medium text-muted-foreground">
             <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-muted-foreground" />
             queued{meta?.runner_name ? ` · ${meta.runner_name}` : ''}
+          </span>
+        ) : staleRunning ? (
+          <span className="flex shrink-0 items-center gap-1 text-[12px] font-medium text-success">
+            <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-success" />
+            running{meta?.runner_name ? ` · ${meta.runner_name}` : ''}
           </span>
         ) : meta?.runner_name ? (
           <span className="shrink-0 text-[12px] text-muted-foreground">

--- a/runner/canopy_runner/canopy_runner/hook_listener.py
+++ b/runner/canopy_runner/canopy_runner/hook_listener.py
@@ -26,6 +26,7 @@ transcript. That is what makes it safe for this path to drop events freely.
 """
 from __future__ import annotations
 
+import errno
 import json
 import logging
 import threading
@@ -173,7 +174,29 @@ class HookListener:
 
         # Bound to 127.0.0.1 explicitly — never 0.0.0.0. This machine holds fleet
         # credentials; the listener must not be reachable off-box.
-        self._server = ThreadingHTTPServer(("127.0.0.1", self.port), _Handler)
+        #
+        # The configured port is a PREFERENCE, not a contract: nothing outside
+        # this process has to predict the number, because we WRITE it into
+        # ~/.claude/settings.json ourselves. What it cannot be is machine-global.
+        # Two accounts on one Mac each install their own settings.json pointing
+        # at the same default 8787, so whichever runner starts first receives
+        # BOTH accounts' hooks — and can only resolve its own emdash sessions,
+        # so the other account's hooks are not merely lost but actively eaten as
+        # "unknown-cwd". The loser used to log a warning and run with live events
+        # off forever (2026-07-28 → 07-30: every restart of the second runner,
+        # zero activity events forwarded, and the chat UI's "running" indicator
+        # dead for every session that runner drove). Taking a free port instead
+        # retires the whole collision class.
+        try:
+            self._server = ThreadingHTTPServer(("127.0.0.1", self.port), _Handler)
+        except OSError as exc:
+            if exc.errno != errno.EADDRINUSE:
+                raise
+            self._server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+            taken, self.port = self.port, self._server.server_address[1]
+            logger.warning(
+                "hook port %d is held by another process; listening on :%d instead "
+                "(the hook config is rewritten to match)", taken, self.port)
         threading.Thread(target=self._server.serve_forever, daemon=True,
                          name="hook-listener").start()
         logger.info("hook listener on 127.0.0.1:%d (forwarding=%s)",

--- a/runner/canopy_runner/canopy_runner/hooks.py
+++ b/runner/canopy_runner/canopy_runner/hooks.py
@@ -226,14 +226,22 @@ def start_hook_listener(cfg: Config, client: Client):
     try:
         listener.start()
     except OSError as exc:
-        # Another process already holds the port (a second runner, a stale
-        # process). Live events are an overlay, so this is a warning, not fatal.
-        logger.warning("hook listener could not bind :%d (%s); live events off",
-                       cfg.hook_port, exc)
+        # `start` already falls back to a free port when the configured one is
+        # merely taken, so reaching here means the loopback socket itself is
+        # unusable. Live events are an overlay, so it stays non-fatal — but it is
+        # logged at ERROR, because the failure is silent everywhere else: the
+        # chat UI just never says "running" again, which reads as the app
+        # ignoring you rather than as a runner with a dead listener.
+        logger.error("hook listener could not bind (%s); live events OFF — the chat "
+                     "UI will not show agent activity for this runner's sessions", exc)
         return None
-    hook_install.install(settings_path, port=cfg.hook_port, nonce=nonce)
+    # `listener.port`, not `cfg.hook_port`: the fallback above may have taken a
+    # different one, and the hook config has to point where we are ACTUALLY
+    # listening. Installing the configured port after binding another is how a
+    # collision turns into hooks curling into a hole.
+    hook_install.install(settings_path, port=listener.port, nonce=nonce)
     logger.info("live hook events: listener on :%d, forwarding=%s",
-                cfg.hook_port, cfg.forward_sessions)
+                listener.port, cfg.forward_sessions)
     _hook_listener = listener
     return listener
 

--- a/runner/canopy_runner/tests/test_hook_listener.py
+++ b/runner/canopy_runner/tests/test_hook_listener.py
@@ -333,3 +333,83 @@ def test_no_menu_reader_configured_is_not_an_error():
     lis.bind_sender(lambda sid, ev: sent.append((sid, ev)))
     assert lis.handle_payload(_payload(hook_event_name="Notification")) == "activity:blocked"
     assert sent[0][1][0]["payload"] == {}
+
+
+def test_a_held_port_falls_back_instead_of_turning_live_events_off(caplog):
+    """The hook port is machine-global; the config that names it is per-account.
+
+    Two runners on one Mac (two macOS accounts) both default to 8787, so the
+    second one used to lose the bind and run with live events off FOREVER — the
+    chat UI's "running" indicator dead for every session it drove. Measured on
+    this machine 2026-07-28 → 07-30. A free port costs nothing, because we write
+    the number into ~/.claude/settings.json ourselves.
+    """
+    import socket
+
+    # `port=0` means DISABLED here, not ephemeral, so the squatter needs a real
+    # number: take one the OS just handed out and release it.
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        held = probe.getsockname()[1]
+    squatter = HookListener(port=held, nonce="n", resolve_session=lambda c: "s",
+                            forward=lambda: True)
+    squatter.bind_sender(lambda sid, ev: None)
+    squatter.start()
+    try:
+        assert squatter.port == held, "the squatter did not take the port"
+        loser = HookListener(port=held, nonce="n2", resolve_session=lambda c: "s",
+                             forward=lambda: True)
+        loser.bind_sender(lambda sid, ev: None)
+        with caplog.at_level("WARNING"):
+            loser.start()
+        try:
+            assert loser._server is not None, "the second runner got no listener"
+            assert loser.port != held, "it re-bound the held port"
+            # The port it reports MUST be the one it is actually on — that is
+            # what gets written into the hook config.
+            assert loser.port == loser._server.server_address[1]
+            assert "is held by another process" in caplog.text
+        finally:
+            loser.stop()
+    finally:
+        squatter.stop()
+
+
+def test_the_hook_config_is_written_with_the_port_actually_bound(monkeypatch, tmp_path):
+    """The failure the fallback would otherwise introduce.
+
+    If `start()` re-homes to a free port but `install()` writes the CONFIGURED
+    one, every hook curls into a hole — strictly worse than the collision it was
+    meant to fix, because now nothing is listening there at all.
+    """
+    import socket
+    from canopy_runner import hooks
+    from canopy_runner.config import Config
+
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        held = probe.getsockname()[1]
+    squatter = HookListener(port=held, nonce="n", resolve_session=lambda c: "s",
+                            forward=lambda: True)
+    squatter.bind_sender(lambda sid, ev: None)
+    squatter.start()
+
+    installed = {}
+    monkeypatch.setattr(hooks.hook_install, "install",
+                        lambda path, port, nonce: installed.update(port=port))
+    monkeypatch.setattr(hooks.Path, "home", classmethod(lambda cls: tmp_path))
+
+    class _Client:
+        def post_session_stream(self, *a, **k):
+            pass
+
+    cfg = Config(base_url="http://x", token="t", runner_id="r", emdash_db="/nope.db",
+                 hook_port=held, forward_sessions=True)
+    listener = hooks.start_hook_listener(cfg, _Client())
+    try:
+        assert listener is not None, "a held port must not turn live events off"
+        assert installed["port"] == listener.port != held
+    finally:
+        if listener is not None:
+            listener.stop()
+        squatter.stop()

--- a/runner/canopy_runner/tests/test_main.py
+++ b/runner/canopy_runner/tests/test_main.py
@@ -722,6 +722,9 @@ def test_the_hook_listener_never_reads_the_screen_by_itself(monkeypatch, tmp_pat
     class _Listener:
         def __init__(self, **kwargs):
             captured.update(kwargs)
+            # `start()` may re-home to a free port when the configured one is
+            # held, so the caller installs `listener.port`, not `cfg.hook_port`.
+            self.port = kwargs.get("port")
 
         def bind_sender(self, _s):
             pass


### PR DESCRIPTION
## The report

"I'm still not getting immediate feedback in the mobile UI that the AI is processing" — *still*, because #490 was supposed to have fixed this.

## What was actually happening

Three independent causes, one per layer. Each alone was enough.

**1. The transcript — where you are actually looking — said nothing.** No assistant row exists until `chat.stream_start`, and `stream_map.py` emits that *together with* `stream_complete` from a single `assistant` ledger event. So it only arrives once the reply's first text does: a claim poll, plus an emdash drive, plus however long the agent thinks. `MessageItem`'s existing "Thinking…" treatment was therefore unreachable on the real runner path, and the conversation sat visually unchanged for the whole wait.

**2. The header chip from #490 could not win.** `meta` is fetched once per session id and never refreshed (`ChatPage.tsx`), so `meta.running` is a page-load snapshot of a 120-second window — and it outranked every branch below `blocked`. Open a chat you were just using and the header *already* read "running", so pressing send changed nothing on screen and the "queued" branch was unreachable. Confirmed against live data: every session the reporter was chatting in had `running=true`.

**3. The live "the agent started" signal was off entirely, on this machine, for two days.** The hook port is machine-global; the config that names it is per-account. Two runners on one Mac (two macOS accounts) both default to 8787, so the second lost the bind:

```
2026-07-27 19:35:43  INFO    hooks: 632 received, 305 forwarded, ... forwarding=True
2026-07-28 19:18:27  WARNING hook listener could not bind :8787 ([Errno 48] Address already in use); live events off
2026-07-29 21:38:54  WARNING hook listener could not bind :8787 ([Errno 48] Address already in use); live events off
```

Worse than lost: the winner *ate* the loser's hooks, resolving them against its own emdash sessions and dropping them as `unknown-cwd`. All 15 live chat sessions were bound to the runner that lost, so `session.activity` never reached any browser — which is also what let (2) go unnoticed, since `liveWorking` was permanently `undefined`.

## The fix

- **`MessageList` gains a trailing pending row.** An *element*, not a row spliced into `messages` — that array is a projection of the durable record and must keep exactly one writer, and a placeholder with a made-up id would need eviction rules against every frame that can follow it. Driven by `awaitingReply` (client-side, instant; nothing server-side can answer sooner) and held up for the rest of the turn by `activity === "working"`, because `awaitingReply` clears on the *first* reply block while the bridge posts each block separately. `blocked` withdraws it — an agent waiting on *you* must never render as an agent working.
- **`meta.running` demoted to last resort** in the header chain: consulted only while nothing live has spoken, dropped for good once anything has.
- **A held hook port takes a free one** and writes *that* into `~/.claude/settings.json` — which we own, so the number never needed to be predictable. Installing the configured port after binding another would be strictly worse than the collision (hooks curling into a hole), so there is a test for exactly that. Only a genuinely unusable socket now turns live events off, and it logs at ERROR rather than WARNING, because the failure is silent everywhere else.

## Verification

- 322 runner tests, 522 frontend tests, `npm run build` clean.
- New: 7 `ChatPanel` pending-row cases (instant on send, survives the first reply block, withdraws on `blocked`, yields to a real assistant row, beats the empty state) and 2 hook-port cases (falls back instead of going dark; installs the port it actually bound).
- Applied on the reporter's machine and confirmed live: `2026-07-30 17:11:31 INFO hook listener on 127.0.0.1:8788 (forwarding=True)`, and `~/.claude/settings.json` repointed to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)