### PR TITLE
fix(runner): three defects a from-scratch rebuild exposed

### DIFF
--- a/apps/harness/services.py
+++ b/apps/harness/services.py
@@ -1999,17 +1999,25 @@ Verify you can operate end-to-end in THIS environment, then report.
    clone it (read-only credentials are staged in this environment).
 2. Run your doctor / preflight / setup-verification checks. READ-ONLY mode:
    take NO outward action — no emails, no posts, no board writes, no deploys,
-   no state mutations anywhere.
-3. Report the result back to canopy-web (this callback is part of the drill —
-   it proves this environment can reach the control plane):
+   no state mutations anywhere. The ONE exception is the report in step 3, which
+   is not an outward action at all: it is this drill's return value.
+3. Report the result. THIS STEP IS MANDATORY AND ALREADY AUTHORIZED — it is how a
+   drill returns its answer to the system that asked for it, the same way any
+   other turn ends by reporting. It is not a message to anyone, it writes no
+   agent state, and it needs no approval. Do NOT stop to request one: this turn
+   runs unattended, so there is nobody to grant it, and a drill that ends without
+   reporting is indistinguishable from a box that could not reach the control
+   plane — which is the exact failure the drill exists to detect.
 
    curl -s -X POST "{report_url}" \\
      -H "Authorization: Bearer $(cat ~/.claude/canopy/workbench-token 2>/dev/null || echo "${{CANOPY_TOKEN:-$CANOPY_PAT}}")" \\
      -H "Content-Type: application/json" \\
      -d '{{"outcome": "pass", "summary": "<one-paragraph findings>"}}'
 
-   Use "outcome": "fail" if ANY check failed, and say which. Keep the summary to
-   one paragraph. Do nothing after reporting."""
+   Use "outcome": "fail" if ANY check failed, and say which. Report whatever you
+   found, including a failure you could not fix — reporting a bad result is the
+   drill succeeding, not the drill failing. Keep the summary to one paragraph. Do
+   nothing after reporting."""
 
 
 def start_drill(runner: Runner, agents: list) -> list[RunnerDrill]:

--- a/runner/ec2/bootstrap_agents.sh
+++ b/runner/ec2/bootstrap_agents.sh
@@ -24,6 +24,11 @@ set -uo pipefail
 AGENT_SLUGS="${AGENT_SLUGS:-ace,ada,echo,eva,hal}"
 AGENT_ROOT="${AGENT_ROOT:-/opt/agents}"
 AGENT_REPO_ORG="${AGENT_REPO_ORG:-dimagi-internal}"
