### PR TITLE
fix(runner): gog never installed, so a rebuilt box had no mail for any agent

### DIFF
--- a/runner/ec2/bootstrap_agents.sh
+++ b/runner/ec2/bootstrap_agents.sh
@@ -125,7 +125,12 @@ for a in d.get("assets", []):
     if a["name"].endswith("_linux_amd64.tar.gz"):
         print(a["browser_download_url"]); break' 2>/dev/null)
     [[ -n "$url" ]] || { fail "could not resolve the latest gogcli linux_amd64 asset"; return 1; }
-    curl -fsSL "$url" -o "$tmp/gog.tar.gz" || { fail "curl download of $url failed"; return 1; }
+    # --retry: this download is flaky in practice. Standing up a box on 2026-08-12
+    # took three attempts (a 503, then a dropped connection, then success), and a
+    # bare curl turns each blip into the same silent outcome as the layout bug —
+    # no gog, so no keyring, no client map, and no gmail token for any agent.
+    curl -fsSL --retry 5 --retry-delay 3 --retry-connrefused "$url" -o "$tmp/gog.tar.gz" \
+      || { fail "curl download of $url failed after retries"; return 1; }
     tarball="$tmp/gog.tar.gz"
   fi
 

--- a/runner/ec2/bootstrap_agents.sh
+++ b/runner/ec2/bootstrap_agents.sh
@@ -129,14 +129,25 @@ for a in d.get("assets", []):
     tarball="$tmp/gog.tar.gz"
   fi
 
-  tar -xzf "$tarball" -C "$tmp" gog || { fail "could not extract 'gog' from $tarball"; return 1; }
-  if sudo -n install -m 0755 "$tmp/gog" /usr/local/bin/gog 2>/dev/null; then
+  # Extract EVERYTHING, then locate the binary — never name the member. gogcli
+  # 0.35.0 stores it as `./gog`, and `tar -xzf … gog` does not match that: a
+  # from-scratch rebuild on 2026-08-12 died here with "tar: gog: Not found in
+  # archive", taking gog with it and so silently skipping the keyring, the
+  # account->client map, and the gmail-token import for ALL FIVE agents. The box
+  # came up healthy in every other respect and could not send a single email.
+  # This is a third-party archive on a `latest` pin, so its layout is not ours to
+  # rely on; find the binary wherever the tarball happens to put it.
+  tar -xzf "$tarball" -C "$tmp" || { fail "could not unpack $tarball"; return 1; }
+  local gogbin
+  gogbin="$(find "$tmp" -type f -name gog -perm -u+x 2>/dev/null | head -1)"
+  [[ -n "$gogbin" ]] || { fail "no executable 'gog' inside $tarball (layout changed?)"; return 1; }
+  if sudo -n install -m 0755 "$gogbin" /usr/local/bin/gog 2>/dev/null; then
     return 0
   fi
   # No passwordless sudo (unexpected on the stock Ubuntu cloud-init AMI, but don't
   # brick the run over it) — fall back to the user's own bin dir.
   mkdir -p "$HOME/.local/bin"
-  install -m 0755 "$tmp/gog" "$HOME/.local/bin/gog"
+  install -m 0755 "$gogbin" "$HOME/.local/bin/gog"
 }
 
 # ── Step 2: gog keyring + account->client map ───────────────────────────────────

