### PR TITLE
fix(runner): a notification marker must not survive a restart

### DIFF
--- a/runner/canopy_runner/canopy_runner/menu_store.py
+++ b/runner/canopy_runner/canopy_runner/menu_store.py
@@ -29,6 +29,10 @@ logger = logging.getLogger("canopy_runner.hooks")
 # string that some future reader has to know to split.
 _PROJECT, _TASK, _MENU = "project", "task", "menu"
 
+# `marker_from_hook`'s source tag. Kept as a literal rather than imported so this
+# module stays free of canopy_transcript, which is what lets it unit-test alone.
+_NOTIFICATION = "notification"
+
 
 class MenuStore:
     """Load/save `{(project, task): menu}` at `path`. Never raises."""
@@ -50,6 +54,19 @@ class MenuStore:
                 continue
             project, task = row.get(_PROJECT), row.get(_TASK)
             if not isinstance(project, str) or not isinstance(task, str) or not task:
+                continue
+            # A notification marker is a claim that a turn was in flight, and
+            # turn state is deliberately NOT persisted — after a restart we do
+            # not know, and the safe answer there is silence. Restoring one
+            # therefore restores a claim nothing can still justify, and it
+            # cannot decay on its own: the `Stop` that would retire it belongs
+            # to a turn that ended while this process was not running.
+            #
+            # Observed: `spark` carried "Claude is waiting for your input" across
+            # a restart and sat on the fleet's waiting list with no way to clear
+            # it. A real menu is different and IS restored — it describes a
+            # dialog still drawn on a screen, and a tap verifies it there.
+            if row[_MENU].get("source") == _NOTIFICATION:
                 continue
             # Marked so an operator reading a report can tell a menu observed this
             # process from one carried across a restart. Nothing branches on it —

--- a/runner/canopy_runner/tests/test_hook_menu.py
+++ b/runner/canopy_runner/tests/test_hook_menu.py
@@ -483,3 +483,30 @@ def test_a_notification_with_no_turn_ever_seen_fails_closed():
     hl = listener()
     hl.handle_payload(NOTIFY)
     assert hl.pending_menu(*KEY) is None
+
+
+def test_a_notification_marker_does_not_survive_a_restart(tmp_path):
+    """It is a claim that a turn was in flight, and turn state is deliberately
+    not persisted — so after a restart nothing can still justify it, and nothing
+    can retire it either: the `Stop` that would belongs to a turn that ended
+    while the process was down. Observed on `spark`, stuck on the fleet's waiting
+    list reading "Claude is waiting for your input" with no way to clear it."""
+    from canopy_runner.menu_store import MenuStore
+
+    path = tmp_path / "m.json"
+    hl = listener(menu_store=MenuStore(path))
+    hl.handle_payload(PROMPT)
+    hl.handle_payload(NOTIFY)
+    assert hl.pending_menu(*KEY) is not None
+
+    assert listener(menu_store=MenuStore(path)).pending_menu(*KEY) is None
+
+
+def test_a_real_menu_still_survives_a_restart(tmp_path):
+    """The distinction that makes the drop above safe: a real menu describes a
+    dialog still drawn on a screen, and a tap verifies it there."""
+    from canopy_runner.menu_store import MenuStore
+
+    path = tmp_path / "m.json"
+    listener(menu_store=MenuStore(path)).handle_payload(ASK)
+    assert listener(menu_store=MenuStore(path)).pending_menu(*KEY) is not None


### PR DESCRIPTION
#568 stops a merely-idle session being reported as blocked, but it cannot undo the ones already written. `spark` came back from the pending-menu store still reading *"Claude is waiting for your input"* and sat on the fleet's waiting list with no way to clear itself.

Two designs from tonight met badly:

- A **notification marker** is a claim that a turn was in flight (#568).
- **Turn state is deliberately not persisted** — after a restart we genuinely don't know, and silence is the safe answer.

So restoring one restores a claim nothing can still justify. Worse, it cannot decay: the `Stop` that would retire it belongs to a turn that ended while the process was down, so it is never coming. The marker is immortal.

Dropped at load. A real menu is a different thing and is still restored — it describes a dialog drawn on a screen that is still there, and a tap verifies it against that screen.

## Tests

- a notification marker does not survive a restart
- a real menu still does — the distinction that makes the drop safe

`runner/canopy_runner`: 424 passed. `ruff --select F`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)