### PR TITLE
feat(sessions): make stored-session maintenance a first-class surface

### DIFF
--- a/apps/canopy_sessions/maintenance.py
+++ b/apps/canopy_sessions/maintenance.py
@@ -1,0 +1,117 @@
+"""Operations on STORED sessions — auditing and repairing transcript rows after
+the fact.
+
+The ingest filters (`persist_transcript_rows`, `post_session_stream`,
+`tail_as_messages`) decide what gets in. This module is the other half: what to
+do about rows already in the table when a rule changes. Every prefix added to
+`SYSTEM_NOISE_PREFIXES` retroactively makes some stored rows wrong, and the only
+way to see them was to read the code and hand-write a query.
+
+The FIRST time this came up it was done as a management command, which meant
+reaching the data required an `aws ecs run-task` against prod with a command
+override — unrepeatable, unauditable, and available only to whoever held AWS
+credentials that day. So the logic lives HERE, and the callers are thin:
+
+  * `apps.mcp.tools.sessions`  — over HTTPS, as the authenticated user, scoped to
+    that user's workspaces. This is the path agents and humans should use.
+  * `purge_transcript_noise`   — the same functions from a shell, for the ops case
+    that has to run unscoped across every workspace.
+
+Both go through `audit_noise` / `purge_noise`, so the two surfaces cannot drift
+and neither can hand-roll its own idea of what "noise" means.
+
+SCOPING FAILS CLOSED. `workspace_slugs` is required and an empty set matches
+NOTHING — an unresolvable user must see zero rows, never every row. Unscoped
+access is the explicit `ALL_WORKSPACES` sentinel, which is greppable precisely so
+its few call sites stay countable.
+"""
+from __future__ import annotations
+
+from django.db.models import Q
+
+from .models import Message
+from .transcript_noise import SYSTEM_NOISE_PREFIXES
+
+# Unscoped access, spelled out. A sentinel rather than `None`, because `None` is
+# what an absent argument or a failed lookup degrades to — and "the scope lookup
+# returned nothing" must never be one typo away from "every workspace".
+ALL_WORKSPACES = "__all_workspaces__"
+
+# Cap on rows returned as examples, however large `sample` is asked to be. The
+# report travels over MCP into a model's context; a thousand-row sample is not a
+# report, it's a denial of service against the reader.
+SAMPLE_MAX = 50
+SAMPLE_TEXT_CHARS = 120
+
+
+def _scoped(qs, workspace_slugs):
+    """`qs` restricted to the caller's workspaces. Empty scope -> nothing."""
+    if workspace_slugs is ALL_WORKSPACES:
+        return qs
+    if not workspace_slugs:
+        return qs.none()
+    return qs.filter(session__workspace__slug__in=workspace_slugs)
+
+
+def noise_queryset(*, workspace_slugs, session_id=None):
+    """Stored USER rows whose text is harness output.
+
+    `istartswith` mirrors `is_system_noise`: prefix-anchored, so a human quoting a
+    marker keeps their message. It cannot mirror that function's `.lstrip()`, so a
+    row with leading whitespace is NOT matched here — the ingest filter is the
+    authority and this is only catching up history. Deliberately under-matching:
+    a missed row is a cosmetic bug, an over-matched one is deleted user speech.
+    """
+    predicate = Q()
+    for prefix in SYSTEM_NOISE_PREFIXES:
+        predicate |= Q(plaintext__istartswith=prefix)
+    qs = Message.objects.filter(predicate, role=Message.USER)
+    if session_id is not None:
+        qs = qs.filter(session_id=session_id)
+    return _scoped(qs, workspace_slugs)
+
+
+def _report(qs, sample: int) -> dict:
+    """Counts + a bounded sample, the shape both audit and purge return."""
+    total = qs.count()
+    rows = []
+    if total and sample > 0:
+        for row in qs.order_by("-created_at").select_related("session")[: min(sample, SAMPLE_MAX)]:
+            rows.append({
+                "session_id": str(row.session_id),
+                "workspace": row.session.workspace_id and row.session.workspace.slug,
+                "turn_index": row.turn_index,
+                "text": " ".join((row.plaintext or "").split())[:SAMPLE_TEXT_CHARS],
+            })
+    return {
+        "matched": total,
+        "sessions": qs.values("session_id").distinct().count() if total else 0,
+        "sample": rows,
+    }
+
+
+def audit_noise(*, workspace_slugs, session_id=None, sample: int = 5) -> dict:
+    """What harness output is stored as user messages. Read-only.
+
+    Returns {"matched", "sessions", "sample": [...]}. Run this before `purge_noise`
+    — "how much of my chat history does this touch" is a question worth answering
+    before the delete, not after.
+    """
+    return _report(noise_queryset(workspace_slugs=workspace_slugs, session_id=session_id), sample)
+
+
+def purge_noise(*, workspace_slugs, session_id=None, sample: int = 5, apply: bool = False) -> dict:
+    """Delete the rows `audit_noise` reports. DRY RUN unless `apply=True`.
+
+    Returns the audit report plus {"applied": bool, "deleted": int}. The sample is
+    captured BEFORE the delete, so the result records what went rather than
+    describing an empty table afterwards.
+    """
+    qs = noise_queryset(workspace_slugs=workspace_slugs, session_id=session_id)
+    report = _report(qs, sample)
+    if not apply:
+        return {**report, "applied": False, "deleted": 0}
+    # `qs.delete()` on a sliced/ordered queryset is an error, and `_report` only
+    # ever slices its own clone, so this deletes exactly what was counted.
+    deleted, _ = qs.delete()
+    return {**report, "applied": True, "deleted": deleted}

