### PR TITLE
fix(inbound): the watch topic belongs to the OAuth client's project, not ours

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -564,6 +564,22 @@ Two response rules that look wrong and aren't: an unverified push gets **404, no
 
 **A Gmail `watch` expires within 7 days and Google won't renew it**, so the **runner** re-arms it (`gmail_watch.py`, 24h before expiry, on the tick it already runs) and reports the expiry. It must be the runner, not the server: `users.watch` is called AS the mailbox, which a service account can only do via **domain-wide delegation** — and `dimagi-ai.com` is a *secondary domain inside the dimagi.com Workspace org* (`C018tavmm`, established in PR #151), not its own tenant, so DWD there would cover every `dimagi.com` mailbox. The runner's per-mailbox OAuth grants are strictly narrower and need no admin-console change; since `gog` has no `watch` verb and won't print a bearer, it does the refresh-token exchange itself from gog's own client file + keyring export, storing nothing new. The topic comes from `InboundPushConfig` (local `gmail_watch_topic` is a fallback).
 
+**The watch topic must live in the GCP project that owns the mailbox's Gmail OAuth
+client** — not where canopy-web runs. Any other topic is refused with `400 Invalid
+topicName does not match projects/<client-project>/topics/*`. The clients are the
+runner's `gog` credentials, so canopy-web cannot know the project and the UI ships a
+placeholder rather than a guess (a real-looking default provisioned cleanly and then
+failed every `users.watch`, leaving the mailbox silently on the poll — paid for
+2026-07-31). Authenticated push also needs `roles/iam.serviceAccountTokenCreator` for
+the Pub/Sub service agent on the push identity, or the subscription is created happily
+and delivers nothing, indistinguishable from a wrong audience. Live on labs since
+2026-07-31 for `hal`/`ada`/`eva` (topics in `canopy-494811`), verified by real Gmail
+notifications arriving ~1s after arming. **Known limit:** `watch_topic` is
+per-*workspace* while the constraint is per-*client project*, so a workspace whose
+mailboxes span two projects cannot be fully expressed — `ace`/`echo` (clients in
+`openclaw-assistant-20260224`) are therefore `enabled=false` and stay on the 300s
+poll. Per-mailbox topics are the real fix and are not built.
+
 **Configured entirely at `/w/:workspace/inbound`** — audience, signer, topic, mailboxes, per-mailbox watch health, and copy-pasteable `gcloud` commands generated from that workspace's own push URL. There are deliberately **no deployment-global inbound settings**: config that lives in env vars and a Django shell is deployment, not configuration, and it is what made the app single-tenant.
 
 ### Storyboards (`apps/storyboards`) — the shareable arc

--- a/docs/runbooks/gmail-push-provisioning.md
+++ b/docs/runbooks/gmail-push-provisioning.md
@@ -19,12 +19,43 @@ The push carries `{emailAddress, historyId}` and **no mail**. canopy-web resolve
 the mailbox to an agent, rings that agent's runners over the WS control channel,
 and the runner does the `gog` read it already does.
 
+## Which GCP project the topic must live in
+
+**The one that owns the mailbox's Gmail OAuth client — not wherever canopy-web
+runs.** Gmail refuses any other topic:
+
+```
+400: Invalid topicName does not match projects/<client-project>/topics/*
+```
+
+The clients are the runner's `gog` credentials
+(`~/Library/Application Support/gogcli/credentials-<client>.json`), so
+canopy-web cannot know the answer and the page does not guess one — the project
+field is a placeholder you must replace. Find the right project by arming once
+and reading the error, which names it.
+
+This cost a full provisioning cycle on 2026-07-31: everything was created in
+`connect-labs` (where canopy-web runs), the subscriptions verified, and every
+`users.watch` failed — mail kept arriving by poll with no push row to explain it.
+
+Consequence worth knowing before you start: **one topic per (project, workspace)
+pair.** The `dimagi` fleet's clients are split across two projects
+(`canopy-494811` for the shared `canopy` client, `openclaw-assistant-20260224`
+for `ace` and `echo`), so a workspace holding mailboxes from both needs a topic
+each — which the per-workspace `watch_topic` cannot express. Today that is
+handled by leaving the odd mailboxes `enabled=false`, which keeps them on the
+300s poll. Making `watch_topic` per-mailbox is the real fix and is not built.
+
 ## The steps
 
 1. **Provision GCP.** The page renders the `gcloud` block with your project,
    topic and push URL already filled in — including the publisher grant to the
    fixed `gmail-api-push@system.gserviceaccount.com`, without which `users.watch`
