### PR TITLE
Call the non-auto turn mode "manual"

### DIFF
--- a/apps/agents/api.py
+++ b/apps/agents/api.py
@@ -164,7 +164,7 @@ def set_runner_preference(request: HttpRequest, slug: str, payload: RunnerPrefer
 
 
 @router.patch("/{slug}/turn-mode", response=AgentDetailOut,
-              summary="Set an agent's turn mode (gated | auto)")
+              summary="Set an agent's turn mode (manual | auto)")
 def set_turn_mode(request: HttpRequest, slug: str, payload: TurnModeIn) -> AgentDetailOut:
     """Flip the agent's runtime autonomy posture — the board-side switch the
     fleet turn procedure reads at preflight (agent-core/turn.md § Turn mode).

--- a/apps/agents/migrations/0015_alter_agent_turn_mode.py
+++ b/apps/agents/migrations/0015_alter_agent_turn_mode.py
@@ -1,0 +1,35 @@
+"""Rename the non-auto turn mode: `gated` -> `manual`.
+
+`gated` described the mechanism (an approval gate); `manual` describes what the
+operator actually does, which is the word the humans running the fleet use. The
+value is stored, so the choices change alone is not enough — AlterField only
+rewrites Python-level choices/default and would leave every existing row saying
+`gated`, which no longer validates and would render as an unknown mode in the UI.
+Hence the RunPython backfill, and a reverse that puts the old value back so this
+migration is not a one-way door.
+"""
+from django.db import migrations, models
+
+
+def gated_to_manual(apps, schema_editor):
+    apps.get_model("agents", "Agent").objects.filter(turn_mode="gated").update(turn_mode="manual")
+
+
+def manual_to_gated(apps, schema_editor):
+    apps.get_model("agents", "Agent").objects.filter(turn_mode="manual").update(turn_mode="gated")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('agents', '0014_agent_turn_mode'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='agent',
+            name='turn_mode',
+            field=models.CharField(choices=[('manual', 'manual (outbound waits for human approval)'), ('auto', 'auto (self-review-and-send, audit on the board)')], default='manual', max_length=8),
+        ),
+        migrations.RunPython(gated_to_manual, manual_to_gated),
+    ]

--- a/apps/agents/models.py
+++ b/apps/agents/models.py
@@ -79,10 +79,10 @@ class Agent(models.Model):
     # field in the agent's repo. Flipped only by a human (the /agents/<slug>
     # toggle or PATCH /turn-mode); deliberately absent from AgentIn so a repo's
     # self-publish upsert can never change its own autonomy.
-    GATED, AUTO = "gated", "auto"
-    TURN_MODE_CHOICES = [(GATED, "gated (outbound waits for human approval)"),
+    MANUAL, AUTO = "manual", "auto"
+    TURN_MODE_CHOICES = [(MANUAL, "manual (outbound waits for human approval)"),
                          (AUTO, "auto (self-review-and-send, audit on the board)")]
-    turn_mode = models.CharField(max_length=8, choices=TURN_MODE_CHOICES, default=GATED)
+    turn_mode = models.CharField(max_length=8, choices=TURN_MODE_CHOICES, default=MANUAL)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 

--- a/apps/agents/schemas.py
+++ b/apps/agents/schemas.py
@@ -50,7 +50,7 @@ class TurnModeIn(StrictModel):
     Deliberately its own endpoint (not part of AgentIn): the agent-repo
     self-publish upsert must never be able to change its own autonomy."""
 
-    turn_mode: Literal["gated", "auto"]
+    turn_mode: Literal["manual", "auto"]
 
 
 class AgentRunnerOut(StrictModel):
@@ -173,11 +173,11 @@ class AgentOut(StrictModel):
     # the Agent.runner_preference JSONField by AgentOut.model_validate(agent);
     # AgentDetailOut inherits it.
     runner_preference: list[str] = Field(default_factory=list)
