### PR TITLE
fix(chat): a paused runner can still answer the dialog it delivered

### DIFF
--- a/apps/canopy_sessions/services.py
+++ b/apps/canopy_sessions/services.py
@@ -227,7 +227,6 @@ def request_backfill(session) -> str:
     (signal it — streamed ordinal rows alone are not the full history); 'unavailable'
     otherwise (tail still shows)."""
     from apps.canopy_sessions.models import RunnerBinding
-    from apps.harness.models import Runner
 
     first = (
         session.messages.order_by("turn_index").values_list("turn_index", flat=True).first()
@@ -236,16 +235,14 @@ def request_backfill(session) -> str:
         return "ready"
     binding = RunnerBinding.objects.select_related("runner").filter(session=session).first()
     # A runner only has to be REACHABLE to ship a transcript — not ready to run
-    # turns. `live_status` returns the self-reported status ONLY while the
-    # heartbeat is fresh (a quiet runner is demoted to STALE/DISCONNECTED), so
-    # ONLINE and DEGRADED are exactly the "still reporting" states.
-    # Gating on ONLINE alone made backfill impossible whenever emdash's CDP port
-    # was down: the runner marks itself DEGRADED and stops CLAIMING, but its poll
-    # loop keeps running and `_drain_backfills` reads the transcript FILE, which
-    # never needed CDP. Found on prod — a degraded runner answered "unavailable"
-    # for history it was perfectly able to ship.
-    reachable = {Runner.ONLINE, Runner.DEGRADED}
-    if binding is None or binding.runner_id is None or binding.runner.live_status not in reachable:
+    # turns (`Runner.is_reachable`). Gating on ONLINE alone made backfill
+    # impossible whenever emdash's CDP port was down: the runner marks itself
+    # DEGRADED and stops CLAIMING, but its poll loop keeps running and
+    # `_drain_backfills` reads the transcript FILE, which never needed CDP.
+    # Found on prod — a degraded runner answered "unavailable" for history it
+    # was perfectly able to ship. A PAUSED runner drains backfills the same way,
+    # every tick before its pause gate.
+    if binding is None or binding.runner_id is None or not binding.runner.is_reachable:
         return "unavailable"
     if not binding.backfill_requested:
         binding.backfill_requested = True
@@ -497,14 +494,12 @@ def _reset_blocker(session) -> tuple[str, object]:
     What actually blocks a reset is having no pointer to a transcript at all (no
     binding), or no live runner to read it (offline/retired — transient).
     """
-    from apps.harness.models import Runner
-
     binding = getattr(session, "runner_binding", None)
     if binding is None or binding.runner_id is None:
         return RESET_NO_BINDING, None
     # Reachable is enough to READ A FILE — mirrors request_backfill, which never
     # needs emdash's CDP port.
-    if binding.runner.live_status not in (Runner.ONLINE, Runner.DEGRADED):
+    if not binding.runner.is_reachable:
         return RESET_RUNNER_UNREACHABLE, binding
     return RESET_OK, binding
 
@@ -954,13 +949,15 @@ def answer_menu(*, session: Session, option: int | None) -> str:
     The keystroke itself is the runner's job: the server knows nothing about
     terminals, and emdash (not canopy) owns the session.
     """
-    from apps.harness.models import Runner  # framework->framework; lazy, import cycle
-
     binding = getattr(session, "runner_binding", None)
     if binding is None or binding.runner_id is None or not binding.session_key:
         return "unbound"
-    reachable = {Runner.ONLINE, Runner.DEGRADED}
-    if binding.runner.live_status not in reachable:
+    # Reachable, not available: pause stops STARTING work, never finishing it,
+    # and a blocked agent is unfinished work already running. The answer rides
+    # the wake-listener thread, which the pause gate never touches — a PAUSED
+    # runner (fresh heartbeat by construction) presses the key just fine, and it
+    # is the runner whose session report delivered this very menu.
+    if not binding.runner.is_reachable:
         return "unavailable"
     from apps.realtime import groups
     groups.publish(groups.runner_group(binding.runner_id), {

--- a/apps/harness/models.py
+++ b/apps/harness/models.py
@@ -259,6 +259,22 @@ class Runner(models.Model):
         self-reported ready. The cascade's availability probe (spec 2026-07-24)."""
         return self.live_status == Runner.ONLINE and self.ready
 
