### PR TITLE
Turn auto mode on and off from your phone

### DIFF
--- a/frontend/src/components/supervisor/AgentKpiCard.test.tsx
+++ b/frontend/src/components/supervisor/AgentKpiCard.test.tsx
@@ -1,10 +1,14 @@
 // @vitest-environment jsdom
-import { afterEach, describe, expect, it } from 'vitest'
-import { cleanup, render, screen } from '@testing-library/react'
-import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
 
-import type { AgentOut } from '@/api/agents'
-import { AgentKpiCard } from './AgentKpiCard'
+import type { AgentOut, TurnMode } from '@/api/agents'
+
+const setAgentTurnMode = vi.fn<(slug: string, mode: TurnMode) => Promise<TurnMode>>()
+vi.mock('@/api/agents', () => ({ setAgentTurnMode }))
+
+const { AgentKpiCard } = await import('./AgentKpiCard')
 
 function agent(overrides: Partial<AgentOut> = {}): AgentOut {
   return {
@@ -24,29 +28,79 @@ function agent(overrides: Partial<AgentOut> = {}): AgentOut {
   } as AgentOut
 }
 
+// Renders the card inside a router that also has a destination route, so a
+// stray navigation caused by the chip tap is observable rather than silent.
 const renderCard = (a: AgentOut, waiting = 0) =>
   render(
-    <MemoryRouter>
-      <AgentKpiCard agent={a} waiting={waiting} />
+    <MemoryRouter initialEntries={['/supervisor']}>
+      <Routes>
+        <Route path="/supervisor" element={<AgentKpiCard agent={a} waiting={waiting} />} />
+        <Route path="/w/canopy/agents/echo" element={<div data-testid="agent-page" />} />
+      </Routes>
     </MemoryRouter>,
   )
 
-afterEach(cleanup)
+beforeEach(() => {
+  setAgentTurnMode.mockResolvedValue('auto')
+  vi.spyOn(window, 'confirm').mockReturnValue(true)
+})
 
-describe('AgentKpiCard', () => {
-  it('badges an agent running in auto mode', () => {
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+  vi.clearAllMocks()
+})
+
+describe('AgentKpiCard turn-mode chip', () => {
+  it('reads out the current mode on each card', () => {
     renderCard(agent({ turn_mode: 'auto' }))
-    expect(screen.getByTestId('agent-auto-echo').textContent).toBe('Auto')
-  })
-
-  it('shows no badge for a gated agent — the default posture stays quiet', () => {
+    expect(screen.getByTestId('agent-mode-echo').textContent).toBe('Auto')
+    cleanup()
     renderCard(agent({ turn_mode: 'gated' }))
-    expect(screen.queryByTestId('agent-auto-echo')).toBeNull()
+    expect(screen.getByTestId('agent-mode-echo').textContent).toBe('Gated')
   })
 
-  it('still renders the waiting count alongside the badge', () => {
+  it('turning auto ON asks first, then flips', async () => {
+    renderCard(agent({ turn_mode: 'gated' }))
+    fireEvent.click(screen.getByTestId('agent-mode-echo'))
+    expect(window.confirm).toHaveBeenCalledOnce()
+    await waitFor(() => expect(setAgentTurnMode).toHaveBeenCalledWith('echo', 'auto'))
+    expect(screen.getByTestId('agent-mode-echo').textContent).toBe('Auto')
+  })
+
+  it('declining the confirm leaves the agent gated and calls nothing', () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false)
+    renderCard(agent({ turn_mode: 'gated' }))
+    fireEvent.click(screen.getByTestId('agent-mode-echo'))
+    expect(setAgentTurnMode).not.toHaveBeenCalled()
+    expect(screen.getByTestId('agent-mode-echo').textContent).toBe('Gated')
+  })
+
+  it('turning auto OFF needs no confirm — the safe direction is one tap', async () => {
+    renderCard(agent({ turn_mode: 'auto' }))
+    fireEvent.click(screen.getByTestId('agent-mode-echo'))
+    expect(window.confirm).not.toHaveBeenCalled()
+    await waitFor(() => expect(setAgentTurnMode).toHaveBeenCalledWith('echo', 'gated'))
+  })
+
+  it('tapping the chip does not navigate to the agent page', async () => {
+    renderCard(agent({ turn_mode: 'auto' }))
+    fireEvent.click(screen.getByTestId('agent-mode-echo'))
+    await waitFor(() => expect(setAgentTurnMode).toHaveBeenCalled())
+    expect(screen.queryByTestId('agent-page')).toBeNull()
+    expect(screen.getByTestId('agent-card-echo')).toBeTruthy()
+  })
+
+  it('reverts and offers a retry when the write fails', async () => {
+    setAgentTurnMode.mockRejectedValue(new Error('offline'))
+    renderCard(agent({ turn_mode: 'auto' }))
+    fireEvent.click(screen.getByTestId('agent-mode-echo'))
+    await waitFor(() => expect(screen.getByTestId('agent-mode-echo').textContent).toBe('Retry'))
+  })
+
+  it('still renders the waiting count alongside the chip', () => {
     renderCard(agent({ turn_mode: 'auto' }), 3)
-    expect(screen.getByTestId('agent-auto-echo')).toBeTruthy()
+    expect(screen.getByTestId('agent-mode-echo')).toBeTruthy()
     expect(screen.getByText('3 waiting on you')).toBeTruthy()
   })
 })

--- a/frontend/src/components/supervisor/AgentKpiCard.tsx
+++ b/frontend/src/components/supervisor/AgentKpiCard.tsx
@@ -1,6 +1,76 @@
-import type { JSX } from 'react'
+import { useState, type JSX, type MouseEvent } from 'react'
 import { Link } from 'react-router-dom'
-import type { AgentOut } from '@/api/agents'
+import { setAgentTurnMode, type AgentOut, type TurnMode } from '@/api/agents'
+
+// The turn-mode chip — readable at a glance, tappable to flip. This is the
+// phone-reachable control: the installed PWA opens at /supervisor, so the
+// Agents tab is the home screen and flipping a mode shouldn't cost four taps
+// into the agent's own page.
+//
+// It lives INSIDE the card's <Link>, so every handler preventDefault +
+// stopPropagation — a tap on the chip must never also navigate.
+//
+// Asymmetric by design. gated -> auto hands an agent permission to send without
+// asking, so it takes a confirm (a fat-fingered tap on a phone must not put an
+// agent on the loose). auto -> gated only ever REMOVES permission, so it applies
+// on first tap: never make the safe direction harder than the dangerous one.
+function TurnModeChip({ slug, mode }: { slug: string; mode: TurnMode }): JSX.Element {
+  const [current, setCurrent] = useState<TurnMode>(mode)
+  const [busy, setBusy] = useState(false)
+  const [failed, setFailed] = useState(false)
+
+  const onTap = async (e: MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault()
+    e.stopPropagation()
+    if (busy) return
+    const next: TurnMode = current === 'auto' ? 'gated' : 'auto'
+    if (
+      next === 'auto' &&
+      !window.confirm(
+        `Put ${slug} in auto mode? It will reply and take outbound actions without waiting for your approval.`,
+      )
+    ) {
+      return
+    }
+    setBusy(true)
+    setFailed(false)
+    const prev = current
+    setCurrent(next)
+    try {
+      await setAgentTurnMode(slug, next)
+    } catch {
+      // Put the chip back where it was: a silent revert would read as "it
+      // worked" on a phone with no console open.
+      setCurrent(prev)
+      setFailed(true)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const auto = current === 'auto'
+  return (
+    <button
+      type="button"
+      onClick={(e) => void onTap(e)}
+      disabled={busy}
+      data-testid={`agent-mode-${slug}`}
+      aria-label={`${slug} turn mode: ${current}. Activate to switch to ${auto ? 'gated' : 'auto'}.`}
+      title={
+        auto
+          ? 'Auto — sends without waiting for you. Tap to require approval again.'
+          : 'Gated — outbound waits for your approval. Tap to allow unattended sending.'
+      }
+      className={`shrink-0 rounded border px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-[0.06em] transition-colors disabled:opacity-50 ${
+        auto
+          ? 'border-warning/40 bg-warning/10 text-warning'
+          : 'border-border bg-muted/40 text-muted-foreground'
+      }`}
+    >
+      {failed ? 'Retry' : auto ? 'Auto' : 'Gated'}
+    </button>
+  )
+}
 
 // One agent's KPIs — the React counterpart of menubar.py's _card (menubar.py:385).
 //
@@ -22,18 +92,7 @@ export function AgentKpiCard({ agent, waiting }: { agent: AgentOut; waiting: num
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-1.5">
           <p className="truncate text-[13px] font-semibold text-foreground">{agent.name}</p>
-          {/* Only `auto` is badged. Gated is the default posture and the safe one —
-              badging it too would put a chip on every card and make the one that
-              actually matters (this agent sends without asking) harder to spot. */}
-          {agent.turn_mode === 'auto' && (
-            <span
-              data-testid={`agent-auto-${agent.slug}`}
-              title="Auto mode — sends without waiting for your approval"
-              className="shrink-0 rounded border border-warning/40 bg-warning/10 px-1 py-px text-[9px] font-bold uppercase tracking-[0.06em] text-warning"
-            >
-              Auto
-            </span>
-          )}
+          <TurnModeChip slug={agent.slug} mode={agent.turn_mode} />
         </div>
         <p className="mt-0.5 text-[11px] text-muted-foreground">
           {waiting > 0 ? `${waiting} waiting on you` : 'nothing waiting'}


### PR DESCRIPTION
## Problem
The installed PWA's `start_url` is `/supervisor`, so the Agents tab is the phone home screen — but after #558 it could only *show* turn mode. Changing it meant tapping into the agent's own page (workspace-scoped route, left-nav block stacked above the content on mobile): about four taps for a switch you want in one, especially while away from a laptop.

## Solution
The badge becomes the control. Same chip, now a button.

**Asymmetric by design:**
- `gated → auto` — confirms first. This hands an agent permission to send unattended; a mis-tap on a phone must not do that silently.
- `auto → gated` — applies on the first tap. It only ever removes permission, and the safe direction should never be harder than the dangerous one.

The chip renders on every card now (quiet grey for gated, warning for auto) because you can't turn auto *on* from a badge that only appears when it's already on. Auto still reads loud, so the agent acting unattended is what your eye lands on.

It lives inside the card's `<Link>`, so the handler `preventDefault`s and `stopPropagation`s.

## Confidence
7 component tests: reads each mode, confirm-then-flip, declining the confirm is a no-op, off-direction skips the confirm, **tapping the chip does not navigate** (asserted against a real destination route, not just the mock), failed write reverts and offers Retry, and the waiting count still renders. `npm run build` (tsc -b + vite) and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)