### PR TITLE
docs(inbound): echo runs on the shared client, so record how a mailbox moves

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -577,12 +577,26 @@ failed every `users.watch`, leaving the mailbox silently on the poll — paid fo
 2026-07-31). Authenticated push also needs `roles/iam.serviceAccountTokenCreator` for
 the Pub/Sub service agent on the push identity, or the subscription is created happily
 and delivers nothing, indistinguishable from a wrong audience. Live on labs since
-2026-07-31 for `hal`/`ada`/`eva` (topics in `canopy-494811`), verified by real Gmail
-notifications arriving ~1s after arming. **Known limit:** `watch_topic` is
-per-*workspace* while the constraint is per-*client project*, so a workspace whose
-mailboxes span two projects cannot be fully expressed — `ace`/`echo` (clients in
-`openclaw-assistant-20260224`) are therefore `enabled=false` and stay on the 300s
-poll. Per-mailbox topics are the real fix and are not built.
+2026-07-31 for `hal`/`ada`/`eva`/`echo` (topics in `canopy-494811`), verified by real
+Gmail notifications arriving ~1s after arming — a freshly armed watch fires its own
+notification, so **arming IS the end-to-end test**; no mail needs sending.
+
+**The fix for a mailbox in the wrong project is to move the mailbox, not the topic.**
+`echo` was realigned onto the shared `canopy` client on 2026-07-31 (its old client
+lived in the retired `openclaw-assistant-20260224`, which nobody here can reach). That
+is a real OAuth re-grant and **the consent cannot be automated** — the password is
+accepted and Google then demands SMS verification of the browser — so it is a human
+step: `gog auth add <email> --client canopy --force-consent --services
+docs,drive,forms,gmail,sheets`, run in the macOS account whose runner is unpaused,
+since gog tokens live in the per-user keychain. Order matters: new token → repoint
+`runner.json`'s `mailboxes.<agent>.client` → **restart the runner** (`Config.load`
+runs once at startup) → only then delete the old credentials. Deleting first takes
+that agent's mail down.
+
+**Known limit:** `watch_topic` is per-*workspace* while the constraint is per-*client
+project*, so a workspace whose mailboxes span two projects cannot be fully expressed.
+`ace` is the one mailbox still on the old client, so it is `enabled=false` and stays
+on the 300s poll. Per-mailbox topics are the real fix and are not built.
 
 **Configured entirely at `/w/:workspace/inbound`** — audience, signer, topic, mailboxes, per-mailbox watch health, and copy-pasteable `gcloud` commands generated from that workspace's own push URL. There are deliberately **no deployment-global inbound settings**: config that lives in env vars and a Django shell is deployment, not configuration, and it is what made the app single-tenant.
 

--- a/docs/runbooks/gmail-push-provisioning.md
+++ b/docs/runbooks/gmail-push-provisioning.md
@@ -39,12 +39,42 @@ This cost a full provisioning cycle on 2026-07-31: everything was created in
 `users.watch` failed — mail kept arriving by poll with no push row to explain it.
 
 Consequence worth knowing before you start: **one topic per (project, workspace)
-pair.** The `dimagi` fleet's clients are split across two projects
-(`canopy-494811` for the shared `canopy` client, `openclaw-assistant-20260224`
-for `ace` and `echo`), so a workspace holding mailboxes from both needs a topic
-each — which the per-workspace `watch_topic` cannot express. Today that is
-handled by leaving the odd mailboxes `enabled=false`, which keeps them on the
-300s poll. Making `watch_topic` per-mailbox is the real fix and is not built.
+pair.** A workspace holding mailboxes whose clients live in different projects
+needs a topic each, which the per-workspace `watch_topic` cannot express. Making
+`watch_topic` per-mailbox is the real fix and is not built.
+
+**So prefer moving the mailbox onto the shared client over adding a topic.** Four
+of the five agents share the `canopy` client in `canopy-494811`; `ace` is the
+holdout, still on a client in the retired `openclaw-assistant-20260224`, which
+nobody here can reach — so it is `enabled=false` and stays on the 300s poll.
+
+Realigning one agent (what `echo` went through on 2026-07-31):
+
+```bash
+# 1. Re-grant. HUMAN STEP — the consent cannot be automated: the password is
+#    accepted and Google then demands SMS verification of the browser. Run it in
+#    the macOS account whose runner is UNPAUSED; gog tokens are per-user keychain.
+gog auth add <email> --client canopy --force-consent \
+  --services docs,drive,forms,gmail,sheets
+
+# 2. Confirm the new bucket exists. `gog auth list` shows the STALE client row
+#    until the old bucket is deleted, so trust this instead:
+gog auth tokens list          # want token:canopy:<email>
+
+# 3. Repoint the runner and RESTART it — Config.load runs once at startup.
+#    Check ~/.canopy/in-flight is 0 first so no chat reply is stranded.
+#    (edit ~/.canopy/runner.json: mailboxes.<agent>.client = "canopy")
+launchctl kickstart -k gui/$(id -u)/com.canopy.runner
+
+# 4. Only NOW delete the old client. Doing this before step 1 succeeds takes that
+#    agent's mail down completely.
+gog auth tokens delete <email> --client <old> -y
+rm "$HOME/Library/Application Support/gogcli/credentials-<old>.json"
+```
+
+Watch out: two agents' credential files can hold the *same* client_id (ace and
+echo did), so check `account_clients` and `runner.json` for other users of a file
+before removing it.
 
 ## The steps
 


### PR DESCRIPTION
Follow-up to #555, which documented a state that changed hours later.

#555 said `ace`/`echo` were both parked on a client in the retired `openclaw-assistant-20260224`. `echo` has since been realigned onto the shared `canopy` client in `canopy-494811` and is **armed and delivering push**. `ace` is the only holdout.

## The substantive change

Faced with a mailbox whose OAuth client sits in a project nobody can reach, the instinct is to find a way to create a topic *there*. The right move is the opposite: move the mailbox onto the client the rest of the fleet already shares. The runbook now carries that procedure rather than only naming the constraint.

Three parts of it are only obvious after doing it:

- **The consent is a human step.** The password (from 1Password) is accepted and Google then demands SMS verification of the headless browser. Not automatable.
- **It must run in the macOS account whose runner is unpaused.** gog tokens live in the per-user keychain, so a grant in the wrong account lands in the wrong keyring and the watch silently still fails.
- **Delete the old credentials last.** The new grant is what replaces them; deleting first takes that agent's mail down entirely.

Plus two traps: `gog auth list` keeps showing the *stale* client row until the old token bucket is deleted (so a successful re-grant looks like it failed — `gog auth tokens list` is the honest view), and two agents' credential files can hold the same `client_id` (ace and echo did), so a file needs checking for other users before removal.

## Live state

| mailbox | client | project | push |
|---|---|---|---|
| `hal`, `ada`, `eva`, `echo` | `canopy` | `canopy-494811` | armed, delivering |
| `ace` | `ace` | `openclaw-assistant-20260224` (unreachable) | `enabled=false`, on the 300s poll |

Docs only — no code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)