### PR TITLE
fix(runner): capture a blocked agent's menu even with nobody watching

### DIFF
--- a/runner/canopy_runner/canopy_runner/hook_listener.py
+++ b/runner/canopy_runner/canopy_runner/hook_listener.py
@@ -60,9 +60,13 @@ class HookListener:
         self.nonce = nonce
         self._resolve_session = resolve_session
         self._forward = forward
-        # Injected: cwd -> (project, emdash task), the key the session report is
+        # Injected: cwd -> the (project, emdash task) keys the session report is
         # built on. Injected for the same reason `resolve_session` is — this
         # module stays testable with no emdash and no worktree on disk.
+        #
+        # Note it is NOT `resolve_session`: that one answers with a canopy session
+        # id and can only do so for a session a viewer is attached to, which is
+        # precisely the case a blocked-agent menu does not need.
         self._resolve_task = resolve_task
         # The live dialog per (project, task), captured from `PreToolUse`.
         # Written from listener threads and read from the report thread; dict
@@ -154,14 +158,17 @@ class HookListener:
         if self._resolve_task is None:
             return
         try:
-            key = self._resolve_task(payload.get("cwd") or "")
-            if not key or not key[1]:
+            keys = self._resolve_task(payload.get("cwd") or "")
+            if not keys:
                 return
             menu = menu_from_hook(payload)
-            if menu is not None:
-                self._pending_menus[key] = menu
-            elif hook_retires_menu(payload):
-                self._pending_menus.pop(key, None)
+            if menu is None and not hook_retires_menu(payload):
+                return
+            for key in keys:
+                if menu is not None:
+                    self._pending_menus[key] = menu
+                else:
+                    self._pending_menus.pop(key, None)
         except Exception:  # noqa: BLE001 — a hook must never see a failure
             logger.debug("menu tracking failed (non-fatal)", exc_info=True)
 

--- a/runner/canopy_runner/canopy_runner/hooks.py
+++ b/runner/canopy_runner/canopy_runner/hooks.py
@@ -139,23 +139,35 @@ def resolve_hook_session(cwd: str) -> str:
     return ""
 
 
-def hook_project_task(cwd: str) -> tuple[str, str]:
-    """This cwd as (project, emdash task), or ("", "") — the session report's key.
+def hook_project_task_keys(cwd: str, *, home: Path | None = None) -> list[tuple[str, str]]:
+    """This cwd as the (project, emdash task) keys the session report looks up by.
 