+# Where an agent's DECLARED plugin dependencies are cloned. Deliberately NOT under
+# AGENT_ROOT: everything there is an AGENT, and a turn resolves its working dir from
+# that tree — a plugin clone sitting among them would read as a sixth agent.
+PLUGIN_DEPS_ROOT="${PLUGIN_DEPS_ROOT:-/opt/agent-plugins}"
+SCRIPT_DIR="${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 CANOPY_PLUGIN_URL="${CANOPY_PLUGIN_URL:-https://github.com/dimagi-internal/canopy.git}"
 
 log()  { printf '[bootstrap-agents] %s\n' "$*"; }
@@ -247,6 +252,67 @@ install_agent_plugin() {
   fi
 }
 
+# ── an agent's DECLARED plugin dependencies ─────────────────────────────────────
+# An agent's capabilities can come from a SIBLING plugin, and installing only its
+# own leaves it passing every structural check while missing the tools it actually
+# calls. Eva's Salesforce / Drive work is `mcp__plugin_chrome-sales_*`; her drill on
+# the freshly rebuilt box (2026-08-12) came back green on identity, rails, hooks,
+# gog auth and the board, and FAILED on `Required plugins` — chrome-sales was never
+# installed, because nothing here installed it.
+#
+# Declared per-agent in config/agent.json `required_plugins`, the same contract
+# `canopy agent doctor`'s check reads: a bare name, or an object with `marketplace`
+# ("owner/repo"), optional `marketplace_name` (defaults to the plugin name) and a
+# `note` naming any follow-up a human still has to do.
+#
+# Cloned, then added as a DIRECTORY source — the same shape as an agent's own
+# plugin, and for the same two reasons: these repos are private, so this reuses the
+# git credential store already staged for the agent clones rather than needing the
+# marketplace to authenticate; and the clone IS the marketplace, so the `git pull`
+# on a later run is also how the dependency updates. No second copy to keep in sync.
+install_required_plugins() {
+  local slug="$1" dest="$2"
+  local cfg="$dest/config/agent.json"
+  [[ -f "$cfg" ]] || return 0
+  if ! command -v claude >/dev/null 2>&1; then
+    warn "$slug: claude CLI not on PATH — required plugins not installed"
+    return 0
+  fi
+
+  local specs
+  specs="$(python3 "$SCRIPT_DIR/required_plugins.py" "$cfg" 2>/dev/null)" || return 0
+  [[ -n "$specs" ]] || return 0
+
+  local pname market mname note pdir
+  while IFS=$'\t' read -r pname market mname note; do
+    [[ -n "$pname" ]] || continue
+    if claude plugin list 2>/dev/null | grep -q "${pname}@${mname}"; then
+      ok "$slug: required plugin ${pname}@${mname} already installed"
+      continue
+    fi
+    if [[ -z "$market" ]]; then
+      warn "$slug: required plugin '$pname' declares no marketplace — cannot install it here"
+      continue
+    fi
+    pdir="$PLUGIN_DEPS_ROOT/$pname"
+    mkdir -p "$PLUGIN_DEPS_ROOT"
+    if ! clone_or_pull "https://github.com/${market}.git" "$pdir" >/dev/null 2>&1; then
+      warn "$slug: clone/pull of $market failed (private repo — is the staged GitHub token valid?)"
+      continue
+    fi
+    if ! claude plugin marketplace list 2>/dev/null | grep -qE "(^|[[:space:]])${mname}\$"; then
+      claude plugin marketplace add "$pdir" >/dev/null 2>&1 \
+        || { warn "$slug: claude plugin marketplace add $pdir failed"; continue; }
+    fi
+    if claude plugin install "${pname}@${mname}" >/dev/null 2>&1; then
+      ok "$slug: installed required plugin ${pname}@${mname}"
+      [[ -n "$note" ]] && log "$slug: follow-up for ${pname}: ${note}"
+    else
+      warn "$slug: claude plugin install ${pname}@${mname} failed"
+    fi
+  done <<<"$specs"
+}
+
 run_agent_provisioner() {
   local slug="$1" dest="$2"
   local setup="$dest/bin/${slug}-setup"
@@ -320,6 +386,7 @@ bootstrap_one_agent() {
   fi
 
   install_agent_plugin "$slug" "$dest"
+  install_required_plugins "$slug" "$dest"
   run_agent_provisioner "$slug" "$dest"
 
   # The gog OAuth-client credential FILE (not an env var): a single 1Password

--- a/runner/ec2/required_plugins.py
+++ b/runner/ec2/required_plugins.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Flatten an agent's `required_plugins` into tab-separated rows for bootstrap.
+
+    name <TAB> marketplace <TAB> marketplace_name <TAB> note
+
+Its own file rather than a heredoc inside bootstrap_agents.sh so it can be tested
+directly, and so the parsing rules live somewhere a reader can find them.
+
+The contract is the one `canopy agent doctor`'s `check_required_plugins` already
+reads, and the two MUST agree: the doctor failing an agent for a missing plugin
+that bootstrap could not have installed (or vice versa) is worse than either check
+alone. An entry is a bare name, or an object with `marketplace` ("owner/repo"),
+optional `marketplace_name` (defaults to the plugin name — true across this fleet:
+eva@eva, chrome-sales@chrome-sales) and an optional `note` for the follow-up a
+human still owes.
+
+Silent on anything malformed: a broken or absent config must not take the whole
+bootstrap down over an optional dependency list.
+"""
+from __future__ import annotations
+
+import json
+import sys
+
+
+def rows(data: dict) -> list[tuple[str, str, str, str]]:
+    out: list[tuple[str, str, str, str]] = []
+    entries = data.get("required_plugins") or []
+    if not isinstance(entries, list):
+        return out
+    for entry in entries:
+        if isinstance(entry, str):
+            name = entry.strip()
+            if name:
+                out.append((name, "", name, ""))
+            continue
+        if not isinstance(entry, dict):
+            continue
+        name = str(entry.get("name") or "").strip()
+        if not name:
+            continue
+        market = str(entry.get("marketplace") or "").strip()
+        mname = str(entry.get("marketplace_name") or "").strip() or name
+        note = " ".join(str(entry.get("note") or "").split())  # never break the TSV
+        out.append((name, market, mname, note))
+    return out
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        return 0
+    try:
+        with open(argv[1]) as fh:
+            data = json.load(fh)
+    except (OSError, ValueError):
+        return 0
+    if not isinstance(data, dict):
+        return 0
+    for row in rows(data):
+        print("\t".join(row))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/runner/ec2/tests/test_required_plugins.py
+++ b/runner/ec2/tests/test_required_plugins.py
@@ -1,0 +1,96 @@
+"""`required_plugins` parsing must agree with the doctor check it mirrors.
+
+Eva's readiness drill on the freshly rebuilt box (2026-08-12) passed identity,
+gating rails, hook wiring, gog auth and the board — and failed `Required plugins`,
+because bootstrap installed each agent's OWN plugin and nothing else. Her
+Salesforce and Drive skills are `mcp__plugin_chrome-sales_*`, so the agent was
+structurally healthy and functionally unable to do its job.
+
+These pin the entry shapes `canopy agent doctor`'s `check_required_plugins`
+accepts, because bootstrap and the doctor reading the same field differently is
+worse than either alone: the doctor would fail an agent over a plugin bootstrap
+never could have installed.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+import sys
+
+SCRIPT = pathlib.Path(__file__).resolve().parent.parent / "required_plugins.py"
+sys.path.insert(0, str(SCRIPT.parent))
+
+from required_plugins import rows  # noqa: E402
+
+
+def test_object_entry_carries_marketplace_and_note():
+    got = rows({"required_plugins": [
+        {"name": "chrome-sales", "marketplace": "dimagi-internal/chrome-sales",
+         "note": "then run the chrome-sales:setup skill"}]})
+    assert got == [("chrome-sales", "dimagi-internal/chrome-sales",
+                    "chrome-sales", "then run the chrome-sales:setup skill")]
+
+
+def test_marketplace_name_defaults_to_the_plugin_name():
+    """True across this fleet — eva@eva, chrome-sales@chrome-sales — and the
+    doctor documents the same default."""
+    got = rows({"required_plugins": [{"name": "x", "marketplace": "o/r"}]})
+    assert got == [("x", "o/r", "x", "")]
+
+
+def test_explicit_marketplace_name_wins():
+    got = rows({"required_plugins": [
+        {"name": "x", "marketplace": "o/r", "marketplace_name": "other"}]})
+    assert got[0][2] == "other"
+
+
+def test_bare_string_entry_is_accepted():
+    """The doctor accepts a bare name; so must this, or the two disagree."""
+    assert rows({"required_plugins": ["plain"]}) == [("plain", "", "plain", "")]
+
+
+def test_a_note_with_newlines_cannot_break_the_tsv():
+    """Output is tab-separated and consumed by `read -r a b c d`. A note carrying a
+    newline would split into a bogus extra row and the loop would try to install a
+    plugin named after a fragment of prose."""
+    got = rows({"required_plugins": [
+        {"name": "x", "marketplace": "o/r", "note": "line one\nline two\ttabbed"}]})
+    assert got[0][3] == "line one line two tabbed"
+    assert "\n" not in got[0][3] and "\t" not in got[0][3]
+
+
+def test_missing_or_malformed_declarations_are_silent():
+    """An optional dependency list must never take the bootstrap down."""
+    assert rows({}) == []
+    assert rows({"required_plugins": None}) == []
+    assert rows({"required_plugins": "not-a-list"}) == []
+    assert rows({"required_plugins": [{"no_name": 1}, 42, None]}) == []
+
+
+def test_cli_is_silent_on_an_unreadable_file(tmp_path):
+    res = subprocess.run([sys.executable, str(SCRIPT), str(tmp_path / "nope.json")],
+                         capture_output=True, text=True, timeout=30)
+    assert res.returncode == 0 and res.stdout == ""
+
+
+def test_cli_emits_tab_separated_rows(tmp_path):
+    cfg = tmp_path / "agent.json"
+    cfg.write_text(json.dumps({"required_plugins": [
+        {"name": "chrome-sales", "marketplace": "dimagi-internal/chrome-sales"}]}))
+    res = subprocess.run([sys.executable, str(SCRIPT), str(cfg)],
+                         capture_output=True, text=True, timeout=30)
+    # Strip the NEWLINE only — not surrounding whitespace. An absent note is a
+    # trailing empty field, and `.strip()` would eat the tab that carries it,
+    # hiding whether the row still has the arity `read -r a b c d` expects.
+    assert res.stdout.rstrip("\n").split("\t") == [
+        "chrome-sales", "dimagi-internal/chrome-sales", "chrome-sales", ""]
+
+
+def test_matches_evas_real_declaration():
+    """The actual config that exposed the gap, if this checkout has it."""
+    cfg = pathlib.Path.home() / "emdash/repositories/eva/config/agent.json"
+    if not cfg.exists():
+        return
+    got = rows(json.loads(cfg.read_text()))
+    assert any(r[0] == "chrome-sales" and r[1] for r in got), got

--- a/runner/ec2/tests/test_wire_preserves_enabled.py
+++ b/runner/ec2/tests/test_wire_preserves_enabled.py
@@ -1,0 +1,147 @@
+"""A rebuild must hand the box back to the fleet on exactly the terms it left.
+
+`wire.sh` promises, in its own header, to replace the predecessor's assignment row
+"(preserving rank + enabled)". It did not. Retiring the predecessor DROPS its
+assignment rows, and step 4 then re-read each agent's list — by which point the
+predecessor was gone, so nothing matched, the append path ran, and that path
+hardcodes `enabled: True`.
+
+Observed 2026-08-12, rebuilding the cloud box: the runner had been deliberately
+DISABLED for all five agents, and came back enabled for all five. Nobody chose
+that, and nothing reported it — the wiring output says "appended" either way. A
+silent config flip on the one path you take while recovering from an outage.
+
+Driven against the real script with `curl` faked on PATH, same approach as
+test_update_runner_sh.py: the whole content of wire.sh is which calls it makes
+with what, so only a real run can prove it.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+
+import pytest
+
+SCRIPT = pathlib.Path(__file__).resolve().parent.parent / "wire.sh"
+NEW = "11111111-1111-1111-1111-111111111111"
+OLD = "22222222-2222-2222-2222-222222222222"
+LAPTOP = "33333333-3333-3333-3333-333333333333"
+
+
+def _fake_curl(tmp: pathlib.Path, *, cloud_enabled: bool) -> pathlib.Path:
+    """A `curl` that serves the fleet and records every PUT body.
+
+    Models the behaviour that caused the bug: once the predecessor is retired, it
+    disappears from each agent's assignment list.
+    """
+    state = tmp / "state"
+    state.mkdir()
+    (state / "retired").write_text("")
+    runners = [
+        {"id": NEW, "kind": "cloud", "name": "cloud-ec2-1", "status": "disconnected"},
+        {"id": OLD, "kind": "cloud", "name": "cloud-ec2-1", "status": "online"},
+    ]
+    (state / "runners.json").write_text(json.dumps(runners))
+    (state / "agents.json").write_text(json.dumps({"items": [{"slug": "eva"}]}))
+    (state / "rows.json").write_text(json.dumps([
+        {"runner_id": LAPTOP, "runner_name": "laptop", "kind": "emdash",
+         "rank": 0, "enabled": True, "online": True, "ready": True},
+        {"runner_id": OLD, "runner_name": "cloud-ec2-1", "kind": "cloud",
+         "rank": 1, "enabled": cloud_enabled, "online": True, "ready": True},
+    ]))
+
+    curl = tmp / "bin" / "curl"
+    curl.parent.mkdir(exist_ok=True)
+    curl.write_text(f'''#!/usr/bin/env python3
+import json, sys, pathlib
+STATE = pathlib.Path({str(state)!r})
+args = sys.argv[1:]
+method = args[args.index("-X") + 1] if "-X" in args else "GET"
+url = next(a for a in args if a.startswith("http"))
+body = None
+for a in args:
+    if a.startswith("--data@") or a.startswith("@"):
+        body = pathlib.Path(a.lstrip("-").lstrip("data").lstrip("@")).read_text()
+if "--data" in args:
+    ref = args[args.index("--data") + 1]
+    if ref.startswith("@"):
+        body = pathlib.Path(ref[1:]).read_text()
+
+retired = set(filter(None, (STATE / "retired").read_text().splitlines()))
+
+if url.endswith("/api/harness/runners/"):
+    print(json.dumps(json.loads((STATE / "runners.json").read_text())))
+elif url.endswith("/retire"):
+    rid = url.rstrip("/").split("/")[-2]
+    with (STATE / "retired").open("a") as fh:
+        fh.write(rid + chr(10))
+    print("{{}}")
+elif "/credential" in url:
+    print(json.dumps({{"has_claude_token": True}}))
+elif "/api/agents/?limit=" in url:
+    print((STATE / "agents.json").read_text())
+elif url.endswith("/runners") and "/api/agents/" in url:
+    if method == "PUT":
+        (STATE / "put.json").write_text(body or "")
+        print("[]")
+    else:
+        # THE BEHAVIOUR THAT CAUSED THE BUG: a retired runner's assignment row
+        # is gone from the agent's list.
+        rows = [r for r in json.loads((STATE / "rows.json").read_text())
+                if r["runner_id"] not in retired]
+        print(json.dumps(rows))
+else:
+    print("{{}}")
+''')
+    curl.chmod(0o755)
+    return state
+
+
+def _run_wire(tmp: pathlib.Path, state_dir: pathlib.Path) -> subprocess.CompletedProcess:
+    home = tmp / "home"
+    (home / ".claude" / "canopy").mkdir(parents=True)
+    (home / ".claude" / "canopy" / "workbench-token").write_text("t0ken\n")
+    # `aws` must SUCCEED: the claude token is fetched under `set -e` with no
+    # fallback, so a failing stub kills the script before step 4 is ever reached.
+    aws = tmp / "bin" / "aws"
+    aws.write_text("#!/bin/sh\necho fake-token\n")
+    aws.chmod(0o755)
+    # `op` may fail — the github token is explicitly optional (`|| GITHUB_TOKEN=""`).
+    op = tmp / "bin" / "op"
+    op.write_text("#!/bin/sh\nexit 1\n")
+    op.chmod(0o755)
+    return subprocess.run(
+        ["bash", str(SCRIPT), "--runner-id", NEW],
+        capture_output=True, text=True, timeout=120,
+        env={"PATH": f"{tmp / 'bin'}:/usr/bin:/bin", "HOME": str(home),
+             "CLAUDE_TOKEN": "x"},
+        cwd=str(SCRIPT.parent),
+    )
+
+
+@pytest.mark.parametrize("cloud_enabled", [False, True])
+def test_rebuild_preserves_the_predecessors_enabled_flag(tmp_path, cloud_enabled):
+    """Whatever the operator had set, the replacement inherits it — in BOTH
+    directions. `False` is the regression that actually happened; `True` guards the
+    over-correction of pinning it off for everyone."""
+    state = _fake_curl(tmp_path, cloud_enabled=cloud_enabled)
+    res = _run_wire(tmp_path, state)
+    put = state / "put.json"
+    assert put.exists(), f"no assignment PUT was made\n{res.stdout}\n{res.stderr}"
+    rows = json.loads(put.read_text())["runners"]
+    by_id = {r["runner_id"]: r["enabled"] for r in rows}
+    assert NEW in by_id, f"new runner missing from the PUT: {rows}"
+    assert OLD not in by_id, f"retired predecessor still in the PUT: {rows}"
+    assert by_id[NEW] is cloud_enabled, (
+        f"enabled flipped {cloud_enabled} -> {by_id[NEW]} across the rebuild")
+    assert by_id[LAPTOP] is True, "an unrelated runner's row was disturbed"
+
+
+def test_rebuild_keeps_the_predecessors_position(tmp_path):
+    """Rank is the availability cascade's order. The replacement takes the slot its
+    predecessor held, rather than being appended behind everything else."""
+    state = _fake_curl(tmp_path, cloud_enabled=False)
+    _run_wire(tmp_path, state)
+    rows = json.loads((state / "put.json").read_text())["runners"]
+    assert [r["runner_id"] for r in rows] == [LAPTOP, NEW]

--- a/runner/ec2/wire.sh
+++ b/runner/ec2/wire.sh
@@ -134,6 +134,33 @@ api POST "/api/harness/runners/${RUNNER_ID}/credential" "$TMP/cred.json" | pytho
 echo "==> credential staged"
 
 # ── Step 3: retire predecessors ──────────────────────────────────────────────────
+#
+# Resolve the agent list and SNAPSHOT every agent's assignment rows FIRST, before
+# anything is retired. Retiring a runner drops its assignment rows, so a snapshot
+# taken afterwards no longer contains the predecessor — step 4 then finds nothing
+# to swap, takes its append path, and appends the new runner with a hardcoded
+# `enabled: True`. On 2026-08-12 that silently re-enabled the cloud runner for all
+# five agents, which had been deliberately disabled. A rebuild must return the box
+# to the fleet on exactly the terms it left, so the state step 4 reasons about has
+# to be read while it still exists.
+if [[ -n "$AGENTS" ]]; then
+  IFS=',' read -ra AGENT_SLUGS <<<"$AGENTS"
+else
+  api GET "/api/agents/?limit=200" > "$TMP/agents.json"
+  # `mapfile`/`readarray` is bash4+ only — macOS ships bash 3.2 as /bin/bash and
+  # this script runs on the OPERATOR's machine, not the (bash5) EC2 box — so
+  # build the array the bash-3.2-compatible way via word-splitting (safe here:
+  # slugs are simple identifiers, never containing spaces or glob chars).
+  AGENT_SLUGS=($(python3 -c "
+import json
+print(' '.join(a['slug'] for a in json.load(open('$TMP/agents.json'))['items']))
+"))
+fi
+for slug in "${AGENT_SLUGS[@]}"; do
+  [[ -n "$slug" ]] || continue
+  api GET "/api/agents/${slug}/runners" > "$TMP/rows-${slug}.json" 2>/dev/null || true
+done
+
 echo ">> retiring other non-retired '$RUNNER_NAME' cloud runners"
 api GET /api/harness/runners/ > "$TMP/runners.json"
 python3 -c "
@@ -154,25 +181,15 @@ else
 fi
 
 # ── Step 4: swap assignments ─────────────────────────────────────────────────────
+# Works from the PRE-RETIRE snapshot taken in step 3 — see the note there. Reading
+# the list again here would see the predecessor already gone and silently reset
+# `enabled`.
 echo ">> swapping agent assignments -> $RUNNER_ID"
-if [[ -n "$AGENTS" ]]; then
-  IFS=',' read -ra AGENT_SLUGS <<<"$AGENTS"
-else
-  api GET "/api/agents/?limit=200" > "$TMP/agents.json"
-  # `mapfile`/`readarray` is bash4+ only — macOS ships bash 3.2 as /bin/bash and
-  # this script runs on the OPERATOR's machine, not the (bash5) EC2 box — so
-  # build the array the bash-3.2-compatible way via word-splitting (safe here:
-  # slugs are simple identifiers, never containing spaces or glob chars).
-  AGENT_SLUGS=($(python3 -c "
-import json
-print(' '.join(a['slug'] for a in json.load(open('$TMP/agents.json'))['items']))
-"))
-fi
 
 for slug in "${AGENT_SLUGS[@]}"; do
   [[ -n "$slug" ]] || continue
   rm -f "$TMP/put-${slug}.json"  # no stale file from a previous slug can leak into this PUT
-  if ! api GET "/api/agents/${slug}/runners" > "$TMP/rows-${slug}.json" 2>/dev/null; then
+  if [[ ! -s "$TMP/rows-${slug}.json" ]]; then
     echo "   $slug: not found — skipping"
     continue
   fi

--- a/tests/test_drill_prompt.py
+++ b/tests/test_drill_prompt.py
@@ -1,0 +1,69 @@
+"""The drill prompt must not forbid the one thing it then requires.
+
+Three of five agents drilled on the rebuilt cloud box (2026-08-12) ran every check,
+passed, and never reported — so the grid read `pending` forever and the box looked
+unreachable when it was fine. hal said why in its turn note: "Drill checks all
+passed, but the final callback needs a flag."
+
+The prompt caused it. Step 2 said "take NO outward action — no emails, no posts,
+no board writes, no state mutations anywhere", and step 3 then asked for a POST.
+Every agent in this fleet runs under a hard guardrail that outbound actions need
+human approval, so the honest reading of those two lines together is "stop and
+ask" — and on an unattended drill there is nobody to ask.
+
+A prompt that contradicts itself gets resolved by the model, not by us, so these
+assert the contradiction is gone and the exemption is explicit.
+"""
+from __future__ import annotations
+
+import re
+
+from apps.harness.services import DRILL_PROMPT
+
+
+def _prompt() -> str:
+    return DRILL_PROMPT.format(agent_slug="eva", report_url="https://example.test/report")
+
+
+def test_the_report_is_named_as_exempt_from_the_read_only_rule():
+    """The no-outward-action line must carry its own exception, in the same breath.
+    An exemption stated three paragraphs later loses to the prohibition."""
+    text = _prompt()
+    para = text[text.index("take NO outward action"):text.index("3.")]
+    assert "exception" in para.lower(), (
+        "the read-only prohibition does not name the report as an exception:\n" + para)
+
+
+def test_the_report_is_marked_mandatory_and_pre_authorized():
+    text = _prompt().lower()
+    assert "mandatory" in text
+    assert "authorized" in text or "authorised" in text
+
+
+def test_the_prompt_forbids_stopping_to_ask_for_approval():
+    """The precise failure mode: agents treated the callback as an outbound action
+    needing a human, on a turn with no human attached."""
+    text = _prompt().lower()
+    assert "nobody" in text or "no one" in text, "the prompt never says nobody is there to ask"
+    assert re.search(r"do not stop|don't stop|do not (?:pause|wait|request)", text), text
+
+
+def test_a_failing_check_must_still_be_reported():
+    """Reporting a bad result is the drill working. An agent that suppresses a
+    failure it could not fix produces the same silence as a dead box."""
+    text = _prompt().lower()
+    assert "including a failure" in text or "report whatever you found" in text
+
+
+def test_the_report_call_is_still_present_and_addressed():
+    text = _prompt()
+    assert "https://example.test/report" in text
+    assert "curl -s -X POST" in text
+    assert '"outcome": "pass"' in text and '"fail"' in text
+
+
+def test_everything_else_is_still_read_only():
+    """The fix must not become a licence to act — only the report is exempted."""
+    text = _prompt()
+    assert "READ-ONLY" in text
+    assert "no emails" in text and "no board writes" in text


### PR DESCRIPTION
All three surfaced by destroying and rebuilding the cloud box, and all three share a shape: **the box came back looking healthy while quietly differing from the fleet it left.**

## 1. The rebuild silently re-enabled a disabled runner

`wire.sh` promises in its own header to replace the predecessor's assignment row *"(preserving rank + enabled)"*. It didn't. Retiring the predecessor **drops its assignment rows**, and step 4 then re-read each agent's list — by which point the predecessor was gone, nothing matched, and the append path ran. That path hardcodes `enabled: True`.

The cloud runner had been deliberately **disabled for all five agents**. It came back **enabled for all five**. The output says `appended` either way, so nothing reported it — a silent config flip on the one path you take while recovering from an outage.

**Fix:** snapshot every agent's assignment rows *before* anything is retired. The state step 4 reasons about has to be read while it still exists.

## 2. An agent's declared plugin dependencies were never installed

Eva's drill on the rebuilt box passed identity, gating rails, hook wiring, gog auth and the board — and failed `Required plugins`. Her Salesforce and Drive work is `mcp__plugin_chrome-sales_*`; bootstrap installed each agent's **own** plugin and nothing else. Structurally healthy, functionally unable to do her job.

`config/agent.json`'s `required_plugins` already carried everything needed — marketplace, optional `marketplace_name`, a follow-up note — because `canopy agent doctor` reads it. **The declaration existed; the install never did.**

Cloned then added as a **directory source**, the same shape as an agent's own plugin: these repos are private, so it reuses the git credential store already staged for the agent clones, and the clone *is* the marketplace, so a later `git pull` is also how the dependency updates.

Parsing lives in `required_plugins.py` rather than a heredoc so it can be tested directly and can't drift from the doctor check it mirrors — the doctor failing an agent over a plugin bootstrap could never have installed is worse than either check alone.

## 3. The drill prompt forbade the one action it then required

Three of five agents ran every check, passed, and never reported — so the grid read `pending` forever and a healthy box looked unreachable. hal's turn note: *"Drill checks all passed, but the final callback needs a flag."*

Step 2 said *"take NO outward action — no emails, no posts, no board writes, no state mutations anywhere"*; step 3 then asked for a POST. Every agent runs under a hard guardrail that outbound actions need human approval, so the honest reading is "stop and ask" — and a drill is unattended by definition.

The report is now the explicit exception **in the same breath as the prohibition**, marked mandatory and pre-authorized, with the prompt stating outright that nobody is there to approve it. It also now says to report a failure you couldn't fix: a suppressed bad result is indistinguishable from a dead box, which is exactly what a drill exists to tell apart.

## Verification

The wire tests run the **real** `wire.sh` against a faked control plane that models the row-disappears-on-retire behaviour. Reverting the fix reproduces production exactly:

```
AssertionError: enabled flipped False -> True across the rebuild
```

Asserted in **both** directions, so the fix can't become "pin it off for everyone", and that an unrelated runner's row is untouched.

2107 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)