--- a/apps/canopy_sessions/management/commands/purge_transcript_noise.py
+++ b/apps/canopy_sessions/management/commands/purge_transcript_noise.py
@@ -1,25 +1,32 @@
 """Remove harness records that were persisted as user messages.
 
-`persist_transcript_rows` now drops these on the way in, but rows written before
-that fix are still in the table — and they are what a person actually sees when
-they open an affected chat. This clears the backlog.
+The ingest filters drop these on the way in; rows written before a given prefix
+was recognised are still in the table, and they are what a person actually sees
+when they open an affected chat. This clears the backlog.
+
+PREFER THE MCP TOOLS. `audit_session_noise` / `purge_session_noise` do the same
+work over HTTPS, scoped to the caller's own workspaces, rate-limited and audited
+— no AWS credentials, no one-off container. This command exists for the case MCP
+deliberately cannot serve: an unscoped sweep across EVERY workspace, which is a
+privileged operation and stays behind shell access on purpose.
 
 DRY RUN BY DEFAULT. It deletes rows, so it asks to be told twice: run it bare to
 see the count and a sample, then `--apply` to commit. Deliberately a command and
 not a data migration — deleting is irreversible, and "how much of my chat history
 does this touch" is a question worth answering before, not after.
+
+The matching and deleting live in `apps.canopy_sessions.maintenance`, shared with
+the MCP tools, so this command cannot develop its own idea of what noise is.
 """
 from __future__ import annotations
 
-from django.core.management.base import BaseCommand
-from django.db.models import Q
+from django.core.management.base import BaseCommand, CommandError
 
-from apps.canopy_sessions.models import Message
-from apps.canopy_sessions.transcript_noise import SYSTEM_NOISE_PREFIXES
+from apps.canopy_sessions import maintenance
 
 
 class Command(BaseCommand):
-    help = "Delete harness records (task notifications, system reminders) stored as user messages."
+    help = "Delete harness records (task notifications, skill bodies, …) stored as user messages."
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -30,31 +37,50 @@ class Command(BaseCommand):
             "--sample", type=int, default=5,
             help="How many matches to print (default 5).",
         )
+        parser.add_argument(
+            "--session", default=None,
+            help="Restrict to one session id (UUID).",
+        )
+        parser.add_argument(
+            "--workspace", action="append", default=None, metavar="SLUG",
+            help="Restrict to a workspace slug. Repeatable. Omit to sweep ALL workspaces.",
+        )
 
     def handle(self, *args, **options):
-        # istartswith mirrors is_system_noise: prefix-anchored so a human quoting
-        # a marker keeps their message. It cannot mirror the .lstrip(), so a row
-        # with leading whitespace survives here — acceptable for a cleanup pass
-        # (the ingest filter is the authority; this is only catching up history).
-        predicate = Q()
-        for prefix in SYSTEM_NOISE_PREFIXES:
-            predicate |= Q(plaintext__istartswith=prefix)
-        qs = Message.objects.filter(predicate, role=Message.USER)
+        # Unscoped is the DEFAULT here (it's the reason this command still
+        # exists) but never silent: an operator deleting across every tenant in
+        # the deployment should see that stated before the numbers.
+        slugs = options["workspace"] or maintenance.ALL_WORKSPACES
+        if slugs is maintenance.ALL_WORKSPACES:
+            self.stdout.write(self.style.WARNING("Scope: ALL workspaces."))
+        else:
+            self.stdout.write(f"Scope: workspace(s) {', '.join(slugs)}.")
 
