### PR TITLE
feat(runner): a stale runner is rung, not left to its 30-minute timer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -393,6 +393,13 @@ never update again — an independent timer means shipping a fix rescues every b
 (it must never heartbeat — that would forge liveness for a daemon that may be dead).
 Log: `~/.canopy/updater.log`. Testing a branch on a box? Bootout the updater first,
 or it reverts you to the deployed sha within 30 minutes.
+**The 30-min timer is the fallback, not the latency**: a heartbeat reporting a sha
+that differs from the deployed expectation gets a `runner.update_available` frame
+back down the control channel, and the daemon kickstarts the updater job
+(`update.nudge` — throttled, skip-if-current, never installs in-process), so a
+stale box converges in ~one heartbeat. Push is the doorbell, the timer is the
+auditor — same shape as Gmail inbound; the timer alone still rescues a daemon too
+dead to hear a frame.
 
 **Runner code provenance.** The heartbeat carries `code_version` (the package's
 `__version__`, legible) and `code_sha` — **the sha of the last commit touching the runner's
@@ -422,7 +429,10 @@ payload in exactly ONE place.
 **The cloud runner is a separate program** (`runner/ec2/cloud_runner.py`): claims on a 15s poll and drains the queue, executes via `claude -p` (or ACP behind `RUNNER_EXECUTOR=acp`, default off), declares its repos via `RUNNER_PROJECTS`, and mirrors the laptop's viewer-stream/backfill contract on its own 3s clock. `bootstrap_agents.sh` provisions the agent fleet on the box — clones each `dimagi-internal/<slug>` repo into `/opt/agents`, installs the canopy plugin, `op inject`s env, maps each agent to its gog OAuth client — invoked from `main()` AFTER `fetch_and_stage_credential()` (not cloud-init, where credentials don't exist yet), and deliberately not `set -e`, so one agent's failure doesn't take down the other four. See `docs/superpowers/specs/2026-07-25-cloud-agent-bootstrap-design.md`.
 
 **The cloud runner AUTO-UPDATES too**, on the laptop's rules (`runner/ec2/update_runner.sh`,
-a `canopy-runner-update.timer` every 30 min): it tracks the **deployed**
+a `canopy-runner-update.timer` every 30 min, plus the same `update_available` nudge —
+`_nudge_updater` does `sudo systemctl start --no-block canopy-runner-update.service`, never
+the script as a child, which the restart inside would kill in the daemon's own cgroup):
+it tracks the **deployed**
 `expected_code_sha` for its own path, defers while a turn is in flight
 (`/opt/canopy-runner/in-flight`, the same file shape `update.mark_busy` writes), is
 READ-ONLY against the control plane (a heartbeat from the updater would forge liveness for a
@@ -546,7 +556,7 @@ Token-based session sharing (the `/canopy:share-session` flow); the app was rena
 
 **The workspace is in the URL, and that IS the multi-tenancy.** Verification binds to that workspace's own `InboundPushConfig`, so a second tenant — its own GCP project, its own push service account — verifies correctly, and one tenant's SA can never satisfy another's check. A *list* of allowed signers would not do: that would let tenant A push for tenant B's mailbox. Naming the tenant in the path (rather than parsing it out of the payload) also means the tenant is known **before** the body is decoded, so no attacker-controlled byte selects the credential it is checked against — and an unknown mailbox is logged against the right workspace instead of leaking the address into the default one. `resolve_mailbox(..., workspace_slug=…)` is the matching gate: `address` is globally unique (a push carries nothing else to disambiguate on), so the tenant match is *checked*, never assumed.
 
-**It is a doorbell, not a reader.** A Gmail push carries `{emailAddress, historyId}` and **no content**, so the receiver resolves mailbox → agent → assigned runners and sends a `runner.check_inbox` control frame (a sixth frame type on the channel already carrying `wake`/`interject`/`cancel`/`stream`/`menu_answer`); the runner does the read it already does. No mail credential enters the web app, the existing idempotency key and "agent's own reply" skip are untouched, and **a forged doorbell cannot inject a fake email** — the worst it does is cause a `gog` read that finds nothing.
+**It is a doorbell, not a reader.** A Gmail push carries `{emailAddress, historyId}` and **no content**, so the receiver resolves mailbox → agent → assigned runners and sends a `runner.check_inbox` control frame (on the channel already carrying `wake`/`interject`/`cancel`/`stream`/`menu_answer`/`update_available`); the runner does the read it already does. No mail credential enters the web app, the existing idempotency key and "agent's own reply" skip are untouched, and **a forged doorbell cannot inject a fake email** — the worst it does is cause a `gog` read that finds nothing.
 
 Two response rules that look wrong and aren't: an unverified push gets **404, not 403** (a probe can't enumerate which workspaces accept push), and a push we can't act on still gets **200** — a 4xx tells Pub/Sub to REDELIVER, so a mailbox we don't own would be retried forever. Runner selection composes `harness.assignment_rows_for(..., ORIGIN_EMAIL, ...)` — the same helper `claim_next_turn` uses — so a strict `email` source rule is honoured and the doorbell can never ring a box that routing would refuse the turn to. Every online assigned runner is rung, not just rank 0: the enqueue is idempotent per `(thread, messageCount)`, so a duplicate read collapses server-side.
 

