### PR TITLE
Reading a runner's credential status shouldn't rewrite it

### DIFF
--- a/apps/harness/api.py
+++ b/apps/harness/api.py
@@ -350,6 +350,20 @@ def set_runner_credential(request: HttpRequest, runner_id: uuid.UUID, payload: R
     return services.runner_credential_status(runner)
 
 
+@router.get("/runners/{runner_id}/credential/status", response=RunnerCredentialStatusOut,
+            summary="Which credential slots are set (masked — booleans, never values)")
+def get_runner_credential_status(request: HttpRequest, runner_id: uuid.UUID):
+    """The operator's read: which slots are filled, without putting a secret on a
+    screen. Separate from the GET below, which returns REAL VALUES for the runner
+    to consume.
+
+    Exists because the only way to read this used to be a no-op POST — and that
+    WROTE, bumping `updated_at`/`updated_by` and destroying the one signal that
+    says when a credential was last actually rotated."""
+    runner = _runner_or_404(request, runner_id)
+    return services.runner_credential_status(runner)
+
+
 @router.get("/runners/{runner_id}/credential", response=RunnerCredentialOut,
             summary="Fetch this runner's credential bundle (the runner, via its PAT)")
 def get_runner_credential(request: HttpRequest, runner_id: uuid.UUID) -> RunnerCredentialOut:

--- a/apps/harness/services.py
+++ b/apps/harness/services.py
@@ -1878,6 +1878,13 @@ def set_runner_credential(runner, *, claude_token=None, claude_token_secondary=N
 
     from .models import RunnerCredential
 
+    # An all-None call is a READ dressed as a write (the shape the CLI used before
+    # there was a status endpoint). Don't create a row and don't touch
+    # updated_at/updated_by for it — that timestamp is the audit trail for when a
+    # credential last actually changed.
+    if all(v is None for v in (claude_token, claude_token_secondary, claude_api_key,
+                               github_token, op_sa_token)):
+        return getattr(runner, "credential", None)
     cred, _ = RunnerCredential.objects.get_or_create(runner=runner)
     if claude_token is not None:
         cred.claude_token_enc = encrypt_secret(claude_token)

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -2295,6 +2295,32 @@ export interface paths {
         readonly patch?: never;
         readonly trace?: never;
     };
+    readonly "/api/harness/runners/{runner_id}/credential/status": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        /**
+         * Which credential slots are set (masked — booleans, never values)
+         * @description The operator's read: which slots are filled, without putting a secret on a
+         *     screen. Separate from the GET below, which returns REAL VALUES for the runner
+         *     to consume.
+         *
+         *     Exists because the only way to read this used to be a no-op POST — and that
+         *     WROTE, bumping `updated_at`/`updated_by` and destroying the one signal that
+         *     says when a credential was last actually rotated.
+         */
+        readonly get: operations["apps_harness_api_get_runner_credential_status"];
+        readonly put?: never;
+        readonly post?: never;
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
     readonly "/api/harness/runners/{runner_id}": {
         readonly parameters: {
             readonly query?: never;
@@ -12939,6 +12965,28 @@ export interface operations {
                 readonly "application/json": components["schemas"]["RunnerCredentialIn"];
             };
         };
+        readonly responses: {
+            /** @description OK */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["RunnerCredentialStatusOut"];
+                };
+            };
+        };
+    };
+    readonly apps_harness_api_get_runner_credential_status: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path: {
+                readonly runner_id: string;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
         readonly responses: {
             /** @description OK */
             readonly 200: {

--- a/tests/test_runner_credential.py
+++ b/tests/test_runner_credential.py
@@ -133,3 +133,41 @@ def test_api_key_is_encrypted_at_rest_like_the_rest(client, runner):
     cred = RunnerCredential.objects.get(runner=runner)
     assert cred.claude_api_key_enc
     assert "sk-ant-secret" not in cred.claude_api_key_enc
+
+
+# --- reading status must not be a write --------------------------------------
+def test_status_endpoint_is_masked_and_does_not_touch_the_audit_trail(client, runner):
+    """Reading which slots are set used to require a no-op POST, which WROTE —
+    bumping updated_at and destroying the only signal for when a credential was
+    last actually rotated."""
+    client.post(_cred_url(runner), data={"claude_token": "SUB1"},
+                content_type="application/json")
+    before = RunnerCredential.objects.get(runner=runner).updated_at
+
+    resp = client.get(_cred_url(runner) + "/status")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["has_claude_token"] is True
+    assert "SUB1" not in resp.content.decode()          # masked, never values
+
+    assert RunnerCredential.objects.get(runner=runner).updated_at == before
+
+
+def test_an_all_none_update_neither_creates_nor_stamps(client, runner):
+    """The old read-as-write shape, now inert."""
+    assert not RunnerCredential.objects.filter(runner=runner).exists()
+    resp = client.post(_cred_url(runner), data={}, content_type="application/json")
+    assert resp.status_code == 200
+    assert not RunnerCredential.objects.filter(runner=runner).exists()
+
+    client.post(_cred_url(runner), data={"claude_token": "C"}, content_type="application/json")
+    stamped = RunnerCredential.objects.get(runner=runner).updated_at
+    client.post(_cred_url(runner), data={}, content_type="application/json")
+    assert RunnerCredential.objects.get(runner=runner).updated_at == stamped
+
+
+def test_status_is_owner_gated_like_the_rest(runner):
+    other = User.objects.create_user("other2", "other2@dimagi.com", "pw")
+    c = Client()
+    c.force_login(other)
+    assert c.get(_cred_url(runner) + "/status").status_code == 404


### PR DESCRIPTION
## Problem
There was no way to read which credential slots are set without a **no-op POST** — and that POST wrote: it created the row and bumped `updated_at`/`updated_by`. So the only audit signal for *when a credential was last actually rotated* got clobbered by looking at it.

Caught in practice within hours of shipping #578: a `canopy runner credential --show` restamped cloud-ec2-1's row to today, right when that timestamp was evidence in diagnosing which account the box's capped token belonged to.

## Solution
- `GET /runners/{id}/credential/status` — masked booleans, owner-gated. Distinct from the existing GET, which returns real values for the *runner* to consume and shouldn't be used to draw an operator checklist.
- An all-None update is now inert: no row created, no timestamp touched.

## Confidence
3 new tests — status is masked and leaves `updated_at` untouched, an all-None POST neither creates nor stamps, and status is owner-gated (404 for a non-owner, no existence leak). Suite green (10 passed); client regenerated, build clean.

Follow-up: the CLI's `--show` should call this endpoint (canopy side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)