### PR TITLE
feat(runner): the cloud box updates itself too

### DIFF
--- a/.github/workflows/deploy-labs.yml
+++ b/.github/workflows/deploy-labs.yml
@@ -123,6 +123,24 @@ jobs:
           echo "committed_at=${TS:-0}" >> "$GITHUB_OUTPUT"
           echo "Runner source last changed at ${SHA:-<none>} (${TS:-0})"
 
+      # The same quantity for the OTHER runner. The cloud box is a different
+      # program with its own path, so one sha cannot describe both — served
+      # per-runner-kind by RunnerOut (spec 2026-07-30).
+      #
+      # bootstrap_agents.sh is in scope alongside the runner itself: it re-runs on
+      # every service start, but nothing ever TRIGGERS a start, so a bootstrap fix
+      # ships only when a human happens to restart the box. Including it here is
+      # what makes the auto-updater supply that missing event.
+      - name: Resolve cloud runner code sha
+        id: cloud_sha
+        run: |
+          PATHS="runner/ec2/cloud_runner.py runner/ec2/bootstrap_agents.sh"
+          SHA="$(git log -1 --format=%H -- $PATHS)"
+          TS="$(git log -1 --format=%ct -- $PATHS)"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "committed_at=${TS:-0}" >> "$GITHUB_OUTPUT"
+          echo "Cloud runner source last changed at ${SHA:-<none>} (${TS:-0})"
+
       # Vendor the canopy plugin into the build context so apps.system can
       # render the /system catalog. canopy is PUBLIC (dimagi-internal/canopy), so
       # this needs no credentials — it used to clone via a CANOPY_PLUGIN_TOKEN PAT
@@ -164,6 +182,8 @@ jobs:
             VITE_CSRF_COOKIE_NAME=csrftoken_canopy
             RUNNER_CODE_SHA=${{ steps.runner_sha.outputs.sha }}
             RUNNER_CODE_COMMITTED_AT=${{ steps.runner_sha.outputs.committed_at }}
+            RUNNER_CLOUD_CODE_SHA=${{ steps.cloud_sha.outputs.sha }}
+            RUNNER_CLOUD_CODE_COMMITTED_AT=${{ steps.cloud_sha.outputs.committed_at }}
           tags: |
             ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPO }}:latest
             ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPO }}:${{ github.sha }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -395,19 +395,53 @@ Log: `~/.canopy/updater.log`. Testing a branch on a box? Bootout the updater fir
 or it reverts you to the deployed sha within 30 minutes.
 
 **Runner code provenance.** The heartbeat carries `code_version` (the package's
-`__version__`, legible) and `code_sha` — **the sha of the last commit touching
-`runner/canopy_runner/canopy_runner/`**, NOT the repo HEAD. The server holds the same
-quantity in `settings.RUNNER_CODE_SHA` (computed by the deploy workflow, which needs
-`fetch-depth: 0`, and baked in as a build arg), and `/supervisor` alerts when both are
-non-empty and differ: that box is executing an older runner. Path-scoped on purpose — HEAD
-moves on every canopy-web commit, so comparing it would demand a runner reinstall for a CSS
-change. **Empty on either side means UNKNOWN and never alerts** (the cloud runner is a
-different program and reports none; a dev server bakes in no expectation). A version number
-is deliberately not the comparison: it depends on someone remembering to bump it, and is
-therefore decorative on the day they forget. See
+`__version__`, legible) and `code_sha` — **the sha of the last commit touching the runner's
+own source**, NOT the repo HEAD. "Its own source" is **per runner kind**, because the fleet
+runs two programs: `runner/canopy_runner/canopy_runner/` for a laptop, `runner/ec2/` for a
+cloud box. The server holds the matching pair (`settings.RUNNER_CODE_SHA` /
+`RUNNER_CLOUD_CODE_SHA`, computed by the deploy workflow — which needs `fetch-depth: 0` —
+and baked in as build args); `RunnerOut.expected_code_sha` serves whichever matches the
+row's `kind`, and `/supervisor` alerts when both are non-empty and differ: that box is
+executing an older runner. Path-scoped on purpose — HEAD moves on every canopy-web commit,
+so comparing it would demand a runner reinstall for a CSS change. **Empty on either side
+means UNKNOWN and never alerts** (an unstamped install; a dev server bakes in no
+expectation). Serving ONE sha to both kinds would be worse than silence — every cloud box
+would read stale forever. A version number is deliberately not the comparison: it depends on
+someone remembering to bump it, and is therefore decorative on the day they forget. See
 `docs/superpowers/specs/2026-07-28-runner-as-installed-package-design.md`.
 
+Provenance also rides the **WebSocket** heartbeat frame, not just the REST one, and that is
+load-bearing rather than tidy: `services.heartbeat` assigns these fields unconditionally, so
+a beat that omits them CLEARS them. The cloud runner's primary heartbeat is the WS frame, so
+without the pass-through in `apps/realtime/consumers.py::_heartbeat` anything it reported
+elsewhere was erased 20 seconds later and `code_sha` read empty forever — looking exactly
+like a runner that never reported one. Same bug class the laptop paid for with `code_branch`
+(four of six call sites silently resetting it): each runner therefore builds its heartbeat
+payload in exactly ONE place.
+
 **The cloud runner is a separate program** (`runner/ec2/cloud_runner.py`): claims on a 15s poll and drains the queue, executes via `claude -p` (or ACP behind `RUNNER_EXECUTOR=acp`, default off), declares its repos via `RUNNER_PROJECTS`, and mirrors the laptop's viewer-stream/backfill contract on its own 3s clock. `bootstrap_agents.sh` provisions the agent fleet on the box — clones each `dimagi-internal/<slug>` repo into `/opt/agents`, installs the canopy plugin, `op inject`s env, maps each agent to its gog OAuth client — invoked from `main()` AFTER `fetch_and_stage_credential()` (not cloud-init, where credentials don't exist yet), and deliberately not `set -e`, so one agent's failure doesn't take down the other four. See `docs/superpowers/specs/2026-07-25-cloud-agent-bootstrap-design.md`.