--- a/apps/harness/models.py
+++ b/apps/harness/models.py
@@ -200,6 +200,16 @@ class Runner(models.Model):
         via `project__in`."""
         return [p for p in self.capabilities.get("projects", []) if p]
 
+    def expected_code_sha(self) -> str:
+        """The sha the DEPLOYED server expects this runner's kind to be running.
+        Per KIND, because the fleet runs two programs (see `code_sha` above); one
+        derivation shared by RunnerOut and the heartbeat's update nudge so the
+        alert and the nudge cannot disagree. Empty means UNKNOWN, never "stale"."""
+        from django.conf import settings
+
+        setting = "RUNNER_CLOUD_CODE_SHA" if self.kind == Runner.CLOUD else "RUNNER_CODE_SHA"
+        return getattr(settings, setting, "") or ""
+
     def session_capable(self) -> bool:
         """Whether this runner executes chat-session turns (the interactive
         front-door — SP2b). Opt-in via `capabilities.sessions: true` so a chat send

--- a/apps/harness/schemas.py
+++ b/apps/harness/schemas.py
@@ -146,11 +146,9 @@ class RunnerOut(Schema):
         # one sha to both would mark every cloud runner permanently stale — the
         # alert would then be pure noise on exactly the boxes it was extended to
         # cover. Either being empty still means UNKNOWN and stays silent.
-        from django.conf import settings
-        from .models import Runner
-
-        setting = "RUNNER_CLOUD_CODE_SHA" if obj.kind == Runner.CLOUD else "RUNNER_CODE_SHA"
-        return getattr(settings, setting, "") or ""
+        # The derivation lives on the model so the heartbeat's update nudge
+        # compares the same quantity this serves.
+        return obj.expected_code_sha()
 
     @staticmethod
     def resolve_expected_code_committed_at(obj) -> int:

--- a/apps/harness/services.py
+++ b/apps/harness/services.py
@@ -150,6 +150,22 @@ def heartbeat(
             runner.capabilities = {**runner.capabilities, "projects": cleaned}
             fields.append("capabilities")
     runner.save(update_fields=fields)
+    # The update nudge: this is the one moment both shas are in hand — the
+    # deploy moved the expectation, the beat just reported what's installed.
+    # Ring the box's control channel so its updater checks NOW instead of
+    # waiting out its 30-min timer. Push is the doorbell, the timer stays the
+    # auditor (and the rescue for a daemon too dead to hear a frame). Sent on
+    # every stale beat, not edge-triggered: the frame is tiny, and the runner
+    # owns the throttle — a missed frame then costs one beat, not one timer
+    # cycle. Empty on either side is UNKNOWN, never "stale".
+    expected = runner.expected_code_sha()
+    if code_sha and expected and code_sha != expected:
+        from apps.realtime import groups
+
+        groups.publish(
+            groups.runner_group(runner.pk),
+            {"type": "runner.update_available", "expected_sha": expected},
+        )
     if active_turn_ids:
         Turn.objects.filter(
             pk__in=active_turn_ids,

--- a/apps/realtime/consumers.py
+++ b/apps/realtime/consumers.py
@@ -256,6 +256,30 @@ class RunnerConsumer(AsyncJsonWebsocketConsumer):
             "desired": message.get("desired"),
         })
 