-    # Runtime autonomy posture (gated | auto) — operational state a turn reads
+    # Runtime autonomy posture (manual | auto) — operational state a turn reads
     # at preflight, flipped from the board. On the base schema so both the
     # agents LIST and the detail view carry it. Literal so the generated TS
     # client gets the union, not string.
-    turn_mode: Literal["gated", "auto"] = "gated"
+    turn_mode: Literal["manual", "auto"] = "manual"
 
 
 class AgentDetailOut(AgentOut):

--- a/frontend/src/api/agents.ts
+++ b/frontend/src/api/agents.ts
@@ -213,7 +213,7 @@ export async function getAgentRunners(slug: string): Promise<AgentRunnerOut[]> {
   return Array.from(unwrap(res, 'getAgentRunners'))
 }
 
-// Flip the agent's runtime autonomy posture (gated | auto) — the board-side
+// Flip the agent's runtime autonomy posture (manual | auto) — the board-side
 // switch the fleet turn procedure reads at preflight. A human decision; the
 // agent's own repo publish can't touch it.
 //

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -1434,7 +1434,7 @@ export interface paths {
         readonly options?: never;
         readonly head?: never;
         /**
-         * Set an agent's turn mode (gated | auto)
+         * Set an agent's turn mode (manual | auto)
          * @description Flip the agent's runtime autonomy posture — the board-side switch the
          *     fleet turn procedure reads at preflight (agent-core/turn.md § Turn mode).
          *     A human decision made from the board; the agent-repo upsert (POST /) cannot
@@ -6046,10 +6046,10 @@ export interface components {
             readonly runner_preference?: readonly string[];
             /**
              * Turn Mode
-             * @default gated
+             * @default manual
              * @enum {string}
              */
-            readonly turn_mode: "gated" | "auto";
+            readonly turn_mode: "manual" | "auto";
         };
         /** Page[AgentOut] */
         readonly Page_AgentOut_: {
@@ -6139,10 +6139,10 @@ export interface components {
             readonly runner_preference?: readonly string[];
             /**
              * Turn Mode
-             * @default gated
+             * @default manual
              * @enum {string}
              */
-            readonly turn_mode: "gated" | "auto";
+            readonly turn_mode: "manual" | "auto";
             /**
              * Sync Count
              * @default 0
@@ -6193,7 +6193,7 @@ export interface components {
              * Turn Mode
              * @enum {string}
              */
-            readonly turn_mode: "gated" | "auto";
+            readonly turn_mode: "manual" | "auto";
         };
         /**
          * AgentRuntimeOut

--- a/frontend/src/components/agents/TurnModeToggle.test.tsx
+++ b/frontend/src/components/agents/TurnModeToggle.test.tsx
@@ -20,14 +20,14 @@ afterEach(() => {
 
 describe('TurnModeToggle', () => {
   it('renders the initial mode as checked', () => {
-    render(<TurnModeToggle agentSlug="echo" initialMode="gated" />)
-    expect(checked('turn-mode-gated')).toBe('true')
+    render(<TurnModeToggle agentSlug="echo" initialMode="manual" />)
+    expect(checked('turn-mode-manual')).toBe('true')
     expect(checked('turn-mode-auto')).toBe('false')
   })
 
   it('flips the mode through the API on click', async () => {
     setAgentTurnMode.mockResolvedValue('auto')
-    render(<TurnModeToggle agentSlug="echo" initialMode="gated" />)
+    render(<TurnModeToggle agentSlug="echo" initialMode="manual" />)
     fireEvent.click(screen.getByTestId('turn-mode-auto'))
     await waitFor(() => expect(setAgentTurnMode).toHaveBeenCalledWith('echo', 'auto'))
     expect(checked('turn-mode-auto')).toBe('true')
@@ -35,10 +35,10 @@ describe('TurnModeToggle', () => {
 
   it('reverts and shows the error when the API rejects', async () => {
     setAgentTurnMode.mockRejectedValue(new Error('nope'))
-    render(<TurnModeToggle agentSlug="echo" initialMode="gated" />)
+    render(<TurnModeToggle agentSlug="echo" initialMode="manual" />)
     fireEvent.click(screen.getByTestId('turn-mode-auto'))
     await waitFor(() => expect(screen.getByText(/nope/)).toBeTruthy())
-    expect(checked('turn-mode-gated')).toBe('true')
+    expect(checked('turn-mode-manual')).toBe('true')
   })
 
   it('clicking the current mode is a no-op', () => {

--- a/frontend/src/components/agents/TurnModeToggle.tsx
+++ b/frontend/src/components/agents/TurnModeToggle.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { setAgentTurnMode, type TurnMode } from '@/api/agents'
 
 const MODES: { mode: TurnMode; label: string; blurb: string }[] = [
-  { mode: 'gated', label: 'Gated', blurb: 'Outbound actions wait for your approval.' },
+  { mode: 'manual', label: 'Manual', blurb: 'Outbound actions wait for your approval.' },
   { mode: 'auto', label: 'Auto', blurb: 'Self-review-and-send; audit lands here on the board.' },
 ]
 

--- a/frontend/src/components/supervisor/AgentKpiCard.test.tsx
+++ b/frontend/src/components/supervisor/AgentKpiCard.test.tsx
@@ -21,7 +21,7 @@ function agent(overrides: Partial<AgentOut> = {}): AgentOut {
     avatar_url: '',
     workspace: 'canopy',
     runner_preference: [],
-    turn_mode: 'gated',
+    turn_mode: 'manual',
     created_at: '2026-07-31T00:00:00Z',
     updated_at: '2026-07-31T00:00:00Z',
     ...overrides,
@@ -56,31 +56,31 @@ describe('AgentKpiCard turn-mode chip', () => {
     renderCard(agent({ turn_mode: 'auto' }))
     expect(screen.getByTestId('agent-mode-echo').textContent).toBe('Auto')
     cleanup()
-    renderCard(agent({ turn_mode: 'gated' }))
-    expect(screen.getByTestId('agent-mode-echo').textContent).toBe('Gated')
+    renderCard(agent({ turn_mode: 'manual' }))
+    expect(screen.getByTestId('agent-mode-echo').textContent).toBe('Manual')
   })
 
   it('turning auto ON asks first, then flips', async () => {
-    renderCard(agent({ turn_mode: 'gated' }))
+    renderCard(agent({ turn_mode: 'manual' }))
     fireEvent.click(screen.getByTestId('agent-mode-echo'))
     expect(window.confirm).toHaveBeenCalledOnce()
     await waitFor(() => expect(setAgentTurnMode).toHaveBeenCalledWith('echo', 'auto'))
     expect(screen.getByTestId('agent-mode-echo').textContent).toBe('Auto')
   })
 
-  it('declining the confirm leaves the agent gated and calls nothing', () => {
+  it('declining the confirm leaves the agent manual and calls nothing', () => {
     vi.spyOn(window, 'confirm').mockReturnValue(false)
-    renderCard(agent({ turn_mode: 'gated' }))
+    renderCard(agent({ turn_mode: 'manual' }))
     fireEvent.click(screen.getByTestId('agent-mode-echo'))
     expect(setAgentTurnMode).not.toHaveBeenCalled()
-    expect(screen.getByTestId('agent-mode-echo').textContent).toBe('Gated')
+    expect(screen.getByTestId('agent-mode-echo').textContent).toBe('Manual')
   })
 
   it('turning auto OFF needs no confirm — the safe direction is one tap', async () => {
     renderCard(agent({ turn_mode: 'auto' }))
     fireEvent.click(screen.getByTestId('agent-mode-echo'))
     expect(window.confirm).not.toHaveBeenCalled()
-    await waitFor(() => expect(setAgentTurnMode).toHaveBeenCalledWith('echo', 'gated'))
+    await waitFor(() => expect(setAgentTurnMode).toHaveBeenCalledWith('echo', 'manual'))
   })
 
   it('tapping the chip does not navigate to the agent page', async () => {

--- a/frontend/src/components/supervisor/AgentKpiCard.tsx
+++ b/frontend/src/components/supervisor/AgentKpiCard.tsx
@@ -10,9 +10,9 @@ import { setAgentTurnMode, type AgentOut, type TurnMode } from '@/api/agents'
 // It lives INSIDE the card's <Link>, so every handler preventDefault +
 // stopPropagation — a tap on the chip must never also navigate.
 //
-// Asymmetric by design. gated -> auto hands an agent permission to send without
+// Asymmetric by design. manual -> auto hands an agent permission to send without
 // asking, so it takes a confirm (a fat-fingered tap on a phone must not put an
-// agent on the loose). auto -> gated only ever REMOVES permission, so it applies
+// agent on the loose). auto -> manual only ever REMOVES permission, so it applies
 // on first tap: never make the safe direction harder than the dangerous one.
 function TurnModeChip({ slug, mode }: { slug: string; mode: TurnMode }): JSX.Element {
   const [current, setCurrent] = useState<TurnMode>(mode)
@@ -23,7 +23,7 @@ function TurnModeChip({ slug, mode }: { slug: string; mode: TurnMode }): JSX.Ele
     e.preventDefault()
     e.stopPropagation()
     if (busy) return
-    const next: TurnMode = current === 'auto' ? 'gated' : 'auto'
+    const next: TurnMode = current === 'auto' ? 'manual' : 'auto'
     if (
       next === 'auto' &&
       !window.confirm(
@@ -55,11 +55,11 @@ function TurnModeChip({ slug, mode }: { slug: string; mode: TurnMode }): JSX.Ele
       onClick={(e) => void onTap(e)}
       disabled={busy}
       data-testid={`agent-mode-${slug}`}
-      aria-label={`${slug} turn mode: ${current}. Activate to switch to ${auto ? 'gated' : 'auto'}.`}
+      aria-label={`${slug} turn mode: ${current}. Activate to switch to ${auto ? 'manual' : 'auto'}.`}
       title={
         auto
           ? 'Auto — sends without waiting for you. Tap to require approval again.'
-          : 'Gated — outbound waits for your approval. Tap to allow unattended sending.'
+          : 'Manual — outbound waits for your approval. Tap to allow unattended sending.'
       }
       className={`shrink-0 rounded border px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-[0.06em] transition-colors disabled:opacity-50 ${
         auto
@@ -67,7 +67,7 @@ function TurnModeChip({ slug, mode }: { slug: string; mode: TurnMode }): JSX.Ele
           : 'border-border bg-muted/40 text-muted-foreground'
       }`}
     >
-      {failed ? 'Retry' : auto ? 'Auto' : 'Gated'}
+      {failed ? 'Retry' : auto ? 'Auto' : 'Manual'}
     </button>
   )
 }

--- a/tests/test_agent_turn_mode_api.py
+++ b/tests/test_agent_turn_mode_api.py
@@ -51,10 +51,10 @@ def _patch(client, slug, mode):
     )
 
 
-def test_new_agent_defaults_to_gated(client, agent):
+def test_new_agent_defaults_to_manual(client, agent):
     res = client.get(f"/api/agents/{agent.slug}/")
     assert res.status_code == 200
-    assert res.json()["turn_mode"] == "gated"
+    assert res.json()["turn_mode"] == "manual"
 
 
 def test_patch_flips_mode_and_returns_it(client, agent):
@@ -64,17 +64,17 @@ def test_patch_flips_mode_and_returns_it(client, agent):
     agent.refresh_from_db()
     assert agent.turn_mode == Agent.AUTO
 
-    res = _patch(client, agent.slug, "gated")
+    res = _patch(client, agent.slug, "manual")
     assert res.status_code == 200
     agent.refresh_from_db()
-    assert agent.turn_mode == Agent.GATED
+    assert agent.turn_mode == Agent.MANUAL
 
 
 def test_patch_rejects_unknown_mode(client, agent):
     res = _patch(client, agent.slug, "yolo")
     assert res.status_code == 422
     agent.refresh_from_db()
-    assert agent.turn_mode == Agent.GATED
+    assert agent.turn_mode == Agent.MANUAL
 
 
 def test_repo_upsert_cannot_touch_turn_mode(client, agent):
@@ -95,7 +95,7 @@ def test_repo_upsert_cannot_touch_turn_mode(client, agent):
     # …and naming the field outright is rejected (AgentIn is strict).
     res = client.post(
         "/api/agents/",
-        data=json.dumps({"slug": "echo", "name": "Echo", "turn_mode": "gated"}),
+        data=json.dumps({"slug": "echo", "name": "Echo", "turn_mode": "manual"}),
         content_type="application/json",
     )
     assert res.status_code == 422
@@ -109,3 +109,41 @@ def test_patch_404s_outside_visible_workspaces(client, agent):
     Agent.objects.create(slug="eva", name="Eva", workspace=other_ws)
     res = _patch(client, "eva", "auto")
     assert res.status_code == 404
+
+
+def test_migration_0015_backfill_renames_stored_gated_rows(agent):
+    """The rename is a DATA change, not just a choices change: any row written
+    before 0015 holds the literal 'gated'. AlterField alone would strand those
+    on a value that no longer validates, so the migration carries a RunPython —
+    this exercises that function against a row forced back to the old value."""
+    import importlib
+
+    from django.apps import apps as django_apps
+
+    mig = importlib.import_module("apps.agents.migrations.0015_alter_agent_turn_mode")
+
+    # .update() bypasses field validation, which is exactly how the pre-rename
+    # rows exist in the deployed DB.
+    Agent.objects.filter(pk=agent.pk).update(turn_mode="gated")
+    mig.gated_to_manual(django_apps, None)
+    agent.refresh_from_db()
+    assert agent.turn_mode == "manual"
+
+    # And it reverses, so 0015 is not a one-way door.
+    mig.manual_to_gated(django_apps, None)
+    agent.refresh_from_db()
+    assert agent.turn_mode == "gated"
+
+
+def test_migration_0015_backfill_leaves_auto_agents_alone(agent):
+    """Only the renamed value moves — an agent someone put in auto must not be
+    quietly de-escalated by a rename migration."""
+    import importlib
+
+    from django.apps import apps as django_apps
+
+    mig = importlib.import_module("apps.agents.migrations.0015_alter_agent_turn_mode")
+    Agent.objects.filter(pk=agent.pk).update(turn_mode="auto")
+    mig.gated_to_manual(django_apps, None)
+    agent.refresh_from_db()
+    assert agent.turn_mode == "auto"


### PR DESCRIPTION
## Problem
`gated` named the mechanism — there's an approval gate in the path. `manual` names what the operator actually does, and it's the word we use out loud. The label was wrong.

## Solution
Rename the value across the model, schemas, API summary, and both UI surfaces (the agent-page toggle and the supervisor chip).

**This is a stored value, so it needs a data migration, not just a choices change.** `AlterField` rewrites only Python-level choices/default — every existing row would still say `gated`, which no longer validates and would render as an unknown mode. Migration 0015 backfills `gated → manual` and reverses cleanly, so it isn't a one-way door.

Rollout is fail-safe in the gap before canopy 0.2.388 reaches every install: an older reader looking for `auto` doesn't match `manual` and falls through to approval-required behavior. The dangerous direction — accidentally reading `auto` — can't happen.

## Confidence
7 backend tests (default is now manual, flip both ways, 422 on unknown, upsert still can't touch it, cross-tenant 404, **plus the migration backfill and its reverse, and that it leaves `auto` agents alone** — a rename must not quietly de-escalate an agent someone put in auto). 11 frontend tests. `npm run build` clean; client regenerated.

Companion PRs update canopy (`agent-core/turn.md` + CLI fallback) and echo's docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)