### PR TITLE
fix(walkthroughs): a logged-out visitor gets a sign-in, not a dead end

### DIFF
--- a/frontend/src/api/client.v2.ts
+++ b/frontend/src/api/client.v2.ts
@@ -1,6 +1,7 @@
 import createClient from "openapi-fetch";
 import type { paths } from "./generated";
 import { API_BASE, getCsrfToken } from "./base";
+import { currentNext, loginHref } from "../auth/loginHref";
 
 // A lapsed session should bounce the user through OAuth exactly ONCE. The guard
 // below is what makes that a bounce and not a loop: if we land back here still
@@ -75,11 +76,10 @@ function redirectToLogin(): void {
   } catch {
     /* unavailable — a best-effort guard is better than blocking the redirect */
   }
-  const next = encodeURIComponent(window.location.pathname + window.location.search);
   loginBounceInFlight = true;
   // Prefix-aware: BASE_URL is "/" at root and "/canopy/" as a labs tenant, so
   // this stays under the deployment instead of bouncing to a sibling tenant.
-  window.location.href = `${import.meta.env.BASE_URL.replace(/\/$/, '')}/accounts/google/login/?next=${next}`;
+  window.location.href = loginHref(currentNext());
 }
 
 // Per-token public-link routes (e.g. /review/<id>?t=…) self-gate on their share

--- a/frontend/src/api/walkthroughs.ts
+++ b/frontend/src/api/walkthroughs.ts
@@ -1,6 +1,27 @@
 import { apiV2 } from "./client.v2";
 import type { components } from "./generated";
 import { withBase } from "../lib/basePath";
+import { problemMessage } from "./problem";
+
+/**
+ * A failed walkthrough call, carrying the HTTP status.
+ *
+ * The status is the whole point: a private walkthrough 404s to an anonymous
+ * caller (deliberate existence-hiding), which is indistinguishable from a
+ * genuine network failure once it has been flattened into a bare
+ * `Error("Failed to load walkthrough")`. The viewer needs the number to offer a
+ * sign-in instead of a dead end — canopy-web#516.
+ *
+ * Same shape as `WorkspaceApiError`; see the note in `workspaces.ts` for why
+ * these branch on `res.response.ok` rather than `res.error`.
+ */
+export class WalkthroughApiError extends Error {
+  status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+  }
+}
 
 export type WalkthroughKind = "html" | "video";
 export type WalkthroughVisibility = "private" | "link";