+    async def runner_check_inbox(self, message):
+        # runner.{id} group_send type="runner.check_inbox" — the Gmail doorbell
+        # (apps/inbound/services.ring): a push said this mailbox changed; the
+        # runner marks it due and reads it on its own poll thread. This handler
+        # is load-bearing beyond forwarding: Channels RAISES on an unhandled
+        # group-message type, so without it the doorbell frame not only never
+        # arrived, it errored the consumer carrying wake/cancel too.
+        await self.send_json({
+            "type": "check_inbox",
+            "mailbox": message.get("mailbox"),
+        })
+
+    async def runner_update_available(self, message):
+        # runner.{id} group_send type="runner.update_available" — this box's
+        # last heartbeat reported a code_sha that differs from the deployed
+        # expectation. The runner kickstarts its SEPARATE updater job, which
+        # re-checks staleness and the in-flight marker itself — the daemon never
+        # installs anything on this signal, and the updater's 30-min timer stays
+        # the rescue path for a daemon too dead to hear a frame.
+        await self.send_json({
+            "type": "update_available",
+            "expected_sha": message.get("expected_sha"),
+        })
+
     async def runner_menu_answer(self, message):
         # runner.{id} group_send type="runner.menu_answer" — a human answered, from
         # the web, the dialog an agent is blocked on. The runner presses the key in

--- a/runner/canopy_runner/canopy_runner/main.py
+++ b/runner/canopy_runner/canopy_runner/main.py
@@ -739,6 +739,15 @@ def main() -> None:
             # `gog` subprocess on the wake-listener thread would block the socket
             # that also carries cancel and wake.
             inbox_due.ring(str(msg["mailbox"]))
+        elif msg.get("type") == "update_available":
+            # A deploy moved this kind's expected runner sha; kickstart the
+            # SEPARATE updater job now instead of waiting out its 30-min timer.
+            # nudge() never installs in-process, never raises, throttles itself,
+            # and skips when the frame raced an install that already happened —
+            # the updater keeps the busy/stale decision either way.
+            from . import update as update_mod
+
+            update_mod.nudge(cfg, str(msg.get("expected_sha") or ""))
         elif msg.get("type") == "menu_answer" and msg.get("session_key"):
             # A human answered, from the web, the dialog an agent is blocked on.
             # Runs on the wake-listener thread and must never raise: this socket

--- a/runner/canopy_runner/canopy_runner/update.py
+++ b/runner/canopy_runner/canopy_runner/update.py
@@ -74,6 +74,65 @@ def in_flight(cfg, *, now: float | None = None) -> int | None:
         return None
 
 
