### PR TITLE
docs(inbound): the whole fleet is on push, and the topic limit is now latent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -576,27 +576,33 @@ placeholder rather than a guess (a real-looking default provisioned cleanly and 
 failed every `users.watch`, leaving the mailbox silently on the poll — paid for
 2026-07-31). Authenticated push also needs `roles/iam.serviceAccountTokenCreator` for
 the Pub/Sub service agent on the push identity, or the subscription is created happily
-and delivers nothing, indistinguishable from a wrong audience. Live on labs since
-2026-07-31 for `hal`/`ada`/`eva`/`echo` (topics in `canopy-494811`), verified by real
-Gmail notifications arriving ~1s after arming — a freshly armed watch fires its own
-notification, so **arming IS the end-to-end test**; no mail needs sending.
+and delivers nothing, indistinguishable from a wrong audience. **Live on labs for the
+whole fleet since 2026-07-31** — `ace`/`ada`/`echo`/`eva`/`hal`, topics in
+`canopy-494811` — verified by real Gmail notifications arriving ~1s after arming. A
+freshly armed watch fires its own notification, so **arming IS the end-to-end test**;
+no mail needs sending, and no agent burns a turn on a probe.
 
 **The fix for a mailbox in the wrong project is to move the mailbox, not the topic.**
-`echo` was realigned onto the shared `canopy` client on 2026-07-31 (its old client
-lived in the retired `openclaw-assistant-20260224`, which nobody here can reach). That
-is a real OAuth re-grant and **the consent cannot be automated** — the password is
-accepted and Google then demands SMS verification of the browser — so it is a human
-step: `gog auth add <email> --client canopy --force-consent --services
-docs,drive,forms,gmail,sheets`, run in the macOS account whose runner is unpaused,
-since gog tokens live in the per-user keychain. Order matters: new token → repoint
-`runner.json`'s `mailboxes.<agent>.client` → **restart the runner** (`Config.load`
-runs once at startup) → only then delete the old credentials. Deleting first takes
-that agent's mail down.
+`echo` and `ace` were realigned onto the shared `canopy` client on 2026-07-31; their
+old clients lived in the retired `openclaw-assistant-20260224`, which nobody here can
+reach, so there was no topic to create. All five mailboxes now share one client, which
+is why one topic per workspace is currently sufficient. That realignment is a real
+OAuth re-grant and **the consent cannot be automated** — the password is accepted and
+Google then demands SMS verification of the browser — so it is a human step: `gog auth
+add <email> --client canopy --force-consent --services docs,drive,forms,gmail,sheets`,
+run in the macOS account whose runner is unpaused, since gog tokens live in the
+per-user keychain. Order matters: new token → repoint `runner.json`'s
+`mailboxes.<agent>.client` → **restart the runner** (`Config.load` runs once at
+startup) → only then delete the old credentials. Deleting first takes that agent's
+mail down. Expect one transient `401` from the token endpoint on the first arm after
+the switch; it self-corrects within seconds.
 
-**Known limit:** `watch_topic` is per-*workspace* while the constraint is per-*client
-project*, so a workspace whose mailboxes span two projects cannot be fully expressed.
-`ace` is the one mailbox still on the old client, so it is `enabled=false` and stays
-on the 300s poll. Per-mailbox topics are the real fix and are not built.
+**Known limit, now latent rather than live:** `watch_topic` is per-*workspace* while
+the real constraint is per-*client project*. Nothing hits it today because the fleet
+shares one client — but introduce an agent whose client lives elsewhere and that
+workspace cannot be expressed by one topic. Per-mailbox topics are the real fix and
+are not built; the interim lever is `enabled=false`, which parks a mailbox on the 300s
+poll without losing its row.
 
 **Configured entirely at `/w/:workspace/inbound`** — audience, signer, topic, mailboxes, per-mailbox watch health, and copy-pasteable `gcloud` commands generated from that workspace's own push URL. There are deliberately **no deployment-global inbound settings**: config that lives in env vars and a Django shell is deployment, not configuration, and it is what made the app single-tenant.
 