@@ -43,17 +64,22 @@ export async function getWalkthrough(
   id: string,
   token?: string | null,
 ): Promise<WalkthroughDetail> {
-  const { data, error } = await apiV2.GET("/api/walkthroughs/{wid}/", {
+  const res = await apiV2.GET("/api/walkthroughs/{wid}/", {
     params: {
       path: { wid: id },
       ...(token ? { query: { t: token } } : {}),
     },
   });
-  if (error) throw new Error("Failed to load walkthrough");
+  if (!res.response.ok) {
+    throw new WalkthroughApiError(
+      res.response.status,
+      problemMessage(res.error, "Failed to load walkthrough"),
+    );
+  }
   // openapi-fetch's immutable response type deep-freezes the `links` array
   // (method signatures become `{}`), which no longer structurally matches the
   // plain schema alias. Same cast `listWalkthroughs` uses for its array body.
-  return data as unknown as WalkthroughDetail;
+  return res.data as unknown as WalkthroughDetail;
 }
 
 export async function patchWalkthrough(

--- a/frontend/src/auth/AuthProvider.tsx
+++ b/frontend/src/auth/AuthProvider.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext, useEffect, useState, type ReactNode } from '
 import { bootstrapCsrf } from '@/api/csrf'
 import { isLoginBounceInFlight, noteAuthSucceeded } from '@/api/client.v2'
 import { getMe, type MeOut as MeResponse } from '@/api/me'
+import { currentNext, loginHref } from './loginHref'
 
 type AuthState =
   | { status: 'loading'; user: null }
@@ -102,8 +103,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 }
 
 function LoginPrompt() {
-  const next = encodeURIComponent(window.location.pathname + window.location.search)
-  const loginHref = `${import.meta.env.BASE_URL.replace(/\/$/, '')}/accounts/google/login/?next=${next}`
+  const href = loginHref(currentNext())
   return (
     <div className="min-h-screen bg-background text-foreground-secondary flex items-center justify-center px-6">
       <div className="max-w-md w-full bg-card border border-border rounded-xl p-8 text-center">
@@ -114,7 +114,7 @@ function LoginPrompt() {
           Sign in with your Dimagi Google account to continue.
         </p>
         <a
-          href={loginHref}
+          href={href}
           className="inline-block w-full rounded-lg bg-primary text-white font-medium py-2.5 hover:bg-primary/90 transition-colors"
         >
           Sign in with Google

--- a/frontend/src/auth/loginHref.test.ts
+++ b/frontend/src/auth/loginHref.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { loginHref } from './loginHref'
+
+describe('loginHref', () => {
+  it('points at the Google OAuth entry under the deployment prefix', () => {
+    // BASE_URL is "/" under vitest, so the prefix collapses to "" — the
+    // trailing-slash strip is what keeps this from becoming "//accounts/…".
+    expect(loginHref('/walkthrough/abc')).toBe(
+      '/accounts/google/login/?next=%2Fwalkthrough%2Fabc',
+    )
+  })
+
+  it('encodes the next target so a query string survives the round trip', () => {
+    // The share token rides in ?t=; an unencoded & would truncate `next` at the
+    // first param and drop the visitor somewhere they did not ask for.
+    const href = loginHref('/walkthrough/abc?t=tok&x=1')
+    expect(href).toContain('next=%2Fwalkthrough%2Fabc%3Ft%3Dtok%26x%3D1')
+    expect(href.split('?')).toHaveLength(2)
+  })
+})

--- a/frontend/src/auth/loginHref.ts
+++ b/frontend/src/auth/loginHref.ts
@@ -1,0 +1,29 @@
+/**
+ * The Google OAuth entry URL, returning to `next` once the session is
+ * established.
+ *
+ * Prefix-aware: `BASE_URL` is `/` at the root deployment and `/canopy/` as a
+ * labs tenant, so the bounce stays under THIS deployment rather than landing on
+ * a sibling tenant's login.
+ *
+ * It lives here because four call sites built this same string by hand — the
+ * API client's 401 bounce, the full-page login card, the invite accept page,
+ * and (canopy-web#516) the walkthrough viewer's anonymous branch. A prefix rule
+ * copied five times is a prefix rule that drifts; copied once, it can't.
+ */
+export function loginHref(next: string): string {
+  const base = (import.meta.env.BASE_URL || '/').replace(/\/$/, '')
+  return `${base}/accounts/google/login/?next=${encodeURIComponent(next)}`
+}
+
+/**
+ * The current location as the `next` to come back to after signing in.
+ *
+ * Path + search deliberately, never the hash: the fragment never reaches the
+ * server, so round-tripping it through `?next=` would be theatre. (A walkthrough
+ * deep link like `#scene-3` is lost across the bounce either way — that is the
+ * browser's contract, not ours.)
+ */
+export function currentNext(): string {
+  return window.location.pathname + window.location.search
+}

--- a/frontend/src/pages/InviteAcceptPage.tsx
+++ b/frontend/src/pages/InviteAcceptPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, type JSX, type ReactNode } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { Button } from 'canopy-ui/ui'
 import { useAuth } from '@/auth/AuthProvider'
+import { loginHref } from '@/auth/loginHref'
 import { getCsrfToken } from '@/api/base'
 import { acceptInvite, previewInvite, WorkspaceApiError, type InvitePreviewOut } from '@/api/workspaces'
 
@@ -15,11 +16,6 @@ const TERMINAL_MESSAGE: Record<string, string> = {
   expired: 'This invite link has expired. Ask the workspace owner to send you a new one.',
   revoked: 'This invite has been revoked.',
   accepted: 'This invite has already been accepted.',
-}
-
-function loginHref(next: string): string {
-  const base = (import.meta.env.BASE_URL || '/').replace(/\/$/, '')
-  return `${base}/accounts/google/login/?next=${encodeURIComponent(next)}`
 }
 
 function Centered({ children }: { children: ReactNode }): JSX.Element {

--- a/frontend/src/pages/WalkthroughViewerPage.test.tsx
+++ b/frontend/src/pages/WalkthroughViewerPage.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { AuthContext } from '@/auth/AuthProvider'
+import { WalkthroughViewerPage } from './WalkthroughViewerPage'
+import * as api from '@/api/walkthroughs'
+
+vi.mock('@/api/walkthroughs', async () => {
+  const actual = await vi.importActual<typeof api>('@/api/walkthroughs')
+  return { ...actual, getWalkthrough: vi.fn() }
+})
+
+const getWalkthrough = api.getWalkthrough as unknown as ReturnType<typeof vi.fn>
+
+type AuthState = React.ContextType<typeof AuthContext>
+
+const ANON: AuthState = { status: 'anonymous', user: null }
+const AUTHED = {
+  status: 'authenticated',
+  user: { email: 'hal@dimagi-ai.com' },
+} as unknown as AuthState
+
+function renderAt(path: string, auth: AuthState) {
+  return render(
+    <AuthContext.Provider value={auth}>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route path="/walkthrough/:id" element={<WalkthroughViewerPage />} />
+        </Routes>
+      </MemoryRouter>
+    </AuthContext.Provider>,
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+  window.history.replaceState({}, '', '/')
+})
+
+describe('WalkthroughViewerPage — anonymous visitor on a private walkthrough (#516)', () => {
+  it('offers sign-in rather than a bare error when the detail fetch 404s', async () => {
+    getWalkthrough.mockRejectedValue(new api.WalkthroughApiError(404, 'Not found'))
+
+    renderAt('/walkthrough/w-1', ANON)
+
+    const link = await screen.findByRole('link', { name: /sign in with google/i })
+    expect(link.getAttribute('href')).toContain('/accounts/google/login/')
+    // The whole point of the fix: they land back on the walkthrough afterwards.
+    expect(link.getAttribute('href')).toContain('next=')
+    expect(screen.queryByText(/Failed to load walkthrough/i)).toBeNull()
+  })
+
+  it.each([401, 403])('treats %i the same as 404 — all mean "you cannot see this"', async (status) => {
+    getWalkthrough.mockRejectedValue(new api.WalkthroughApiError(status, 'nope'))
+
+    renderAt('/walkthrough/w-1', ANON)
+
+    expect(await screen.findByRole('link', { name: /sign in with google/i })).toBeTruthy()
+  })
+
+  it('says the share link is stale when one was supplied and still refused', async () => {
+    // A ?t= holder is NOT simply logged out — their token was rotated or is
+    // wrong, so "this is shared with Dimagi" would be the wrong explanation.
+    window.history.replaceState({}, '', '/walkthrough/w-1?t=stale-token')
+    getWalkthrough.mockRejectedValue(new api.WalkthroughApiError(404, 'Not found'))
+
+    renderAt('/walkthrough/w-1?t=stale-token', ANON)
+
+    expect(await screen.findByText(/no longer valid/i)).toBeTruthy()
+  })
+
+  it('does NOT offer sign-in for a transient failure — that would be a lie', async () => {
+    // A network drop is not an access problem; sending the user through OAuth
+    // would "fix" it only by coincidence of the reload.
+    getWalkthrough.mockRejectedValue(new Error('Failed to fetch'))
+
+    renderAt('/walkthrough/w-1', ANON)
+
+    await waitFor(() => expect(screen.getByText(/Failed to fetch/)).toBeTruthy())
+    expect(screen.queryByRole('link', { name: /sign in with google/i })).toBeNull()
+  })
+})
+
+describe('WalkthroughViewerPage — signed-in visitor', () => {
+  it('names both live possibilities instead of offering a pointless re-login', async () => {
+    getWalkthrough.mockRejectedValue(new api.WalkthroughApiError(404, 'Not found'))
+
+    renderAt('/walkthrough/w-1', AUTHED)
+
+    expect(await screen.findByText(/Walkthrough not available/i)).toBeTruthy()
+    expect(screen.queryByRole('link', { name: /sign in with google/i })).toBeNull()
+  })
+})

--- a/frontend/src/pages/WalkthroughViewerPage.tsx
+++ b/frontend/src/pages/WalkthroughViewerPage.tsx
@@ -6,16 +6,23 @@ import {
   patchWalkthrough,
   rotateWalkthroughToken,
   walkthroughContentUrl,
+  WalkthroughApiError,
   type WalkthroughDetail,
 } from '../api/walkthroughs'
+import { useAuth } from '@/auth/AuthProvider'
+import { currentNext, loginHref } from '@/auth/loginHref'
 import { withSceneHash } from '../lib/sceneHash'
 import { timeHashSeconds, withTimeFragment } from '../lib/timeHash'
+
+/** A failed load, keeping the status so the render can tell the cases apart. */
+type LoadError = { status: number | null; message: string }
 
 export function WalkthroughViewerPage() {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
+  const auth = useAuth()
   const [w, setW] = useState<WalkthroughDetail | null>(null)
-  const [error, setError] = useState<string | null>(null)
+  const [error, setError] = useState<LoadError | null>(null)
   const [busy, setBusy] = useState(false)
   const [copied, setCopied] = useState(false)
   const shareToken = new URLSearchParams(window.location.search).get('t')
@@ -25,7 +32,13 @@ export function WalkthroughViewerPage() {
     let cancelled = false
     getWalkthrough(id, shareToken)
       .then((d) => !cancelled && setW(d))
-      .catch((e) => !cancelled && setError(String(e.message || e)))
+      .catch((e: unknown) => {
+        if (cancelled) return
+        setError({
+          status: e instanceof WalkthroughApiError ? e.status : null,
+          message: e instanceof Error ? e.message : String(e),
+        })
+      })
     return () => {
       cancelled = true
     }
@@ -39,7 +52,7 @@ export function WalkthroughViewerPage() {
       const updated = await patchWalkthrough(w.id, { visibility: next })
       setW(updated)
     } catch (e: any) {
-      setError(String(e?.message || e))
+      setError({ status: null, message: String(e?.message || e) })
     } finally {
       setBusy(false)
     }
@@ -56,7 +69,7 @@ export function WalkthroughViewerPage() {
       setCopied(true)
       setTimeout(() => setCopied(false), 2000)
     } catch (e: any) {
-      setError(String(e?.message || e))
+      setError({ status: null, message: String(e?.message || e) })
     }
   }
 
@@ -68,7 +81,7 @@ export function WalkthroughViewerPage() {
       const updated = await rotateWalkthroughToken(w.id)
       setW(updated)
     } catch (e: any) {
-      setError(String(e?.message || e))
+      setError({ status: null, message: String(e?.message || e) })
     } finally {
       setBusy(false)
     }
@@ -82,14 +95,72 @@ export function WalkthroughViewerPage() {
       await deleteWalkthrough(w.id)
       navigate('/walkthroughs')
     } catch (e: any) {
-      setError(String(e?.message || e))
+      setError({ status: null, message: String(e?.message || e) })
       setBusy(false)
     }
   }
 
   if (error) {
+    // A private walkthrough 404s to a caller who can't see it — deliberate
+    // existence-hiding, and correct. But "gated" and "gone" arrive here as the
+    // same status, so the ONLY honest thing to say is what the visitor can
+    // actually do next. For someone who simply hasn't signed in yet, that's
+    // sign in; the same 404 still applies afterwards if they genuinely lack
+    // access, so this leaks nothing they couldn't already infer. Before
+    // canopy-web#516 they got a bare red "Failed to load walkthrough" and
+    // reasonably concluded the link was broken — on a real shareout.
+    const gated = error.status === 401 || error.status === 403 || error.status === 404
+
+    if (gated && auth.status !== 'authenticated') {
+      return (
+        <div className="flex min-h-[60vh] items-center justify-center px-6">
+          <div className="max-w-md w-full rounded-xl border border-border bg-card p-8 text-center">
+            <h1 className="mb-2 text-lg font-semibold text-foreground">
+              Sign in to view this walkthrough
+            </h1>
+            <p className="mb-6 text-sm text-muted-foreground">
+              {shareToken
+                ? 'This share link is no longer valid — it may have been rotated. If you have a Dimagi account, sign in to view the walkthrough directly.'
+                : 'This walkthrough is shared with Dimagi. Sign in with your Dimagi Google account to open it.'}
+            </p>
+            <a
+              href={loginHref(currentNext())}
+              className="inline-block w-full rounded-lg bg-primary px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-primary/90"
+            >
+              Sign in with Google
+            </a>
+            {/* The card only renders for an anonymous visitor, so "already
+                signed in?" would be addressing nobody. The person who needs a
+                line here is the one for whom the button is a dead end: a
+                non-Dimagi recipient of a forwarded link. */}
+            <p className="mt-4 text-xs text-muted-foreground">
+              Not a Dimagi account? Ask whoever sent you the link to share it with you.
+            </p>
+          </div>
+        </div>
+      )
+    }
+
+    // Signed in and still refused: they ARE the audience and it still didn't
+    // resolve, so name both live possibilities rather than a generic failure.
+    if (gated) {
+      return (
+        <div className="flex min-h-[60vh] items-center justify-center px-6">
+          <div className="max-w-md w-full rounded-xl border border-border bg-card p-8 text-center">
+            <h1 className="mb-2 text-lg font-semibold text-foreground">
+              Walkthrough not available
+            </h1>
+            <p className="text-sm text-muted-foreground">
+              It may have been deleted, or it may not be shared with your account. Ask whoever
+              sent you the link to re-share it.
+            </p>
+          </div>
+        </div>
+      )
+    }
+
     return (
-      <div className="max-w-4xl mx-auto p-6 text-destructive/90">Error: {error}</div>
+      <div className="max-w-4xl mx-auto p-6 text-destructive/90">Error: {error.message}</div>
     )
   }
   if (!w) {


### PR DESCRIPTION
Closes #516.

## The problem

Opening a private walkthrough's **view** URL while logged out rendered a bare red
`Error: Failed to load walkthrough` on an otherwise empty page. That's the link most likely to
be sent — the uploader prints it first, and it's what gets pasted into a PR or a doc — so a
colleague who simply hasn't signed in yet this session concludes the link is broken. It happened
on a real shareout.

The 404 underneath is **correct and unchanged**: a private walkthrough hides its own existence
from a caller who can't see it. The defect was that the viewer couldn't tell that 404 apart from
a network failure, because `getWalkthrough` flattened every non-ok response into one status-less
`Error`.

## The fix

Carry the status (`WalkthroughApiError` — the same shape `workspaces.ts` already uses) and branch:

| state | before | after |
|---|---|---|
| anonymous + 401/403/404 | `Error: Failed to load walkthrough` | sign-in card, returning to this URL |
| anonymous + stale `?t=` | same | told the link was rotated (they're not merely logged out) |
| signed in + 401/403/404 | same | names both live possibilities: deleted, or not shared with you |
| network / anything else | same | **unchanged** |

This leaks nothing extra: an anonymous visitor already can't distinguish a private walkthrough
from a nonexistent one, and the same 404 still applies after signing in if they genuinely lack
access.

A network drop deliberately does **not** get the sign-in card — it isn't an access problem, and
routing it through OAuth would "fix" it only by coincidence of the reload.

## Drive-by

`loginHref()` / `currentNext()` are extracted to `auth/loginHref.ts`. Four call sites were
building that URL by hand — the API client's 401 bounce, the full-page login card, the invite
accept page — and this branch would have been the fifth. The prefix rule (`BASE_URL` is `/` at
root and `/canopy/` as a labs tenant) now lives in one place.

## Verification

Not just green tests — **rendered in the real app**, against a stub serving production's exact
responses (`/api/me/` 401, detail 404), at 1440x900 and 390x844. Confirmed the button's href
round-trips: `/accounts/google/login/?next=%2Fwalkthrough%2Fabc%3Ft%3Dstale`.

Looking at it is what caught a copy bug the tests never would have: the footnote read
"Already signed in?" on a card that only ever renders for someone who is *not*. It now addresses
the person the button is actually a dead end for — a non-Dimagi recipient of a forwarded link.

CI gates run locally:
- `npm run build` (`tsc -b` + `vite build`) — clean
- `npm run test` — **585 passed, 62 files**
- lint is not a CI gate here; verified this adds **no new** lint findings vs. baseline

The six new viewer tests fail **5/6** against the old render branch (the survivor is the
"don't offer sign-in for a network error" guard, which correctly holds in both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)