-   returns 403 and does not say why. Console links are on the page too.
+   returns 403 and does not say why, and the
+   `roles/iam.serviceAccountTokenCreator` grant to the Pub/Sub service agent,
+   without which the subscription is created happily and then never delivers
+   anything (which looks exactly like a wrong audience). Console links are on the
+   page too.
 
 2. **Tell the workspace what to trust.** Audience (must equal the push endpoint
    exactly) and the push service account. **Blank audience refuses every push** —
@@ -81,8 +112,22 @@ of a test email, and the resulting turn's `origin_ref.discovered_by == "push"`.
 If it reads `"poll"`, push is registered but not delivering — and a
 `gmail.push.missed` row at `error` will already be saying so.
 
+A freshly armed watch delivers its own notification within about a second, so
+arming is itself the end-to-end test — you should see a `gmail.push` row per
+mailbox immediately, before any mail is sent. To probe the path again later
+without making an agent burn a turn, publish a synthetic doorbell:
+
+```bash
+gcloud pubsub topics publish <topic> --project=<project> \
+  --message='{"emailAddress":"hal@dimagi-ai.com","historyId":"1"}'
+```
+
+That exercises delivery, OIDC verification and mailbox resolution; because the
+doorbell carries no mail, the worst it causes is a `gog` read that finds nothing.
+
 | you see | it means |
 |---|---|
+| `400 Invalid topicName does not match …` in the runner log | the topic is in the wrong project — see above; the error names the right one |
 | `gmail.push.unknown_mailbox` (warn) | step 3 not done for that address |
 | `gmail.push.no_runner` (warn) | push arrived, no online runner assigned to that agent |
 | `gmail.push.missed` (error) | a live watch exists but the poll found the mail first |

--- a/frontend/src/pages/InboundPushPage.tsx
+++ b/frontend/src/pages/InboundPushPage.tsx
@@ -184,6 +184,13 @@ export function InboundPushPage(): JSX.Element | null {
           <label className="space-y-1 text-sm">
             <span className="text-muted-foreground">GCP project</span>
             <Input value={project} onChange={(e) => setProject(e.target.value)} />
+            <span className="block text-xs text-muted-foreground">
+              Must be the project that owns the mailbox's Gmail OAuth client, not
+              wherever canopy-web runs — Gmail refuses a topic from anywhere else
+              (<code>Invalid topicName does not match projects/…</code>). Mailboxes
+              in this workspace whose clients live in different projects need a
+              topic each, which one <code>watch_topic</code> cannot hold.
+            </span>
           </label>
           <label className="space-y-1 text-sm">
             <span className="text-muted-foreground">Topic name</span>

--- a/frontend/src/pages/inboundSetup.test.ts
+++ b/frontend/src/pages/inboundSetup.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  DEFAULT_PROJECT,
   consoleLinks,
   setupCommands,
   suggestedServiceAccount,
@@ -44,6 +45,23 @@ describe('setupCommands', () => {
     })
     expect(out).toContain('canopy-push@my-proj.iam.gserviceaccount.com')
   })
+
+  it('lets Pub/Sub mint OIDC tokens as the push identity', () => {
+    // Omitting this creates the subscription successfully and then delivers
+    // nothing — indistinguishable from a wrong audience.
+    expect(cmds).toContain('--role=roles/iam.serviceAccountTokenCreator')
+    expect(cmds).toContain('@gcp-sa-pubsub.iam.gserviceaccount.com')
+  })
+})
+
+describe('DEFAULT_PROJECT', () => {
+  it('is a placeholder, never a real project', () => {
+    // Gmail requires the topic to live in the OAuth client's own project, which
+    // canopy-web cannot know. Defaulting to a real one (`connect-labs`) produced
+    // a runnable block whose every users.watch then failed, leaving the mailbox
+    // silently on the poll. Obviously-incomplete beats confidently-wrong.
+    expect(DEFAULT_PROJECT).toMatch(/^<.*>$/)
+  })
 })
 
 describe('topicPath', () => {
@@ -52,7 +70,7 @@ describe('topicPath', () => {
   })
 
   it('falls back rather than emitting a broken path', () => {
-    expect(topicPath('', '')).toBe('projects/connect-labs/topics/canopy-gmail-push')
+    expect(topicPath('', '')).toBe(`projects/${DEFAULT_PROJECT}/topics/canopy-gmail-push`)
   })
 })
 

--- a/frontend/src/pages/inboundSetup.ts
+++ b/frontend/src/pages/inboundSetup.ts
@@ -13,7 +13,21 @@ export type SetupInputs = {
   serviceAccount: string
 }
 