+
+**The cloud runner AUTO-UPDATES too**, on the laptop's rules (`runner/ec2/update_runner.sh`,
+a `canopy-runner-update.timer` every 30 min): it tracks the **deployed**
+`expected_code_sha` for its own path, defers while a turn is in flight
+(`/opt/canopy-runner/in-flight`, the same file shape `update.mark_busy` writes), is
+READ-ONLY against the control plane (a heartbeat from the updater would forge liveness for a
+daemon that may be dead), and is a **separate unit** — a runner that crash-loops can never
+update itself. It installs by `git show <that sha>:runner/ec2/cloud_runner.py` out of the
+`/opt/canopy-web` clone the box already keeps: pinned to the sha (never `origin/main`, which
+would run undeployed code AND leave the box permanently mismatched), and read from the
+object store so an agent turn that left the clone on a branch cannot change what installs.
+**Secrets Manager is now a first-boot SEED, not the update channel** — `canopy-fetch-env`
+installs it only when there is no `cloud_runner.py` on disk, because re-fetching it on every
+start would revert every update at the next restart. So `./up.sh` no longer ships runner code
+to a running box; code ships by merge + deploy, and the on-box override is
+`canopy-runner-update --ref <ref>` / `--from-secret`. Provenance for the seed comes from
+`up.sh`'s own `git log`, published as a second secret (`runner-code-sha`) rather than a
+stack parameter — a parameter lives in UserData, and changing UserData stop/starts the
+running box, which this value would do on every runner commit. Without that stamp a fresh
+box answers `unknown` forever, which looks identical to being up to date. Cloud-init only runs on an
+instance's FIRST boot, so this ships with a stack recycle (`./down.sh && ./up.sh &&
+./wire.sh --drill`). See `docs/superpowers/specs/2026-07-30-cloud-runner-auto-update-design.md`.
 
 **Recurring turns** — the runner-facing half of scheduling; the supervisor's CRUD is the `/api/agents/{slug}/schedules/` surface above. `runner_id` is a query param on both routes; the tenant is derived from `runner.paired_by` (the human who paired the runner) rather than the `Runner.workspace` FK — see the Design Decisions entry below.
 - `GET /api/harness/schedules/?runner_id=…` — runner syncs the schedules it may fire. **Tenant-scoped, never scoped by `capabilities`** (a caller-supplied hint, not a boundary — see b4f5ead).

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,13 @@ ENV RUNNER_CODE_SHA=$RUNNER_CODE_SHA
 # Committer epoch of that same commit — the ordering the sha can't carry.
 ARG RUNNER_CODE_COMMITTED_AT="0"
 ENV RUNNER_CODE_COMMITTED_AT=$RUNNER_CODE_COMMITTED_AT
+# The same pair for the CLOUD runner (runner/ec2), a different program on a
+# different path — one sha cannot describe both, so RunnerOut serves whichever
+# matches the row's kind. Same late placement, same empty-means-unknown rule.
+ARG RUNNER_CLOUD_CODE_SHA=""
+ENV RUNNER_CLOUD_CODE_SHA=$RUNNER_CLOUD_CODE_SHA
+ARG RUNNER_CLOUD_CODE_COMMITTED_AT="0"
+ENV RUNNER_CLOUD_CODE_COMMITTED_AT=$RUNNER_CLOUD_CODE_COMMITTED_AT
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/apps/harness/models.py
+++ b/apps/harness/models.py
@@ -113,17 +113,20 @@ class Runner(models.Model):
     # remembering to bump it, and is therefore decorative on the day they forget,
     # which is the day it matters).
     code_version = models.CharField(max_length=64, blank=True, default="")
-    # The sha of the last commit that touched the runner's OWN source
-    # (`runner/canopy_runner/canopy_runner/`) — NOT the repo HEAD, which moves on
-    # every canopy-web commit and would mark every runner stale on a CSS change.
-    # `settings.RUNNER_CODE_SHA` holds the same quantity computed at image-build
-    # time, and the supervisor alerts when both are non-empty and differ.
+    # The sha of the last commit that touched the runner's OWN source — NOT the
+    # repo HEAD, which moves on every canopy-web commit and would mark every runner
+    # stale on a CSS change. "Its own source" is per KIND, because the fleet runs
+    # two programs: `runner/canopy_runner/canopy_runner/` for a laptop,
+    # `runner/ec2/` for a cloud box. The server holds the matching pair
+    # (`settings.RUNNER_CODE_SHA` / `RUNNER_CLOUD_CODE_SHA`, computed at
+    # image-build time and served per row by RunnerOut), and the supervisor alerts
+    # when both are non-empty and differ.
     #
     # Empty means UNKNOWN and must stay silent: a source checkout with no git, a
-    # shallow clone, the cloud runner (a different program with its own
-    # deployment). A staleness alert fired on partial information is worse than
-    # no alert — and this repo has paid for NULL/empty-means-something predicates
-    # before (see the six tenancy predicates that grew a "means allow" leg).
+    # shallow clone, an unstamped install. A staleness alert fired on partial
+    # information is worse than no alert — and this repo has paid for
+    # NULL/empty-means-something predicates before (see the six tenancy predicates
+    # that grew a "means allow" leg).
     code_sha = models.CharField(max_length=64, blank=True, default="")
     # Committer epoch of that same commit — the ORDER a sha cannot carry.
     #

--- a/apps/harness/schemas.py
+++ b/apps/harness/schemas.py
@@ -141,14 +141,28 @@ class RunnerOut(Schema):
 
     @staticmethod
     def resolve_expected_code_sha(obj) -> str:
+        # Per KIND, because the fleet runs two different programs: a laptop
+        # executes runner/canopy_runner, a cloud box executes runner/ec2. Serving
+        # one sha to both would mark every cloud runner permanently stale — the
+        # alert would then be pure noise on exactly the boxes it was extended to
+        # cover. Either being empty still means UNKNOWN and stays silent.
         from django.conf import settings
-        return getattr(settings, "RUNNER_CODE_SHA", "") or ""
+        from .models import Runner
+
+        setting = "RUNNER_CLOUD_CODE_SHA" if obj.kind == Runner.CLOUD else "RUNNER_CODE_SHA"
+        return getattr(settings, setting, "") or ""
 
     @staticmethod
     def resolve_expected_code_committed_at(obj) -> int:
         from django.conf import settings
+        from .models import Runner
+
+        setting = (
+            "RUNNER_CLOUD_CODE_COMMITTED_AT" if obj.kind == Runner.CLOUD
+            else "RUNNER_CODE_COMMITTED_AT"
+        )
         try:
-            return int(getattr(settings, "RUNNER_CODE_COMMITTED_AT", 0) or 0)
+            return int(getattr(settings, setting, 0) or 0)
         except (TypeError, ValueError):
             # A malformed build arg must not 500 the whole runners list — unknown
             # (0) simply means the alert keeps today's direction-less behaviour.

--- a/apps/realtime/consumers.py
+++ b/apps/realtime/consumers.py
@@ -273,7 +273,7 @@ class RunnerConsumer(AsyncJsonWebsocketConsumer):
             turn = await self._claim()
             await self.send_json({"type": "claim.result", "turn": turn})
         elif action == "heartbeat":
-            await self._heartbeat(content.get("active_turn_ids") or [])
+            await self._heartbeat(content.get("active_turn_ids") or [], content)
             await self.send_json({"type": "heartbeat.ack"})
         elif action == "start":
             ok = await self._start(content.get("turn_id"), content.get("session_id") or "")
@@ -320,10 +320,42 @@ class RunnerConsumer(AsyncJsonWebsocketConsumer):
         return _serialize_turn(turn) if turn else None
 
     @database_sync_to_async
-    def _heartbeat(self, active_turn_ids):
+    def _heartbeat(self, active_turn_ids, frame=None):
+        """Provenance rides this frame, and it HAS to.
+
+        `services.heartbeat` assigns code_branch/code_version/code_sha/
+        code_committed_at unconditionally, so a call that omits them RESETS them.
+        This path is the cloud runner's primary heartbeat (every 20s), so without
+        the pass-through anything it reports over REST — at pairing, or from a
+        lease-renewal beat — is erased moments later, and `code_sha` reads empty
+        forever while looking exactly like a runner that never reported one.
+
+        Same failure the laptop's `provenance.py` docstring records from the other
+        side: six call sites, four silently clearing the field. The fix there was
+        one stamping point; here it is not dropping what the stamp sent.
+
+        A runner too old to send these simply sends nothing, which resets to empty
+        — i.e. UNKNOWN, which is what an unknown-provenance runner should report,
+        and what this path already did for everyone.
+        """
+        frame = frame or {}
+        try:
+            committed_at = int(frame.get("code_committed_at") or 0)
+        except (TypeError, ValueError):
+            # Provenance is decoration on a liveness call. A malformed value must
+            # cost the runner its timestamp, never its heartbeat — losing the beat
+            # would take it offline and stop it claiming.
+            committed_at = 0
         runner = Runner.objects.filter(pk=self._runner_pk).first()
         if runner is not None:
-            harness_services.heartbeat(runner, active_turn_ids=active_turn_ids)
+            harness_services.heartbeat(
+                runner,
+                active_turn_ids=active_turn_ids,
+                code_branch=str(frame.get("code_branch") or ""),
+                code_version=str(frame.get("code_version") or ""),
+                code_sha=str(frame.get("code_sha") or ""),
+                code_committed_at=committed_at,
+            )
 
     def _turn_owned_sync(self, turn_id):
         """A turn THIS runner claimed — the only ones it may start/append/finish.

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -386,6 +386,18 @@ RUNNER_CODE_SHA = env("RUNNER_CODE_SHA", default="")
 # rather than merely "different" (a sha is an identity, not a position).
 RUNNER_CODE_COMMITTED_AT = env.int("RUNNER_CODE_COMMITTED_AT", default=0)
 
+# The same pair for the CLOUD runner, scoped to `runner/ec2/cloud_runner.py` +
+# `runner/ec2/bootstrap_agents.sh`. A separate quantity because it is a separate
+# program: one sha cannot describe both runners, and serving the laptop's to a
+# cloud box would mark every one of them stale forever. `RunnerOut` picks the pair
+# that matches the row's `kind`.
+#
+# bootstrap_agents.sh counts as the cloud runner's code because it re-runs on every
+# service start — but nothing ever triggers a start, so before auto-update a fix to
+# it shipped only when a human restarted the box (spec 2026-07-30).
+RUNNER_CLOUD_CODE_SHA = env("RUNNER_CLOUD_CODE_SHA", default="")
+RUNNER_CLOUD_CODE_COMMITTED_AT = env.int("RUNNER_CLOUD_CODE_COMMITTED_AT", default=0)
+
 # Key for at-rest field encryption (per-runner credentials — apps/common/encryption.py).
 # Empty → derived from SECRET_KEY (fine for dev). Set explicitly in production so the
 # encryption key can rotate independently of SECRET_KEY.

--- a/docs/superpowers/specs/2026-07-30-cloud-runner-auto-update-design.md
+++ b/docs/superpowers/specs/2026-07-30-cloud-runner-auto-update-design.md
@@ -1,0 +1,190 @@
+# The cloud runner updates itself too
+
+**Date:** 2026-07-30
+**Status:** designed
+**Supersedes for the cloud box:** `runner/ec2/README.md` § "Updating the runner code"
+**Sibling:** `docs/superpowers/specs/2026-07-28-runner-as-installed-package-design.md`
+(the laptop half — this spec is that spec applied to the other runner)
+
+## The problem
+
+The laptop runner auto-updates: a launchd timer asks the control plane which sha
+was DEPLOYED, and installs exactly that when the box is behind and idle. Shipping
+laptop runner code is therefore `merge to main` + a deploy.
+
+The cloud runner has none of it. Its bytes reach the box through Secrets Manager
+(`canopy/cloud-runner/runner-code`), published by an operator running `up.sh` from
+a laptop with AWS credentials, and re-installed by `canopy-fetch-env` on every
+service start. So shipping cloud runner code is: find the operator, find their AWS
+session, `./up.sh && systemctl restart canopy-runner`. Nothing on the box knows
+what it *should* be running, and nothing on the server knows what it *is* running —
+`Runner.code_sha` is empty for every cloud box, and `codeProvenance.ts` documents
+that silence as intended ("the cloud runner is a separate program that reports
+none").
+
+The result is a box that drifts silently and only ever in one direction. Measured
+2026-07-30: the stack was created 2026-07-26 and never updated, while
+`runner/ec2/` had moved since — nobody had noticed, because there is no surface on
+which that could have shown up.
+
+## What "expected" means for a cloud box
+
+The same thing it means for a laptop, computed over a different path.
+
+`deploy-labs.yml` already resolves `RUNNER_CODE_SHA` as
+`git log -1 --format=%H -- runner/canopy_runner/canopy_runner`. This adds
+`RUNNER_CLOUD_CODE_SHA` over **`runner/ec2/cloud_runner.py runner/ec2/bootstrap_agents.sh`**,
+with `RUNNER_CLOUD_CODE_COMMITTED_AT` as the `%ct` of that same commit — a sha is an
+identity and cannot say "behind" on its own, which is the whole reason the laptop
+carries both.
+
+Both files, not just the runner: `bootstrap_agents.sh` is re-run on every service
+start, but nothing ever *triggers* a start. A bootstrap fix therefore ships today
+only when a human happens to restart the box, which is the same absent event this
+spec exists to supply.
+
+`RunnerOut.expected_code_sha` resolves per `obj.kind` — `cloud` gets the cloud
+pair, everything else keeps today's. That is the entire server surface: the
+supervisor's existing banner, its ordering, and its unknown-means-silent rule all
+carry over untouched.
+
+### The heartbeat that erases it
+
+`services.heartbeat()` assigns `code_sha` / `code_branch` / `code_version` /
+`code_committed_at` **unconditionally**, and the cloud runner's primary heartbeat
+is a WebSocket frame whose consumer (`apps/realtime/consumers.py::_heartbeat`)
+calls that function with no provenance at all. So provenance sent on the REST
+paths would be wiped by the next WS beat 20 seconds later, and the field would
+read empty forever while looking like it had simply never been reported.
+
+This is the bug class `provenance.py`'s own docstring records — six call sites,
+four of which silently reset the field — so the fix is the same shape: the
+consumer passes provenance through, and the cloud runner stamps it in ONE place
+(`_heartbeat_body()`) used by all four of its heartbeat call sites (idle REST,
+lease renewal, pairing, WS beat).
+
+The laptop is unaffected: it uses that socket only as a wake listener and never
+sends a `heartbeat` action over it.
+
+## What the box knows about itself
+
+**`/opt/canopy-runner/build-info.json`** — `{sha, committed_at, installed_at, ref}`,
+written by whoever installed the bytes. There is no git history at
+`/opt/canopy-runner`, so the running code cannot derive its own provenance the way
+a source-mode laptop runner can; it has to be stamped, exactly as
+`install-runner.sh` stamps `_build_info.py`.
+
+Missing, unreadable, or malformed means **UNKNOWN**, and unknown does nothing and
+says nothing. This repo has paid for empty-means-something predicates before.
+
+**`/opt/canopy-runner/in-flight`** — `{count, at}`, rewritten every heartbeat tick,
+byte-identical to `update.mark_busy`'s file so the two runners' markers stay
+interchangeable. Including the rule that matters most: a marker older than 120s is
+not "busy", it is a daemon that has stopped running its loop — which is precisely
+the case auto-update exists to rescue, so it must never block the update.
+
+## The updater
+
+`runner/ec2/update_runner.sh`, installed to `/usr/local/bin/canopy-runner-update`
+and driven by a `canopy-runner-update.timer` every 30 minutes.
+
+**A separate systemd unit, not a thread in the runner.** A runner that
+crash-loops is exactly when auto-update matters, and a self-updating process
+cannot rescue itself: it never heartbeats, never learns it is behind, and stays
+bricked until a human notices. An independent timer means shipping a fix is
+enough. (Same reasoning, verbatim, as the laptop's separate launchd job.)
+
+It runs as root, so it can write `/opt` and restart the unit with no sudo dance.
+
+**Read-only against the control plane.** It asks `GET /api/harness/runners/` for
+its own row's `expected_code_sha` and must NEVER heartbeat — a heartbeat from this
+second process would stamp the runner ONLINE and forge liveness for a daemon that
+may be dead.
+
+The decision is `update.py` transliterated:
+
+| verdict | meaning | action |
+|---|---|---|
+| `current` | stamp == expected | nothing |
+| `stale` | differ, nothing in flight | install `expected` |
+| `busy` | differ, a turn is in flight | nothing; try in 30 min |
+| `unknown` | either side empty / unreachable | nothing |
+
+Every verdict exits 0. This runs on a timer, and a non-zero exit for the ordinary
+case fills the journal with false failures and trains everyone to ignore it.
+
+**Install pins to the sha, never `origin/main`.** `git -C /opt/canopy-web` fetches
+that commit (the clone is `--depth 1`, so fetch it by sha with a deepening
+fallback), then `git show <sha>:runner/ec2/cloud_runner.py`. Installing main
+instead would run code nothing has deployed AND leave `code_sha != expected`
+permanently, so the staleness banner would fire forever on exactly the boxes
+auto-updating correctly.
+
+Reading the file out of git rather than checking the clone out also means an agent
+turn that leaves `/opt/canopy-web` on a branch cannot change what gets installed —
+the coupling that bit the laptop three times.
+
+Before anything is moved into place the candidate is `python3 -m py_compile`d:
+systemd's `ExecStart` points straight at this file, so a truncated or garbage copy
+is a box that will not boot. Then stamp, then `systemctl restart canopy-runner`.
+
+**Escape hatches**, both deliberate acts: `--ref <ref>` installs something else
+(a branch, for debugging a box), `--from-secret` restores the Secrets Manager
+bytes. `--check` prints the verdict and changes nothing.
+
+## Secrets Manager becomes a first-boot seed
+
+`canopy-fetch-env` runs on every service start and rewrites
+`/opt/canopy-runner/cloud_runner.py` from the secret. Left alone it would revert
+every auto-update at the next restart, so it changes to install the secret's bytes
+only when that file is **absent**. Its `runner.env` handling is untouched.
+
+`up.sh` also publishes the seed's PROVENANCE, so a fresh box's first update check
+is a real answer rather than `unknown`. That goes in a second Secrets Manager entry
+(`canopy/cloud-runner/runner-code-sha`) and deliberately NOT in a CloudFormation
+parameter: a parameter is interpolated into UserData, CFN applies a UserData change
+to a running instance as a **stop/start**, and this value changes on every runner
+commit — so a parameter would bounce the live box, new public IP and all, every
+time anyone ran `up.sh`. If the operator's clone cannot resolve the sha, `up.sh`
+says so — a seed with no stamp means that box never auto-updates, and silence there
+is indistinguishable from the feature working.
+
+**Consequence, stated plainly:** `./up.sh` is no longer how runner code reaches a
+running box. Code ships by merge + deploy, like the laptop's; the on-box override
+is `canopy-runner-update --ref` / `--from-secret`.
+
+## Rollout
+
+`canopy-fetch-env`, the systemd units and the updater script all live in
+cloud-init's `write_files`, which only runs on an instance's FIRST boot. So this
+ships with a stack recycle:
+
+```bash
+cd runner/ec2 && ./down.sh && ./up.sh && ./wire.sh --drill
+```
+
+The order matters in one respect only: the deploy carrying `RUNNER_CLOUD_CODE_SHA`
+should land first, or the fresh box's first checks read `unknown` (harmless, and
+self-corrects at the next deploy).
+
+## Testing
+
+- `runner/ec2/tests/` — stdlib-only, run in CI from its own dir in a bare env
+  (the only thing proving `cloud_runner.py` has not grown a dependency on
+  canopy-web's environment): stamp reading incl. missing/garbage, the in-flight
+  marker, and that every heartbeat call site carries provenance.
+- A pytest-driven bash test for `update_runner.sh` with fake `curl` / `git` /
+  `systemctl` on PATH, the way `test_install_job_self_protection.py` drives the
+  laptop installer — the verdict logic and "which commands ran against what" is
+  invisible to any amount of reading the script.
+- Django: a `cloud` row serves the cloud expected sha while an `emdash` row serves
+  the laptop one, and a WS heartbeat no longer erases reported provenance.
+
+## Out of scope
+
+- `packages/canopy_transcript` and `canopy_acp` are exposed onto `sys.path` from
+  the clone at main tip on every start, not at the deployed sha. Pre-existing, and
+  a different question (they are libraries, not the executable); noted so the
+  inconsistency is on the record rather than discovered later.
+- Giving the box write access to its own code secret. The update source is git
+  precisely so a runner cannot rewrite the channel it boots from.

--- a/frontend/src/components/supervisor/codeProvenance.ts
+++ b/frontend/src/components/supervisor/codeProvenance.ts
@@ -36,9 +36,15 @@ export function runnerCodeAlerts(runners: readonly RunnerOut[] | null): RunnerCo
       continue // one code-provenance banner per runner; the branch is the louder fault
     }
     // BOTH sides must be known. An empty sha means "unknown", not "different":
-    // the cloud runner is a separate program that reports none, a dev server has
-    // no expectation baked in, and a shallow clone yields nothing. Alerting on
-    // partial information would cry wolf on exactly the boxes we know least about.
+    // a dev server has no expectation baked in, a shallow clone yields nothing,
+    // and an unstamped install cannot say. Alerting on partial information would
+    // cry wolf on exactly the boxes we know least about.
+    //
+    // The cloud runner used to be the headline example here — a separate program
+    // reporting nothing. Since spec 2026-07-30 it reports its own sha and the
+    // server serves it the expectation for ITS path (runner/ec2), so cloud rows
+    // now participate in this alert on the same terms as laptops. Nothing below
+    // changed: both sides known, both non-empty, ordered by commit time.
     if (runner.code_sha && runner.expected_code_sha && runner.code_sha !== runner.expected_code_sha) {
       // A sha is a NAME, not a position: `!==` means different, and there are
       // three ways to differ (older, newer, divergent). Calling all of them

--- a/runner/ec2/README.md
+++ b/runner/ec2/README.md
@@ -21,7 +21,8 @@ wire.
 
 ## Files
 - `runner.cfn.yaml` — the whole stack (instance + SG + IAM role + key pair + cloud-init).
-- `cloud_runner.py` — the self-contained (stdlib-only) runner. `up.sh` splices it into the template as base64 at deploy time (single source of truth).
+- `cloud_runner.py` — the self-contained (stdlib-only) runner. `up.sh` publishes it to Secrets Manager as the first-boot seed; after that the box updates itself from git (see "Updating the runner code" below).
+- `update_runner.sh` — the auto-updater: installs the DEPLOYED runner sha when this box is behind and idle. Run on a 30-minute systemd timer via a thin `/usr/local/bin/canopy-runner-update` shim, and read from the canopy-web clone so it ships by deploy like everything else.
 - `bootstrap_agents.sh` — idempotent agent-fleet bootstrap (tooling, gog, per-agent clones + secrets, claude plugins). Runs ON the box, from a live `canopy-web` clone — not baked into the template. See "Bootstrap" below.
 - `secrets.sh` — put/update this runner's secrets in Secrets Manager (values read from a file/stdin, never shell history).
 - `up.sh` — validate + render + `cloudformation deploy`; pulls the private key from SSM for SSH.
@@ -273,6 +274,10 @@ back to `rm -f`) whether the import succeeded or not.
 - `canopy/cloud-runner/claude-oauth-token` — a **dedicated** claude setup-token (`CLAUDE_CODE_OAUTH_TOKEN`). Mint with `claude setup-token` as `ace@dimagi-ai.com` (Max subscription). It's long-lived and non-rotating, so the runner is self-sufficient after one bootstrap. **Do not copy ace-web's live OAuth blob** — its refresh tokens rotate on every use, so a second consumer gets invalidated (verified: it 401s / can't refresh). **Required**.
 - `canopy/cloud-runner/op-service-account-token` — a 1Password service-account token, same one the laptop runners use for now (see the design spec's "out of scope: dedicated cloud SA token"). **Optional** — without it, `bootstrap_agents.sh`'s `canopy provision` and gmail-token-import steps skip (logged, not fatal); the runner still comes up and can serve `canopy-web`-repo turns.
 
+Two more are published by `up.sh` itself, not staged by hand:
+- `canopy/cloud-runner/runner-code` — `cloud_runner.py` as gzip+base64, the first-boot seed.
+- `canopy/cloud-runner/runner-code-sha` — that seed's provenance (`{"sha", "committed_at"}`), which the box stamps into `/opt/canopy-runner/build-info.json` so its first auto-update check can answer. A secret rather than a stack parameter because a parameter lives in UserData, and changing UserData stop/starts the running instance.
+
 Stage them with `./secrets.sh {canopy|claude|op} <file|->`. `wire.sh` reads the
 `canopy`/`claude`/`op` secrets from Secrets Manager and `Canopy-Shared/github-token`
 from 1Password, and `POST`s them all into the freshly-paired runner's credential
@@ -309,22 +314,70 @@ provisions; distinct from `RunnerAgents`, which is which agents this runner may
 CLAIM turns for), `RunnerWorkspace` (dimagi), `RunnerName`. `SshCidr` is set to
 your IP automatically.
 
-## Updating the runner code
-`up.sh` splices `cloud_runner.py` into the template's UserData as base64, but
-**CloudFormation applies a UserData change to an existing instance as a
-stop/start — it does NOT re-run cloud-init.** cloud-init's `write_files` (and
-everything else in the `#cloud-config` block) only runs on an instance's
-*first* boot. So editing `cloud_runner.py` and running `./up.sh` again updates
-the *template*, but a box that's already up keeps running the old bytes on
-disk until it's replaced — a silent deploy gap, not a redeploy.
+## Updating the runner code — it updates itself
 