+# --- the update doorbell -----------------------------------------------------
+#
+# The server rings `update_available` down the control channel the moment a
+# heartbeat reports a sha that differs from the deployed expectation — on EVERY
+# stale beat, so a missed frame costs one beat, not one timer cycle. The daemon
+# therefore owns the throttle: one kick per window, not sixty an hour while the
+# updater is deliberately deferring (busy).
+NUDGE_MIN_SECONDS = 600.0
+_last_nudge_at = 0.0
+
+UPDATER_LABEL = "com.canopy.runner.updater"
+
+
+def _kickstart_updater() -> None:
+    import os
+    import subprocess
+
+    subprocess.run(
+        ["launchctl", "kickstart", f"gui/{os.getuid()}/{UPDATER_LABEL}"],
+        capture_output=True, timeout=15, check=True,
+    )
+
+
+def nudge(cfg, expected_sha: str, *, now: float | None = None) -> bool:
+    """The `update_available` doorbell: kickstart the SEPARATE updater job now
+    instead of waiting out its 30-minute timer.
+
+    Never installs in-process — the updater re-checks staleness and the
+    in-flight marker itself, so busy deferral, the read-only check and the
+    crash-loop rescue are inherited, not re-implemented. Skips when the frame
+    raced an install that already happened (expected == installed). Runs on the
+    wake-listener thread, so it must never raise: that socket also carries
+    cancel and wake."""
+    global _last_nudge_at
+    from . import provenance
+
+    now = time.time() if now is None else now
+    expected = (expected_sha or "").strip()
+    installed = provenance.code_sha()
+    # Empty on either side is UNKNOWN, never "stale" — the same rule
+    # update_status applies on the timer path.
+    if not expected or not installed or expected == installed:
+        return False
+    if now - _last_nudge_at < NUDGE_MIN_SECONDS:
+        return False
+    # Advance the throttle on the ATTEMPT, not the success: a broken launchctl
+    # would otherwise warn on every ~10s heartbeat, and the 30-min timer is the
+    # rescue for that case regardless.
+    _last_nudge_at = now
+    try:
+        _kickstart_updater()
+    except Exception as exc:  # noqa: BLE001 — a launchctl hiccup must not cost the socket
+        logger.warning("update nudge: could not kickstart %s: %s", UPDATER_LABEL, exc)
+        return False
+    logger.info("update nudge: kickstarted %s (expected %s, installed %s)",
+                UPDATER_LABEL, expected[:12], installed[:12])
+    return True
+
+
 def update_status(cfg, client, *, installed_sha: str | None = None,
                   now: float | None = None) -> tuple[str, str]:
     """(status, expected_sha).

--- a/runner/canopy_runner/tests/test_update_nudge.py
+++ b/runner/canopy_runner/tests/test_update_nudge.py
@@ -1,0 +1,86 @@
+"""The update doorbell: an `update_available` control frame kickstarts the
+SEPARATE updater job instead of waiting out its 30-minute timer.
+
+The daemon never installs anything on this signal — the updater re-checks
+staleness and the in-flight marker itself, so every safety property of the
+timer path (busy deferral, read-only check, crash-loop rescue) is inherited
+rather than re-implemented. The frame is sent on every stale heartbeat, so the
+daemon owns the throttle.
+"""
+import pytest
+
+from canopy_runner import provenance, update
+from canopy_runner.config import Config
+
+SHIPPED = "a" * 40
+OLD = "b" * 40
+
+
+@pytest.fixture()
+def cfg(tmp_path):
+    return Config(base_url="http://x", token="t", runner_id="r-1",
+                  emdash_db=str(tmp_path / "e.db"),
+                  state_path=str(tmp_path / "state.json"))
+
+
+@pytest.fixture(autouse=True)
+def _fresh_throttle(monkeypatch):
+    monkeypatch.setattr(update, "_last_nudge_at", 0.0)
+
+
+@pytest.fixture()
+def kicks(monkeypatch):
+    calls = []
+    monkeypatch.setattr(update, "_kickstart_updater", lambda: calls.append(1))
+    monkeypatch.setattr(provenance, "code_sha", lambda: OLD)
+    return calls
+
+
+def test_nudge_kickstarts_the_updater(cfg, kicks):
+    assert update.nudge(cfg, SHIPPED) is True
+    assert len(kicks) == 1
+
+
+def test_nudge_skips_when_already_current(cfg, kicks, monkeypatch):
+    # The frame raced an install that already happened (or our own heartbeat
+    # simply hadn't reported the new sha yet) — nothing to do.
+    monkeypatch.setattr(provenance, "code_sha", lambda: SHIPPED)
+    assert update.nudge(cfg, SHIPPED) is False
+    assert kicks == []
+
+
+def test_nudge_throttles_repeat_frames(cfg, kicks):
+    # The server rings on EVERY stale heartbeat (~10s). The updater needs one
+    # kick, not sixty an hour while it is deliberately deferring (busy).
+    assert update.nudge(cfg, SHIPPED) is True
+    assert update.nudge(cfg, SHIPPED) is False
+    assert len(kicks) == 1
+
+
+def test_nudge_fires_again_after_the_throttle_window(cfg, kicks):
+    import time
+    assert update.nudge(cfg, SHIPPED) is True
+    assert update.nudge(cfg, SHIPPED, now=time.time() + update.NUDGE_MIN_SECONDS + 1) is True
+    assert len(kicks) == 2
+
+
+def test_empty_expected_never_kicks(cfg, kicks):
+    # Empty means UNKNOWN, never "stale" — same rule as update_status.
+    assert update.nudge(cfg, "") is False
+    assert kicks == []
+
+
+def test_unknown_installed_sha_never_kicks(cfg, kicks, monkeypatch):
+    monkeypatch.setattr(provenance, "code_sha", lambda: "")
+    assert update.nudge(cfg, SHIPPED) is False
+    assert kicks == []
+
+
+def test_a_failing_kickstart_never_raises(cfg, monkeypatch):
+    # This runs on the wake-listener thread, which also carries cancel and
+    # wake — losing the socket over a launchctl hiccup is never worth it.
+    def boom():
+        raise OSError("launchctl went away")
+    monkeypatch.setattr(update, "_kickstart_updater", boom)
+    monkeypatch.setattr(provenance, "code_sha", lambda: OLD)
+    assert update.nudge(cfg, SHIPPED) is False

--- a/runner/ec2/cloud_runner.py
+++ b/runner/ec2/cloud_runner.py
@@ -262,6 +262,60 @@ def _mark_in_flight(count: int) -> None:
         pass
 
 
+# --- the update doorbell -----------------------------------------------------
+#
+# The server rings `update_available` down the WS the moment a heartbeat reports
+# a sha that differs from the deployed expectation — on EVERY stale beat, so a
+# missed frame costs one beat, not one timer cycle. The daemon owns the throttle.
+UPDATE_NUDGE_MIN_SECONDS = 600.0
+_last_update_nudge = 0.0
+
+
+def _start_update_unit() -> None:
+    # `systemctl start`, never running update_runner.sh as a child: the updater
+    # restarts canopy-runner.service, and a child of this process would be
+    # killed in the daemon's own cgroup mid-install by that restart. Handing
+    # the work to systemd puts it in the unit's cgroup, where the restart it
+    # performs cannot reach it. `--no-block` because the oneshot takes ~a
+    # minute and this thread carries wake and heartbeat. The scoped sudoers
+    # line ships in runner.cfn.yaml.
+    subprocess.run(
+        ["sudo", "-n", "systemctl", "start", "--no-block", "canopy-runner-update.service"],
+        capture_output=True, timeout=15, check=True,
+    )
+
+
+def _nudge_updater(expected_sha: str, *, now: float | None = None) -> bool:
+    """The `update_available` doorbell: start the SEPARATE update unit now
+    instead of waiting out its 30-minute timer.
+
+    Never installs in-process — the unit re-checks staleness and the in-flight
+    marker itself, so busy deferral and the crash-loop rescue are inherited,
+    not re-implemented. Skips when the frame raced an install that already
+    happened. Never raises: the WS loop it runs on also carries wake,
+    heartbeat and claim."""
+    global _last_update_nudge
+    now = time.time() if now is None else now
+    expected = (expected_sha or "").strip()
+    installed = build_info()["sha"]
+    # Empty on either side is UNKNOWN, never "stale" — the fleet provenance rule.
+    if not expected or not installed or expected == installed:
+        return False
+    if now - _last_update_nudge < UPDATE_NUDGE_MIN_SECONDS:
+        return False
+    # Advance the throttle on the ATTEMPT, not the success: a broken systemctl
+    # would otherwise warn on every ~20s beat, and the timer rescues that case.
+    _last_update_nudge = now
+    try:
+        _start_update_unit()
+    except Exception as exc:  # noqa: BLE001
+        _log(f"update nudge: could not start canopy-runner-update.service: {exc}")
+        return False
+    _log(f"update nudge: started canopy-runner-update.service "
+         f"(expected {expected[:12]}, installed {installed[:12]})")
+    return True
+
+
 def _heartbeat_body(active_turn_ids: list[str], **extra) -> dict:
     """THE heartbeat payload — one stamping point, for all four call sites.
 