--- a/runner/ec2/tests/test_install_gog.py
+++ b/runner/ec2/tests/test_install_gog.py
@@ -1,0 +1,127 @@
+"""`install_gog` must survive the gogcli tarball's layout, because it is not ours.
+
+Same approach as test_update_runner_sh.py: run the real bash against real tarballs,
+because the whole content of this function is which commands run against what.
+
+THE INCIDENT. A from-scratch cloud rebuild on 2026-08-12 died here:
+
+    tar: gog: Not found in archive
+    FAIL: could not extract 'gog' from .../gogcli_0.35.0_linux_amd64.tar.gz
+    WARN: gog install failed — per-agent gmail steps below will be skipped
+
+gogcli 0.35.0 stores the binary as `./gog`, and `tar -xzf … gog` does not match
+that member. gog never installed, so step 2 skipped the keyring and the
+account->client map, and step 3 skipped the gmail-token import for ALL FIVE
+agents. The box came up online, ready, claiming turns, and unable to send a
+single email. It had gone unnoticed because the previous box was built on
+2026-07-26, when the layout still happened to match — a latent break that only
+fires on a rebuild, which is exactly the property that makes rebuilding worth
+testing.
+
+So: never name the member. Extract, then find the binary wherever it landed.
+"""
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import tarfile
+
+import pytest
+
+SCRIPT = pathlib.Path(__file__).resolve().parent.parent / "bootstrap_agents.sh"
+
+
+def _extract_function(path: pathlib.Path, name: str) -> str:
+    """The literal text of one top-level bash function, `name() {` to its closing `}`."""
+    lines = path.read_text().splitlines()
+    start = next(i for i, l in enumerate(lines) if l.startswith(f"{name}() {{"))
+    end = next(i for i in range(start + 1, len(lines)) if lines[i] == "}")
+    return "\n".join(lines[start:end + 1])
+
+
+def _make_tarball(dst: pathlib.Path, member: str) -> pathlib.Path:
+    """A gogcli-shaped tarball storing an executable gog at `member`."""
+    binary = dst / "gog-src"
+    binary.write_text("#!/bin/sh\necho gog\n")
+    binary.chmod(0o755)
+    tgz = dst / "gogcli_9.9.9_linux_amd64.tar.gz"
+    with tarfile.open(tgz, "w:gz") as tf:
+        tf.add(binary, arcname=member)
+    return tgz
+
+
+def _run_install_gog(tmp_path: pathlib.Path, tarball: pathlib.Path) -> subprocess.CompletedProcess:
+    """Source the script and call install_gog with the download already staged.
+
+    `gh` and `curl` are stubbed to no-ops and the tarball is pre-placed in the temp
+    dir install_gog creates, so the test exercises the EXTRACT path — the part that
+    broke — without reaching the network.
+    """
+    home = tmp_path / "home"
+    (home / ".local" / "bin").mkdir(parents=True)
+    stub_bin = tmp_path / "stubbin"
+    stub_bin.mkdir()
+    for name in ("gh", "curl", "sudo"):
+        # sudo must FAIL so install_gog takes its documented no-passwordless-sudo
+        # fallback into ~/.local/bin, which is writable in a test.
+        p = stub_bin / name
+        p.write_text("#!/bin/sh\nexit 1\n")
+        p.chmod(0o755)
+    # mktemp -d is what install_gog uses for its workspace; force it somewhere we
+    # can pre-seed, then drop the tarball in with the name its `find` looks for.
+    work = tmp_path / "work"
+    work.mkdir()
+    mktemp = stub_bin / "mktemp"
+    mktemp.write_text(f"#!/bin/sh\nprintf '%s' '{work}'\n")
+    mktemp.chmod(0o755)
+    (work / tarball.name).write_bytes(tarball.read_bytes())
+
+    # bootstrap_agents.sh is not source-safe (sourcing it runs the whole bootstrap),
+    # so slice out the REAL install_gog text and drive that. Still the shipped code,
+    # not a paraphrase of it — a rewritten copy would pass while the box fails.
+    fn = _extract_function(SCRIPT, "install_gog")
+    script = (
+        "log(){ :; }; ok(){ :; }; warn(){ echo \"WARN: $*\"; }; fail(){ echo \"FAIL: $*\"; }\n"
+        f"{fn}\n"
+        "install_gog\n"
+    )
+    return subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True, text=True, timeout=60,
+        env={"PATH": f"{stub_bin}:/usr/bin:/bin", "HOME": str(home)},
+        cwd=str(tmp_path),
+    )
+
+
+# KEEP ALL THREE. The `./gog` case is the one that broke production, but it only
+# FAILS the old code under GNU tar (Linux, and CI): bsdtar on macOS normalizes the
+# leading `./` when matching a named member, so a dev running this locally sees it
+# pass either way. The nested case fails everywhere, which is what makes the trio
+# honest — do not prune it as redundant with `./gog`.
+@pytest.mark.parametrize("member", [
+    "gog",              # the layout that used to ship
+    "./gog",            # gogcli 0.35.0 — what actually broke the rebuild (GNU tar only)
+    "gogcli_9.9.9_linux_amd64/gog",   # a plausible next layout: nested in a dir
+])
+def test_install_gog_handles_every_tarball_layout(tmp_path, member):
+    tgz = _make_tarball(tmp_path, member)
+    res = _run_install_gog(tmp_path, tgz)
+    installed = tmp_path / "home" / ".local" / "bin" / "gog"
+    assert installed.exists(), (
+        f"gog not installed from a tarball storing it at {member!r}\n"
+        f"stdout: {res.stdout}\nstderr: {res.stderr}"
+    )
+    assert installed.stat().st_mode & 0o111, "installed gog is not executable"
+
+
+def test_install_gog_fails_loudly_when_the_archive_has_no_binary(tmp_path):
+    """A tarball with no gog at all must produce a NAMED failure, not a silent skip
+    that leaves five agents mailless while the box reports healthy."""
+    other = tmp_path / "readme.txt"
+    other.write_text("not a binary\n")
+    tgz = tmp_path / "gogcli_9.9.9_linux_amd64.tar.gz"
+    with tarfile.open(tgz, "w:gz") as tf:
+        tf.add(other, arcname="./README.txt")
+    res = _run_install_gog(tmp_path, tgz)
+    assert not (tmp_path / "home" / ".local" / "bin" / "gog").exists()
+    assert "no executable 'gog'" in (res.stdout + res.stderr)


