### PR TITLE
Stop a dead port in the hook config from silently turning live events off

### DIFF
--- a/runner/canopy_runner/canopy_runner/hook_install.py
+++ b/runner/canopy_runner/canopy_runner/hook_install.py
@@ -109,6 +109,31 @@ def install(settings_path: Path, *, port: int, nonce: str) -> bool:
     return True
 
 
+def is_current(settings_path: Path, *, port: int, nonce: str) -> bool:
+    """True when every hooked event carries exactly our current command.
+
+    The question `install` cannot answer on its own: this file is shared by the
+    whole account, `install` runs once at startup, and anything that writes
+    afterwards wins. Comparing against `hook_command` rather than parsing a port
+    out means a rotated nonce counts as drift too — a stale nonce is rejected by
+    the listener, which is silent in the same way a dead port is.
+    """
+    settings = _load(settings_path)
+    hooks = settings.get("hooks")
+    if not isinstance(hooks, dict):
+        return False
+    want = hook_command(port, nonce)
+    for event in HOOK_EVENTS:
+        ours = [e for e in hooks.get(event, []) if isinstance(e, dict) and _is_ours(e)]
+        if len(ours) != 1:
+            return False
+        commands = [h.get("command") for h in ours[0].get("hooks", [])
+                    if isinstance(h, dict)]
+        if commands != [want]:
+            return False
+    return True
+
+
 def remove(settings_path: Path) -> bool:
     """Remove canopy's hook, leaving every other hook in place.
 

--- a/runner/canopy_runner/canopy_runner/hooks.py
+++ b/runner/canopy_runner/canopy_runner/hooks.py
@@ -78,6 +78,44 @@ def maybe_report_hooks(now_fn=time.monotonic) -> None:
     )
 
 
+def ensure_hook_config(settings_path=None) -> bool:
+    """Re-point the hook config at the live listener if it has drifted. Returns
+    True if it was repaired.
+
+    `install` runs ONCE, at startup — but `~/.claude/settings.json` is one file
+    per ACCOUNT, shared by every runner instance and every Claude Code session on
+    it, so whatever writes last wins permanently. The free-port fallback is
+    itself such a writer: a second instance that loses the port race takes an
+    ephemeral port and re-points the account's hooks at itself. When that
+    instance exits, every hook on the account curls a port nothing is listening
+    on — the live-events-off failure the fallback exists to prevent, arriving by
+    a different door. Observed 2026-07-30: runner on :8788, config on :49366,
+    nothing bound there.
+
+    So the config is treated as observed state that converges, not as a fact
+    declared once — the same shape as `capabilities["projects"]` (reported, never
+    typed) and session liveness (polled, self-healing). One small read per tick
+    buys an invariant that repairs itself within a poll no matter who wrote over
+    it.
+
+    Deliberately NOT folded into `maybe_report_hooks`: that returns early while
+    `received == 0`, and "no hooks are arriving" is precisely the condition being
+    healed, so the repair would be unreachable exactly when it is needed.
+    """
+    listener = _hook_listener
+    if listener is None or listener.port <= 0:
+        return False
+    path = settings_path or (Path.home() / ".claude" / "settings.json")
+    if hook_install.is_current(path, port=listener.port, nonce=listener.nonce):
+        return False
+    if not hook_install.install(path, port=listener.port, nonce=listener.nonce):
+        return False
+    logger.warning(
+        "hook config no longer pointed at this listener (something else wrote %s); "
+        "re-pointed it at :%d", path, listener.port)
+    return True
+
+
 def resolve_hook_session(cwd: str) -> str:
     """A hook's cwd -> canopy session id, or "" if this isn't a session we back.
 

--- a/runner/canopy_runner/canopy_runner/main.py
+++ b/runner/canopy_runner/canopy_runner/main.py
@@ -374,6 +374,11 @@ def run_once(cfg: Config, client: Client) -> str:
     # finishing a turn here frees the session for the next message. Runs even while
     # CDP is down — the transcript keeps growing whether or not we can drive emdash.
     hooks.maybe_report_hooks()
