### PR TITLE
fix(items): put the date on the card, so a stale one can be told from a fresh one

### DIFF
--- a/frontend/src/components/items/ItemAge.test.tsx
+++ b/frontend/src/components/items/ItemAge.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { ItemAge } from './ItemAge'
+
+afterEach(cleanup)
+
+// Regression origin (2026-08-12): the inbox rendered a queue of undecided cards with
+// no date anywhere on them. Jonathan: "I can't tell if these are recent or just old
+// and I should close." Every case below is a card he could be looking at.
+//
+// Plain DOM assertions on purpose — this repo does not register @testing-library/jest-dom,
+// so toHaveTextContent and friends are not available here.
+
+const NOW = new Date('2026-08-12T18:00:00Z')
+
+const text = () => screen.getByTestId('item-age').textContent ?? ''
+
+describe('ItemAge', () => {
+  it('shows how old a card is, which is the question being asked', () => {
+    render(<ItemAge createdAt="2026-08-10T18:00:00Z" now={NOW} />)
+    expect(text()).toContain('2d ago')
+  })
+
+  it('reads "just now" for a card posted this minute', () => {
+    render(<ItemAge createdAt="2026-08-12T17:59:30Z" now={NOW} />)
+    expect(text()).toContain('just now')
+  })
+
+  it('carries the absolute timestamp on hover, for when the exact day matters', () => {
+    render(<ItemAge createdAt="2026-08-10T18:00:00Z" now={NOW} />)
+    const title = screen.getByTestId('item-age').getAttribute('title') ?? ''
+    expect(title).toMatch(/2026/)
+    expect(title).toMatch(/Aug/)
+  })
+
+  it('adds the decision age on a card that has been decided', () => {
+    render(<ItemAge createdAt="2026-08-10T18:00:00Z" decidedAt="2026-08-12T15:00:00Z" now={NOW} />)
+    expect(text()).toContain('2d ago')
+    expect(text()).toContain('decided 3h ago')
+  })
+
+  it('shows only the created age when the item is still open', () => {
+    render(<ItemAge createdAt="2026-08-10T18:00:00Z" decidedAt={null} now={NOW} />)
+    expect(text()).not.toContain('decided')
+  })
+
+  it('renders nothing rather than "NaNd ago" when the date is unusable', () => {
+    const empty = render(<ItemAge createdAt="" now={NOW} />)
+    expect(empty.container.innerHTML).toBe('')
+    cleanup()
+    const bad = render(<ItemAge createdAt="not-a-date" now={NOW} />)
+    expect(bad.container.innerHTML).toBe('')
+  })
+
+  it('drops an unusable decided_at without losing the created age', () => {
+    render(<ItemAge createdAt="2026-08-10T18:00:00Z" decidedAt="not-a-date" now={NOW} />)
+    expect(text()).toContain('2d ago')
+    expect(text()).not.toContain('decided')
+  })
+})