-Until there's a real re-provisioning mechanism, ship a `cloud_runner.py` change by
-recycling the stack:
+**Ship a `cloud_runner.py` change by merging it and deploying canopy-web.** Within
+30 minutes the box installs it and restarts itself. Same rules as the laptop
+runner, and the same reasons — see
+`docs/superpowers/specs/2026-07-30-cloud-runner-auto-update-design.md`.
+
+How it works: `canopy-runner-update.timer` runs `update_runner.sh` every 30
+minutes as the service user. It asks the control plane for **its own row's
+`expected_code_sha`** — the sha of `runner/ec2/{cloud_runner.py,bootstrap_agents.sh}`
+in the DEPLOYED image, so already through CI, the merge queue and a deploy — and
+compares it to `/opt/canopy-runner/build-info.json`, the stamp left by whoever
+installed the running bytes. If they differ and no turn is in flight
+(`/opt/canopy-runner/in-flight`, rewritten by the daemon every heartbeat), it
+installs `git show <that sha>:runner/ec2/cloud_runner.py` from the `/opt/canopy-web`
+clone, re-stamps, and restarts the service.
+
+Four things worth knowing:
+
+- **It never tracks `origin/main`.** Installing main would run code nothing has
+  deployed and leave `code_sha != expected_code_sha` permanently — the staleness
+  banner would fire forever on exactly the boxes updating correctly.
+- **A stale busy-marker is not "busy".** A marker older than 120s means the daemon
+  stopped writing it (stopped, wedged, crash-looping) — the case auto-update exists
+  to rescue, so it never blocks.
+- **It only ever GETs.** A heartbeat from the updater would stamp the runner ONLINE
+  and forge liveness for a daemon that may be dead.
+- **It is a separate systemd unit**, because a runner that crash-loops could never
+  update itself.
+
+Watch it: `journalctl -u canopy-runner-update -f`. Ask without changing anything:
+`canopy-runner-update --check` → `current|stale|busy|unknown`.
+
+### Secrets Manager is now a first-boot seed
+`canopy-fetch-env` installs the `runner-code` secret only when there is no
+`cloud_runner.py` on disk. Past that the updater owns the file — re-fetching the
+secret on every start would silently revert every update at the next restart. So
+**`./up.sh` no longer ships runner code to a running box.** Two deliberate
+overrides, both on the box:
+
 ```bash
-./down.sh          # keeps the secrets (no --purge-secrets)
-./up.sh && ./wire.sh --drill   # fresh instance, fresh cloud-init, new code; re-wire it
+sudo -u ubuntu canopy-runner-update --ref my-branch  # run a branch, deliberately
+sudo -u ubuntu canopy-runner-update --from-secret    # go back to the published bytes
 ```
-`bootstrap_agents.sh` doesn't have this gap — see "Bootstrap" above.
+
+`up.sh` still publishes the secret (it is what a FRESH instance boots from) and now
+also passes `RunnerCodeSha`/`RunnerCodeCommittedAt` so the seed is stamped. If it
+warns that it could not resolve the sha, fix that before deploying: an unstamped
+box answers `unknown` forever, which looks exactly like a box that is up to date.
+
+### The cloud-init gap (still real for everything else)
+**CloudFormation applies a UserData change to an existing instance as a stop/start
+— it does NOT re-run cloud-init**, which only runs `write_files`/`runcmd` on an
+instance's *first* boot. So the units, `canopy-fetch-env`, and the
+`canopy-runner-update` shim are frozen on a running box. Changing any of them means
+recycling the stack:
+
+```bash
+./down.sh                      # keeps the secrets (no --purge-secrets)
+./up.sh && ./wire.sh --drill   # fresh instance, fresh cloud-init; re-wire it
+```
+`bootstrap_agents.sh` and `update_runner.sh` itself don't have this gap — both are
+read from the canopy-web clone (see "Bootstrap" above; the shim in UserData is a
+dozen lines that just `git show`s the real updater out of `origin/main`).
 
 ## Notes
 - **Ephemeral by design.** The claude token lives only in Secrets Manager + in

--- a/runner/ec2/README.md
+++ b/runner/ec2/README.md
@@ -379,6 +379,33 @@ recycling the stack:
 read from the canopy-web clone (see "Bootstrap" above; the shim in UserData is a
 dozen lines that just `git show`s the real updater out of `origin/main`).
 
+### Retrofitting a LIVE box instead of recycling it
+A recycle destroys the instance's EBS volume, and that volume is not empty: it holds
+the five agent clones, the gog keyring with all five gmail tokens, and every
+provisioned `~/.<slug>/.env`. `bootstrap_agents.sh` rebuilds all of it idempotently
+from 1Password, so a recycle is recoverable — but it also mints a NEW runner id,
+which is why `wire.sh` has to re-swap every agent's assignments afterwards.
+
+If you would rather keep that state, the only things missing from a running box are
+the cloud-init bits (the shim, the sudoers rule, the two units) and the stamp — the
+updater itself comes from git. Over SSM:
+
+```bash
+# 1. stamp what the box is currently running (from a canopy-web checkout):
+git log -1 --format='{"sha": "%H", "committed_at": %ct, "ref": "retrofit"}' \
+  -- runner/ec2/cloud_runner.py runner/ec2/bootstrap_agents.sh
+#    → write that JSON to /opt/canopy-runner/build-info.json (chown ubuntu:ubuntu)
+# 2. copy the four write_files blocks out of runner.cfn.yaml onto the box:
+#    /usr/local/bin/canopy-runner-update (0755), /etc/sudoers.d/canopy-runner-update
+#    (0440), and the canopy-runner-update .service + .timer
+# 3. systemctl daemon-reload && systemctl enable --now canopy-runner-update.timer
+# 4. canopy-runner-update --check   # expect: current (or stale, if a deploy is ahead)
+```
+
+Get step 1 right or skip it entirely — a WRONG sha is worse than none. An absent
+stamp reads `unknown` and does nothing; a stamp claiming a sha this box is not
+running would either suppress a real update or trigger a needless one.
+
 ## Notes
 - **Ephemeral by design.** The claude token lives only in Secrets Manager + in
   `/opt/canopy-runner/runner.env` (chmod 600) on the box; `down.sh` removes the box.