+    # The hook config is shared by the whole account and written by anything that
+    # starts a listener, so it can be pointed away from us after startup. Checked
+    # every tick rather than on the report's cadence: the report is gated on hooks
+    # ARRIVING, which is the very thing a drifted config stops.
+    hooks.ensure_hook_config()
     chat_pump.pump_chat_bridges(cfg, client)
     sessions.maybe_report_sessions(cfg, client)
     streams.sync_session_streams(cfg, client)

--- a/runner/canopy_runner/tests/test_hook_listener.py
+++ b/runner/canopy_runner/tests/test_hook_listener.py
@@ -413,3 +413,94 @@ def test_the_hook_config_is_written_with_the_port_actually_bound(monkeypatch, tm
         if listener is not None:
             listener.stop()
         squatter.stop()
+
+
+# -- the hook config must keep pointing at the LIVE listener ------------------
+#
+# `~/.claude/settings.json` is ONE file per account, shared by every runner
+# instance and every Claude Code session on it. `install()` runs once, at
+# startup — so anything that rewrites the file afterwards wins permanently.
+# The free-port fallback is exactly such a writer: a second instance that loses
+# the race takes an ephemeral port and re-points the account's hooks at itself,
+# and if it then exits, every hook curls a port nothing is listening on.
+#
+# Observed live 2026-07-30: the runner listening on :8788, the config pointing
+# at :49366, nothing bound there, and the hook receipt rate collapsing from 293
+# per 5 minutes to 88 as sessions restarted onto the dead port.
+
+
+def _idle_listener(port, nonce):
+    """A listener that has never received a hook — the state a repair must work in."""
+    listener = HookListener(port=port, nonce=nonce,
+                            resolve_session=lambda cwd: "s", forward=lambda: True)
+    listener.bind_sender(lambda sid, ev: None)
+    return listener
+
+
+def test_a_config_pointing_somewhere_else_is_re_pointed_at_the_live_listener(
+        tmp_path, monkeypatch):
+    settings = tmp_path / "settings.json"
+    hook_install.install(settings, port=49366, nonce="from-an-instance-that-died")
+    monkeypatch.setattr(hooks, "_hook_listener", _idle_listener(8788, "live"))
+
+    assert hooks.ensure_hook_config(settings) is True
+    assert hook_install.is_current(settings, port=8788, nonce="live")
+
+
+def test_the_repair_does_not_wait_for_a_hook_to_arrive(tmp_path, monkeypatch):
+    """The condition being healed IS "no hooks are arriving", so the repair must
+    not be gated on one. `maybe_report_hooks` returns early while `received == 0`
+    — folding the repair in there would make it unreachable in precisely the
+    state that needs it."""
+    settings = tmp_path / "settings.json"
+    hook_install.install(settings, port=49366, nonce="stale")
+    listener = _idle_listener(8788, "live")
+    monkeypatch.setattr(hooks, "_hook_listener", listener)
+
+    assert listener.received == 0
+    assert hooks.ensure_hook_config(settings) is True
+
+
+def test_a_config_already_pointing_at_us_is_left_alone(tmp_path, monkeypatch):
+    """Re-writing an already-correct file every tick would churn a file other
+    processes read, for nothing."""
+    settings = tmp_path / "settings.json"
+    hook_install.install(settings, port=8788, nonce="live")
+    before = settings.read_text()
+    monkeypatch.setattr(hooks, "_hook_listener", _idle_listener(8788, "live"))
+
+    assert hooks.ensure_hook_config(settings) is False
+    assert settings.read_text() == before
+
+
+def test_a_repair_preserves_hooks_canopy_did_not_install(tmp_path, monkeypatch):
+    """emdash writes its own hooks; the repair goes through `install`, which
+    already protects them, and this pins that it stays true on this path."""
+    settings = tmp_path / "settings.json"
+    settings.write_text(json.dumps({"hooks": {"Stop": [
+        {"hooks": [{"type": "command", "command": "curl emdash-of-its-own"}]}]}}))
+    hook_install.install(settings, port=49366, nonce="stale")
+    monkeypatch.setattr(hooks, "_hook_listener", _idle_listener(8788, "live"))
+
+    hooks.ensure_hook_config(settings)
+
+    assert "emdash-of-its-own" in settings.read_text()
+
+
+def test_nothing_is_written_when_the_listener_never_started(tmp_path, monkeypatch):
+    """`hook_port = 0` (or a bind that truly failed) leaves no listener. Writing
+    a config then would point hooks at a port we are not on."""
+    settings = tmp_path / "settings.json"
+    monkeypatch.setattr(hooks, "_hook_listener", None)
+
+    assert hooks.ensure_hook_config(settings) is False
+    assert not settings.exists()
+
+
+def test_is_current_sees_a_changed_port(tmp_path):
+    settings = tmp_path / "settings.json"
+    hook_install.install(settings, port=8788, nonce="n")
+
+    assert hook_install.is_current(settings, port=8788, nonce="n")
+    assert not hook_install.is_current(settings, port=49366, nonce="n")
+    assert not hook_install.is_current(settings, port=8788, nonce="rotated")


### PR DESCRIPTION
## The problem

#534 fixed the two-runner port collision: on `EADDRINUSE` the listener takes a free port and installs *that* one, so a second account's runner no longer runs blind forever. That part works — verified on a box with both runners on `181221d` and the two-account collision genuinely retired.

But it introduced a new writer of `~/.claude/settings.json`, and that file is **one file per account** — shared by every runner instance and every Claude Code session on it. `install` runs once, at startup. So anything that writes it afterwards wins permanently.

A second instance that loses the port race is exactly such a writer: it takes an ephemeral port and re-points the whole account's hooks at itself. When it exits, every hook curls a port nothing is listening on.

**Observed live, 2026-07-30:**

| | |
|---|---|
| Runner (pid 61330, up since 17:58) | listening on `:8788`, answers `200` |
| `~/.claude/settings.json`, rewritten 20:12 | all five hooks → `:49366` |
| Listening on `:49366` | nothing — `curl` returns `000` |

with the receipt rate collapsing from **293 hooks per 5 min to 88** as sessions restarted onto the dead port. Same outcome as the bug #534 fixed — live events off, silently — reached by a different route.

Not hand-repairable, either: the nonce in the file belongs to whichever process wrote it, so writing the right port in isolation just gets every hook rejected as a bad nonce. Only a restart fixes it today.

## The fix

Treat the hook config as observed state that converges, rather than a fact declared once at boot — the shape `capabilities["projects"]` (reported, never typed) and session liveness (polled, self-healing) already use here. Each tick, if the file no longer carries this listener's exact command, re-assert it.

`is_current` compares against `hook_command(port, nonce)` rather than parsing a port out, so a **rotated nonce counts as drift too** — a stale nonce is rejected by the listener, which is silent in precisely the same way a dead port is.

### Two things worth flagging

**It is not folded into `maybe_report_hooks`.** That returns early while `received == 0`, and "no hooks are arriving" is the exact condition being healed — the repair would be unreachable in the only state that needs it. There's a test pinning that.

**It runs every tick, not on a timer.** One small JSON read per poll. A timer would be a second piece of timing state to get wrong for no measurable saving.

## Confidence

Six tests, each watched failing first: drift is repaired; a matching config is left byte-identical (no churn on a file other processes read); the repair works with `received == 0`; hooks canopy did not install survive it; nothing is written when no listener started; and `is_current` catches a changed port *and* a rotated nonce.

Full runner suite: 344 passed.

## Rollout note

Runner code, so it takes effect once `main` deploys and boxes update to that sha. The box this was found on was repaired by hand in the meantime (a restart, which reinstalls port and nonce together).

🤖 Generated with [Claude Code](https://claude.com/claude-code)