### PR TITLE
fix(runner): creating a task must not wait on frames nobody is drawing

### DIFF
--- a/runner/canopy_runner/canopy_runner/cdp/emdash_control.mjs
+++ b/runner/canopy_runner/canopy_runner/cdp/emdash_control.mjs
@@ -235,8 +235,41 @@ try {
     }
     const before = await taskNames();
     // Initial-conversation prompt is a contenteditable in the Create Task dialog.
-    const ce = page.locator('[role=dialog] [contenteditable="true"], [class*=Dialog] [contenteditable="true"]').first();
-    await ce.click();
+    //
+    // Focused via JS, NOT `locator.click()`. Playwright's click first waits for the
+    // element to be visible, enabled and STABLE — and "stable" means its box was
+    // unchanged across two ANIMATION FRAMES. macOS renders one login session at a
+    // time, so while the display belongs to the other macOS account this window
+    // paints nothing, no frames arrive, and the click hangs for its full 30s even
+    // though CDP answers perfectly. This was the file's last actionability-gated
+    // call and so its only occlusion-sensitive one, against the promise made at the
+    // top of this file; it cost two turns and marked the box not-ready on
+    // 2026-08-10, ~6 minutes after the other account logged in. Separate CDP ports
+    // isolate the two runners, but the SCREEN is machine-wide and cannot be split.
+    // `keyboard.insertText` dispatches to the focused element with no actionability
+    // check, so it needs no equivalent.
+    const CE_SELECTOR = '[role=dialog] [contenteditable="true"], [class*=Dialog] [contenteditable="true"]';
+    // The wait still has to exist — the dialog is React-rendered and the 1s above is
+    // not a guarantee. On 2026-07-30 this call site spent its 30s because the dialog
+    // never appeared AT ALL, which must stay a legible failure rather than become an
+    // instant false negative. It polls on a TIMER because Playwright's default
+    // polling is 'raf', which would reintroduce the exact dependency this removes.
+    try {
+      await page.waitForFunction((sel) => !!document.querySelector(sel),
+                                 CE_SELECTOR, { polling: 250, timeout: 30000 });
+    } catch {
+      fail('the New Task dialog never rendered its prompt editor');
+    }
+    const focusedPrompt = await page.evaluate((sel) => {
+      const ce = document.querySelector(sel);
+      if (!ce) return false;
+      ce.focus();
+      // Confirm focus actually MOVED. insertText goes wherever focus is, so a silent
+      // no-op here would type the prompt into the task-name input (or nowhere) and
+      // still report the task as created.
+      return document.activeElement === ce || ce.contains(document.activeElement);
+    }, CE_SELECTOR);
+    if (!focusedPrompt) fail('could not focus the New Task dialog prompt editor');
     await page.keyboard.insertText(prompt);   // atomic commit, not char-by-char
     const created = await page.evaluate(() => {
       const dlg = document.querySelector('[role=dialog],[class*=Dialog],[class*=modal]');

--- a/runner/canopy_runner/tests/test_cdp_occlusion_proof.py
+++ b/runner/canopy_runner/tests/test_cdp_occlusion_proof.py
@@ -1,0 +1,60 @@
+"""The CDP sidecar must stay occlusion-proof — a STATIC guard on emdash_control.mjs.
+
+The sidecar's header promises it "works while emdash is backgrounded (no foreground
+focus needed)", and the whole file is written to keep that promise: every click goes
+through `page.evaluate(... el.click())` rather than Playwright's `locator.click()`.
+
+The difference is not stylistic. `locator.click()` first waits for the element to be
+visible, enabled and STABLE, and "stable" means its bounding box was unchanged across
+two ANIMATION FRAMES. macOS renders one login session at a time, so while the display
+belongs to the other macOS account this window paints nothing, no frames arrive, and
+the call hangs for its full timeout — while CDP answers perfectly, so nothing else
+looks wrong. Separate debug ports isolate the two runners from each other; the SCREEN
+is machine-wide and cannot be split.
+
+One such call survived in the `create` path and cost two turns on 2026-08-10, ~6
+minutes after the other account logged in; each failure wrote `~/.canopy/not-ready`
+and took the box out of routing. It had been in the file the whole time and fired
+three times in two weeks, because it only bites when a turn starts while the display
+is elsewhere — rare enough to look like a fluke, frequent enough to keep happening.
+
+The sidecar needs a live emdash to exercise (see test_cdp_control.py), so behaviour
+here cannot be unit-tested. Reading the source can still hold the line.
+"""
+import re
+from pathlib import Path
+
+SIDECAR = Path(__file__).resolve().parents[1] / "canopy_runner" / "cdp" / "emdash_control.mjs"
+
+
+def _code_lines():
+    """Source with comment-only lines dropped — the rule is about calls, and the
+    comments explaining the rule necessarily name the thing they forbid."""
+    return [ln for ln in SIDECAR.read_text().splitlines()
+            if not ln.lstrip().startswith("//")]
+
+
+def test_sidecar_makes_no_actionability_gated_calls():
+    """No `page.locator(...)`. Its click/fill/press all gate on rendering."""
+    offenders = [ln.strip() for ln in _code_lines() if "page.locator(" in ln]
+    assert not offenders, (
+        "emdash_control.mjs must not use Playwright locators — they gate on the window "
+        "painting, which it does not while the other macOS account holds the display. "
+        "Dispatch the click/focus inside page.evaluate instead:\n  "
+        + "\n  ".join(offenders))
+
+
+def test_sidecar_waits_poll_on_a_timer_not_animation_frames():
+    """`waitForFunction` defaults to `polling: 'raf'`, which is the same dependency by
+    another name: a wait that never ticks while the window is backgrounded. Every call
+    must name an explicit numeric polling interval."""
+    for ln in _code_lines():
+        if "waitForFunction(" not in ln:
+            continue
+        # The call spans lines; check the whole statement it opens.
+        src = SIDECAR.read_text()
+        for call in re.findall(r"waitForFunction\((?:[^()]|\([^()]*\))*\)", src, re.S):
+            assert re.search(r"polling:\s*\d", call), (
+                "waitForFunction must pass a numeric `polling` — the default 'raf' "
+                f"stalls while emdash is backgrounded:\n{call}")
+        break


### PR DESCRIPTION
## What broke

`acedimagi-mbp-cdp` went `ready: false` this morning with:

```
emdash create failed: locator.click: Timeout 30000ms exceeded.
Call log:
  - waiting for locator('[role=dialog] [contenteditable="true"], …').first()
    - locator resolved to <div … data-testid="prompt-editor" …>
  - attempting click action
    - waiting for element to be visible, enabled and stable   ← hung the full 30s
```

The element was found. It just never became *actionable*.

`emdash_control.mjs` promises at the top that it is **occlusion-proof** — "uses JS-dispatched clicks so it works while emdash is backgrounded (no foreground focus needed)". Every click in the file goes through `page.evaluate(… el.click())` to keep that promise: the sidebar button, the Create button, the menu items, the tab switch. One call didn't — `locator.click()` on the New Task dialog's prompt editor.

Playwright's click first waits for visible + enabled + **stable**, and stable means the bounding box was unchanged across two **animation frames**. macOS renders one login session at a time, so while the display belongs to the other macOS account this window paints nothing, no frames arrive, and the click hangs out its whole timeout. CDP answers perfectly the entire time, so nothing else looks broken.

## What it cost

Two turns died back to back on 2026-08-10 — `b6855cad…` (ace) and `48b04369…` (hal) — starting ~6 minutes after the other account logged in. Each wrote `~/.canopy/not-ready`, taking the box out of routing until the 15-minute TTL expired. Both turns are terminal `failed`; they do not retry themselves.

The line had been there all along, and has fired exactly 3 times in the whole 19MB runner log. It only bites when a turn happens to start while the display is elsewhere — rare enough to read as a fluke, frequent enough to keep happening.

## What was *not* wrong

This presents as a two-runner problem, and the two-runner design is fine. Ports 9223/9222, hook ports 8788/8787, separate emdash user-data-dirs, separate runner ids — nothing collided, and the second runner was `paused` so it wasn't claiming anything.

Ports isolate a *control channel*. The **screen** is machine-wide and cannot be split by configuration. The fix is to stop depending on it.

## The change

- Focus the prompt editor in JS, matching every other interaction in the file.
- **Confirm focus actually moved.** `keyboard.insertText` goes wherever focus is, so a silent no-op would type the prompt into the task-name input and still report the task as created.
- **Keep the wait**, but poll on a timer. The dialog is React-rendered and the preceding 1s sleep is not a guarantee — on 2026-07-30 this same call site burned its 30s because the dialog never appeared *at all*, which must stay a legible failure rather than become an instant false negative. `waitForFunction` defaults to `polling: 'raf'`, which would reintroduce the exact dependency being removed.

## Tests

The sidecar needs a live emdash to exercise (as `test_cdp_control.py` says in its docstring), so behaviour here can't be unit-tested. The new test is a **static guard on the source**: no `page.locator`, and no rAF-polled wait.

Verified **red against the pre-fix file**, not just green after it:

```
E  AssertionError: emdash_control.mjs must not use Playwright locators …
E      const ce = page.locator('[role=dialog] [contenteditable="true"], …').first();
```

`uv run --with pytest pytest` in `runner/canopy_runner` (CI's exact invocation): **431 passed**. `node --check` clean.

## Not verified

Reproducing the failure means switching the display to the other macOS account and firing a turn, which I can't do from here. The mechanism is inferred from the hang point plus the timing, and the fix removes the whole class rather than one sub-check — but a live confirm is still worth doing.

Also worth knowing: the laptop runner is an installed package, so this reaches the boxes when the auto-updater picks up the deployed sha, not on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)