--- a/runner/ec2/cloud_runner.py
+++ b/runner/ec2/cloud_runner.py
@@ -43,6 +43,11 @@ Config comes from the environment (see runner/ec2/README.md):
                      pulls canopy-web from, to run its bootstrap_agents.sh
   POLL_SECONDS      idle poll interval (default: 15)
   STATE_FILE        runner-id cache (default: ~/.canopy-cloud-runner.json)
+  RUNNER_HOME       where this runner's bytes + its two auto-update files live
+                     (default: /opt/canopy-runner) — `build-info.json` says what
+                     code is installed, `in-flight` says whether now is a safe
+                     moment to replace it. Both are written here and read by
+                     runner/ec2/update_runner.sh; see spec 2026-07-30.
 `claude` authenticates from CLAUDE_CODE_OAUTH_TOKEN (a dedicated setup-token from
 Secrets Manager, staged into the service env by cloud-init). AGENT_SLUGS /
 AGENT_REPO_ORG / GITHUB_TOKEN / OP_SERVICE_ACCOUNT_TOKEN are consumed by
@@ -152,6 +157,14 @@ STREAM_POLL_SECONDS = float(os.environ.get("STREAM_POLL_SECONDS", "3"))
 LEASE_HEARTBEAT_SECONDS = int(os.environ.get("LEASE_HEARTBEAT_SECONDS", "60"))
 STATE_FILE = pathlib.Path(os.environ.get("STATE_FILE", str(pathlib.Path.home() / ".canopy-cloud-runner.json")))
 
+# Where this runner's bytes live, and the two files the auto-updater
+# (runner/ec2/update_runner.sh, spec 2026-07-30) shares with it:
+#   build-info.json — what code is installed, stamped by whoever installed it.
+#   in-flight       — how many turns this box is carrying right now.
+RUNNER_HOME = pathlib.Path(os.environ.get("RUNNER_HOME", "/opt/canopy-runner"))
+BUILD_INFO_FILE = pathlib.Path(os.environ.get("BUILD_INFO_FILE", str(RUNNER_HOME / "build-info.json")))
+IN_FLIGHT_FILE = pathlib.Path(os.environ.get("IN_FLIGHT_FILE", str(RUNNER_HOME / "in-flight")))
+
 # Bound on reaping the claude subprocess in run_claude's cleanup (review N1) —
 # a bare, untimed proc.wait() can hang the RUNNER forever if the child is still
 # alive with an undrained stdout pipe (a mid-loop exception leaves exactly that
