### PR TITLE
See at a glance which agents are running in auto mode

### DIFF
--- a/frontend/src/components/supervisor/AgentKpiCard.test.tsx
+++ b/frontend/src/components/supervisor/AgentKpiCard.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+import type { AgentOut } from '@/api/agents'
+import { AgentKpiCard } from './AgentKpiCard'
+
+function agent(overrides: Partial<AgentOut> = {}): AgentOut {
+  return {
+    id: 1,
+    slug: 'echo',
+    name: 'Echo',
+    description: '',
+    persona: '',
+    email: '',
+    avatar_url: '',
+    workspace: 'canopy',
+    runner_preference: [],
+    turn_mode: 'gated',
+    created_at: '2026-07-31T00:00:00Z',
+    updated_at: '2026-07-31T00:00:00Z',
+    ...overrides,
+  } as AgentOut
+}
+
+const renderCard = (a: AgentOut, waiting = 0) =>
+  render(
+    <MemoryRouter>
+      <AgentKpiCard agent={a} waiting={waiting} />
+    </MemoryRouter>,
+  )
+
+afterEach(cleanup)
+
+describe('AgentKpiCard', () => {
+  it('badges an agent running in auto mode', () => {
+    renderCard(agent({ turn_mode: 'auto' }))
+    expect(screen.getByTestId('agent-auto-echo').textContent).toBe('Auto')
+  })
+
+  it('shows no badge for a gated agent — the default posture stays quiet', () => {
+    renderCard(agent({ turn_mode: 'gated' }))
+    expect(screen.queryByTestId('agent-auto-echo')).toBeNull()
+  })
+
+  it('still renders the waiting count alongside the badge', () => {
+    renderCard(agent({ turn_mode: 'auto' }), 3)
+    expect(screen.getByTestId('agent-auto-echo')).toBeTruthy()
+    expect(screen.getByText('3 waiting on you')).toBeTruthy()
+  })
+})

--- a/frontend/src/components/supervisor/AgentKpiCard.tsx
+++ b/frontend/src/components/supervisor/AgentKpiCard.tsx
@@ -20,7 +20,21 @@ export function AgentKpiCard({ agent, waiting }: { agent: AgentOut; waiting: num
       className="flex items-center gap-3 rounded-lg border border-border bg-card p-3 transition-colors hover:border-primary/40"
     >
       <div className="min-w-0 flex-1">
-        <p className="truncate text-[13px] font-semibold text-foreground">{agent.name}</p>
+        <div className="flex items-center gap-1.5">
+          <p className="truncate text-[13px] font-semibold text-foreground">{agent.name}</p>
+          {/* Only `auto` is badged. Gated is the default posture and the safe one —
+              badging it too would put a chip on every card and make the one that
+              actually matters (this agent sends without asking) harder to spot. */}
+          {agent.turn_mode === 'auto' && (
+            <span
+              data-testid={`agent-auto-${agent.slug}`}
+              title="Auto mode — sends without waiting for your approval"
+              className="shrink-0 rounded border border-warning/40 bg-warning/10 px-1 py-px text-[9px] font-bold uppercase tracking-[0.06em] text-warning"
+            >
+              Auto
+            </span>
+          )}
+        </div>
         <p className="mt-0.5 text-[11px] text-muted-foreground">
           {waiting > 0 ? `${waiting} waiting on you` : 'nothing waiting'}
         </p>


### PR DESCRIPTION
## Problem
Turn mode (canopy-web#551) is only visible on an agent's own overview page. Supervisor — the fleet-level surface you actually scan — showed nothing, so "which of my agents are sending without asking me?" had no answer short of opening each agent or hitting the CLI.

## Solution
An `AUTO` badge on `AgentKpiCard` in the supervisor Agents tab. No API change and no extra fetch: `turn_mode` already rides on `AgentOut`, which that tab's `listAgents` call returns — the data was there, just unrendered.

Only `auto` is badged. Gated is the default and the safe posture; badging it too would put a chip on every card and bury the one that matters.

## Confidence
3 new component tests (badges auto, stays quiet for gated, coexists with the waiting count); `npm run build` (tsc -b + vite) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)