+    @property
+    def is_reachable(self) -> bool:
+        """Is the daemon still THERE — a weaker question than `is_available`.
+
+        ONLINE, DEGRADED and PAUSED are exactly the states `live_status` can only
+        serve on a fresh heartbeat: degraded stops claiming (CDP down), paused
+        stops starting anything new, but both daemons keep their poll loop and
+        control channel up (a parked box that dies reads STALE, not PAUSED). This
+        is the gate for work that FINISHES or reads what already exists — pressing
+        a menu answer into a blocked session, shipping a transcript — never for
+        starting new work, which is `is_available`'s question. Excluding PAUSED
+        here made a parked runner refuse the very menu its own session report had
+        just delivered (2026-07-31, ada blocked on a box parked for a rate limit).
+        """
+        return self.live_status in (self.ONLINE, self.DEGRADED, self.PAUSED)
+
 
 class Turn(models.Model):
     """One unit of agent work — the execution envelope around board commands."""

--- a/tests/test_chat_pending_question.py
+++ b/tests/test_chat_pending_question.py
@@ -292,3 +292,61 @@ def test_a_waiting_session_sorts_above_everything(monkeypatch):
     ])
     titles = [r["title"] for r in client.get("/api/canopy-sessions/").json()]
     assert titles[0] == "spark", f"the waiting session sank to {titles.index('spark')}"
+
+
+# -- the phone can answer it -----------------------------------------------
+
+
+def test_an_answer_reaches_a_paused_runner(monkeypatch):
+    """Pause stops STARTING work, never finishing it — and a blocked agent is
+    unfinished work already running. PAUSED is only ever served while the
+    heartbeat is fresh (a parked box that dies reads STALE), so a paused runner
+    is by construction still reporting — it is the runner that delivered this
+    very menu, since session reports run before the pause gate — and its control
+    channel is up. Refusing it turned every tap into a dead button the moment a
+    box was parked: found live 2026-07-31, first real use (jj-mbp-cdp parked for
+    a rate limit, ada blocked on AskUserQuestion, every answer 'unavailable')."""
+    published = []
+    monkeypatch.setattr("apps.realtime.groups.publish",
+                        lambda g, m: published.append((g, m)))
+    jj, ws, runner, client = _setup()
+    runner.paused = True
+    runner.save(update_fields=["paused"])
+    _report(client, runner.id, [
+        {"emdash_task": "spark", "project": "ace", "question": MENU},
+    ])
+    session = RunnerBinding.objects.get(session_key="spark").session
+
+    assert runner.live_status == Runner.PAUSED
+    res = client.post(
+        f"/api/canopy-sessions/{session.id}/answer-menu",
+        {"option": 1}, content_type="application/json",
+    )
+    assert res.json() == {"ok": True, "reason": ""}
+    frames = [m for _g, m in published if m.get("type") == "runner.menu_answer"]
+    assert frames and frames[0]["option"] == 1
+    assert frames[0]["session_key"] == "spark"
+
+
+def test_an_answer_to_a_dead_runner_is_still_refused(monkeypatch):
+    """The widening stops at liveness: a stale heartbeat means nobody is there
+    to press anything, paused or not, and 'sent' would be a lie."""
+    published = []
+    monkeypatch.setattr("apps.realtime.groups.publish",
+                        lambda g, m: published.append((g, m)))
+    jj, ws, runner, client = _setup()
+    _report(client, runner.id, [
+        {"emdash_task": "spark", "project": "ace", "question": MENU},
+    ])
+    session = RunnerBinding.objects.get(session_key="spark").session
+    runner.paused = True
+    runner.last_heartbeat_at = timezone.now() - timezone.timedelta(hours=1)
+    runner.save(update_fields=["paused", "last_heartbeat_at"])
+
+    assert runner.live_status == Runner.STALE
+    res = client.post(
+        f"/api/canopy-sessions/{session.id}/answer-menu",
+        {"option": 1}, content_type="application/json",
+    )
+    assert res.json() == {"ok": False, "reason": "unavailable"}
+    assert not [m for _g, m in published if m.get("type") == "runner.menu_answer"]