-        total = qs.count()
-        if not total:
+        try:
+            report = maintenance.purge_noise(
+                workspace_slugs=slugs,
+                session_id=options["session"],
+                sample=options["sample"],
+                apply=options["apply"],
+            )
+        except (ValueError, TypeError) as exc:
+            # Overwhelmingly a malformed --session UUID; surface it as a usage
+            # error rather than a traceback.
+            raise CommandError(f"Bad argument: {exc}") from exc
+
+        if not report["matched"]:
             self.stdout.write(self.style.SUCCESS("No harness records found."))
             return
 
-        sessions = qs.values("session_id").distinct().count()
-        self.stdout.write(f"{total} harness record(s) across {sessions} session(s).")
-        for row in qs.order_by("-created_at")[: options["sample"]]:
-            head = " ".join((row.plaintext or "").split())[:90]
-            self.stdout.write(f"  session={row.session_id} index={row.turn_index} :: {head}")
+        self.stdout.write(
+            f"{report['matched']} harness record(s) across {report['sessions']} session(s)."
+        )
+        for row in report["sample"]:
+            self.stdout.write(
+                f"  session={row['session_id']} index={row['turn_index']} :: {row['text']}"
+            )
 
-        if not options["apply"]:
+        if not report["applied"]:
             self.stdout.write(self.style.WARNING("Dry run — re-run with --apply to delete."))
             return
-
-        deleted, _ = qs.delete()
-        self.stdout.write(self.style.SUCCESS(f"Deleted {deleted} row(s)."))
+        self.stdout.write(self.style.SUCCESS(f"Deleted {report['deleted']} row(s)."))