@@ -2036,6 +2090,8 @@ def run_over_ws(runner_id: str) -> bool:
                         # regardless, so a dropped frame costs one tick, never
                         # a permanently unattached viewer.
                         _sync_session_views(runner_id)
+                    elif mtype == "update_available":
+                        _nudge_updater(str(msg.get("expected_sha") or ""))
                 elif raw == "":
                     break  # server closed the socket
                 if time.monotonic() - last_beat >= HEARTBEAT_SECONDS:

--- a/runner/ec2/runner.cfn.yaml
+++ b/runner/ec2/runner.cfn.yaml
@@ -279,6 +279,11 @@ Resources:
                 # bytes. Scoped to that command rather than relying on the AMI's
                 # default blanket NOPASSWD for `ubuntu`.
                 ubuntu ALL=(root) NOPASSWD: /usr/bin/systemctl restart canopy-runner.service
+                # The daemon's update NUDGE (an `update_available` WS frame) starts
+                # the update unit off-cycle instead of waiting out the 30-min timer.
+                # `start`, never the script as a child — the restart above would
+                # kill a child in the daemon's own cgroup mid-install.
+                ubuntu ALL=(root) NOPASSWD: /usr/bin/systemctl start --no-block canopy-runner-update.service
             - path: /etc/systemd/system/canopy-runner-update.service
               content: |
                 [Unit]