--- a/tests/test_session_backfill.py
+++ b/tests/test_session_backfill.py
@@ -140,3 +140,25 @@ def test_session_backfill_rejects_unbound_runner():
     )
     assert resp.status_code == 404
     assert s.messages.count() == 0
+
+
+def test_backfill_requested_when_runner_is_paused(monkeypatch):
+    """Same shape as the DEGRADED case above, one state over: a paused runner's
+    poll loop runs `drain_backfills` every tick BEFORE the pause gate — pause
+    stops starting turns, not shipping files it already has."""
+    published = []
+    monkeypatch.setattr("apps.realtime.groups.publish", lambda g, m: published.append((g, m)))
+    user = User.objects.create_user("jj", "jj@dimagi.com", "pw")
+    ws = Workspace.objects.create(slug="w1", display_name="W1", created_by=user)
+    WorkspaceMembership.objects.create(user=user, workspace=ws, role=WorkspaceMembership.OWNER)
+    s = Session.objects.create(workspace=ws, created_by=user, origin=Session.ORIGIN_RUNNER, title="t")
+    r = Runner.objects.create(
+        name="laptop", workspace=ws, location=Runner.LOCAL, paired_by=user,
+        status=Runner.ONLINE, last_heartbeat_at=timezone.now(), paused=True,
+    )
+    RunnerBinding.objects.create(session=s, runner=r, session_key="echo-1")
+    c = Client(); c.force_login(user)
+
+    assert r.live_status == Runner.PAUSED
+    assert c.post(f"/api/canopy-sessions/{s.id}/backfill").json() == {"status": "requested"}
+    assert published, "a paused (but alive) runner must still be signalled"


### PR DESCRIPTION
## The bug (found live, 2026-07-31)

Jonathan parked `jj-mbp-cdp` for a rate limit. `ada` blocked on an AskUserQuestion. The phone showed the menu perfectly — and every tap on an answer was a dead button.

The paradox is the tell: the menu *arrived through the paused runner* (session reports run every tick before the pause gate), but `answer_menu` refused to relay the answer back because `live_status == PAUSED` wasn't in its `reachable = {ONLINE, DEGRADED}` set. `POST /answer-menu` → `{ok: false, reason: "unavailable"}`, rendered as a small "runner is offline" note that reads as nothing happening.

## Why the fix is safe by construction

- **Pause stops STARTING work, never finishing it** — and a blocked agent is unfinished work already running. Answering its dialog is the finishing half.
- **PAUSED is only served on a fresh heartbeat** (`live_status` ranks pause below the liveness checks — a parked box that dies reads STALE). So PAUSED == provably-alive daemon, exactly like ONLINE/DEGRADED.
- **The runner side already works while paused**: the `menu_answer` frame is handled on the wake-listener thread, which the pause gate never touches; session reports, chat-bridge pumps, and `drain_backfills` all run before `run_once`'s pause return.

## The change

`Runner.is_reachable` — one home for the "still reporting" question (ONLINE | DEGRADED | PAUSED), distinct from `is_available` ("can start new work"). Used at the three gates that were asking reachability but answering availability:

- `answer_menu` (the reported bug)
- `request_backfill` (same defect: a paused runner drains backfills every tick)
- `_reset_blocker` (reset only reads a transcript file)

This is the same widening DEGRADED got when CDP-down made backfill permanently "unavailable" for history the runner could ship — one state further, with the same shape.

A stale/dead runner is still refused (test included): the widening stops at liveness, because "sent" to a dead box would be a lie.

## Tests

- `test_an_answer_reaches_a_paused_runner` — the bug, red before / green after
- `test_an_answer_to_a_dead_runner_is_still_refused` — the boundary holds
- `test_backfill_requested_when_runner_is_paused` — sibling gate
- Full suite: 2018 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)