-export const DEFAULT_PROJECT = 'connect-labs'
+/**
+ * Deliberately NOT a real project.
+ *
+ * Gmail requires the watch topic to live in the **same GCP project as the OAuth
+ * client that calls `users.watch`** — otherwise the call fails with
+ * `Invalid topicName does not match projects/<that-project>/topics/*`. Those
+ * clients live on the runner, in gog's config, so canopy-web cannot know the
+ * answer and has no business guessing it.
+ *
+ * This used to default to `connect-labs`, which is plausible, runnable, and
+ * wrong: it provisions cleanly and every `users.watch` then fails, so the
+ * mailbox silently keeps polling. A placeholder makes the generated block
+ * obviously incomplete instead of confidently broken.
+ */
+export const DEFAULT_PROJECT = '<project-owning-the-gmail-oauth-client>'
 export const DEFAULT_TOPIC = 'canopy-gmail-push'
 
 /** `canopy-push@<project>.iam.gserviceaccount.com` — the conventional name. */
@@ -32,6 +46,15 @@ export function topicPath(project: string, topic: string): string {
  * `gmail-api-push@system.gserviceaccount.com` is a FIXED Google-owned account,
  * not a placeholder — without the publisher grant, `users.watch` returns 403 and
  * the error does not say why.
+ *
+ * Step 5 grants the Pub/Sub service agent permission to mint OIDC tokens as the
+ * push identity. Creating an authenticated push subscription succeeds without it
+ * and then never delivers, which looks identical to a wrong audience.
+ *
+ * `project` must own the Gmail OAuth client — see {@link DEFAULT_PROJECT}. One
+ * topic per (project, workspace): mailboxes in a single workspace whose clients
+ * live in different projects need a topic each, which the per-workspace
+ * `watch_topic` cannot express today.
  */
 export function setupCommands({ pushUrl, project, topic, serviceAccount }: SetupInputs): string {
   const p = (project || DEFAULT_PROJECT).trim()
@@ -53,7 +76,14 @@ export function setupCommands({ pushUrl, project, topic, serviceAccount }: Setup
     `gcloud iam service-accounts create ${saName} \\`,
     `  --display-name="canopy-web inbound push"`,
     ``,
-    `# 4. The push subscription — audience MUST equal the endpoint below`,
+    `# 4. Let Pub/Sub mint OIDC tokens as that identity. Without this the`,
+    `#    subscription is created happily and then never delivers.`,
+    `PROJECT_NUMBER=$(gcloud projects describe ${p} --format='value(projectNumber)')`,
+    `gcloud iam service-accounts add-iam-policy-binding ${sa} \\`,
+    `  --member="serviceAccount:service-$PROJECT_NUMBER@gcp-sa-pubsub.iam.gserviceaccount.com" \\`,
+    `  --role=roles/iam.serviceAccountTokenCreator`,
+    ``,
+    `# 5. The push subscription — audience MUST equal the endpoint below`,
     `gcloud pubsub subscriptions create ${t}-sub \\`,
     `  --topic=${t} \\`,
     `  --push-endpoint="${pushUrl}" \\`,


### PR DESCRIPTION
Found while provisioning Gmail push on labs for real. Push is **now live** for `hal`/`ada`/`eva`; this PR fixes what made getting there take two attempts.

## The bug

Gmail refuses a `users.watch` whose topic is outside the project owning the calling OAuth client:

```
400 Invalid topicName does not match projects/<client-project>/topics/*
```

The page defaulted the project to `connect-labs` — where canopy-web runs. Plausible, runnable, wrong. Everything provisioned cleanly, both subscriptions verified, and **every arming attempt failed**, so mail kept arriving on the 300s poll with no push row to explain the absence. The real project only surfaced from the runner log.

canopy-web genuinely cannot know it: the clients are the runner's `gog` credentials on its own disk. So the default is now an obvious placeholder rather than a guess — the generated block deliberately doesn't run until someone fills the project in.

## Also fixed

The generated commands were missing `roles/iam.serviceAccountTokenCreator` for the Pub/Sub service agent. Authenticated push without it creates the subscription happily and then delivers **nothing** — presenting identically to a wrong audience, i.e. the exact failure this page exists to prevent.

## Limit documented, not papered over

`watch_topic` is per-**workspace**; the constraint is per-**client project**. A workspace whose mailboxes span two projects cannot be expressed. Concretely on labs:

| mailbox | client project | state |
|---|---|---|
| `hal`, `ada`, `eva` | `canopy-494811` | armed, on push |
| `ace`, `echo` | `openclaw-assistant-20260224` | `enabled=false`, on the 300s poll |

Per-mailbox topics are the real fix and are deliberately **not** built here — that is a schema change, and this PR is the correction to what already shipped.

## Verification

A freshly armed watch delivers its own notification in ~1 second, so **arming is itself the end-to-end test**: three real `gmail.push` rows landed on labs before any mail was sent, each naming the runner it rang. The runbook now says so, and documents a synthetic-doorbell probe for re-testing later without making an agent burn a turn on it.

Backend 2075 passed / 1 skipped. Frontend 564 passed, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)