--- a/runner/ec2/tests/test_update_nudge.py
+++ b/runner/ec2/tests/test_update_nudge.py
@@ -1,0 +1,87 @@
+"""The update doorbell, cloud half: an `update_available` WS frame starts the
+SEPARATE systemd update unit instead of waiting out its 30-minute timer.
+
+The daemon never installs in-process — and must not even run the script as a
+child: the updater restarts canopy-runner.service, and a child would die in the
+daemon's own cgroup mid-install. `systemctl start` hands the work to systemd's
+cgroup, where the restart it performs cannot kill it. The unit re-checks
+staleness and the in-flight marker itself, so busy deferral and the crash-loop
+rescue are inherited, not re-implemented.
+"""
+from __future__ import annotations
+
+import pytest
+
+SHIPPED = "a" * 40
+OLD = "b" * 40
+
+
+@pytest.fixture
+def runner(tmp_path, monkeypatch, load_cloud_runner):
+    monkeypatch.setenv("RUNNER_HOME", str(tmp_path))
+    monkeypatch.setenv("BUILD_INFO_FILE", str(tmp_path / "build-info.json"))
+    monkeypatch.setenv("IN_FLIGHT_FILE", str(tmp_path / "in-flight"))
+    mod = load_cloud_runner()
+    mod._last_update_nudge = 0.0
+    return mod
+
+
+@pytest.fixture
+def kicks(runner, monkeypatch):
+    calls = []
+    monkeypatch.setattr(runner, "_start_update_unit", lambda: calls.append(1))
+    monkeypatch.setattr(runner, "build_info",
+                        lambda refresh=False: {"sha": OLD, "committed_at": 1})
+    return calls
+
+
+def test_nudge_starts_the_update_unit(runner, kicks):
+    assert runner._nudge_updater(SHIPPED) is True
+    assert len(kicks) == 1
+
+
+def test_nudge_skips_when_already_current(runner, kicks, monkeypatch):
+    monkeypatch.setattr(runner, "build_info",
+                        lambda refresh=False: {"sha": SHIPPED, "committed_at": 1})
+    assert runner._nudge_updater(SHIPPED) is False
+    assert kicks == []
+
+
+def test_nudge_throttles_repeat_frames(runner, kicks):
+    # The server rings on EVERY stale heartbeat (~20s). One kick per window —
+    # the unit may be deliberately deferring (busy) for hours.
+    assert runner._nudge_updater(SHIPPED) is True
+    assert runner._nudge_updater(SHIPPED) is False
+    assert len(kicks) == 1
+
+
+def test_nudge_fires_again_after_the_window(runner, kicks):
+    import time
+    assert runner._nudge_updater(SHIPPED) is True
+    later = time.time() + runner.UPDATE_NUDGE_MIN_SECONDS + 1
+    assert runner._nudge_updater(SHIPPED, now=later) is True
+    assert len(kicks) == 2
+
+
+def test_empty_expected_never_kicks(runner, kicks):
+    # Empty means UNKNOWN, never "stale" — the fleet-wide provenance rule.
+    assert runner._nudge_updater("") is False
+    assert kicks == []
+
+
+def test_unknown_installed_sha_never_kicks(runner, kicks, monkeypatch):
+    monkeypatch.setattr(runner, "build_info",
+                        lambda refresh=False: {"sha": "", "committed_at": 0})
+    assert runner._nudge_updater(SHIPPED) is False
+    assert kicks == []
+
+
+def test_a_failing_start_never_raises(runner, monkeypatch):
+    # This runs on the WS loop that also carries wake and heartbeat — a
+    # systemctl hiccup must not cost the socket.
+    def boom():
+        raise OSError("systemctl went away")
+    monkeypatch.setattr(runner, "_start_update_unit", boom)
+    monkeypatch.setattr(runner, "build_info",
+                        lambda refresh=False: {"sha": OLD, "committed_at": 1})
+    assert runner._nudge_updater(SHIPPED) is False