--- a/frontend/src/components/items/ItemAge.tsx
+++ b/frontend/src/components/items/ItemAge.tsx
@@ -1,0 +1,55 @@
+import type { JSX } from 'react'
+import { relativeTime } from '@/components/activity/turnLog'
+
+// How old an Item is — read from ONE place by both card surfaces (the shared inbox
+// ItemCard and the batch view's own card), for the same reason the bands are shared:
+// two renderers of the same object drift.
+//
+// Jonathan, 2026-08-12, looking at a queue of undecided cards: "everything needs to
+// have a date displayed on the card, I can't tell if these are recent or just old
+// and I should close." Age IS the question, so the relative form leads. The absolute
+// timestamp goes on hover, for when the exact day is what matters.
+
+/** Parse to a printable age, or null if the value isn't a usable date. Guarding here
+ *  matters: relativeTime() on an unparseable string yields a cheerful "NaNd ago". */
+function age(iso: string | null | undefined, now: Date): string | null {
+  if (!iso) return null
+  const t = new Date(iso)
+  if (Number.isNaN(t.getTime())) return null
+  return relativeTime(iso, now)
+}
+
+/** Absolute form for the tooltip — local time, unambiguous month. */
+function absolute(iso: string): string {
+  const t = new Date(iso)
+  if (Number.isNaN(t.getTime())) return ''
+  return t.toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+export function ItemAge({
+  createdAt,
+  decidedAt,
+  now = new Date(),
+}: {
+  createdAt: string
+  decidedAt?: string | null
+  /** Injected in tests; defaulted so neither card surface has to thread it through. */
+  now?: Date
+}): JSX.Element | null {
+  const created = age(createdAt, now)
+  if (!created) return null
+  const decided = age(decidedAt, now)
+
+  return (
+    <span data-testid="item-age" title={absolute(createdAt)} className="whitespace-nowrap">
+      {created}
+      {decided && <span className="text-foreground-subtle"> · decided {decided}</span>}
+    </span>
+  )
+}

--- a/frontend/src/components/items/ItemCard.test.tsx
+++ b/frontend/src/components/items/ItemCard.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { ItemCard } from './ItemCard'
+import type { ItemOut } from '@/api/items'
+
+afterEach(cleanup)
+
+// The regression was not in the date helper — it was that no card called one.
+// Jonathan, 2026-08-12, on a queue of undecided cards: "everything needs to have a
+// date displayed on the card, I can't tell if these are recent or just old and I
+// should close." So assert it at the level he actually looks at.
+
+function item(over: Partial<ItemOut> = {}): ItemOut {
+  return {
+    id: 'item-1',
+    agent_slug: 'ada',
+    idempotency_key: 'k1',
+    kind: 'review',
+    title: 'A decision that needs making',
+    body: '',
+    origin: 'api',
+    origin_ref: {},
+    state: 'open',
+    decision: '',
+    comment: '',
+    decided_by: '',
+    decided_by_email: null,
+    decided_at: null,
+    dispatch: [],
+    dispatched_at: null,
+    batch_key: 'b1',
+    created_at: '2026-08-10T18:00:00Z',
+    ...over,
+  } as ItemOut
+}
+
+describe('ItemCard', () => {
+  it('shows the item age on the card', () => {
+    render(<ItemCard item={item()} onActed={() => {}} />)
+    expect(screen.getByTestId('item-age').textContent).toBeTruthy()
+  })
+
+  it('still shows the age when there is no other meta to sit beside it', () => {
+    render(<ItemCard item={item({ dispatch: [] })} onActed={() => {}} />)
+    expect(screen.getByTestId('item-age')).toBeTruthy()
+  })
+
+  it('shows the age on a question, not just a review', () => {
+    render(<ItemCard item={item({ kind: 'question' })} onActed={() => {}} />)
+    expect(screen.getByTestId('item-age')).toBeTruthy()
+  })
+
+  it('keeps the dispatch hint alongside the age', () => {
+    render(
+      <ItemCard
+        item={item({ dispatch: [{ target_agent: 'eva' }] as ItemOut['dispatch'] })}
+        onActed={() => {}}
+      />,
+    )
+    expect(screen.getByTestId('item-age')).toBeTruthy()
+    expect(document.body.textContent).toContain('dispatches to eva')
+  })
+})

--- a/frontend/src/components/items/ItemCard.tsx
+++ b/frontend/src/components/items/ItemCard.tsx
@@ -1,6 +1,7 @@
 import { useState, type JSX } from 'react'
 import { decideItem, dismissItem, type ItemDecision, type ItemOut } from '@/api/items'
 import { Markdown } from '@/components/Markdown'
+import { ItemAge } from '@/components/items/ItemAge'
 
 // One actionable inbox row, shared by both surfaces that render open items: the
 // /supervisor fleet queue and the per-agent rail. Every open Item is decidable in
@@ -57,7 +58,12 @@ export function ItemCard({
       className="rounded-lg border border-border bg-card p-3"
     >
       <p className="text-[13px] font-semibold leading-snug text-foreground">{item.title}</p>
-      {meta && <p className="mt-1 text-[11px] leading-snug text-muted-foreground">{meta}</p>}
+      {/* Age is never conditional — an undecided card with no date on it cannot be
+          triaged, which is the whole complaint this row exists to answer. */}
+      <p className="mt-1 flex flex-wrap items-center gap-x-1.5 text-[11px] leading-snug text-muted-foreground">
+        <ItemAge createdAt={item.created_at} decidedAt={item.decided_at} />
+        {meta && <span>· {meta}</span>}
+      </p>
       {item.body && (
         <Markdown className="mt-1 text-[12px] leading-snug text-foreground-secondary">
           {item.body}

--- a/frontend/src/pages/agents/ItemsSection.tsx
+++ b/frontend/src/pages/agents/ItemsSection.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, type JSX } from 'react'
 import { useOutletContext, useSearchParams } from 'react-router-dom'
 import { listItems, decideItem, type ItemOut, type ItemDecision } from '@/api/items'
 import { Markdown } from '@/components/Markdown'
+import { ItemAge } from '@/components/items/ItemAge'
 import type { AgentOutletContext } from '@/pages/AgentWorkspacePage'
 
 // A batch of Items reviewed in one sitting — Ada's fleet audit's home. It belongs
@@ -50,6 +51,12 @@ function ItemCard({
           </span>
         )}
       </div>
+
+      {/* Same reason as the inbox row: a card with no date on it can't be judged
+          stale, and this view mixes open cards with long-decided ones. */}
+      <p className="mt-1 text-[11px] leading-snug text-muted-foreground">
+        <ItemAge createdAt={item.created_at} decidedAt={item.decided_at} />
+      </p>
 
       {item.body && (
         <Markdown className="mt-2 text-[13px] leading-snug text-foreground-secondary">


### PR DESCRIPTION
## The problem

Neither surface that renders an `Item` showed when it was created.

> "everything needs to have a date displayed on the card, I can't tell if these are recent or just old and I should close" — Jonathan, 2026-08-12, looking at a queue of undecided cards on Ada's board

Age is the one thing the triage decision turns on, and it was the one thing absent from the card.

## The fix

New `ItemAge` — relative age (`2d ago`), absolute timestamp on hover — called from **both** renderers:

- `components/items/ItemCard.tsx` (the shared inbox + `/supervisor` fleet queue row)
- `pages/agents/ItemsSection.tsx` (the batch view's own card)

One component rather than two, for the reason `ItemCard.tsx` already gives about shared band identity: two renderers of the same object drift. On a decided item it also shows how long ago it was decided, since that view mixes open cards with long-settled ones.

Reuses the existing `relativeTime()` from `components/activity/turnLog` rather than adding a fourth date formatter in this codebase, and guards the parse — `relativeTime()` on an unparseable string renders a cheerful `NaNd ago`.

## Verification

The regression was never in a date helper — it was that no card called one, so the test asserts at the card level:

```
# against the pre-fix ItemCard
$ git checkout origin/main -- src/components/items/ItemCard.tsx && npx vitest run src/components/items/ItemCard.test.tsx
Tests  4 failed (4)

# after
$ npx vitest run src/components/items/
Tests  11 passed (11)

$ npx vitest run
Test Files  63 passed (63)
     Tests  592 passed (592)

$ npm run build      # tsc -b + vite
✓ built
```

Note: this repo doesn't register `@testing-library/jest-dom`, so the new tests use plain DOM assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)