--- a/apps/mcp/tests/test_session_tools.py
+++ b/apps/mcp/tests/test_session_tools.py
@@ -1,0 +1,205 @@
+"""Stored-session maintenance over MCP: scoped, dry-run by default, auditable.
+
+These tools delete chat history, so the tests here are mostly about what they
+must REFUSE to do: reach another workspace's rows, delete without being asked
+twice, or fall back to global scope when the caller can't be resolved.
+"""
+from __future__ import annotations
+
+import contextlib
+
+import pytest
+from asgiref.sync import async_to_sync
+from django.contrib.auth import get_user_model
+from fastmcp.server.auth import AccessToken
+from mcp.server.auth.middleware.auth_context import (
+    AuthenticatedUser,
+    auth_context_var,
+)
+
+from apps.canopy_sessions.models import Message, Session
+from apps.mcp.server import mcp
+from apps.workspaces.models import Workspace, WorkspaceMembership
+
+User = get_user_model()
+
+SKILL_BODY = "Base directory for this skill: /Users/jj/.claude/plugins/cache/superpowers/…"
+
+
+@contextlib.contextmanager
+def as_user(user):
+    """Run the block with `user` set as the authenticated MCP caller."""
+    access = AccessToken(
+        token="test-token",
+        client_id=str(user.pk),
+        scopes=["canopy:user"],
+        claims={"sub": str(user.pk), "user_id": user.pk, "email": user.email},
+    )
+    tok = auth_context_var.set(AuthenticatedUser(access))
+    try:
+        yield
+    finally:
+        auth_context_var.reset(tok)
+
+
+def _workspace(slug, user, *, member=True):
+    ws = Workspace.objects.create(slug=slug, display_name=slug.title(), created_by=user)
+    if member:
+        WorkspaceMembership.objects.create(
+            user=user, workspace=ws, role=WorkspaceMembership.OWNER
+        )
+    return ws
+
+
+def _session_with(ws, rows):
+    session = Session.objects.create(
+        workspace=ws, origin=Session.ORIGIN_RUNNER, title="s"
+    )
+    for i, (role, text) in enumerate(rows):
+        Message.objects.create(session=session, turn_index=i, role=role, plaintext=text)
+    return session
+
+
+def _call(tool, args):
+    # A dict-returning tool's structured_content IS the dict (only list returns
+    # get wrapped under "result").
+    return async_to_sync(mcp.call_tool)(tool, args).structured_content
+
+
+@pytest.mark.django_db
+def test_tools_are_registered():
+    tools = async_to_sync(mcp.list_tools)()
+    assert {"audit_session_noise", "purge_session_noise"} <= {t.name for t in tools}
+
+
+@pytest.mark.django_db
+def test_audit_finds_the_skill_body_and_leaves_it_alone():
+    user = User.objects.create_user(username="jj", email="jj@dimagi.com")
+    ws = _workspace("canopy", user)
+    _session_with(ws, [
+        (Message.USER, "go look at the fleet"),
+        (Message.ASSISTANT, "on it"),
+        (Message.USER, SKILL_BODY),
+    ])
+
+    with as_user(user):
+        report = _call("audit_session_noise", {})
+
+    assert report["matched"] == 1
+    assert report["sessions"] == 1
+    assert report["sample"][0]["text"].startswith("Base directory for this skill:")
+    assert report["sample"][0]["workspace"] == "canopy"
+    assert Message.objects.count() == 3  # read-only
+
+
+@pytest.mark.django_db
+def test_purge_is_a_dry_run_until_told_twice():
+    user = User.objects.create_user(username="jj", email="jj@dimagi.com")
+    ws = _workspace("canopy", user)
+    _session_with(ws, [(Message.USER, SKILL_BODY), (Message.ASSISTANT, "on it")])
+
+    with as_user(user):
+        dry = _call("purge_session_noise", {})
+    assert dry == {**dry, "applied": False, "deleted": 0}
+    assert dry["matched"] == 1
+    assert Message.objects.count() == 2
+
+    with as_user(user):
+        done = _call("purge_session_noise", {"apply": True})
+    assert done["applied"] is True
+    assert done["deleted"] == 1
+    # The sample is captured BEFORE the delete — a result that described an empty
+    # table would be useless as a record of what went.
+    assert done["sample"][0]["text"].startswith("Base directory for this skill:")
+    assert list(Message.objects.values_list("plaintext", flat=True)) == ["on it"]
+
+
+@pytest.mark.django_db
+def test_another_workspaces_rows_are_invisible_and_untouchable():
+    """The management command sweeps every tenant. The MCP surface must not —
+    this is the whole reason the scoped path exists."""
+    mine = User.objects.create_user(username="jj", email="jj@dimagi.com")
+    theirs = User.objects.create_user(username="amie", email="amie@dimagi.com")
+    _session_with(_workspace("mine", mine), [(Message.USER, SKILL_BODY)])
+    _session_with(_workspace("theirs", theirs), [(Message.USER, SKILL_BODY)])
+
+    with as_user(mine):
+        report = _call("purge_session_noise", {"apply": True})
+
+    assert report["matched"] == 1 and report["deleted"] == 1
+    remaining = Message.objects.select_related("session__workspace")
+    assert [m.session.workspace.slug for m in remaining] == ["theirs"]
+
+
+@pytest.mark.django_db
+def test_an_unresolvable_caller_sees_nothing_rather_than_everything():
+    """Scope fails CLOSED. If the user can't be resolved the scope is empty, and
+    an empty scope must match no rows — never degrade to global."""
+    user = User.objects.create_user(username="jj", email="jj@dimagi.com")
+    _session_with(_workspace("canopy", user, member=False), [(Message.USER, SKILL_BODY)])
+
+    stranger = User.objects.create_user(username="nobody", email="nobody@example.com")
+    with as_user(stranger):
+        report = _call("purge_session_noise", {"apply": True})
+
+    assert report["matched"] == 0
+    assert report["deleted"] == 0
+    assert Message.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_a_single_session_can_be_targeted():
+    user = User.objects.create_user(username="jj", email="jj@dimagi.com")
+    ws = _workspace("canopy", user)
+    keep = _session_with(ws, [(Message.USER, SKILL_BODY)])
+    target = _session_with(ws, [(Message.USER, SKILL_BODY)])
+
+    with as_user(user):
+        report = _call("purge_session_noise", {"session_id": str(target.id), "apply": True})
+
+    assert report["deleted"] == 1
+    assert list(Message.objects.values_list("session_id", flat=True)) == [keep.id]
+
+
+@pytest.mark.django_db
+def test_a_real_message_is_never_matched():
+    """Prefix-anchored: a human ASKING about a skill's base directory is talking."""
+    user = User.objects.create_user(username="jj", email="jj@dimagi.com")
+    ws = _workspace("canopy", user)
+    _session_with(ws, [(Message.USER, "what is the base directory for this skill?")])
+
+    with as_user(user):
+        report = _call("purge_session_noise", {"apply": True})
+
+    assert report["matched"] == 0
+    assert Message.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_an_assistant_row_quoting_a_marker_survives():
+    user = User.objects.create_user(username="jj", email="jj@dimagi.com")
+    ws = _workspace("canopy", user)
+    _session_with(ws, [(Message.ASSISTANT, SKILL_BODY)])
+
+    with as_user(user):
+        report = _call("purge_session_noise", {"apply": True})
+
+    assert report["matched"] == 0
+    assert Message.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_the_sample_is_bounded_however_much_is_asked_for():
+    """The report travels into a model's context; an unbounded sample is a
+    denial of service against whoever reads it."""
+    from apps.canopy_sessions import maintenance
+
+    user = User.objects.create_user(username="jj", email="jj@dimagi.com")
+    ws = _workspace("canopy", user)
+    _session_with(ws, [(Message.USER, SKILL_BODY) for _ in range(80)])
+
+    with as_user(user):
+        report = _call("audit_session_noise", {"sample": 1000})
+
+    assert report["matched"] == 80
+    assert len(report["sample"]) == maintenance.SAMPLE_MAX

