### PR TITLE
Tell me when a chat message bounced off a question the agent is asking

### DIFF
--- a/runner/canopy_runner/canopy_runner/execute.py
+++ b/runner/canopy_runner/canopy_runner/execute.py
@@ -25,7 +25,7 @@ import re
 import time
 from pathlib import Path
 
-from . import cdp_control, chat_bridge, dialog, emdash, readiness, transcript
+from . import cdp_control, chat_bridge, dialog, emdash, hooks, readiness, transcript
 from .tail import TailReader
 
 logger = logging.getLogger("canopy_runner.execute")
@@ -233,6 +233,52 @@ def prompt_with_attachments(prompt: str, paths: list[pathlib.Path]) -> str:
         f"with the Read tool before replying:\n{lines}"
     )
 
+def _blocking_dialog_note(cfg, client, runner_id: str, turn: dict, task: str, exc) -> str:
+    """Why a reuse send failed, in terms the human can act on — and, when the
+    answer is "a dialog is up", the dialog itself.
+
+    `COMPOSER_NOT_VISIBLE` means something is drawn where the input line should
+    be, and the overwhelmingly common something is a menu the agent is waiting
+    on. That is the one send failure a human can actually resolve, and it used
+    to be the quietest thing in the system: the phone got a failed turn carrying
+    a runner-internal string, so "the agent asked you something" and "the send
+    broke" looked identical. Observed 2026-07-30 — three sends bounced off an
+    unanswered AskUserQuestion and the session sat dead for 139 minutes.
+
+    Reading the screen here is free of the hazard that rules it out on a hook
+    signal (see `hooks.start_hook_listener`): `open-send` has ALREADY opened this
+    task, so it is the active terminal and no focus is stolen. A human asked for
+    this send; the read is part of servicing it.
+
+    Best-effort throughout — this is the failure path, and nothing here may turn
+    a reported failure into an unreported one.
+    """
+    plain = f"chat reuse send failed: {str(exc)[:200]}"
+    if "COMPOSER_NOT_VISIBLE" not in str(exc):
+        return plain
+    try:
+        # The hook path's serializer, deliberately: a menu must reach the phone
+        # in ONE shape whichever path found it, or the client grows two readers.
+        menu = hooks.read_hook_menu_from(cdp_control, task, cdp_port=cfg.cdp_port)
+    except Exception:  # noqa: BLE001
+        logger.debug("could not read the dialog on %s", task, exc_info=True)
+        return plain
+    if menu is None:
+        # Mid-redraw or a stale frame — the error's other causes. Saying "blocked"
+        # here would report an agent as needing a human when it is merely busy.
+        return plain
+    session_id = (turn.get("origin_ref") or {}).get("chat_session_id") or ""
+    try:
+        client.post_session_stream(runner_id, session_id, [{
+            "kind": "activity:blocked", "seq": -1, "index": -1,
+            "payload": {"menu": menu},
+        }])
+    except Exception:  # noqa: BLE001 — observability may never cost a turn
+        logger.debug("could not ship the dialog for session %s", session_id, exc_info=True)
+    question = menu.get("question") or "a question"
+    return f"not delivered — the agent is waiting on {question}"
+
+
 def execute_chat_turn(cfg, client, runner_id: str, turn: dict, cancel_check=None) -> str:
     """A chat SESSION turn: inject the human's message into the session's emdash session,
     and REGISTER a bridge that carries the assistant reply back into the ledger — unlike
@@ -268,7 +314,9 @@ def execute_chat_turn(cfg, client, runner_id: str, turn: dict, cancel_check=None
             res = cdp_control.open_and_send(task, prompt, port=cfg.cdp_port)
         except Exception as exc:  # noqa: BLE001 — any send failure ends the turn
             logger.error("chat reuse send failed turn=%s task=%s: %s", turn_id, task, exc)
-            client.fail_turn(turn_id, f"chat reuse send failed: {str(exc)[:200]}")
+            client.fail_turn(
+                turn_id, _blocking_dialog_note(cfg, client, runner_id, turn, task, exc)
+            )
             return f"failed:{turn_id}"
         # A collision is `ok: true` with action="collision" and NOTHING delivered —
         # not an exception. This path used to discard the result entirely, so a

--- a/runner/canopy_runner/tests/test_execute_chat.py
+++ b/runner/canopy_runner/tests/test_execute_chat.py
@@ -6,6 +6,8 @@ import pytest
 
 from canopy_runner import chat_bridge, execute
 
+from .test_menu import BUSY, PERMISSION
+
 
 class _FakeClient:
     def __init__(self):
@@ -134,3 +136,77 @@ def test_a_collision_is_not_an_exception_so_it_must_be_inspected(monkeypatch):
     res = execute.cdp_control.open_and_send("task-1", "the message")
     assert res["ok"] is True             # NOT an error
     assert res["action"] == "collision"  # but nothing was delivered
+
+
+# -- a send that bounces off a dialog must say WHAT is being asked ------------
+
+class _ReuseClient(_FakeClient):
+    """A chat client whose session already has an emdash task to reuse."""
+
+    def __init__(self):
+        super().__init__()
+        self.streamed = []
+
+    def resolve_session(self, *a, **k):
+        return {"reuse": True, "emdash_task_id": "ada-chat-1435"}
+
+    def post_session_stream(self, runner_id, session_id, events):
+        self.streamed.append({"session_id": session_id, "events": events})
+
+
+def _bounce_off_a_dialog(monkeypatch, screen):
+    """A reuse send that fails COMPOSER_NOT_VISIBLE, with `screen` on the terminal."""
+    def _no_composer(task, text, clear_first=False, port=9222):
+        raise execute.cdp_control.CDPError(
+            'COMPOSER_NOT_VISIBLE: no input line in the rendered frame for '
+            f'task "{task}" (mid-redraw, a menu is up, or a stale frame) '
+            '— refusing a blind send')
+
+    monkeypatch.setattr(execute.cdp_control, "open_and_send", _no_composer)
+    monkeypatch.setattr(execute.cdp_control, "read_terminal", lambda task, port=9222: screen)
+    monkeypatch.setattr(execute.emdash, "task_state", lambda *a, **k: "open")
+    cfg = types.SimpleNamespace(cdp_port=9222, emdash_db="/nonexistent")
+    client = _ReuseClient()
+    res = execute.execute_chat_turn(cfg, client, "runner1", _turn())
+    return res, client
+
+
+def test_composer_not_visible_ships_the_dialog_the_agent_is_waiting_on(monkeypatch):
+    """The composer is missing BECAUSE a dialog is where the input line should be.
+
+    `open-send` has already opened that task, so it is the active terminal and the
+    menu is free to read — no focus steal, which is what rules reading one out on a
+    hook signal. Without this the phone gets a bare failed turn: no question, no
+    buttons, and no way to tell "the agent asked you something" from "the send
+    broke". That is the silence that cost 2026-07-30 two hours.
+    """
+    res, client = _bounce_off_a_dialog(monkeypatch, PERMISSION)
+
+    assert res.startswith("failed:")
+    blocked = [e for s in client.streamed for e in s["events"]
+               if e["kind"] == "activity:blocked"]
+    assert blocked, "the phone was never told the agent is waiting on a dialog"
+    menu = blocked[0]["payload"]["menu"]
+    assert menu["question"] == "Do you want to proceed?"
+    assert [o["label"] for o in menu["options"]][0] == "Yes"
+    assert client.streamed[0]["session_id"] == "s1"
+
+
+def test_a_bounced_send_says_the_agent_is_waiting_not_just_the_cdp_error(monkeypatch):
+    """`chat reuse send failed: COMPOSER_NOT_VISIBLE...` is a runner-internal
+    string. The human needs the actionable half: their message did not land
+    because the agent is waiting on a question."""
+    _res, client = _bounce_off_a_dialog(monkeypatch, PERMISSION)
+
+    assert "waiting" in (client.failed or "").lower()
+
+
+def test_a_bounce_with_no_dialog_on_screen_stays_a_plain_failure(monkeypatch):
+    """Mid-redraw and stale frames hit the same error with NO menu. Reporting
+    "blocked" there would tell the phone an agent needs a human when it is merely
+    busy — the negative case `menu.BUSY` exists to protect."""
+    res, client = _bounce_off_a_dialog(monkeypatch, BUSY)
+
+    assert res.startswith("failed:")
+    assert not [e for s in client.streamed for e in s["events"]
+                if e["kind"] == "activity:blocked"]


### PR DESCRIPTION
## The problem

On 2026-07-30 three messages sent from a phone vanished. The session sat dead for **139 minutes**.

The agent had ended its turn with an `AskUserQuestion`, so a menu was drawn where the composer normally is. Every subsequent send hit `COMPOSER_NOT_VISIBLE` and failed closed — correctly; blind-typing into a dialog is exactly what that guard prevents. But the only thing the phone received was a failed turn carrying a runner-internal string:

```
chat reuse send failed: COMPOSER_NOT_VISIBLE: no input line in the rendered
frame for task "..." (mid-redraw, a menu is up, or a stale frame)
```

So "the agent asked you something" and "the send broke" looked identical, and the one failure the human could actually resolve was the quietest thing in the system.

## The fix

When a reuse send bounces with `COMPOSER_NOT_VISIBLE`, read the dialog off the screen and ship it as `activity:blocked`, then fail the turn with the actionable half — `not delivered — the agent is waiting on <question>`.

**The change is smaller than the problem suggests, because the rest already exists.** `stream_map.turn_event_to_frames` already maps `activity:*` + a `menu` payload into a `session.activity` frame, and `MenuPrompt.tsx` already renders the buttons. Nothing was telling them to. This wires the one missing producer and reuses `hooks.read_hook_menu_from` as the serializer, so a menu reaches the phone in one shape whichever path found it.

### Why reading the screen is safe here

`hooks.start_hook_listener` documents at length why a menu must **not** be read on a hook signal: `openTask` clicks the task and steals emdash's focus, which was reported twice on 2026-07-28 and manufactured the very leaked-keystroke collisions the send guard exists to catch.

That hazard does not apply on this path. `open-send` has **already** opened this task before failing, so it is the active terminal — the read costs no additional focus change, and a human just asked for this send.

## Confidence

Three tests, each written failing first:

- a bounce with a dialog on screen ships `activity:blocked` carrying the parsed question and options, addressed to the right session
- the failure note says the agent is *waiting*, not just the CDP error
- **a bounce with no dialog stays a plain failure** — `COMPOSER_NOT_VISIBLE` also covers mid-redraw and stale frames, and reporting "blocked" there would tell the phone an agent needs a human when it is merely busy

The dialog fixture is the captured-from-a-real-PTY one already in `test_menu.py`, not a hand-written string. Full runner suite: 325 passed.

## What this does not fix

If you never send, you are still never told. Proactive `blocked` for a session with no viewer attached needs the cwd→session map widened beyond viewer-attached sessions, which needs the sessions report to return ids — a separate change. This covers the journey that actually happens: you send, and you are told why it did not land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)