### PR DESCRIPTION
Found by destroying and rebuilding the cloud runner from scratch — the first real test of that path since the stack was created on 2026-07-26.

## What happened

```
tar: gog: Not found in archive
FAIL: could not extract 'gog' from .../gogcli_0.35.0_linux_amd64.tar.gz
WARN: gog install failed — per-agent gmail steps below will be skipped
```

gogcli 0.35.0 stores the binary as `./gog`, and `tar -xzf … gog` doesn't match that member under GNU tar. So gog never landed, and everything downstream of it quietly skipped:

- step 2: keyring + `account->client` map — **skipped**
- step 3: gmail-token import — **skipped for all five agents**

## Why it was dangerous rather than merely broken

The box came up **online, ready, and claiming turns** — with no mail for anyone. Nothing else looked wrong: runner healthy, agent repos cloned, `.env` files materialized, canopy CLI installed and current (0.2.399). The readiness drill caught it, which is the drill earning its keep, but the box was already in rotation.

And it was latent, not new. The previous box was built on 2026-07-26 when `gog` at the archive root still matched, and nothing re-ran `install_gog` afterwards because it's guarded on `command -v gog`. **A break that only fires on a rebuild is invisible until you rebuild.**

## Fix

Never name the member — extract, then find an executable `gog` wherever it landed. This is a third-party archive on a `latest` pin; its layout is explicitly not ours to depend on. A missing binary now fails with a named error instead of a silent skip.

## Tests

They drive the **real function text**, sliced out of the script rather than paraphrased — a rewritten copy would pass while the box fails. Three layouts (`gog`, `./gog`, nested) plus an archive with no binary.

Verified they catch the original: restoring the old extraction reproduces `tar: gog: Not found in archive`. One caveat recorded in the test — the `./gog` case only fails the old code under **GNU tar**; bsdtar on macOS normalizes the leading `./`, so the nested case carries the signal locally. Both are kept deliberately.

131 passed in `runner/ec2/tests/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)