-    Deliberately NOT keyed on the task alone: emdash task names are not unique
-    across projects (the server carries the same warning), and a menu attached to
-    the wrong session would put someone else's buttons on your phone.
+    **Deliberately does NOT consult `_hook_sessions`.** That map is rebuilt
+    wholesale from `sync_streams`, which returns only the sessions a VIEWER is
+    attached to — so keying a menu off it would capture one exactly when somebody
+    already had the chat open, and lose it in every case that matters. You go and
+    look BECAUSE the session stopped; the menu has to be there before you arrive.
+    That is the same shape as the bug #510 left behind, one layer down.
+
+    Nothing here needs a canopy session id anyway: the report is keyed by
+    (project, emdash task), and the worktree path carries both.
+
+    Returns every candidate because the directory may carry emdash's random
+    de-dupe suffix and the cwd alone cannot say which form the report uses. They
+    are all derived from this one path, so at most one is ever queried — storing
+    under each is a spelling, not an ambiguity.
+
+    Still (project, task) and never the task alone: emdash task names are not
+    unique across projects, and a menu attached to the wrong session puts
+    somebody else's buttons on your phone.
     """
     if not cwd:
-        return ("", "")
-    parsed = transcript_core.parse_emdash_worktree(cwd, home=Path.home())
+        return []
+    parsed = transcript_core.parse_emdash_worktree(cwd, home=home or Path.home())
     if parsed is None:
-        return ("", "")
+        return []
     project, task = parsed
-    for candidate in transcript_core.emdash_task_candidates(task):
-        if _hook_sessions.get((project, candidate)):
-            return (project, candidate)
-    return ("", "")
+    return [(project, c) for c in transcript_core.emdash_task_candidates(task) if c]
 
 
 def pending_hook_menu(project: str, task: str):
@@ -289,8 +301,10 @@ def start_hook_listener(cfg: Config, client: Client):
         forward=lambda: cfg.forward_sessions,
         # NOT read_menu (see above) — this is the cheap half: `PreToolUse` for
         # AskUserQuestion already carries the whole dialog, so the listener can
-        # hold it for the session report without touching emdash at all.
-        resolve_task=hook_project_task,
+        # hold it for the session report without touching emdash at all. And it
+        # resolves off the cwd alone, so it covers every session on the box
+        # rather than only the ones somebody is already watching.
+        resolve_task=hook_project_task_keys,
     )
     listener.bind_sender(
         lambda session_id, events: client.post_session_stream(

--- a/runner/canopy_runner/tests/test_hook_menu.py
+++ b/runner/canopy_runner/tests/test_hook_menu.py
@@ -39,7 +39,7 @@ def listener(**kw):
         port=0, nonce="n",
         resolve_session=lambda cwd: "sess" if cwd == CWD else "",
         forward=kw.pop("forward", lambda: True),
-        resolve_task=lambda cwd: KEY if cwd == CWD else ("", ""),
+        resolve_task=lambda cwd: [KEY] if cwd == CWD else [],
         **kw,
     )
 
@@ -146,3 +146,45 @@ def test_a_session_with_no_dialog_still_reports_None():
         hook_menu_for=lambda p, t: None,
     )
     assert sessions[0]["question"] is None
+
+
+def test_the_menu_does_not_depend_on_anybody_watching():
+    """The regression that made the first cut of this fix nearly inert: the key
+    was resolved through `_hook_sessions`, which is rebuilt wholesale from
+    `sync_streams` — only the sessions a VIEWER is attached to. A menu captured
+    only while somebody already has the chat open is captured only in the case
+    that does not need it; you go and look BECAUSE the session stopped."""
+    from canopy_runner import hooks
+
+    hooks._hook_sessions.clear()          # nobody is watching anything
+    keys = hooks.hook_project_task_keys(
+        "/Users/x/emdash/worktrees/canopy-web/emdash/some-task-ab12x",
+        home=__import__("pathlib").Path("/Users/x"),
+    )
+    assert keys, "a session with no viewer must still resolve to a report key"
+    assert all(k[0] == "canopy-web" for k in keys)
+
+
+def test_a_path_that_is_not_an_emdash_worktree_resolves_to_nothing():
+    from canopy_runner import hooks
+
+    home = __import__("pathlib").Path("/Users/x")
+    assert hooks.hook_project_task_keys("/tmp/somewhere", home=home) == []
+    assert hooks.hook_project_task_keys("", home=home) == []
+
+
+def test_every_spelling_of_the_task_gets_the_menu():
+    """The worktree dir may carry emdash's de-dupe suffix and the cwd cannot say
+    which form the session report uses, so the menu is stored under each. They
+    come from one path, so at most one is ever queried."""
+    hl = HookListener(
+        port=0, nonce="n", resolve_session=lambda cwd: "",
+        forward=lambda: True,
+        resolve_task=lambda cwd: [("p", "task-ab12x"), ("p", "task")],
+    )
+    hl.handle_payload({**ASK, "cwd": "/any"})
+    assert hl.pending_menu("p", "task-ab12x") is not None
+    assert hl.pending_menu("p", "task") is not None
+    hl.handle_payload({"hook_event_name": "Stop", "cwd": "/any"})
+    assert hl.pending_menu("p", "task-ab12x") is None
+    assert hl.pending_menu("p", "task") is None


### PR DESCRIPTION
Follow-up to #560, found by testing it on the live box straight after the deploy.

#560 made `PreToolUse` the producer of the blocked-agent menu — correctly, since the transcript cannot see a live dialog. But it resolved the session key through `hooks._hook_sessions`, and that map is rebuilt **wholesale** by `streams.sync_streams` from the sessions a **viewer is attached to**:

```python
hooks._hook_sessions.clear()
for sid, s in desired.items():          # desired = sessions someone is watching
    hooks._hook_sessions[(s["project"], s["session_key"])] = sid
```

So the menu got captured exactly when somebody already had the chat open, and lost in every case that matters. **You go and look BECAUSE the session stopped** — the menu has to already be there when you arrive. It is the same shape as the bug #510 left behind, one layer down.

Measured on the live box immediately after the deploy: `hooks: 5539 received, 36 forwarded, 5503 dropped (cwd not a session we back)`. The fix was landing for well under 1% of hook traffic.

## The fix

Nothing on this path needs a canopy session id. The session report is keyed by `(project, emdash_task)` and the worktree cwd carries both, so the menu key is derived from the path alone — covering every Claude Code session in an emdash worktree on the box, watched or not. `resolve_hook_session` is untouched; the live-event path genuinely does need a session id to post against.

The menu is stored under **every candidate spelling** of the task name, because the directory may carry emdash's random de-dupe suffix and the cwd cannot say which form the report uses. They derive from one path, so at most one is ever queried — a spelling, not an ambiguity. Still keyed on `(project, task)` and never the task alone: task names are not unique across projects, and a misattached menu puts somebody else's buttons on your phone.

## Tests

`test_the_menu_does_not_depend_on_anybody_watching` clears `_hook_sessions` outright and asserts a key still resolves — that is the regression, pinned.

`runner/canopy_runner`: 395 passed. `packages/canopy_transcript`: 49 passed. `ruff --select F`: clean.

## Honest status

The full round trip — a real `AskUserQuestion` firing `PreToolUse` on a live daemon and the menu arriving on a phone — still has not been observed end to end; that needs the next session that actually blocks, after this deploys. What made me look here was that round trip failing: I fed two live dialogs' real screen content at the listener and watched both get dropped as unknown-cwd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)