@@ -192,6 +205,87 @@ def _api(method: str, path: str, body: dict | None = None) -> tuple[int, dict | 
     except urllib.error.URLError as exc:
         _log(f"{method} {path} -> URLError {exc.reason}")
         return 0, None
+
+
+# ── code provenance + the busy marker (auto-update's two shared files) ──────
+_BUILD_INFO: dict | None = None
+
+
+def build_info(*, refresh: bool = False) -> dict:
+    """What code is this box running — `{"sha": str, "committed_at": int}`.
+
+    Stamped into a file by whoever INSTALLED the bytes (canopy-fetch-env for the
+    first-boot seed, update_runner.sh for every update since), because there is no
+    git history at /opt/canopy-runner to derive it from. The laptop runner has the
+    same two provenances and the same answer: `_build_info.py`, stamped at build
+    time by install-runner.sh.
+
+    Missing, unreadable, or malformed yields empty/0 — which every consumer treats
+    as UNKNOWN and stays silent about. A staleness alert fired on partial
+    information is worse than no alert.
+
+    Cached for the process's lifetime ON PURPOSE, exactly as `provenance.code_sha`
+    is: this answers "which bytes did I START with". The updater rewrites the stamp
+    moments before restarting the service, so re-reading it live would report the
+    new sha while still executing the old code — clearing the staleness banner for
+    the box that is still stale.
+    """
+    global _BUILD_INFO
+    if _BUILD_INFO is not None and not refresh:
+        return _BUILD_INFO
+    info = {"sha": "", "committed_at": 0}
+    try:
+        raw = json.loads(BUILD_INFO_FILE.read_text())
+        info["sha"] = str(raw.get("sha") or "").strip()
+        info["committed_at"] = int(raw.get("committed_at") or 0)
+    except (OSError, ValueError, TypeError, AttributeError):
+        pass
+    _BUILD_INFO = info
+    return info
+
+
+def _mark_in_flight(count: int) -> None:
+    """Publish how many turns this box is carrying, for the auto-updater.
+
+    An update restarts the service, so it must not land mid-turn. Same file shape
+    and same semantics as the laptop's `update.mark_busy` — including that a marker
+    older than 120s means the daemon has stopped writing it (stopped, wedged,
+    crash-looping) and therefore must NOT read as busy: that is the case
+    auto-update exists to rescue.
+
+    Best-effort: a failure here can never affect a turn.
+    """
+    try:
+        IN_FLIGHT_FILE.parent.mkdir(parents=True, exist_ok=True)
+        IN_FLIGHT_FILE.write_text(json.dumps({"count": int(count), "at": time.time()}))
+    except OSError:
+        pass
+
+
+def _heartbeat_body(active_turn_ids: list[str], **extra) -> dict:
+    """THE heartbeat payload — one stamping point, for all four call sites.
+
+    `services.heartbeat` assigns code_sha/code_committed_at unconditionally, so any
+    call site that omits them RESETS the fields. This runner heartbeats from four
+    places (pairing, the idle REST loop, the WS beat, the per-turn lease renewer),
+    and the laptop already paid for the version of this bug where four of six sites
+    silently cleared `code_branch` (see provenance.py). Building the body in one
+    function is what makes that unrepresentable rather than merely fixed.
+
+    `code_branch` is deliberately absent: /opt/canopy-runner is not a checkout, and
+    reporting a branch would be inventing one. Writing the busy marker here too
+    means it is refreshed by whatever heartbeat is live — including the lease
+    renewer, which is the only one beating while a long turn runs.
+    """
+    info = build_info()
+    _mark_in_flight(len(active_turn_ids))
+    return {
+        "active_turn_ids": active_turn_ids,
+        "host": RUNNER_HOST,
+        "code_sha": info["sha"],
+        "code_committed_at": info["committed_at"],
+        **extra,
+    }
 
 
 def _chunk_transcript_lines(
@@ -274,8 +368,7 @@ def _start_lease_renewal(runner_id: str, turn_id: str) -> threading.Event:
 
     def _loop() -> None:
         while not stop.wait(LEASE_HEARTBEAT_SECONDS):
-            _api("POST", f"/runners/{runner_id}/heartbeat",
-                 {"active_turn_ids": [turn_id], "host": RUNNER_HOST})
+            _api("POST", f"/runners/{runner_id}/heartbeat", _heartbeat_body([turn_id]))
 
     threading.Thread(target=_loop, daemon=True, name=f"lease-{turn_id[:8]}").start()
     return stop
@@ -294,8 +387,7 @@ def pair_or_load() -> str:
             # where a laptop must not: this comes from env, so there is no read to
             # fail and no way to mistake "cannot tell" for "have none".
             status, _ = _api("POST", f"/runners/{rid}/heartbeat",
-                              {"active_turn_ids": [], "host": RUNNER_HOST,
-                               "projects": list(RUNNER_CAPS.get("projects") or [])})
+                             _heartbeat_body([], projects=list(RUNNER_CAPS.get("projects") or [])))
             if status == 200:
                 _log(f"reusing runner {rid}")
                 # Capabilities were historically fixed at pairing time; re-pairing
@@ -1715,8 +1807,7 @@ def run_over_rest(runner_id: str) -> None:
         # Every in-flight turn rides the heartbeat so the server renews all of
         # their leases — with concurrency, reporting only the newest would let
         # the others expire mid-run.
-        _api("POST", f"/runners/{runner_id}/heartbeat",
-             {"active_turn_ids": _in_flight_ids(), "host": RUNNER_HOST})
+        _api("POST", f"/runners/{runner_id}/heartbeat", _heartbeat_body(_in_flight_ids()))
         # Attached viewers are served on this path too — a runner that fell back
         # to REST must not also silently stop being watchable.
         _sync_session_views(runner_id)
@@ -1911,7 +2002,11 @@ def run_over_ws(runner_id: str) -> bool:
             # Report in-flight turns, not []: each worker also has its own lease
             # renewer, but a heartbeat that claims nothing is running while four
             # turns are executing is a lie the server acts on.
-            _ws_request(ws, {"action": "heartbeat", "active_turn_ids": _in_flight_ids()},
+            # Provenance rides THIS frame too, not just the REST ones: the WS beat
+            # is the cloud runner's primary heartbeat, and the server assigns those
+            # fields unconditionally — so a frame that omitted them would erase
+            # what the REST paths reported, every 20 seconds.
+            _ws_request(ws, {"action": "heartbeat", **_heartbeat_body(_in_flight_ids())},
                         "heartbeat.ack", timeout=15)
 
         try:

--- a/runner/ec2/down.sh
+++ b/runner/ec2/down.sh
@@ -16,7 +16,7 @@ rm -f "./${STACK}-key.pem"
 echo "==> stack deleted."
 
 if [[ "${1:-}" == "--purge-secrets" ]]; then
-  for s in canopy/cloud-runner/canopy-pat canopy/cloud-runner/claude-oauth-token canopy/cloud-runner/op-service-account-token canopy/cloud-runner/runner-code; do
+  for s in canopy/cloud-runner/canopy-pat canopy/cloud-runner/claude-oauth-token canopy/cloud-runner/op-service-account-token canopy/cloud-runner/runner-code canopy/cloud-runner/runner-code-sha; do
     echo ">> deleting secret $s"
     "${AWS[@]}" secretsmanager delete-secret --secret-id "$s" --force-delete-without-recovery || true
   done

--- a/runner/ec2/runner.cfn.yaml
+++ b/runner/ec2/runner.cfn.yaml
@@ -90,13 +90,33 @@ Parameters:
     Default: canopy/cloud-runner/runner-code
     Description: >
       Secrets Manager id holding cloud_runner.py as a single-line gzip+base64
-      blob, published by up.sh on every deploy. The code does NOT live in
-      UserData: EC2 caps UserData at 16 KB and the gz+b64 runner alone is ~12 KB,
-      which (plus the rest of this cloud-config) blew the cap and made the stack
-      undeployable — CREATE_FAILED "User data is limited to 16384 bytes". Keeping
-      it in Secrets Manager also means the runner code is re-fetched by
-      canopy-fetch-env on every service start, so `./up.sh && systemctl restart
-      canopy-runner` ships new runner bytes without recycling the instance.
+      blob, published by up.sh. The code does NOT live in UserData: EC2 caps
+      UserData at 16 KB and the gz+b64 runner alone is ~12 KB, which (plus the
+      rest of this cloud-config) blew the cap and made the stack undeployable —
+      CREATE_FAILED "User data is limited to 16384 bytes".
+
+      As of spec 2026-07-30 this is a FIRST-BOOT SEED, not the update channel:
+      canopy-fetch-env installs it only when there is no cloud_runner.py on disk.
+      Past that the auto-updater owns the file and tracks the DEPLOYED sha, so
+      re-fetching the secret on every start would revert every update at the next
+      restart. `canopy-runner-update --from-secret` is the way back to these bytes.
+  RunnerCodeShaSecret:
+    Type: String
+    Default: canopy/cloud-runner/runner-code-sha
+    Description: >
+      Secrets Manager id holding the PROVENANCE of the seed above, as the JSON
+      `{"sha": ..., "committed_at": ...}` up.sh resolves from git (path-scoped to
+      runner/ec2/{cloud_runner.py,bootstrap_agents.sh} — the same quantity the
+      deploy computes for `expected_code_sha`). canopy-fetch-env writes it to
+      /opt/canopy-runner/build-info.json when it installs the seed, so a fresh
+      box's FIRST update check is a real answer instead of `unknown` — which would
+      mean it never auto-updates, and looks exactly like being up to date.
+
+      A SECRET rather than a CloudFormation parameter deliberately: a parameter is
+      interpolated into UserData, and CFN applies a UserData change to a running
+      instance as a stop/start. The sha changes on every runner commit, so passing
+      it as a parameter would bounce the live box (new public IP and all) every
+      time anyone ran up.sh. Absent → unknown → silent, as everywhere else.
 
 Resources:
   KeyPair:
@@ -184,12 +204,26 @@ Resources:
                 umask 077
                 install -d -o ubuntu -g ubuntu /opt/canopy-runner
                 # cloud_runner.py lives in Secrets Manager, not UserData (16 KB cap).
+                # SEED ONLY — install it when there is nothing on disk, and never
+                # again. Past first boot the auto-updater owns this file and tracks
+                # the DEPLOYED sha; re-fetching here on every start would revert
+                # every update at the next restart, silently, forever.
+                # `canopy-runner-update --from-secret` is the deliberate way back.
                 # Decode to a temp file and mv into place so a failed fetch can never
                 # leave a truncated script that systemd would then try to exec.
-                secret ${RunnerCodeSecret} | base64 -d | gunzip > /opt/canopy-runner/cloud_runner.py.new
-                chown ubuntu:ubuntu /opt/canopy-runner/cloud_runner.py.new
-                chmod 0755 /opt/canopy-runner/cloud_runner.py.new
-                mv /opt/canopy-runner/cloud_runner.py.new /opt/canopy-runner/cloud_runner.py
+                if [ ! -s /opt/canopy-runner/cloud_runner.py ]; then
+                  secret ${RunnerCodeSecret} | base64 -d | gunzip > /opt/canopy-runner/cloud_runner.py.new
+                  chown ubuntu:ubuntu /opt/canopy-runner/cloud_runner.py.new
+                  chmod 0755 /opt/canopy-runner/cloud_runner.py.new
+                  mv /opt/canopy-runner/cloud_runner.py.new /opt/canopy-runner/cloud_runner.py
+                  # What the seed IS, so the first update check can answer at all.
+                  # Its own secret, not a template parameter — a parameter would be
+                  # baked into UserData, and this value changes on every runner
+                  # commit, so up.sh would stop/start the live box every time.
+                  secret ${RunnerCodeShaSecret} > /opt/canopy-runner/build-info.json 2>/dev/null \
+                    || echo '{}' > /opt/canopy-runner/build-info.json
+                  chown ubuntu:ubuntu /opt/canopy-runner/build-info.json
+                fi
                 # gog's `file` keyring backend (the only option on a headless box —
                 # there is no OS keychain) encrypts with a password it PROMPTS for.
                 # With no TTY the prompt is impossible, so every `gog auth tokens
@@ -215,6 +249,60 @@ Resources:
                 ENV
                 chown ubuntu:ubuntu /opt/canopy-runner/runner.env
                 chmod 600 /opt/canopy-runner/runner.env
+            - path: /usr/local/bin/canopy-runner-update
+              permissions: '0755'
+              content: |
+                #!/usr/bin/env bash
+                # Thin shim. The REAL updater is runner/ec2/update_runner.sh in the
+                # canopy-web clone this box already keeps — so the updater itself
+                # ships by deploy rather than being frozen here, where cloud-init
+                # only ever runs on an instance's FIRST boot (and where a 16 KB
+                # UserData cap could not hold it anyway).
+                #
+                # Read from origin/main, never the working tree: agent turns run in
+                # this clone and one may have left it on a branch.
+                set -uo pipefail
+                REPO="${!CANOPY_WEB_REPO_DIR:-/opt/canopy-web}"
+                TMP=$(mktemp)
+                trap 'rm -f "$TMP"' EXIT
+                git -C "$REPO" show origin/main:runner/ec2/update_runner.sh > "$TMP" 2>/dev/null || true
+                if [ ! -s "$TMP" ]; then
+                  echo "$(date -u +%FT%TZ) canopy-runner-update: no update_runner.sh in $REPO yet; skipping."
+                  exit 0
+                fi
+                bash "$TMP" "$@"
+            - path: /etc/sudoers.d/canopy-runner-update
+              permissions: '0440'
+              content: |
+                # The auto-updater runs as the service user and needs exactly one
+                # privileged action: restarting the runner after installing new
+                # bytes. Scoped to that command rather than relying on the AMI's
+                # default blanket NOPASSWD for `ubuntu`.
+                ubuntu ALL=(root) NOPASSWD: /usr/bin/systemctl restart canopy-runner.service
+            - path: /etc/systemd/system/canopy-runner-update.service
+              content: |
+                [Unit]
+                Description=Canopy cloud runner auto-update (install the deployed sha)
+                [Service]
+                Type=oneshot
+                User=ubuntu
+                Environment=HOME=/home/ubuntu
+                Environment=PATH=/home/ubuntu/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+                ExecStart=/usr/local/bin/canopy-runner-update
+            - path: /etc/systemd/system/canopy-runner-update.timer
+              content: |
+                [Unit]
+                Description=Ask every 30 min whether this box is behind the deployed runner
+                [Timer]
+                # Not at boot: the runner clones canopy-web and bootstraps the agent
+                # fleet in its first minutes, and an update RESTARTS the service —
+                # doing that mid-bootstrap would undo work nothing re-runs until the
+                # next start.
+                OnBootSec=30min
+                OnUnitActiveSec=30min
+                AccuracySec=1min
+                [Install]
+                WantedBy=timers.target
             - path: /etc/systemd/system/canopy-runner.service
               content: |
                 [Unit]
@@ -264,6 +352,11 @@ Resources:
             - [ bash, -c, "/usr/local/bin/canopy-fetch-env" ]
             - [ systemctl, daemon-reload ]
             - [ systemctl, enable, --now, canopy-runner.service ]
+            # The auto-updater. A SEPARATE unit from the runner on purpose: a
+            # runner that crash-loops can never update itself (it never heartbeats,
+            # so it never learns it is behind), and an independent timer means
+            # shipping a fix is enough to rescue the box. Spec 2026-07-30.
+            - [ systemctl, enable, --now, canopy-runner-update.timer ]
 
 Outputs:
   InstanceId:

--- a/runner/ec2/tests/test_auto_update.py
+++ b/runner/ec2/tests/test_auto_update.py
@@ -1,0 +1,141 @@
+"""The runner's half of auto-update: what it says it is, and when it is busy.
+
+Two files it shares with runner/ec2/update_runner.sh, and one invariant about how
+they are reported. See
+docs/superpowers/specs/2026-07-30-cloud-runner-auto-update-design.md.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+import time
+
+import pytest
+
+SOURCE = pathlib.Path(__file__).resolve().parent.parent / "cloud_runner.py"
+
+
+@pytest.fixture
+def runner(tmp_path, monkeypatch, load_cloud_runner):
+    """A module whose RUNNER_HOME is a temp dir — set BEFORE import, because the
+    two paths are resolved at module level."""
+    monkeypatch.setenv("RUNNER_HOME", str(tmp_path))
+    monkeypatch.setenv("BUILD_INFO_FILE", str(tmp_path / "build-info.json"))
+    monkeypatch.setenv("IN_FLIGHT_FILE", str(tmp_path / "in-flight"))
+    return load_cloud_runner()
+
+
+def _stamp(tmp_path, **fields):
+    (tmp_path / "build-info.json").write_text(json.dumps(fields))
+
+
+# --- what code am I running -------------------------------------------------
+def test_build_info_reads_the_stamp(runner, tmp_path):
+    _stamp(tmp_path, sha="abc123", committed_at=1753900000)
+    info = runner.build_info(refresh=True)
+    assert info == {"sha": "abc123", "committed_at": 1753900000}
+
+
+def test_a_missing_stamp_is_unknown_not_an_error(runner):
+    # /opt/canopy-runner has no git history, so an unstamped install genuinely
+    # cannot know. Unknown must be silent, never a crash on the heartbeat path.
+    assert runner.build_info(refresh=True) == {"sha": "", "committed_at": 0}
+
+
+@pytest.mark.parametrize("body", ["not json at all", "[]", '{"sha": null}', ""])
+def test_a_malformed_stamp_is_unknown(runner, tmp_path, body):
+    (tmp_path / "build-info.json").write_text(body)
+    assert runner.build_info(refresh=True)["sha"] == ""
+
+
+def test_a_non_numeric_committed_at_does_not_break_the_sha(runner, tmp_path):
+    _stamp(tmp_path, sha="abc123", committed_at="nonsense")
+    # Both fields come from one parse, so a bad timestamp currently costs the sha
+    # too — assert whichever way it degrades, it degrades to UNKNOWN and not to a
+    # raised exception on the heartbeat path.
+    info = runner.build_info(refresh=True)
+    assert info["committed_at"] == 0
+
+
+def test_build_info_is_cached_for_the_process_lifetime(runner, tmp_path):
+    # The updater rewrites the stamp moments BEFORE restarting the service. If the
+    # running process re-read it live, it would report the new sha while still
+    # executing the old bytes — clearing the staleness banner for a box that is
+    # still stale. Same reasoning as provenance.code_sha's functools.cache.
+    _stamp(tmp_path, sha="old", committed_at=1)
+    assert runner.build_info(refresh=True)["sha"] == "old"
+    _stamp(tmp_path, sha="new", committed_at=2)
+    assert runner.build_info()["sha"] == "old"
+    assert runner.build_info(refresh=True)["sha"] == "new"
+
+
+# --- is now a safe moment ---------------------------------------------------
+def test_mark_in_flight_writes_the_shape_the_laptop_writes(runner, tmp_path):
+    runner._mark_in_flight(3)
+    raw = json.loads((tmp_path / "in-flight").read_text())
+    assert raw["count"] == 3
+    assert abs(raw["at"] - time.time()) < 5
+    # `count` + `at`, and nothing else: update.mark_busy writes exactly this, and
+    # runner/ec2/update_runner.sh reads both runners' markers with one parser.
+    assert set(raw) == {"count", "at"}
+
+
+def test_marking_in_flight_never_raises(runner, monkeypatch, tmp_path):
+    # Best-effort by contract: a failure here must not touch the turn it is
+    # reporting on.
+    monkeypatch.setattr(runner, "IN_FLIGHT_FILE", tmp_path / "nope" / "x" / "in-flight")
+    monkeypatch.setattr(pathlib.Path, "mkdir", lambda *a, **k: (_ for _ in ()).throw(OSError))
+    runner._mark_in_flight(1)  # must not raise
+
+
+# --- one stamping point -----------------------------------------------------
+def test_heartbeat_body_carries_provenance_and_marks_the_marker(runner, tmp_path):
+    _stamp(tmp_path, sha="abc123", committed_at=1753900000)
+    runner.build_info(refresh=True)
+    body = runner._heartbeat_body(["t1", "t2"])
+    assert body["code_sha"] == "abc123"
+    assert body["code_committed_at"] == 1753900000
+    assert body["active_turn_ids"] == ["t1", "t2"]
+    assert body["host"] == runner.RUNNER_HOST
+    assert json.loads((tmp_path / "in-flight").read_text())["count"] == 2
+
+
+def test_heartbeat_body_reports_no_branch(runner):
+    # /opt/canopy-runner is not a checkout. Reporting a branch would be inventing
+    # one, and the supervisor alerts on any branch that is not `main`.
+    assert "code_branch" not in runner._heartbeat_body([])
+
+
+def test_heartbeat_body_passes_extras_through(runner):
+    body = runner._heartbeat_body([], projects=["canopy-web"])
+    assert body["projects"] == ["canopy-web"]
+
+
+def test_every_heartbeat_call_site_goes_through_the_one_stamping_point():
+    """The regression guard, and the reason `_heartbeat_body` exists.
+
+    `services.heartbeat` assigns the provenance fields unconditionally, so a
+    heartbeat that omits them CLEARS them — a single call site left behind erases
+    what the other three report. The laptop paid for this exact bug with
+    `code_branch` (four of six sites silently resetting it, see provenance.py);
+    the fix there and here is one payload builder.
+
+    Asserted on the SOURCE because the failure is which dict a call site passes,
+    which no amount of running the module reveals.
+    """
+    source = SOURCE.read_text()
+    sites = [
+        line.strip() for line in source.splitlines()
+        if re.search(r'/heartbeat"|"action": "heartbeat"', line)
+        and not line.strip().startswith("#")
+    ]
+    assert len(sites) >= 4, f"expected every heartbeat call site, found {sites}"
+    for site in sites:
+        # The payload may be on the same line as the URL or the next one; assert on
+        # the window rather than the line so formatting cannot defeat the check.
+        idx = source.index(site)
+        window = source[idx:idx + 400]
+        assert "_heartbeat_body" in window, (
+            f"heartbeat call site builds its own payload and will erase provenance: {site}"
+        )

--- a/runner/ec2/tests/test_update_runner_sh.py
+++ b/runner/ec2/tests/test_update_runner_sh.py
@@ -1,0 +1,283 @@
+"""The updater's decision procedure, driven for real.
+
+`update_runner.sh` is a linear bash program whose whole content is WHICH commands
+run against WHAT — invisible to any amount of reading it. So these run the real
+script against a real git repo, with `curl` and the restart command faked on PATH,
+and assert on the calls it makes.
+
+The four verdicts mirror the laptop's `update.py` exactly (current | stale | busy |
+unknown), and the two that look like edge cases are the load-bearing ones: a stale
+busy-marker must NOT read as busy (that box is the one auto-update exists to
+rescue), and either sha being empty must read as unknown (installing an empty sha
+would be a reinstall loop against a target that does not exist).
+
+See docs/superpowers/specs/2026-07-30-cloud-runner-auto-update-design.md.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+import time
+
+import pytest
+
+SCRIPT = pathlib.Path(__file__).resolve().parent.parent / "update_runner.sh"
+RUNNER_ID = "11111111-2222-3333-4444-555555555555"
+GOOD_RUNNER = "#!/usr/bin/env python3\nprint('i am the new runner')\n"
+
+
+def _git(repo: pathlib.Path, *args: str) -> str:
+    out = subprocess.run(
+        ["git", "-C", str(repo), *args], capture_output=True, text=True,
+        env={"PATH": "/usr/bin:/bin", "HOME": str(repo),
+             "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@x",
+             "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@x"},
+    )
+    assert out.returncode == 0, out.stderr
+    return out.stdout.strip()
+
+
+class Box:
+    """A fake cloud box: runner home, a canopy-web clone, and stubbed commands."""
+
+    def __init__(self, tmp_path: pathlib.Path):
+        self.root = tmp_path
+        self.home = tmp_path / "opt" / "canopy-runner"
+        self.home.mkdir(parents=True)
+        self.repo = tmp_path / "opt" / "canopy-web"
+        self.bin = tmp_path / "bin"
+        self.bin.mkdir()
+        (self.home / "runner.env").write_text(
+            "CANOPY_BASE_URL=https://labs.example/canopy\nCANOPY_TOKEN=tok\n"
+        )
+        (tmp_path / "state.json").write_text(json.dumps({"runner_id": RUNNER_ID}))
+        self.curl_log = tmp_path / "curl.log"
+        self.restart_log = tmp_path / "restart.log"
+        self.api_body = tmp_path / "api.json"
+        self.api_body.write_text("[]")
+        self._write_stub("curl", f'echo "$@" >> "{self.curl_log}"\ncat "{self.api_body}"\n')
+        self._write_stub("fake-restart", f'echo "$@" >> "{self.restart_log}"\n')
+        self.seed_repo(GOOD_RUNNER)
+
+    def _write_stub(self, name: str, body: str) -> None:
+        path = self.bin / name
+        path.write_text("#!/bin/sh\n" + body)
+        path.chmod(0o755)
+
+    # -- setup helpers --
+    def seed_repo(self, runner_source: str) -> str:
+        """Commit `runner_source` as runner/ec2/cloud_runner.py; return the sha.
+
+        `--allow-empty` so re-seeding identical content still advances HEAD, and
+        the sha returned is PATH-SCOPED — the same `git log -1 -- <paths>` the
+        script and deploy-labs.yml both run. That is the point of the whole
+        scheme: HEAD moves on every canopy-web commit, this does not.
+        """
+        first = not self.repo.exists()
+        src = self.repo / "runner" / "ec2"
+        src.mkdir(parents=True, exist_ok=True)
+        (src / "cloud_runner.py").write_text(runner_source)
+        (src / "bootstrap_agents.sh").write_text("#!/bin/bash\n")
+        if first:
+            _git(self.repo.parent, "init", "-q", "canopy-web")
+        _git(self.repo, "add", "-A")
+        _git(self.repo, "commit", "-q", "--allow-empty", "-m", "runner")
+        return _git(self.repo, "log", "-1", "--format=%H", "--",
+                    "runner/ec2/cloud_runner.py", "runner/ec2/bootstrap_agents.sh")
+
+    def stamp(self, sha: str, committed_at: int = 1) -> None:
+        (self.home / "build-info.json").write_text(
+            json.dumps({"sha": sha, "committed_at": committed_at})
+        )
+
+    def expect(self, sha: str) -> None:
+        """What the control plane says this runner SHOULD be running."""
+        self.api_body.write_text(json.dumps(
+            [{"id": RUNNER_ID, "name": "cloud-ec2-1", "expected_code_sha": sha}]
+        ))
+
+    def busy(self, count: int, age_seconds: float = 0.0) -> None:
+        (self.home / "in-flight").write_text(
+            json.dumps({"count": count, "at": time.time() - age_seconds})
+        )
+
+    @property
+    def installed(self) -> str:
+        target = self.home / "cloud_runner.py"
+        return target.read_text() if target.exists() else ""
+
+    @property
+    def restarted(self) -> bool:
+        return self.restart_log.exists()
+
+    # -- run it --
+    def run(self, *args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["bash", str(SCRIPT), *args], capture_output=True, text=True,
+            env={
+                "PATH": f"{self.bin}:/usr/bin:/bin",
+                "HOME": str(self.root),
+                "RUNNER_HOME": str(self.home),
+                "CANOPY_WEB_REPO_DIR": str(self.repo),
+                "STATE_FILE": str(self.root / "state.json"),
+                "RESTART_CMD": str(self.bin / "fake-restart"),
+            },
+        )
+
+
+@pytest.fixture
+def box(tmp_path):
+    return Box(tmp_path)
+
+
+# --- the four verdicts ------------------------------------------------------
+def test_current_when_the_stamp_matches_the_deployed_sha(box):
+    sha = box.seed_repo(GOOD_RUNNER)
+    box.stamp(sha)
+    box.expect(sha)
+    out = box.run("--check")
+    assert out.stdout.startswith("current"), out.stdout
+    assert out.returncode == 0
+
+
+def test_stale_when_they_differ_and_nothing_is_in_flight(box):
+    sha = box.seed_repo(GOOD_RUNNER)
+    box.stamp("0" * 40)
+    box.expect(sha)
+    assert box.run("--check").stdout.startswith("stale")
+
+
+def test_busy_while_a_turn_is_in_flight(box):
+    sha = box.seed_repo(GOOD_RUNNER)
+    box.stamp("0" * 40)
+    box.expect(sha)
+    box.busy(count=1)
+    assert box.run("--check").stdout.startswith("busy")
+
+
+def test_a_stale_marker_does_not_read_as_busy(box):
+    # THE case auto-update exists for: a daemon that stopped writing the marker is
+    # stopped, wedged or crash-looping — not busy. Treating it as busy would leave
+    # exactly the broken boxes un-rescuable, forever.
+    sha = box.seed_repo(GOOD_RUNNER)
+    box.stamp("0" * 40)
+    box.expect(sha)
+    box.busy(count=4, age_seconds=600)
+    assert box.run("--check").stdout.startswith("stale")
+
+
+def test_unknown_when_the_box_has_no_stamp(box):
+    box.expect(box.seed_repo(GOOD_RUNNER))
+    assert box.run("--check").stdout.startswith("unknown")
+
+
+def test_unknown_when_the_server_expects_nothing(box):
+    # A dev image bakes in no expectation. Empty means UNKNOWN, never "different".
+    box.stamp("abc123")
+    box.expect("")
+    assert box.run("--check").stdout.startswith("unknown")
+
+
+def test_unknown_when_this_runner_is_not_in_the_fleet_list(box):
+    # Retired, or invisible to this token. Reinstalling would not fix either.
+    box.stamp("abc123")
+    box.api_body.write_text(json.dumps([{"id": "someone-else", "expected_code_sha": "x" * 40}]))
+    assert box.run("--check").stdout.startswith("unknown")
+
+
+def test_unknown_when_the_control_plane_is_unreachable(box):
+    box.stamp("abc123")
+    box._write_stub("curl", "exit 7\n")
+    out = box.run("--check")
+    assert out.stdout.startswith("unknown")
+    assert out.returncode == 0
+
+
+# --- installing -------------------------------------------------------------
+def test_stale_and_idle_installs_the_expected_sha_and_restarts(box):
+    box.stamp("0" * 40)
+    sha = box.seed_repo("#!/usr/bin/env python3\nprint('shipped')\n")
+    box.expect(sha)
+
+    out = box.run()
+    assert out.returncode == 0, out.stderr
+    assert "print('shipped')" in box.installed
+    assert box.restarted
+    assert "canopy-runner.service" in box.restart_log.read_text()
+
+    stamped = json.loads((box.home / "build-info.json").read_text())
+    assert stamped["sha"] == sha
+    assert stamped["ref"] == sha
+    # Re-stamped means the very next check reads `current` — without it the box
+    # would reinstall and restart every 30 minutes, forever.
+    assert box.run("--check").stdout.startswith("current")
+
+
+def test_current_installs_nothing(box):
+    sha = box.seed_repo(GOOD_RUNNER)
+    box.stamp(sha)
+    box.expect(sha)
+    box.run()
+    assert box.installed == ""
+    assert not box.restarted
+
+
+def test_busy_installs_nothing(box):
+    sha = box.seed_repo(GOOD_RUNNER)
+    box.stamp("0" * 40)
+    box.expect(sha)
+    box.busy(count=2)
+    box.run()
+    assert box.installed == ""
+    assert not box.restarted
+
+
+def test_it_refuses_to_install_a_file_that_does_not_parse(box):
+    # systemd's ExecStart points straight at this file: a truncated or broken copy
+    # is a box that will not boot. Better to stay stale than to install that.
+    box.stamp("0" * 40)
+    (box.home / "cloud_runner.py").write_text("# the working runner\n")
+    sha = box.seed_repo("def broken(:\n  syntax error\n")
+    box.expect(sha)
+
+    out = box.run()
+    assert "REFUSING" in out.stdout
+    assert box.installed == "# the working runner\n"
+    assert not box.restarted
+    assert not (box.home / "cloud_runner.py.new").exists()
+
+
+def test_a_sha_not_yet_in_the_clone_is_retried_not_failed(box):
+    # The deploy can be ahead of this box's clone. Survivable and self-correcting:
+    # log it and wait for the next cycle rather than shouting every 30 minutes.
+    box.stamp("0" * 40)
+    box.expect("f" * 40)
+    out = box.run()
+    assert "will retry" in out.stdout
+    assert not box.restarted
+
+
+# --- the read-only rule -----------------------------------------------------
+def test_the_updater_never_writes_to_the_control_plane(box):
+    # A heartbeat from this second process would stamp the runner ONLINE and
+    # overwrite the provenance the real daemon reports — forging liveness for a
+    # daemon that may be dead. It must only ever GET.
+    box.stamp("0" * 40)
+    box.expect(box.seed_repo(GOOD_RUNNER))
+    box.run()
+    calls = box.curl_log.read_text()
+    assert "runners/" in calls
+    assert "-X POST" not in calls and "--data" not in calls and "-d " not in calls
+    assert "heartbeat" not in calls
+
+
+# --- deliberate overrides ---------------------------------------------------
+def test_ref_installs_something_else_on_purpose(box):
+    sha = box.seed_repo("#!/usr/bin/env python3\nprint('branch build')\n")
+    box.stamp("0" * 40)
+    box.expect("0" * 40)  # the server thinks this box is current
+    out = box.run("--ref", sha)
+    assert out.returncode == 0, out.stderr
+    assert "print('branch build')" in box.installed
+    assert box.restarted

--- a/runner/ec2/up.sh
+++ b/runner/ec2/up.sh
@@ -46,6 +46,40 @@ else
 fi
 echo "   ${#B64} bytes published"
 
+# Provenance of the bytes just published, stamped onto the box when cloud-init
+# installs the seed. The SAME quantity deploy-labs.yml computes for the server's
+# `expected_code_sha`, over the same paths — the two are compared directly, so they
+# have to be the same command.
+#
+# Without it a fresh box reports unknown provenance, its first auto-update check
+# answers `unknown`, and it therefore never updates — which looks exactly like a
+# box that is up to date. Say so rather than shipping that silently.
+#
+# Published as its OWN secret rather than a template parameter: a parameter is
+# interpolated into UserData, and CFN applies a UserData change to a running
+# instance as a stop/start — this value changes on every runner commit, so it
+# would bounce the live box (new public IP and all) every time up.sh ran.
+SHA_SECRET="${SHA_SECRET:-canopy/cloud-runner/runner-code-sha}"
+SHA_PATHS=(cloud_runner.py bootstrap_agents.sh)
+CODE_SHA="$(git log -1 --format=%H -- "${SHA_PATHS[@]}" 2>/dev/null || true)"
+CODE_AT="$(git log -1 --format=%ct -- "${SHA_PATHS[@]}" 2>/dev/null || true)"
+if [ -n "$CODE_SHA" ]; then
+  echo ">> publishing seed provenance ${CODE_SHA:0:12} (${CODE_AT:-0}) -> $SHA_SECRET"
+  STAMP="{\"sha\": \"$CODE_SHA\", \"committed_at\": ${CODE_AT:-0}, \"ref\": \"seed\"}"
+  if "${AWS[@]}" secretsmanager describe-secret --secret-id "$SHA_SECRET" >/dev/null 2>&1; then
+    "${AWS[@]}" secretsmanager put-secret-value --secret-id "$SHA_SECRET" \
+      --secret-string "$STAMP" >/dev/null
+  else
+    "${AWS[@]}" secretsmanager create-secret --name "$SHA_SECRET" \
+      --description 'provenance of the cloud_runner.py seed — published by up.sh' \
+      --secret-string "$STAMP" >/dev/null
+  fi
+else
+  echo "!! WARNING: could not resolve the cloud runner source sha (shallow clone?)." >&2
+  echo "   A box seeded from this publish reports unknown provenance and will" >&2
+  echo "   NEVER auto-update — which looks exactly like a box that is up to date." >&2
+fi
+
 echo ">> validating template"
 "${AWS[@]}" cloudformation validate-template --template-body "file://runner.cfn.yaml" >/dev/null
 

--- a/runner/ec2/update_runner.sh
+++ b/runner/ec2/update_runner.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+#
+# Should this cloud box install newer runner bytes right now?
+#
+#   canopy-runner-update               # the timer's mode: install iff stale + idle
+#   canopy-runner-update --check       # print the verdict, change nothing
+#   canopy-runner-update --ref BRANCH  # install something else, deliberately
+#   canopy-runner-update --from-secret # restore the Secrets Manager bytes
+#
+# The cloud half of the auto-update story the laptop runner already has
+# (runner/canopy_runner/canopy_runner/update.py + install-runner.sh --if-stale).
+# The question has the same three parts, each answered by whoever actually knows:
+#
+#   * WHAT IS INSTALLED — /opt/canopy-runner/build-info.json, locally. Deliberately
+#     NOT the server's record of code_sha: that is only as fresh as the last
+#     heartbeat, and a runner crash-looping (the case where auto-update matters
+#     MOST) has not sent one.
+#   * WHAT SHOULD BE INSTALLED — `expected_code_sha` off this runner's own row.
+#     That is the cloud runner source in the DEPLOYED image, so it has already been
+#     through CI, the merge queue and a deploy. Tracking origin/main instead would
+#     install code nothing has deployed AND leave the box permanently mismatched
+#     against the server — the staleness banner would then fire forever on exactly
+#     the boxes auto-updating correctly.
+#   * WHETHER NOW IS SAFE — /opt/canopy-runner/in-flight, rewritten by the running
+#     daemon on every heartbeat. An update restarts the service; restarting mid-turn
+#     strands the work.
+#
+# READ-ONLY against the control plane, and that is load-bearing: this must never
+# heartbeat. A heartbeat from this second process would stamp the runner ONLINE and
+# overwrite the provenance the real daemon reports — forging liveness for a daemon
+# that may be dead.
+#
+# Runs as the SERVICE USER (ubuntu), not root. /opt/canopy-runner and
+# /opt/canopy-web are both ubuntu-owned, so nothing here needs privilege except the
+# restart itself — and root git-ing around in a directory agent turns can write
+# would both trip git's dubious-ownership guard and hand root an attack surface for
+# no benefit. The one privileged step goes through a sudoers rule scoped to exactly
+# `systemctl restart canopy-runner.service`.
+#
+# A SEPARATE unit from the runner, not a thread inside it: a runner that
+# crash-loops can never update itself — it never heartbeats, never learns it is
+# behind, and stays bricked until a human notices. An independent timer means
+# shipping a fix is enough to rescue the box.
+#
+# See docs/superpowers/specs/2026-07-30-cloud-runner-auto-update-design.md.
+set -uo pipefail
+
+RUNNER_HOME="${RUNNER_HOME:-/opt/canopy-runner}"
+ENV_FILE="${ENV_FILE:-$RUNNER_HOME/runner.env}"
+TARGET="$RUNNER_HOME/cloud_runner.py"
+STAMP="$RUNNER_HOME/build-info.json"
+BUSY="$RUNNER_HOME/in-flight"
+REPO_DIR="${CANOPY_WEB_REPO_DIR:-/opt/canopy-web}"
+REPO_URL="${CANOPY_WEB_REPO_URL:-https://github.com/dimagi-internal/canopy-web.git}"
+STATE_FILE="${STATE_FILE:-$HOME/.canopy-cloud-runner.json}"
+SERVICE="${SERVICE:-canopy-runner.service}"
+RESTART_CMD="${RESTART_CMD:-sudo -n systemctl restart}"
+CODE_SECRET="${CODE_SECRET:-canopy/cloud-runner/runner-code}"
+RUNNER_SRC="runner/ec2/cloud_runner.py"
+# The paths the DEPLOYED sha is computed over (deploy-labs.yml's cloud_sha step).
+# Kept identical here so a stamp written by this script names the same commit the
+# server expects — bootstrap_agents.sh included, because a restart is how it ships.
+SHA_PATHS=("runner/ec2/cloud_runner.py" "runner/ec2/bootstrap_agents.sh")
+# The daemon rewrites the busy marker every heartbeat (20s). Older than this means
+# it is not running its loop at all — stopped, wedged, or crash-looping. That is
+# NOT busy: it is the case this script exists to rescue, so it must never block.
+BUSY_MAX_AGE=120
+
+MODE="update"
+REF=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --check) MODE="check"; shift ;;
+    --ref) REF="${2:?--ref needs a git ref}"; MODE="pinned"; shift 2 ;;
+    --from-secret) MODE="secret"; shift ;;
+    -h|--help) sed -n '2,9p' "$0"; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+log() { echo "$(date -u +%FT%TZ) canopy-runner-update: $*"; }
+
+# --- what is installed ------------------------------------------------------
+json_field() {  # <file> <key> <default>
+  python3 - "$1" "$2" "$3" <<'PY' 2>/dev/null || echo "$3"
+import json, sys
+path, key, default = sys.argv[1], sys.argv[2], sys.argv[3]
+try:
+    with open(path) as fh:
+        print(json.load(fh).get(key) or default)
+except Exception:
+    print(default)
+PY
+}
+
+INSTALLED_SHA="$(json_field "$STAMP" sha "")"
+
+# --- whether now is safe ----------------------------------------------------
+in_flight() {  # echoes a count, or "" when the marker cannot be trusted
+  python3 - "$BUSY" "$BUSY_MAX_AGE" <<'PY' 2>/dev/null
+import json, sys, time
+path, max_age = sys.argv[1], float(sys.argv[2])
+try:
+    with open(path) as fh:
+        raw = json.load(fh)
+    if time.time() - float(raw["at"]) > max_age:
+        sys.exit(0)          # stale marker: unknown, and unknown must not block
+    print(int(raw["count"]))
+except Exception:
+    pass
+PY
+}
+
+# --- what should be installed ----------------------------------------------
+expected_sha() {
+  # GET the fleet list and pick our own row. Read-only by construction: there is no
+  # POST anywhere in this script, deliberately (see the header).
+  local base token rid
+  [ -r "$ENV_FILE" ] || { echo ""; return; }
+  base="$(sed -n 's/^CANOPY_BASE_URL=//p' "$ENV_FILE" | tail -1)"
+  token="$(sed -n 's/^CANOPY_TOKEN=//p' "$ENV_FILE" | tail -1)"
+  rid="$(json_field "$STATE_FILE" runner_id "")"
+  [ -n "$base" ] && [ -n "$token" ] && [ -n "$rid" ] || { echo ""; return; }
+  # `python3 -c`, NOT `python3 - <<HEREDOC`: a heredoc redirects stdin, so it would
+  # silently win over the pipe and the parser would read the PROGRAM instead of the
+  # response — every box answering `unknown`, forever, with nothing in the log.
+  curl -fsS --max-time 30 -H "Authorization: Bearer $token" \
+      "${base%/}/api/harness/runners/" 2>/dev/null \
+    | python3 -c '
+import json, sys
+rid = sys.argv[1]
+try:
+    rows = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+rows = rows.get("items", rows) if isinstance(rows, dict) else rows
+for row in rows or []:
+    if str(row.get("id")) == rid:
+        print((row.get("expected_code_sha") or "").strip())
+        break
+' "$rid" 2>/dev/null
+}
+
+# --- verdict ----------------------------------------------------------------
+# current | stale | busy | unknown — the same four the laptop's update.py returns,
+# and unknown covers EITHER side being empty for the same reason it does there: a
+# dev server bakes in no expectation, and installing an empty sha would be a
+# reinstall loop against a target that does not exist.
+verdict() {
+  local expected="$1" carrying
+  if [ -z "$expected" ] || [ -z "$INSTALLED_SHA" ]; then echo "unknown"; return; fi
+  if [ "$expected" = "$INSTALLED_SHA" ]; then echo "current"; return; fi
+  carrying="$(in_flight)"
+  if [ -n "$carrying" ] && [ "$carrying" -gt 0 ] 2>/dev/null; then echo "busy"; return; fi
+  echo "stale"
+}
+
+# --- install ----------------------------------------------------------------
+fetch_commit() {  # make <ref> resolvable in the clone
+  local ref="$1"
+  if [ ! -d "$REPO_DIR/.git" ]; then
+    git clone --quiet "$REPO_URL" "$REPO_DIR" || return 1
+  fi
+  git -C "$REPO_DIR" rev-parse --verify --quiet "${ref}^{commit}" >/dev/null && return 0
+  # The bootstrap clone is --depth 1, so an older commit simply is not here yet.
+  # Ask for that object by name first (GitHub serves reachable shas); deepen only
+  # if it refuses, because unshallowing this repo is not free.
+  git -C "$REPO_DIR" fetch --quiet origin "$ref" 2>/dev/null \
+    || git -C "$REPO_DIR" fetch --quiet --unshallow origin 2>/dev/null \
+    || git -C "$REPO_DIR" fetch --quiet origin main 2>/dev/null
+  git -C "$REPO_DIR" rev-parse --verify --quiet "${ref}^{commit}" >/dev/null
+}
+
+install_bytes() {  # <candidate> <sha> <committed_at> <ref-label>
+  local candidate="$1" sha="$2" committed_at="$3" ref="$4"
+  # systemd's ExecStart points straight at this file, so a truncated or malformed
+  # copy is a box that will not boot. Parse it before it can ever be started — the
+  # counterpart of `plutil -lint`ing a plist before going near the running job.
+  # `ast.parse` rather than py_compile so this leaves no __pycache__ behind.
+  if ! python3 -c 'import ast,sys; ast.parse(open(sys.argv[1]).read())' "$candidate" 2>/dev/null; then
+    log "REFUSING to install: $candidate does not parse. The running runner is untouched."
+    rm -f "$candidate"
+    return 1
+  fi
+  chmod 0755 "$candidate" || return 1
+  mv "$candidate" "$TARGET" || return 1
+  python3 - "$STAMP" "$sha" "$committed_at" "$ref" <<'PY'
+import json, sys, time
+path, sha, committed_at, ref = sys.argv[1:5]
+with open(path, "w") as fh:
+    json.dump({"sha": sha, "committed_at": int(committed_at or 0),
+               "installed_at": int(time.time()), "ref": ref}, fh)
+PY
+  log "installed ${sha:-<unknown>} ($ref) -> $TARGET; restarting $SERVICE"
+  # The only privileged step, and the only reason this box grants the service user
+  # any sudo at all — scoped to this exact command by a sudoers drop-in.
+  $RESTART_CMD "$SERVICE"
+}
+
+install_from_git() {  # <git ref or sha>
+  local ref="$1" sha committed_at tmp
+  fetch_commit "$ref" || {
+    # In timer mode this is survivable and self-correcting: the sha may simply not
+    # have reached this clone yet. Wait for the next cycle rather than shouting
+    # every 30 minutes.
+    log "ref $ref is not in $REPO_DIR yet; will retry."
+    return 1
+  }
+  sha="$(git -C "$REPO_DIR" log -1 --format=%H "$ref" -- "${SHA_PATHS[@]}")"
+  committed_at="$(git -C "$REPO_DIR" log -1 --format=%ct "$ref" -- "${SHA_PATHS[@]}")"
+  tmp="$TARGET.new"
+  # `git show`, never a checkout: agent turns run in this clone and one may have
+  # left it on a branch. Reading the blob out of the object store cannot be
+  # affected by that — it is the working-tree coupling that bit the laptop three
+  # times before the runner became an installed package.
+  if ! git -C "$REPO_DIR" show "$ref:$RUNNER_SRC" > "$tmp" 2>/dev/null; then
+    log "ref $ref has no $RUNNER_SRC; nothing installed."
+    rm -f "$tmp"
+    return 1
+  fi
+  install_bytes "$tmp" "$sha" "${committed_at:-0}" "$ref"
+}
+
+install_from_secret() {
+  local tmp="$TARGET.new"
+  if ! aws secretsmanager get-secret-value --secret-id "$CODE_SECRET" \
+        --query SecretString --output text 2>/dev/null | base64 -d | gunzip > "$tmp"; then
+    log "could not read $CODE_SECRET; nothing installed."
+    rm -f "$tmp"
+    return 1
+  fi
+  # The secret carries no provenance, so the stamp is CLEARED rather than guessed.
+  # Unknown is the honest answer: those bytes are whatever an operator published,
+  # and a borrowed sha would tell the fleet this box is current when it is not.
+  install_bytes "$tmp" "" 0 "secret:$CODE_SECRET"
+}
+
+# --- main -------------------------------------------------------------------
+case "$MODE" in
+  secret)
+    install_from_secret
+    exit $?
+    ;;
+  pinned)
+    log "installing $REF by hand — this box reads as stale until a deploy ships it"
+    install_from_git "$REF"
+    exit $?
+    ;;
+esac
+
+EXPECTED="$(expected_sha)"
+V="$(verdict "$EXPECTED")"
+
+if [ "$MODE" = "check" ]; then
+  echo "$V expected=${EXPECTED:-<unknown>} installed=${INSTALLED_SHA:-<unknown>}"
+  exit 0
+fi
+
+case "$V" in
+  stale)
+    log "behind — installing ${EXPECTED:0:12} (running ${INSTALLED_SHA:0:12})"
+    install_from_git "$EXPECTED"
+    ;;
+  *)
+    # current | busy | unknown all mean "do nothing", and all exit 0. This runs on
+    # a timer: a non-zero exit for the ordinary case fills the journal with false
+    # failures and trains everyone to ignore the one that matters.
+    log "$V — nothing to do."
+    ;;
+esac
+exit 0

