### PR TITLE
feat(chat): tell me an agent is waiting, instead of waiting to be found

### DIFF
--- a/apps/canopy_sessions/api.py
+++ b/apps/canopy_sessions/api.py
@@ -218,11 +218,19 @@ def list_sessions(
         rows = rows.filter(Q(status=Session.ARCHIVED) | unseen)
 
     out = [_out(s) for s in rows]
-    # Running first, then genuinely-most-recent. Sorting by created_at made a
-    # dead repo and a live one interleave arbitrarily (both "created" in the
-    # same report sweep); last_activity_at is the real signal. The client can
-    # re-group by project — this is the default order.
-    out.sort(key=lambda r: (not r["running"], -(r["last_activity_at"].timestamp())))
+    # Waiting first, then running, then genuinely-most-recent. Sorting by
+    # created_at made a dead repo and a live one interleave arbitrarily (both
+    # "created" in the same report sweep); last_activity_at is the real signal.
+    # The client can re-group by project — this is the default order.
+    #
+    # `waiting_on_you` outranks both because activity ordering actively BURIES
+    # it: a session stops writing the moment it asks, so the longer somebody has
+    # been kept waiting the further down it sinks, and the row you can actually
+    # do something about ends up below a dozen you cannot. Same trap the runner
+    # side avoids by reading the question for every session rather than the top
+    # K — this is that trap one layer up.
+    out.sort(key=lambda r: (not r["waiting_on_you"], not r["running"],
+                            -(r["last_activity_at"].timestamp())))
     # Clamp AFTER the sort, never as a queryset slice: the queryset is ordered by
     # -created_at, so slicing it could drop the running session this sort exists to
     # float. `state=active` already bounds the set; this is a payload backstop.

--- a/apps/harness/services.py
+++ b/apps/harness/services.py
@@ -1583,6 +1583,26 @@ def replace_reported_sessions(
             groups.publish(groups.session_group(session_id),
                            {"type": "session.menu", "menu": menu})
 
+        # And to the phone in your pocket, for the agents that just STARTED
+        # waiting. Only the null -> menu edge: a retraction is not news, and the
+        # UI it would correct is already corrected by the frame above.
+        #
+        # This is the half no rendering fix could cover. A menu that renders
+        # perfectly still needs somebody to open the app, and the failure being
+        # fixed here is 52 minutes of nobody knowing there was anything to open.
+        asking = [(sid, menu) for sid, menu in menu_changes if menu]
+        if asking:
+            from apps.canopy_sessions.models import Session
+            from apps.push import services as push_services
+
+            sessions = Session.objects.select_related(
+                "agent", "runner_binding", "runner_binding__runner"
+            ).in_bulk([sid for sid, _ in asking])
+            for session_id, menu in asking:
+                session = sessions.get(session_id)
+                if session is not None:
+                    push_services.notify_session_question(session, menu)
+
     transaction.on_commit(_fire_reported)
     return len(deduped)
 

--- a/apps/push/services.py
+++ b/apps/push/services.py
@@ -150,3 +150,73 @@ def mark_dirty(agent_id: int) -> None:
     """
     _dirty_set().add(agent_id)
     transaction.on_commit(_flush)
+
+
+# --- A blocked agent asking a question ---------------------------------------
+#
+# A SECOND producer, deliberately not routed through the item snapshot above.
+#
+# The snapshot exists because the waiting set is a COUNT with no natural event.
+# This is the opposite shape: an agent going from "working" to "waiting on a
+# human" is a discrete edge, observed once, and the notification can carry the
+# actual question rather than a tally. It is also not an `Item` and must not
+# become one — `Item`'s decisions are implement/skip/defer and `implement`
+# dispatches a Turn, whereas answering a dialog is a KEYSTROKE into a live
+# session. An inbox row whose buttons enqueue a turn would be wrong in a way
+# that runs code.
+#
+# Why it matters at all: rendering the menu perfectly still requires somebody to
+# open the app. `spark` sat blocked for 52 minutes on 2026-07-31 with nobody
+# looking, and no amount of UI fixes that.
+
+QUESTION_BODY_MAX = 140
+
+
+def _question_audience(session):
+    """Who should be told this session is waiting, or None.
+
+    The agent's owner when there is one; otherwise the human who PAIRED the
+    runner — the person whose laptop the session is actually sitting on. A
+    runner-discovered session (what `spark` was) has no agent, so without the
+    second leg the case that motivated this would notify nobody.
+
+    Fails closed on None, the same way `runner.paired_by` gates tenancy: with
+    nobody identifiable, we stay silent rather than broadcast a workspace.
+    """
+    agent = getattr(session, "agent", None)
+    owner = getattr(agent, "owner", None) if agent is not None else None
+    if owner is not None:
+        return owner
+    binding = getattr(session, "runner_binding", None)
+    runner = getattr(binding, "runner", None) if binding is not None else None
+    return getattr(runner, "paired_by", None) if runner is not None else None
+
+
+def notify_session_question(session, menu: dict) -> int:
+    """Push "this agent is asking you something", deep-linked to the answer.
+
+    The URL is the CHAT, not `/supervisor`: the whole point is that the tap
+    lands on the buttons. Sending someone to a dashboard to hunt for which
+    session it was is the same delay this exists to remove, just shorter.
+
+    Best-effort — a push must never cost the session report that triggered it.
+    """
+    if not menu:
+        return 0
+    user = _question_audience(session)
+    if user is None:
+        return 0
+    question = str(menu.get("question") or "").strip() or "a question"
+    if len(question) > QUESTION_BODY_MAX:
+        question = question[: QUESTION_BODY_MAX - 1].rstrip() + "…"
+    name = (session.title or "").strip() or "An agent"
+    try:
+        return send_to_user(
+            user,
+            title=f"{name} is asking",
+            body=question,
+            url=f"/w/{session.workspace_id}/chat/{session.id}",
+        )
+    except Exception:  # noqa: BLE001 — never let a notification break the report
+        logger.exception("push: session-question notify failed for %s", session.pk)
+        return 0

--- a/frontend/src/components/chat/ChatSessionsPanel.tsx
+++ b/frontend/src/components/chat/ChatSessionsPanel.tsx
@@ -212,11 +212,22 @@ export function ChatSessionsPanel({
     [sessions],
   )
   const visible = showOffline ? sessions : liveSessions
+  // Counted over the WHOLE list, not `visible`: a session waiting on a human is
+  // the one thing you want to know is there even when the current filter is
+  // hiding it. Sits beside the heading so it reads from a collapsed tab.
+  const waitingCount = sessions.filter((s) => s.waiting_on_you).length
 
   return (
     <div className="flex min-h-0 flex-col">
       <div className="flex items-center justify-between gap-2 pb-2">
-        <h2 className="text-sm font-semibold text-foreground">{heading}</h2>
+        <h2 className="flex items-center gap-1.5 text-sm font-semibold text-foreground">
+          {heading}
+          {waitingCount > 0 && (
+            <span className="rounded bg-warning/15 px-1.5 py-0.5 text-[11px] font-medium text-warning">
+              {waitingCount} waiting on you
+            </span>
+          )}
+        </h2>
         <DropdownMenu onOpenChange={(open: boolean) => { if (!open) resetPending() }}>
           <DropdownMenuTrigger
             render={<Button size="sm" disabled={creating || (agents.length === 0 && projects.length === 0)} />}

--- a/frontend/src/components/chat/sessionSort.test.ts
+++ b/frontend/src/components/chat/sessionSort.test.ts
@@ -77,3 +77,48 @@ describe("projectHeader", () => {
     expect(projectHeader(rows, 0, "project")).toBe("No project");
   });
 });
+
+describe("a session waiting on a human", () => {
+  const waiting = (project: string, at: string) => ({
+    ...row(project, at),
+    waiting_on_you: true,
+  });
+
+  it("sorts above everything, however long ago it last spoke", () => {
+    // The trap this exists for: a session stops writing the INSTANT it asks, so
+    // activity ordering pushes it further down the longer it is kept waiting —
+    // the one row you can act on ends up under every row you cannot.
+    const rows = [
+      row("canopy-web", T.now, true),
+      row("ace", T.min5),
+      waiting("spark", T.wk1),
+    ];
+    expect(sortSessions(rows, "time").map((r) => r.project)).toEqual([
+      "spark",
+      "canopy-web",
+      "ace",
+    ]);
+  });
+
+  it("stays inside its project group in project mode", () => {
+    // Project mode's contract is that a row appears under its repo heading;
+    // floating a waiting row out of its group would break the grouping it is
+    // named for.
+    const rows = [
+      row("ace", T.now),
+      waiting("reef", T.wk1),
+      row("ace", T.wk1),
+    ];
+    expect(sortSessions(rows, "project").map((r) => r.project)).toEqual([
+      "ace",
+      "ace",
+      "reef",
+    ]);
+  });
+
+  it("outranks running, which is not the same question", () => {
+    // "running" means the agent is busy; "waiting" means YOU are the blocker.
+    const rows = [row("busy", T.now, true), waiting("blocked", T.hr4)];
+    expect(sortSessions(rows, "time")[0].project).toBe("blocked");
+  });
+});

--- a/frontend/src/components/chat/sessionSort.ts
+++ b/frontend/src/components/chat/sessionSort.ts
@@ -11,11 +11,20 @@ export type SessionSort = "time" | "project";
 type Sortable = {
   project?: string | null;
   running?: boolean;
+  waiting_on_you?: boolean;
   last_activity_at: string;
 };
 
 const activityDesc = (a: Sortable, b: Sortable) =>
   Date.parse(b.last_activity_at) - Date.parse(a.last_activity_at);
+
+/** A session blocked on a human sorts above everything, in every mode.
+ *
+ *  Activity ordering actively buries it: a session stops writing the instant it
+ *  asks, so the longer somebody has been kept waiting the further down it goes
+ *  — the one row you can act on ends up under a dozen you cannot. */
+const waitingFirst = (a: Sortable, b: Sortable) =>
+  Number(Boolean(b.waiting_on_you)) - Number(Boolean(a.waiting_on_you));
 
 /** Sort a copy; never mutates the input. */
 export function sortSessions<T extends Sortable>(
@@ -24,16 +33,19 @@ export function sortSessions<T extends Sortable>(
 ): T[] {
   const copy = [...rows];
   if (mode === "project") {
-    // Grouped by repo, and inside a repo the liveliest first: running, then
-    // most-recently-active. Blank projects (web chats) sort last, not first.
+    // Grouped by repo, and inside a repo: waiting on a human, then running,
+    // then most-recently-active. Blank projects (web chats) sort last, not
+    // first. Waiting stays INSIDE the group here — project mode's whole
+    // contract is that a row appears under its repo heading.
     return copy.sort(
       (a, b) =>
         projectKey(a).localeCompare(projectKey(b)) ||
+        waitingFirst(a, b) ||
         Number(Boolean(b.running)) - Number(Boolean(a.running)) ||
         activityDesc(a, b),
     );
   }
-  return copy.sort(activityDesc);
+  return copy.sort((a, b) => waitingFirst(a, b) || activityDesc(a, b));
 }
 
 /** "" (a web chat) sorts after every named project rather than to the top. */

--- a/tests/test_chat_pending_question.py
+++ b/tests/test_chat_pending_question.py
@@ -181,3 +181,114 @@ def test_the_snapshot_shape_is_stable_when_nothing_is_pending():
         draft=None, messages=[],
     )
     assert "menu" in dto and dto["menu"] is None
+
+
+# -- you are TOLD, rather than having to go and look ------------------------
+#
+# NOTE the `django_capture_on_commit_callbacks` fixture on every test here. The
+# push fires from `transaction.on_commit`, which NEVER runs under the default
+# non-transactional test DB — so without it these tests pass while asserting
+# nothing, including the one that checks a push failure is survivable.
+
+
+def _sent(monkeypatch):
+    from apps.push import services as push_services
+
+    calls = []
+    monkeypatch.setattr(push_services, "send_to_user",
+                        lambda user, **kw: calls.append((user, kw)) or 1)
+    return calls
+
+
+def test_a_new_question_pushes_to_the_runner_s_owner(
+        monkeypatch, django_capture_on_commit_callbacks):
+    """The half no rendering fix covers. A perfectly rendered menu still needs
+    somebody to open the app; spark's 52 minutes were 52 minutes of nobody
+    knowing there was anything to open.
+
+    A runner-discovered session has NO agent, so the audience has to fall back
+    to whoever paired the runner — otherwise the exact case that motivated this
+    notifies nobody."""
+    sent = _sent(monkeypatch)
+    _jj, _ws, runner, client = _setup()
+    with django_capture_on_commit_callbacks(execute=True):
+        _report(client, runner.id, [
+            {"emdash_task": "spark", "project": "ace", "question": MENU}])
+
+    assert len(sent) == 1, "nobody was told the agent is waiting"
+    user, kw = sent[0]
+    assert user.username == "jj"                        # the runner's pairer
+    assert kw["body"] == "How should the run proceed?"  # the question itself
+    session = Session.objects.get(runner_binding__session_key="spark")
+    # The CHAT, not /supervisor: the tap has to land on the buttons.
+    assert kw["url"] == f"/w/dimagi/chat/{session.id}"
+
+
+def test_the_same_question_does_not_push_again_every_ten_seconds(
+        monkeypatch, django_capture_on_commit_callbacks):
+    """The report repeats on a ~10s heartbeat. Re-pushing an unchanged dialog
+    would turn one agent waiting into a notification every ten seconds."""
+    sent = _sent(monkeypatch)
+    _jj, _ws, runner, client = _setup()
+    for _ in range(3):
+        with django_capture_on_commit_callbacks(execute=True):
+            _report(client, runner.id, [
+                {"emdash_task": "spark", "project": "ace", "question": MENU}])
+    assert len(sent) == 1
+
+
+def test_answering_does_not_push(monkeypatch, django_capture_on_commit_callbacks):
+    """A retraction is not news — and the UI it would correct has already been
+    corrected by the session.menu frame."""
+    sent = _sent(monkeypatch)
+    _jj, _ws, runner, client = _setup()
+    for question in (MENU, None):
+        with django_capture_on_commit_callbacks(execute=True):
+            _report(client, runner.id, [
+                {"emdash_task": "spark", "project": "ace", "question": question}])
+    assert len(sent) == 1
+
+
+def test_a_long_question_is_truncated_for_a_lock_screen(
+        monkeypatch, django_capture_on_commit_callbacks):
+    sent = _sent(monkeypatch)
+    _jj, _ws, runner, client = _setup()
+    long_menu = {**MENU, "question": "Why " * 200}
+    with django_capture_on_commit_callbacks(execute=True):
+        _report(client, runner.id, [
+            {"emdash_task": "spark", "project": "ace", "question": long_menu}])
+    body = sent[0][1]["body"]
+    assert len(body) <= 140 and body.endswith("…")
+
+
+def test_a_push_failure_never_costs_the_session_report(
+        monkeypatch, django_capture_on_commit_callbacks):
+    """This runs inside the liveness report. A notification must never be the
+    reason the fleet stops reporting which sessions are alive."""
+    from apps.push import services as push_services
+
+    def _boom(*a, **kw):
+        raise RuntimeError("push service down")
+
+    monkeypatch.setattr(push_services, "send_to_user", _boom)
+
+    _jj, _ws, runner, client = _setup()
+    with django_capture_on_commit_callbacks(execute=True):
+        assert _report(client, runner.id, [
+            {"emdash_task": "spark", "project": "ace", "question": MENU},
+        ]).status_code == 200
+    assert RunnerBinding.objects.get(session_key="spark").pending_question is not None
+
+
+def test_a_waiting_session_sorts_above_everything(monkeypatch):
+    """Activity ordering BURIES it: a session stops writing the instant it asks,
+    so the longer somebody has been kept waiting the further down it sinks."""
+    _sent(monkeypatch)
+    _jj, _ws, runner, client = _setup()
+    _report(client, runner.id, [
+        {"emdash_task": "chatty", "project": "ace", "question": None},
+        {"emdash_task": "louder", "project": "ace", "question": None},
+        {"emdash_task": "spark", "project": "ace", "question": MENU},
+    ])
+    titles = [r["title"] for r in client.get("/api/canopy-sessions/").json()]
+    assert titles[0] == "spark", f"the waiting session sank to {titles.index('spark')}"


### PR DESCRIPTION
Follow-up to #544. That PR made the dialog **reach the phone once you go and look**. That isn't what cost 52 minutes — `spark` sat blocked because nobody *knew*. A perfectly rendered menu still needs somebody to open the app.

## What closes the loop

**Push, on the block edge.** Carries the question itself, deep-linked to the **chat** rather than `/supervisor` — the tap has to land on the buttons, not on a dashboard where you hunt for which session it was. Fires only on the `null -> menu` transition: the report repeats every ~10s, and a retraction is not news (the UI it would correct is already corrected by the `session.menu` frame).

**The audience falls back to the runner's pairer.** A runner-discovered session has no agent, and `spark` was exactly that — without the second leg, the case that motivated all of this notifies nobody. Fails closed when neither is identifiable rather than broadcasting a workspace, the same way `runner.paired_by` gates tenancy.

**Waiting sorts first**, server and client. Activity ordering actively *buries* it: a session stops writing the instant it asks, so the longer somebody has been kept waiting the further down it sinks, and the one row you can act on ends up under a dozen you cannot. Same trap the runner side avoids by reading every session rather than the top K — this is it one layer up. In project mode it stays inside its group, because that mode's contract is that a row appears under its repo heading.

**"N waiting on you"** beside the Sessions heading, counted over the whole list rather than the filtered view, so it reads from a collapsed tab.

## Deliberately not an `Item`

`Item`'s decisions are `implement`/`skip`/`defer`, and `implement` **dispatches a Turn** — whereas answering a dialog is a *keystroke into a live session*. An inbox row whose buttons enqueue a turn would be wrong in a way that runs code. So this is a second push producer beside the item-count snapshot, not a projection back into the inbox that `2026-07-21-supervisor-inbox-items-only-design.md` deliberately emptied.

## One test-infrastructure note worth reading

The push fires from `transaction.on_commit`, which **never runs** under the default non-transactional test DB. The first version of these tests passed while asserting nothing — including the one checking that a push failure cannot cost the liveness report. They now take `django_capture_on_commit_callbacks`; without it that whole block is theatre.

## Verification

Backend 2015, frontend 533, build clean, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)