--- a/tests/test_realtime_runner_consumer.py
+++ b/tests/test_realtime_runner_consumer.py
@@ -209,6 +209,45 @@ async def test_cancel_frame_reaches_the_runner():
     await comm.disconnect()
 
 
+async def test_check_inbox_frame_reaches_the_runner():
+    # The Gmail doorbell (apps/inbound/services.ring) publishes this type; a
+    # missing handler here doesn't just drop the frame — Channels raises on an
+    # unhandled type, so the doorbell would also cost the runner its socket.
+    from channels.layers import get_channel_layer
+
+    from apps.realtime import groups
+
+    user, ws, agent, runner = await database_sync_to_async(_setup)()
+    comm = await _connect(runner.id, user)
+    await comm.connect()
+
+    layer = get_channel_layer()
+    await layer.group_send(groups.runner_group(runner.id), {
+        "type": "runner.check_inbox", "mailbox": "hal@dimagi-ai.com",
+    })
+    frame = await comm.receive_json_from(timeout=2)
+    assert frame == {"type": "check_inbox", "mailbox": "hal@dimagi-ai.com"}
+    await comm.disconnect()
+
+
+async def test_update_available_frame_reaches_the_runner():
+    from channels.layers import get_channel_layer
+
+    from apps.realtime import groups
+
+    user, ws, agent, runner = await database_sync_to_async(_setup)()
+    comm = await _connect(runner.id, user)
+    await comm.connect()
+
+    layer = get_channel_layer()
+    await layer.group_send(groups.runner_group(runner.id), {
+        "type": "runner.update_available", "expected_sha": "a" * 40,
+    })
+    frame = await comm.receive_json_from(timeout=2)
+    assert frame == {"type": "update_available", "expected_sha": "a" * 40}
+    await comm.disconnect()
+
+
 async def test_send_message_interjects_the_running_runner():
     from apps.canopy_sessions.models import Session
     from apps.canopy_sessions.services import send_message

--- a/tests/test_runner_update_nudge.py
+++ b/tests/test_runner_update_nudge.py
@@ -1,0 +1,89 @@
+"""The update nudge: a heartbeat that reports a stale code_sha rings the box's
+updater NOW instead of leaving it to the 30-minute timer.
+
+The server is the only party that sees both shas the moment they diverge (a
+deploy moves `expected_code_sha`; the very next heartbeat reports the old
+installed sha), so it publishes `runner.update_available` down the control
+channel the runner already holds. The daemon never installs anything on this
+signal — it kickstarts the separate updater job, which independently re-checks
+staleness and the in-flight marker. The 30-min timer survives as the rescue
+path for a daemon too dead to hear a frame (the same push-is-the-doorbell,
+poll-is-the-auditor shape as Gmail inbound).
+"""
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+from django.contrib.auth.models import User
+from django.utils import timezone
+
+from apps.harness import services
+from apps.harness.models import Runner
+
+pytestmark = pytest.mark.django_db
+
+LAPTOP_SHA = "1111111111111111111111111111111111111111"
+CLOUD_SHA = "2222222222222222222222222222222222222222"
+OLD_SHA = "9999999999999999999999999999999999999999"
+
+
+@pytest.fixture
+def shas(settings):
+    settings.RUNNER_CODE_SHA = LAPTOP_SHA
+    settings.RUNNER_CLOUD_CODE_SHA = CLOUD_SHA
+
+
+def _runner(kind: str = Runner.EMDASH) -> Runner:
+    user = User.objects.create_user(f"u-{kind}", f"{kind}@dimagi.com", "pw")
+    return Runner.objects.create(
+        name=f"box-{kind}", kind=kind, paired_by=user,
+        status=Runner.ONLINE, last_heartbeat_at=timezone.now(),
+    )
+
+
+def test_stale_heartbeat_publishes_update_available(shas):
+    r = _runner()
+    with mock.patch("apps.realtime.groups.publish") as pub:
+        services.heartbeat(r, active_turn_ids=[], code_sha=OLD_SHA)
+    frames = [c.args[1] for c in pub.call_args_list
+              if c.args[1].get("type") == "runner.update_available"]
+    assert frames == [{"type": "runner.update_available", "expected_sha": LAPTOP_SHA}]
+
+
+def test_current_heartbeat_stays_quiet(shas):
+    r = _runner()
+    with mock.patch("apps.realtime.groups.publish") as pub:
+        services.heartbeat(r, active_turn_ids=[], code_sha=LAPTOP_SHA)
+    assert not any(c.args[1].get("type") == "runner.update_available"
+                   for c in pub.call_args_list)
+
+
+def test_cloud_runner_is_compared_against_the_cloud_sha(shas):
+    # The fleet runs two programs; nudging a cloud box because it doesn't match
+    # the LAPTOP's sha would ring it forever.
+    r = _runner(Runner.CLOUD)
+    with mock.patch("apps.realtime.groups.publish") as pub:
+        services.heartbeat(r, active_turn_ids=[], code_sha=CLOUD_SHA)
+    assert not any(c.args[1].get("type") == "runner.update_available"
+                   for c in pub.call_args_list)
+
+
+def test_empty_expected_means_unknown_never_stale(settings):
+    # A dev server bakes in no expectation. Empty must stay silent — nudging on
+    # it would ring every runner on every heartbeat forever.
+    settings.RUNNER_CODE_SHA = ""
+    r = _runner()
+    with mock.patch("apps.realtime.groups.publish") as pub:
+        services.heartbeat(r, active_turn_ids=[], code_sha=OLD_SHA)
+    assert not any(c.args[1].get("type") == "runner.update_available"
+                   for c in pub.call_args_list)
+
+
+def test_empty_reported_means_unknown_never_stale(shas):
+    # An unstamped install reports no sha; that is UNKNOWN, not "different".
+    r = _runner()
+    with mock.patch("apps.realtime.groups.publish") as pub:
+        services.heartbeat(r, active_turn_ids=[], code_sha="")
+    assert not any(c.args[1].get("type") == "runner.update_available"
+                   for c in pub.call_args_list)