--- a/apps/mcp/tools/__init__.py
+++ b/apps/mcp/tools/__init__.py
@@ -7,4 +7,5 @@ exactly once, after the FastMCP instance is constructed.
 from . import (
     insights,  # noqa: F401
     schedules,  # noqa: F401
+    sessions,  # noqa: F401
 )

--- a/apps/mcp/tools/sessions.py
+++ b/apps/mcp/tools/sessions.py
@@ -1,0 +1,124 @@
+"""Stored-session maintenance MCP tools — run as the authenticated user.
+
+`audit_session_noise` (read) and `purge_session_noise` (write) call the SAME
+shared functions as the `purge_transcript_noise` management command
+(`apps.canopy_sessions.maintenance`), so the two surfaces can never drift.
+
+This exists because the alternative was reaching prod data with a one-off
+`aws ecs run-task` command override: unrepeatable, unauditable, and gated on
+whoever held AWS credentials. Over MCP the same work is a normal authenticated
+call — scoped to the caller's workspaces, rate-limited, and written to the audit
+log like every other write.
+
+Every tool:
+  * resolves the authenticated user from the access token,
+  * scopes to that user's workspaces (empty scope sees NOTHING — fails closed),
+  * (for writes) enforces a per-user rate limit,
+  * runs the ORM work via sync_to_async,
+  * writes an MCPAuditLog row (best-effort).
+"""
+from __future__ import annotations
+
+from asgiref.sync import sync_to_async
+
+from apps.canopy_sessions import maintenance
+from apps.mcp.audit import current_user_id, write_audit
+from apps.mcp.rate_limit import RateLimitError, check_write_limit
+from apps.mcp.server import mcp
+from apps.workspaces import services as wsvc
+
+
+@mcp.tool
+async def audit_session_noise(
+    session_id: str | None = None,
+    sample: int = 5,
+) -> dict:
+    """Report harness output stored as USER messages in your sessions.
+
+    Claude Code writes task notifications, system reminders, skill bodies and
+    interrupt markers as `type: "user"` transcript records, so they can land in
+    the store looking like something a person typed. Ingest filters them now;
+    this finds rows written before a given prefix was recognised.
+
+    Args:
+      - session_id: restrict to one session (UUID). Omit for all your sessions.
+      - sample: example rows to include (clamped to 50; default 5).
+
+    Returns {"matched", "sessions", "sample": [{session_id, workspace,
+    turn_index, text}]}. Read-only — see `purge_session_noise` to delete.
+    """
+    user_id = current_user_id()
+    summary = f"session_id={session_id} sample={sample}"
+    slugs = await sync_to_async(wsvc.workspace_slugs_for_user_id, thread_sensitive=True)(user_id)
+    try:
+        report = await sync_to_async(maintenance.audit_noise, thread_sensitive=True)(
+            workspace_slugs=slugs, session_id=session_id, sample=sample,
+        )
+    except Exception as exc:  # noqa: BLE001
+        await write_audit(
+            user_id=user_id, tool="audit_session_noise",
+            args_summary=summary, ok=False, error=str(exc),
+        )
+        raise
+    await write_audit(
+        user_id=user_id, tool="audit_session_noise",
+        args_summary=f"{summary} -> matched={report['matched']}", ok=True,
+    )
+    return report
+
+
+@mcp.tool
+async def purge_session_noise(
+    session_id: str | None = None,
+    apply: bool = False,
+    sample: int = 5,
+) -> dict:
+    """Delete harness output stored as USER messages in your sessions.
+
+    DRY RUN BY DEFAULT: without `apply=True` this reports what WOULD go and
+    deletes nothing. Deleting is irreversible and the match is only as good as
+    the current prefix list, so the intended sequence is audit -> read the count
+    -> apply.
+
+    Args:
+      - session_id: restrict to one session (UUID). Omit for all your sessions.
+      - apply: actually delete. Default False.
+      - sample: example rows to include (clamped to 50; default 5).
+
+    Returns the audit report plus {"applied", "deleted"}. Scoped to your
+    workspaces; rate-limited per user.
+    """
+    user_id = current_user_id()
+    summary = f"session_id={session_id} apply={apply} sample={sample}"
+
+    # Rate-limit only the destructive call. A dry run is a read wearing this
+    # tool's name, and making it cost a write slot would push callers toward
+    # skipping straight to apply — the opposite of what the gate is for.
+    if apply and user_id is not None:
+        try:
+            check_write_limit(user_id)
+        except RateLimitError as exc:
+            await write_audit(
+                user_id=user_id, tool="purge_session_noise",
+                args_summary=summary, ok=False, error=str(exc),
+            )
+            raise
+
+    slugs = await sync_to_async(wsvc.workspace_slugs_for_user_id, thread_sensitive=True)(user_id)
+    try:
+        report = await sync_to_async(maintenance.purge_noise, thread_sensitive=True)(
+            workspace_slugs=slugs, session_id=session_id, sample=sample, apply=apply,
+        )
+    except Exception as exc:  # noqa: BLE001
+        await write_audit(
+            user_id=user_id, tool="purge_session_noise",
+            args_summary=summary, ok=False, error=str(exc),
+        )
+        raise
+
+    await write_audit(
+        user_id=user_id, tool="purge_session_noise",
+        args_summary=f"{summary} -> matched={report['matched']} deleted={report['deleted']}",
+        ok=True,
+    )
+    return report