--- a/tests/test_realtime_runner_consumer.py
+++ b/tests/test_realtime_runner_consumer.py
@@ -320,3 +320,61 @@ async def test_ws_claim_agrees_with_the_rest_claim_payload():
                   "workspace_slug", "prompt"):
         assert claimed[field] == rest[field], f"{field} disagrees: {claimed[field]!r} vs {rest[field]!r}"
     await comm.disconnect()
+
+
+# --- heartbeat provenance ----------------------------------------------------
+# `services.heartbeat` assigns code_sha/code_branch/code_version/code_committed_at
+# UNCONDITIONALLY, so a call that omits them clears them. This is the cloud
+# runner's primary heartbeat (every 20s), so before spec 2026-07-30 anything it
+# reported over REST was erased moments later and `code_sha` read empty forever —
+# indistinguishable from a runner that never reported one.
+async def test_ws_heartbeat_records_code_provenance():
+    user, _ws, _a, runner = await database_sync_to_async(_setup)()
+    comm = await _connect(runner.id, user)
+    await comm.connect()
+    await comm.send_json_to({
+        "action": "heartbeat", "active_turn_ids": [],
+        "code_sha": "abc123", "code_committed_at": 1753900000, "code_version": "9.9.9",
+    })
+    assert (await comm.receive_json_from(timeout=2))["type"] == "heartbeat.ack"
+
+    fresh = await database_sync_to_async(Runner.objects.get)(pk=runner.id)
+    assert fresh.code_sha == "abc123"
+    assert fresh.code_committed_at == 1753900000
+    assert fresh.code_version == "9.9.9"
+    await comm.disconnect()
+
+
+async def test_ws_heartbeat_does_not_erase_provenance_it_resent():
+    # The regression itself: beat twice and the sha must still be there. A pass
+    # here with a single beat would prove nothing — the erasure happened on the
+    # NEXT one.
+    user, _ws, _a, runner = await database_sync_to_async(_setup)()
+    comm = await _connect(runner.id, user)
+    await comm.connect()
+    for _ in range(2):
+        await comm.send_json_to({"action": "heartbeat", "active_turn_ids": [],
+                                 "code_sha": "deadbee"})
+        await comm.receive_json_from(timeout=2)
+
+    fresh = await database_sync_to_async(Runner.objects.get)(pk=runner.id)
+    assert fresh.code_sha == "deadbee"
+    await comm.disconnect()
+
+
+async def test_ws_heartbeat_survives_a_malformed_committed_at():
+    # Provenance is decoration on a liveness call. A runner sending garbage must
+    # lose its timestamp, never its heartbeat — losing the beat would take it
+    # offline and stop it claiming.
+    user, _ws, _a, runner = await database_sync_to_async(_setup)()
+    comm = await _connect(runner.id, user)
+    await comm.connect()
+    await comm.send_json_to({"action": "heartbeat", "active_turn_ids": [],
+                             "code_sha": "abc123", "code_committed_at": "not-a-number"})
+    assert (await comm.receive_json_from(timeout=2))["type"] == "heartbeat.ack"
+
+    fresh = await database_sync_to_async(Runner.objects.get)(pk=runner.id)
+    assert fresh.status == Runner.ONLINE
+    assert fresh.code_sha == "abc123"
+    assert fresh.code_committed_at == 0
+    await comm.disconnect()