### PR DESCRIPTION
## What

A deploy that moves `expected_code_sha` now **rings** every stale runner over the control channel it already holds, instead of leaving convergence to the updater's 30-minute timer. Observed motivation (2026-07-31): two deploys landed 19 minutes apart; jj-mbp-cdp's updater ticked between them and the box then sat visibly "out of date" on `/supervisor` for most of half an hour, with in-flight count 0 the whole time.

- **Server** — `services.heartbeat` is the one moment both shas are in hand (the deploy moved the expectation, the beat just reported what's installed). When they differ it publishes `runner.update_available` to the runner's group. The kind→setting derivation moved onto the model (`Runner.expected_code_sha()`) so the nudge and `RunnerOut` compare the same quantity. Empty on either side stays UNKNOWN and silent. Sent on every stale beat rather than edge-triggered — the frame is tiny and the runner owns the throttle, so a missed frame costs one beat, not one timer cycle.
- **Laptop runner** — `update.nudge()`: kickstarts the separate `com.canopy.runner.updater` launchd job. Throttled (10 min), skip-if-current, never installs in-process, never raises on the wake-listener thread.
- **Cloud runner** — `_nudge_updater()`: `sudo systemctl start --no-block canopy-runner-update.service` — never the script as a child, which the restart inside would kill in the daemon's own cgroup mid-install. Scoped sudoers line added to `runner.cfn.yaml` (today's boxes ride the AMI's blanket NOPASSWD; the line makes a future locked-down box explicit).

Both updaters keep the busy/stale decision, so busy deferral, the read-only check and the crash-loop rescue are **inherited**, not re-implemented — and the 30-min timer survives as the auditor for a daemon too dead to hear a frame. Same doorbell/auditor shape as Gmail inbound (#542).

## Also fixes

`RunnerConsumer` had **no handler** for the `runner.check_inbox` frame that `apps/inbound/services.ring()` publishes — Channels raises on an unhandled group-message type, so the Gmail doorbell frame never reached a runner and errored the consumer carrying wake/cancel too. Handler added with a regression test.

## Tests

- `tests/test_runner_update_nudge.py` — heartbeat publish rules (stale/current/per-kind/empty-means-unknown)
- `tests/test_realtime_runner_consumer.py` — both new frames reach the socket
- `runner/canopy_runner/tests/test_update_nudge.py`, `runner/ec2/tests/test_update_nudge.py` — kick, skip-if-current, throttle, unknown-sha, failing-kick-never-raises

Full backend suite 2044 passed; laptop runner 370 passed; cloud runner 113 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)