--- a/docs/runbooks/gmail-push-provisioning.md
+++ b/docs/runbooks/gmail-push-provisioning.md
@@ -43,12 +43,13 @@ pair.** A workspace holding mailboxes whose clients live in different projects
 needs a topic each, which the per-workspace `watch_topic` cannot express. Making
 `watch_topic` per-mailbox is the real fix and is not built.
 
-**So prefer moving the mailbox onto the shared client over adding a topic.** Four
-of the five agents share the `canopy` client in `canopy-494811`; `ace` is the
-holdout, still on a client in the retired `openclaw-assistant-20260224`, which
-nobody here can reach — so it is `enabled=false` and stays on the 300s poll.
+**So prefer moving the mailbox onto the shared client over adding a topic.** As of
+2026-07-31 all five agents share the `canopy` client in `canopy-494811`, which is
+the only reason one topic per workspace suffices — `echo` and `ace` were moved off
+clients in the retired `openclaw-assistant-20260224`, a project nobody here can
+reach, so there was no topic to create for them.
 
-Realigning one agent (what `echo` went through on 2026-07-31):
+Realigning one agent (what `echo` and `ace` went through on 2026-07-31):
 
 ```bash
 # 1. Re-grant. HUMAN STEP — the consent cannot be automated: the password is
@@ -73,8 +74,17 @@ rm "$HOME/Library/Application Support/gogcli/credentials-<old>.json"
 ```
 
 Watch out: two agents' credential files can hold the *same* client_id (ace and
-echo did), so check `account_clients` and `runner.json` for other users of a file
-before removing it.
+echo did — two files, one OAuth client), so check `account_clients` and
+`runner.json` for other users of a file before removing it. Also expect one
+transient `401` from `oauth2.googleapis.com/token` on the first arm after the
+switch, immediately followed by a successful arm; it self-corrects and is not
+worth chasing.
+
+Verify by re-reading every mailbox afterwards (`gog gmail messages list "in:inbox"
+-a <email> --max 1`) — the point of the ordering above is that mail never stops,
+so check that it didn't. In the runner log a pushed mailbox reads
+`inbox[<agent>]: RUNG` where a polled one reads `polled`; that word is the
+quickest confirmation that an agent is actually on push.
 
 ## The steps
 


### PR DESCRIPTION
Third and last correction in this chain (#555 → #556 → here), each because the live state moved while the docs were being written.

`ace` was the final mailbox still on a client in the retired `openclaw-assistant-20260224`. It moved to the shared `canopy` client, armed, and its next inbox read logged `RUNG` rather than `polled`. **All five agents now deliver mail by push.**

| mailbox | client | project | state |
|---|---|---|---|
| `ace`, `ada`, `echo`, `eva`, `hal` | `canopy` | `canopy-494811` | armed, delivering push |

Mail latency for the fleet goes from up to 5 minutes (the 300s poll) to ~1 second.

## The limit didn't vanish, it went latent

`watch_topic` is still per-**workspace** while the real constraint is per-**client project**. Nothing hits it *only* because the fleet now shares one client. Recording it as latent — along with what would wake it (an agent whose OAuth client lives in another project) — seemed more useful than deleting it, which would lose the reason one topic per workspace happens to be sufficient, or leaving it reading as a live problem, which it isn't.

## Two things the ace move taught that echo's hadn't

- **A transient `401` from `oauth2.googleapis.com/token` on the first arm after a switch**, followed seconds later by a successful arm. Happened on both agents; self-corrects. Undocumented, it looks exactly like the failure this runbook exists to diagnose.
- **`RUNG` vs `polled` in the runner log** is the fastest confirmation an agent is genuinely on push rather than merely configured for it — worth stating, because every server-side field can read correct while the mailbox is still polling.

Also adds the post-move verification the careful ordering exists to protect: re-read every mailbox afterwards. The reason to grant before deleting is that mail never stops, and that's only true if someone actually checks.

Docs only. Backend 2075 passed / 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)