--- a/tests/test_runner_expected_code_sha.py
+++ b/tests/test_runner_expected_code_sha.py
@@ -1,0 +1,71 @@
+"""`expected_code_sha` is per RUNNER KIND, because the fleet runs two programs.
+
+A laptop executes `runner/canopy_runner/canopy_runner`; a cloud box executes
+`runner/ec2`. One sha cannot describe both, and serving the laptop's to a cloud
+runner would mark every cloud box permanently stale — noise on exactly the rows
+the alert was extended to cover.
+
+See docs/superpowers/specs/2026-07-30-cloud-runner-auto-update-design.md.
+"""
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth.models import User
+from django.utils import timezone
+
+from apps.harness.models import Runner
+from apps.harness.schemas import RunnerOut
+
+pytestmark = pytest.mark.django_db
+
+LAPTOP_SHA = "1111111111111111111111111111111111111111"
+CLOUD_SHA = "2222222222222222222222222222222222222222"
+
+
+@pytest.fixture
+def shas(settings):
+    settings.RUNNER_CODE_SHA = LAPTOP_SHA
+    settings.RUNNER_CODE_COMMITTED_AT = 1753000000
+    settings.RUNNER_CLOUD_CODE_SHA = CLOUD_SHA
+    settings.RUNNER_CLOUD_CODE_COMMITTED_AT = 1754000000
+
+
+def _runner(kind: str) -> Runner:
+    user = User.objects.create_user(f"u-{kind}", f"{kind}@dimagi.com", "pw")
+    return Runner.objects.create(
+        name=f"box-{kind}", kind=kind, paired_by=user,
+        status=Runner.ONLINE, last_heartbeat_at=timezone.now(),
+    )
+
+
+def test_cloud_runner_is_told_the_cloud_sha(shas):
+    out = RunnerOut.from_orm(_runner(Runner.CLOUD))
+    assert out.expected_code_sha == CLOUD_SHA
+    assert out.expected_code_committed_at == 1754000000
+
+
+def test_laptop_runner_is_told_the_laptop_sha(shas):
+    out = RunnerOut.from_orm(_runner(Runner.EMDASH))
+    assert out.expected_code_sha == LAPTOP_SHA
+    assert out.expected_code_committed_at == 1753000000
+
+
+def test_a_remote_runner_keeps_the_laptop_expectation(shas):
+    # `remote` runs the same package as `emdash` (services.session_capable groups
+    # them). Only `cloud` is the other program.
+    out = RunnerOut.from_orm(_runner(Runner.REMOTE))
+    assert out.expected_code_sha == LAPTOP_SHA
+
+
+def test_an_unset_cloud_sha_is_unknown_not_the_laptops(settings):
+    # A build without the new arg (a dev image, a local build) must degrade to
+    # UNKNOWN — which is silent — never borrow the other runner's sha, which would
+    # differ from what every cloud box reports and alert on all of them forever.
+    settings.RUNNER_CODE_SHA = LAPTOP_SHA
+    settings.RUNNER_CLOUD_CODE_SHA = ""
+    assert RunnerOut.from_orm(_runner(Runner.CLOUD)).expected_code_sha == ""
+
+
+def test_a_malformed_committed_at_does_not_500_the_list(settings):
+    settings.RUNNER_CLOUD_CODE_COMMITTED_AT = "not-an-int"
+    assert RunnerOut.from_orm(_runner(Runner.CLOUD)).expected_code_committed_at == 0