### PR DESCRIPTION
## Why

To purge the harness rows that predate a noise-prefix change, the only path was:

```
aws ecs run-task --cluster labs-jj-cluster --task-definition labs-jj-canopy-web \
  --overrides '{"containerOverrides":[{"command":["python","manage.py","purge_transcript_noise"]}]}'
```

Unrepeatable, unauditable, unscoped across every tenant, and gated on whoever held AWS credentials that day. That's a stunt, not a capability — and stored sessions will need work again.

## What

The matching and deleting move to `apps/canopy_sessions/maintenance.py`; both callers get thin.

**MCP — the path to actually use.** `audit_session_noise` (read) and `purge_session_noise` (write), following the `insights` tool pattern exactly: authenticated user, workspace-scoped, rate-limited on the destructive call, `MCPAuditLog` row per call. No AWS, no container, no shell.

```jsonc
audit_session_noise()                              // what's in there
purge_session_noise()                              // dry run — reports, deletes nothing
purge_session_noise({apply: true})                 // commit
purge_session_noise({session_id: "…", apply: true})// one session
```

**The management command keeps the case MCP deliberately can't serve** — an unscoped sweep across *every* workspace. It gained `--session` / `--workspace`, and now prints its scope before the numbers, so an operator deleting across all tenants sees that stated first.

## Safety properties

- **Scope fails closed.** `workspace_slugs` is required; an empty set matches nothing. Unscoped is the explicit `ALL_WORKSPACES` sentinel, not `None` — "the scope lookup returned nothing" must never be one typo from "every workspace". An unresolvable caller sees zero rows.
- **Dry run by default** on both surfaces. The sample is captured *before* the delete, so the result records what went rather than describing an empty table.
- **Deliberately under-matches.** `istartswith` can't mirror `is_system_noise`'s `.lstrip()`, so a leading-whitespace row survives. A missed row is cosmetic; an over-matched one is deleted user speech.
- **Only the apply path costs a write slot.** Rate-limiting the dry run would push callers toward skipping straight to `apply` — the opposite of what the gate is for.
- **One definition.** Both surfaces call `audit_noise`/`purge_noise`, so they can't drift — the same discipline #533 applied to the noise rule itself.

## Tests

9 on the MCP surface, most about what it must **refuse**: reaching another workspace's rows, deleting without being asked twice, degrading to global scope when the caller can't be resolved, matching a human who quotes a marker, and touching assistant rows.

`1938 passed, 1 skipped` (was 1925); `ruff check . --select F --ignore F403,F405` clean.

## Not in scope

The `maintenance` module is shaped so other stored-session operations slot in, but I didn't invent any. This ships the one operation there's a real need for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)