### PR TITLE
fix(inbound): the push URL we hand an operator points at us, not a neighbour

### DIFF
--- a/apps/inbound/services.py
+++ b/apps/inbound/services.py
@@ -222,14 +222,20 @@ def push_url(request, workspace_slug: str) -> str:
     does not — this runs behind FORCE_SCRIPT_NAME=/canopy on labs, so a
     hand-written URL drops the prefix and the pushes go nowhere, silently.
     """
-    from django.urls import reverse
+    from django.urls import get_script_prefix, reverse
 
+    # The namespace is the one apps/api/api.py declares (``urls_namespace``), NOT
+    # Ninja's ``api-1.0.0`` default. Naming the default here reversed nothing, and
+    # because the fallback below hardcoded a prefix-less path, every deployment
+    # behind FORCE_SCRIPT_NAME served a push URL pointing at a SIBLING tenant —
+    # accepted by something that is not us, so the mailbox just kept polling.
     try:
-        base = request.build_absolute_uri(reverse("api-1.0.0:gmail_push",
-                                                  kwargs={"workspace": workspace_slug}))
+        path = reverse("api_v2:gmail_push", kwargs={"workspace": workspace_slug})
     except Exception:  # noqa: BLE001 — never let URL reversal break a config read
-        base = request.build_absolute_uri(f"/api/inbound/gmail/{workspace_slug}/")
-    return base
+        # Carry the script prefix here too: a fallback that silently drops it is
+        # how the bug above stayed invisible.
+        path = f"{get_script_prefix().rstrip('/')}/api/inbound/gmail/{workspace_slug}/"
+    return request.build_absolute_uri(path)
 
 
 def watch_state(mailbox) -> str:

--- a/tests/test_inbound_config_api.py
+++ b/tests/test_inbound_config_api.py
@@ -78,6 +78,61 @@ def test_config_serves_the_push_url_so_nobody_hand_copies_it(owner, workspace):
     assert body["push_url"].endswith("/api/inbound/gmail/dimagi/")
 
 
+def test_push_url_carries_the_script_prefix():
+    """The whole reason this value is server-computed.
+
+    Labs runs behind ``FORCE_SCRIPT_NAME=/canopy``; a push URL missing that
+    prefix resolves to a SIBLING tenant on the same host, so pushes are accepted
+    by something that is not us and the mailbox silently keeps polling. Asserting
+    only the tail (the test above) cannot see this — it passes either way, which
+    is exactly how the prefix-less URL shipped.
+
+    Driven through the service rather than the test client on purpose: the real
+    WSGI/ASGI handlers call ``set_script_prefix``, ``django.test.Client`` does
+    not, so a client-level test is structurally blind to this bug.
+    """
+    from django.test import RequestFactory
+    from django.urls import set_script_prefix
+
+    from apps.inbound import services
+
+    try:
+        set_script_prefix("/canopy/")
+        url = services.push_url(RequestFactory().get("/api/inbound/config/dimagi"), "dimagi")
+    finally:
+        set_script_prefix("/")
+
+    assert url.endswith("/canopy/api/inbound/gmail/dimagi/"), url
+
+
+def test_push_url_reverses_rather_than_falling_back(monkeypatch):
+    """The fallback must stay unreachable in practice.
+
+    Naming a namespace that does not exist (Ninja's ``api-1.0.0`` default, where
+    this API declares ``api_v2``) made ``reverse`` raise on every call, and the
+    bare ``except`` turned that into a plausible-looking wrong URL instead of a
+    loud failure — so the route was never actually consulted.
+
+    Patching ``reverse`` to a sentinel proves the service reaches it: if the name
+    is wrong again, the call raises, the except branch hands back a hand-built
+    path, and the sentinel is absent. Fixing only the fallback's prefix would
+    satisfy the test above while leaving the route unreversed; this catches that.
+    """
+    import django.urls
+    from django.test import RequestFactory
+
+    from apps.inbound import services
+
+    # `push_url` imports from django.urls at call time, so patching there lands.
+    monkeypatch.setattr(
+        django.urls, "reverse",
+        lambda name, kwargs=None: f"/sentinel/{name}/{kwargs['workspace']}/",
+    )
+    url = services.push_url(RequestFactory().get("/api/inbound/config/dimagi"), "dimagi")
+
+    assert "/sentinel/api_v2:gmail_push/dimagi/" in url, url
+
+
 def test_owner_can_set_config(owner, workspace):
     r = _c(owner).put(
         "/api/inbound/config/dimagi",


### PR DESCRIPTION
## What

`GET /api/inbound/config/{ws}` served a push URL **missing the `/canopy` script prefix** — the one thing the field exists to get right.

Live on labs before this fix:

```
push_url → https://labs.connect.dimagi.com/api/inbound/gmail/connect/   ← not this app
real     → https://labs.connect.dimagi.com/canopy/api/inbound/gmail/connect/
```

The first returns a sibling tenant's HTML; the second returns this app's RFC 7807 404 (correctly refusing an unverified push).

## Why it happened

Two faults compounding:

1. It reversed `api-1.0.0:gmail_push` — Ninja's *default* namespace — but `apps/api/api.py` declares `urls_namespace="api_v2"`. So `reverse()` raised `NoReverseMatch` on **every** call and the route was never consulted.
2. The bare `except` then hand-built `f"/api/inbound/gmail/{slug}/"` with no prefix — turning a wrong name into a plausible-looking URL instead of a loud failure.

## Impact

An operator following `/w/:workspace/inbound` would paste that URL into both `--push-endpoint` and `--push-auth-token-audience`. Every push would then be delivered to something that is not us, no event row would ever appear, and the mailbox would keep taking its 300s poll — the precise silent failure `push_url` was written to prevent. Caught while provisioning; nothing was provisioned against the bad URL.

## The fix

Reverse the declared namespace, and give the fallback the script prefix too — a fallback that drops it is how this stayed invisible. `apps/walkthroughs` and `apps/storyboards` already build share links with `get_script_prefix()`; inbound had drifted off that pattern.

## Tests

The existing test asserted only `endswith("/api/inbound/gmail/dimagi/")` — true of the broken and correct URL alike, which is why it shipped.

- `test_push_url_carries_the_script_prefix` drives the **service**, not the client: the real WSGI/ASGI handlers call `set_script_prefix`, `django.test.Client` does not, so a client-level test is structurally blind to this.
- `test_push_url_reverses_rather_than_falling_back` patches `reverse` to a sentinel, proving the service reaches it — fixing only the fallback's prefix would satisfy the first test while leaving the route unreversed.

Both verified to fail against the pre-fix code, and against the partial "fix" that repairs only the fallback. Full suite: 2046 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)