### PR DESCRIPTION
The laptop runner has tracked the deployed sha and installed it on a timer since spec `2026-07-28`. The cloud runner had none of it — its bytes reached the box through Secrets Manager, published by an operator with AWS credentials, so shipping a change meant finding that operator. Nothing on the box knew what it should be running and nothing on the server knew what it was: `code_sha` was empty for every cloud row, and `codeProvenance.ts` documented that silence as intended.

It drifted, silently and in one direction only — the live stack was created 2026-07-26 and never updated, while `runner/ec2` moved on.

## The same three questions, answered the same way

| | laptop | cloud (this PR) |
|---|---|---|
| what is installed | `_build_info.py`, stamped at build | `/opt/canopy-runner/build-info.json`, stamped at install |
| what should be | `expected_code_sha` off its own row | same row, resolved **per kind** |
| is now safe | `~/.canopy/in-flight` | `/opt/canopy-runner/in-flight`, same file shape |

`expected_code_sha` becomes per-`kind` because the fleet runs two programs: a laptop executes `runner/canopy_runner`, a cloud box executes `runner/ec2`. `deploy-labs.yml` computes the second path-scoped sha (`cloud_runner.py` + `bootstrap_agents.sh` — the latter re-runs on every service start, but nothing ever *triggered* one), and serving one sha to both kinds would mark every cloud box stale forever.

`update_runner.sh` runs on a 30-minute systemd timer as the service user, and is read-only against the control plane — a heartbeat from it would forge liveness for a daemon that may be dead. It installs `git show <sha>:runner/ec2/cloud_runner.py` from the clone the box already keeps: pinned (never `origin/main`, which would run undeployed code *and* leave the box permanently mismatched), and read from the object store so an agent turn that left the clone on a branch cannot change what installs. A **separate unit**, because a runner that crash-loops can never update itself.

Secrets Manager drops to a first-boot **seed**: `canopy-fetch-env` installs it only when there is no `cloud_runner.py` on disk, since re-fetching on every start would revert every update at the next restart. So `./up.sh` no longer ships runner code to a running box — code ships by merge + deploy, and the on-box overrides are `canopy-runner-update --ref <ref>` / `--from-secret`. The seed's provenance is published as its own secret rather than a stack parameter: a parameter lives in UserData, and changing UserData **stop/starts** the running instance — which this value would do on every runner commit.

## Two bugs found on the way

Both would have made this look like it worked while doing nothing:

- **`services.heartbeat` assigns provenance unconditionally, and the WS consumer called it with none.** That frame is the cloud runner's primary heartbeat, so anything reported over REST was erased 20s later and `code_sha` read empty forever — indistinguishable from never reporting one. The consumer passes it through now, and the runner builds its payload in ONE place across all four heartbeat call sites. This is the bug the laptop already paid for with `code_branch` (four of six sites silently clearing it).
- **The updater's expected-sha parser was fed its program on stdin via heredoc**, which silently beat the pipe carrying the API response. Every box would have answered `unknown` forever. The bash-driven tests caught it.

## Testing

- `runner/ec2/tests/test_update_runner_sh.py` — 15 tests driving the real script against a real git repo with `curl`/restart faked on PATH: the four verdicts, a stale marker not reading as busy, refusing to install a file that does not parse, and that it never writes to the control plane.
- `runner/ec2/tests/test_auto_update.py` — the stamp (incl. missing/garbage/uncached), the marker's shape, and a source-level guard that every heartbeat call site goes through the one payload builder.
- `tests/test_runner_expected_code_sha.py` + 3 consumer tests (verified failing without the fix, passing with it).
- Full suites green: 1952 backend, 105 cloud-runner, frontend build + `codeProvenance` tests. `generated.ts` confirmed unchanged (resolver bodies only).

## Rollout

Cloud-init only runs on an instance's first boot, so this ships with a recycle:

```bash
cd runner/ec2 && ./down.sh && ./up.sh && ./wire.sh --drill
```

Land the deploy carrying `RUNNER_CLOUD_CODE_SHA` first, or the fresh box's first checks read `unknown` (harmless; self-corrects at the next deploy).

Spec: `docs/superpowers/specs/2026-07-30-cloud-runner-auto-update-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)