### PR TITLE
Make a tabbed / multi-select AskUserQuestion answerable from the web

### DIFF
--- a/apps/canopy_sessions/api.py
+++ b/apps/canopy_sessions/api.py
@@ -393,7 +393,8 @@ def answer_menu(request: HttpRequest, session_id: uuid.UUID, payload: MenuAnswer
     Same shape `reset` uses for the same reason.
     """
     session = _session_or_404(request, session_id)
-    outcome = services.answer_menu(session=session, option=payload.option)
+    outcome = services.answer_menu(session=session, option=payload.option,
+                                   selections=payload.selections)
     return {"ok": outcome == "sent", "reason": "" if outcome == "sent" else outcome}
 
 

--- a/apps/canopy_sessions/schemas.py
+++ b/apps/canopy_sessions/schemas.py
@@ -195,5 +195,14 @@ class MenuAnswerIn(Schema):
     `None` means refuse — sent as Escape. Deliberately nullable rather than a
     magic number: every dialog offers Esc, and it is the only answer that is
     safe when the option numbering is not what the client thought it was.
+
+    `selections` carries the whole answer to an `AskUserQuestion`: one list of
+    chosen option numbers per declared question, in declaration order, empty for
+    a question left unanswered. A single `option` cannot express "Red and Blue",
+    and cannot reach the tab holding question 2 at all — so a multi-select or a
+    multi-question ask was unanswerable from the web until this field existed.
+    `option` is still sent beside it (the first pick) purely so a runner older
+    than this behaves exactly as it does today instead of pressing Escape.
     """
     option: int | None = None
+    selections: list[list[int]] | None = None

--- a/apps/canopy_sessions/services.py
+++ b/apps/canopy_sessions/services.py
@@ -976,8 +976,20 @@ def project_events(turn: Turn, rows) -> int:
     return created
 
 
-def answer_menu(*, session: Session, option: int | None) -> str:
+def answer_menu(*, session: Session, option: int | None,
+                selections: list[list[int]] | None = None) -> str:
     """Answer the dialog an agent is blocked on, from the web.
+
+    `selections` is the whole answer: one list of chosen option numbers per
+    declared question, in declaration order. It is what a multi-select or a
+    multi-question ask needs, because there a number key toggles a checkbox and
+    the dialog waits on an explicit Submit — a single `option` cannot express
+    "Red and Blue", and cannot reach the tab holding the second question at all.
+
+    `option` is still sent alongside it, set to the first pick, and is the ONLY
+    field a runner older than this understands. That is deliberate: such a runner
+    keeps doing exactly what it does today rather than seeing an empty option and
+    pressing Escape, which would cancel the dialog outright.
 
     Returns "sent" | "unavailable" | "unbound", mirroring `request_backfill`'s
     refusal shape rather than raising: a menu can go stale between the phone
@@ -1004,7 +1016,8 @@ def answer_menu(*, session: Session, option: int | None) -> str:
     # runner drains on its poll tick. Publishing alone is how an answer gets lost
     # in silence when the control channel is down — see RunnerBinding.pending_answer.
     answer_id = str(uuid.uuid4())
-    binding.pending_answer = {"id": answer_id, "option": option, "at": time.time()}
+    binding.pending_answer = {"id": answer_id, "option": option,
+                              "selections": selections, "at": time.time()}
     binding.save(update_fields=["pending_answer"])
 
     from apps.realtime import groups
@@ -1013,6 +1026,7 @@ def answer_menu(*, session: Session, option: int | None) -> str:
         "session_id": str(session.id),
         "session_key": binding.session_key,
         "option": option,
+        "selections": selections,
         "answer_id": answer_id,
     })
     return "sent"

--- a/apps/harness/api.py
+++ b/apps/harness/api.py
@@ -870,7 +870,8 @@ def list_menu_answers(request: HttpRequest, runner_id: uuid.UUID):
     return {"answers": [
         {"session_id": str(b.session_id), "session_key": b.session_key,
          "answer_id": (b.pending_answer or {}).get("id") or "",
-         "option": (b.pending_answer or {}).get("option")}
+         "option": (b.pending_answer or {}).get("option"),
+         "selections": (b.pending_answer or {}).get("selections")}
         for b in bindings
     ]}
 

--- a/apps/harness/schemas.py
+++ b/apps/harness/schemas.py
@@ -812,6 +812,11 @@ class MenuAnswerOut(Schema):
     session_key: str
     answer_id: str
     option: int | None = None
+    #: One list of chosen option numbers per declared question. A runner that
+    #: predates this ignores the field and presses `option`, which is what it
+    #: does today — so the poll tick never gets WORSE than the current
+    #: behaviour on an ask this shape cannot express.
+    selections: list[list[int]] | None = None
 
 
 class MenuAnswerSyncOut(Schema):

--- a/frontend/packages/canopy-ui/src/chat/MenuPrompt.tsx
+++ b/frontend/packages/canopy-ui/src/chat/MenuPrompt.tsx
@@ -1,12 +1,32 @@
-import type { SessionMenu } from "./protocol";
+import { useMemo, useState } from "react";
+import type { MenuQuestion, SessionMenu } from "./protocol";
 
 export interface MenuPromptProps {
   menu: SessionMenu;
   busy?: boolean;
   error?: string;
-  onAnswer: (option: number | null) => void;
+  /** `selections` is the whole answer — one list of chosen option numbers per
+   *  question. Omitted for the single-question single-select dialogs that a
+   *  lone `option` has always been able to answer. */
+  onAnswer: (option: number | null, selections?: number[][] | null) => void;
   /** Injectable for tests; defaults to the wall clock. */
   now?: number;
+}
+
+/** Whether this ask needs the full form rather than a row of buttons.
+ *
+ *  One single-select question is the shape a lone keypress answers, and it is
+ *  the overwhelmingly common one — a permission prompt, a yes/no. Anything else
+ *  (several questions, or one that takes several answers) cannot be completed by
+ *  pressing a single button, so rendering buttons for it is a lie. */
+export function needsForm(menu: SessionMenu): boolean {
+  const qs = menu.questions;
+  if (!qs || qs.length === 0) return false;
+  return qs.length > 1 || qs.some((q) => q.multi_select);
+}
+
+function isAnswered(picks: number[] | undefined): boolean {
+  return Boolean(picks && picks.length > 0);
 }
 
 /** How old a dialog may be before we say so. The runner re-reports every ~10s,
@@ -50,6 +70,120 @@ export function menuAge(menu: SessionMenu, now: number): string {
  * somebody to choose blind, which is the same failure as showing no menu, only
  * quieter.
  */
+/** Every question at once, answered in one go.
+ *
+ *  Deliberately NOT a tab strip mirroring the terminal's. The terminal shows one
+ *  question at a time because it has one screen and a cursor; a phone has a
+ *  scroll, and the thing that actually went wrong was somebody answering what
+ *  looked like the whole ask and it turning out to be tab 2 of 3. Showing all of
+ *  them, with one Send at the end, makes "have I finished?" answerable by
+ *  looking — which is the only question this surface has ever got wrong.
+ */
+function AnswerForm({
+  menu,
+  questions,
+  busy,
+  onAnswer,
+}: {
+  menu: SessionMenu;
+  questions: MenuQuestion[];
+  busy: boolean;
+  onAnswer: MenuPromptProps["onAnswer"];
+}) {
+  const [picks, setPicks] = useState<Record<number, number[]>>({});
+
+  const toggle = (q: MenuQuestion, number: number) => {
+    setPicks((prev) => {
+      const current = prev[q.index] ?? [];
+      if (!q.multi_select) return { ...prev, [q.index]: [number] };
+      return {
+        ...prev,
+        [q.index]: current.includes(number)
+          ? current.filter((n) => n !== number)
+          : [...current, number].sort((a, b) => a - b),
+      };
+    });
+  };
+
+  const remaining = useMemo(
+    () => questions.filter((q) => !isAnswered(picks[q.index])).length,
+    [questions, picks],
+  );
+
+  const send = () => {
+    // Positional, and every question gets an entry even when unanswered: the
+    // runner walks the tabs in this order, so a missing entry would silently
+    // shift every later answer onto the wrong question.
+    const selections = questions.map((q) => picks[q.index] ?? []);
+    // `option` is the first pick, for a runner too old to read `selections`.
+    // Sending null there would read as "refuse" and cancel the dialog.
+    onAnswer(selections[0]?.[0] ?? null, selections);
+  };
+
+  return (
+    <div className="mt-2 flex flex-col gap-3">
+      {questions.map((q) => (
+        <div key={q.index}>
+          <div className="text-[12px] font-medium uppercase tracking-wide text-muted-foreground">
+            {q.header || `Question ${q.index + 1}`}
+            {q.multi_select ? " · pick any" : ""}
+          </div>
+          <div className="mt-0.5 text-[13px] text-foreground">{q.question}</div>
+          <div className="mt-1.5 flex flex-col gap-1">
+            {q.options.map((option) => {
+              const on = (picks[q.index] ?? []).includes(option.number);
+              return (
+                <button
+                  key={option.number}
+                  type="button"
+                  disabled={busy}
+                  aria-pressed={on}
+                  onClick={() => toggle(q, option.number)}
+                  className={`flex items-start gap-2 rounded border px-2.5 py-2 text-left disabled:opacity-50 ${
+                    on ? "border-warning bg-warning/10" : "border-input bg-card hover:bg-muted"
+                  }`}
+                >
+                  <span aria-hidden className="mt-[1px] shrink-0 text-[13px]">
+                    {on ? (q.multi_select ? "☑" : "◉") : q.multi_select ? "☐" : "○"}
+                  </span>
+                  <span>
+                    <span className="block text-[13px] font-medium text-foreground">
+                      {option.label}
+                    </span>
+                    {option.description ? (
+                      <span className="mt-0.5 block text-[12px] leading-snug text-muted-foreground">
+                        {option.description}
+                      </span>
+                    ) : null}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          disabled={busy || remaining > 0}
+          onClick={send}
+          className="rounded bg-warning px-3 py-1.5 text-[13px] font-medium text-warning-foreground disabled:opacity-50"
+        >
+          {busy ? "Sending…" : "Send answers"}
+        </button>
+        {remaining > 0 ? (
+          <span className="text-[12px] text-muted-foreground">
+            {remaining} question{remaining === 1 ? "" : "s"} still to answer
+          </span>
+        ) : null}
+      </div>
+      {menu.body ? (
+        <div className="text-[12px] text-muted-foreground">{menu.body}</div>
+      ) : null}
+    </div>
+  );
+}
+
 export function MenuPrompt({ menu, busy = false, error, onAnswer, now = Date.now() }: MenuPromptProps) {
   const described = menu.options.some((o) => o.description);
   // A dialog Claude Code drew with no tool call behind it — a permission prompt,
@@ -63,6 +197,7 @@ export function MenuPrompt({ menu, busy = false, error, onAnswer, now = Date.now
   // refuse button below is an action, not a placeholder.
   const optionless = menu.options.length === 0;
   const age = menuAge(menu, now);
+  const form = needsForm(menu);
   return (
     <div className="rounded-md border border-warning/30 bg-warning/10 px-3 py-2.5 text-sm">
       <div className="flex items-center gap-1.5 font-medium text-warning">
@@ -72,13 +207,22 @@ export function MenuPrompt({ menu, busy = false, error, onAnswer, now = Date.now
           <span className="ml-auto text-[11px] font-normal text-muted-foreground">{age}</span>
         ) : null}
       </div>
-      {menu.body ? (
+      {menu.body && !form ? (
         <pre className="mt-1.5 max-h-32 overflow-auto whitespace-pre-wrap break-all rounded bg-muted px-2 py-1.5 font-mono text-[12px] text-foreground-secondary">
           {menu.body}
         </pre>
       ) : null}
-      <div className="mt-2 text-foreground">{menu.question}</div>
-      {optionless ? (
+      {/* The form prints each question against its own options, so the single
+          top-level question would be question 1 shown twice. */}
+      {form ? null : <div className="mt-2 text-foreground">{menu.question}</div>}
+      {form ? (
+        <AnswerForm
+          menu={menu}
+          questions={menu.questions ?? []}
+          busy={busy}
+          onAnswer={onAnswer}
+        />
+      ) : optionless ? (
         <div className="mt-1.5 text-[12px] leading-snug text-muted-foreground">
           The options can only be read at the keyboard — open this session in emdash to
           pick one. Cancelling from here still works.

--- a/frontend/packages/canopy-ui/src/chat/protocol.ts
+++ b/frontend/packages/canopy-ui/src/chat/protocol.ts
@@ -70,12 +70,35 @@ export interface Participant {
  *  actually blocks a fleet running `bypass permissions`), and the runner can
  *  still read it off the rendered screen for the dialogs a transcript cannot
  *  see. `source` says which, and a client is free to ignore it. */
+/** One question of an `AskUserQuestion`. The TUI draws these as TABS and will
+ *  not submit until each has an answer — so a surface that renders only the
+ *  first one cannot complete the ask no matter which button is pressed. That
+ *  was the bug: a two-question closeout showed one question, and a tap toggled
+ *  a checkbox on a dialog that then sat waiting for a Submit nobody could
+ *  reach (eva, 2026-08-12). */
+export interface MenuQuestion {
+  index: number;
+  question: string;
+  header?: string;
+  /** Whether this question takes ANY number of answers. The TUI renders it as
+   *  checkboxes and a number key TOGGLES one instead of answering, which is why
+   *  a client that cannot see this flag renders the wrong control AND the
+   *  runner presses the wrong key. */
+  multi_select?: boolean;
+  options: { number: number; label: string; description?: string }[];
+}
+
 export interface SessionMenu {
   question: string;
   title?: string;
   body?: string;
   selected?: number | null;
   source?: string;
+  /** Every question in the ask, in declaration order. Absent on a dialog with
+   *  no tool call behind it (a permission prompt, a trust gate) and on a menu
+   *  from a producer older than this — in both cases the client falls back to
+   *  the single-question fields above, which still describe question 1. */
+  questions?: MenuQuestion[];
   /** `description` is present on the transcript path and is often the only
    *  thing that distinguishes two options — "Proceed to Phase 4" does not say
    *  that Phase 4 is test-gated, and its description does. */

--- a/frontend/src/api/chat.ts
+++ b/frontend/src/api/chat.ts
@@ -276,13 +276,18 @@ export function attachmentUrl(attachmentId: string): string {
 export function answerMenu(
   id: string,
   option: number | null,
+  selections?: number[][] | null,
 ): Promise<{ ok: boolean; reason: string }> {
   return request<{ ok: boolean; reason: string }>(
     `/api/canopy-sessions/${encodeURIComponent(id)}/answer-menu`,
     {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ option }),
+      // `option` rides along with `selections` rather than being replaced by it:
+      // it is the only field a runner older than this understands, and sending
+      // it the first pick keeps such a runner doing what it does today instead
+      // of reading a null option as "refuse" and pressing Escape.
+      body: JSON.stringify(selections ? { option, selections } : { option }),
     },
   );
 }

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -8554,6 +8554,8 @@ export interface components {
             readonly answer_id: string;
             /** Option */
             readonly option?: number | null;
+            /** Selections */
+            readonly selections?: readonly (readonly number[])[] | null;
         };
         /** MenuAnswerSyncOut */
         readonly MenuAnswerSyncOut: {
@@ -9094,10 +9096,20 @@ export interface components {
          *     `None` means refuse — sent as Escape. Deliberately nullable rather than a
          *     magic number: every dialog offers Esc, and it is the only answer that is
          *     safe when the option numbering is not what the client thought it was.
+         *
+         *     `selections` carries the whole answer to an `AskUserQuestion`: one list of
+         *     chosen option numbers per declared question, in declaration order, empty for
+         *     a question left unanswered. A single `option` cannot express "Red and Blue",
+         *     and cannot reach the tab holding question 2 at all — so a multi-select or a
+         *     multi-question ask was unanswerable from the web until this field existed.
+         *     `option` is still sent beside it (the first pick) purely so a runner older
+         *     than this behaves exactly as it does today instead of pressing Escape.
          */
         readonly MenuAnswerIn: {
             /** Option */
             readonly option?: number | null;
+            /** Selections */
+            readonly selections?: readonly (readonly number[])[] | null;
         };
         /**
          * StreamStateOut

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -522,7 +522,7 @@ export function ChatPage() {
   const [answerError, setAnswerError] = useState('')
   const answeredAt = useRef(0)
   const onAnswerMenu = useCallback(
-    async (option: number | null) => {
+    async (option: number | null, selections?: number[][] | null) => {
       if (!id) return
       setAnswering(true)
       setAnswerError('')
@@ -533,7 +533,7 @@ export function ChatPage() {
       // here, where we know a tap just happened.
       answeredAt.current = Date.now()
       try {
-        const res = await answerMenu(id, option)
+        const res = await answerMenu(id, option, selections)
         if (!res.ok) {
           setAnswerError(
             res.reason === 'unavailable'

--- a/packages/canopy_transcript/canopy_transcript/questions.py
+++ b/packages/canopy_transcript/canopy_transcript/questions.py
@@ -93,24 +93,13 @@ def _blocks(record):
     return tuple(b for b in content if isinstance(b, dict)) if isinstance(content, list) else ()
 
 
-def _menu_from_input(payload) -> dict | None:
-    """One `AskUserQuestion` tool input -> the menu dict, or None if unusable.
-
-    Fails closed exactly like `find_menu`: no options means nothing to press,
-    and a phone told an agent is blocked when it is working is a signal nobody
-    trusts twice.
-    """
-    if not isinstance(payload, dict):
-        return None
-    questions = payload.get("questions")
-    if not isinstance(questions, list) or not questions:
-        return None
-    first = questions[0]
-    if not isinstance(first, dict):
+def _one_question(raw, index: int) -> dict | None:
+    """One entry of `questions[]` -> a question dict, or None if unusable."""
+    if not isinstance(raw, dict):
         return None
 
     options = []
-    raw_options = first.get("options")
+    raw_options = raw.get("options")
     if not isinstance(raw_options, list):
         return None
     for opt in raw_options:
@@ -128,9 +117,9 @@ def _menu_from_input(payload) -> dict | None:
     if not options:
         return None
 
-    question = first.get("question")
+    question = raw.get("question")
     question = question.strip() if isinstance(question, str) else ""
-    header = first.get("header")
+    header = raw.get("header")
     header = header.strip() if isinstance(header, str) else ""
     if not question:
         # A dialog with no question still has real options; the header is what
@@ -140,21 +129,89 @@ def _menu_from_input(payload) -> dict | None:
     if not question:
         return None
 
-    # AskUserQuestion may carry several questions and the TUI shows them one at
-    # a time. Say so rather than presenting a 1-of-3 dialog as the whole ask.
+    return {
+        "index": index,
+        "question": question,
+        "header": header,
+        # The whole reason this file changed. The TUI draws a multi-select as
+        # CHECKBOXES and a number key TOGGLES one instead of answering — so a
+        # client that cannot see this flag renders "pick one" buttons for a
+        # "pick any" question, and the runner presses a key that selects
+        # nothing. Verified against a live TUI capture; see
+        # `canopy_runner/tests/test_menu.py`.
+        "multi_select": bool(raw.get("multiSelect")),
+        "options": options,
+    }
+
+
+def _menu_from_input(payload) -> dict | None:
+    """One `AskUserQuestion` tool input -> the menu dict, or None if unusable.
+
+    Fails closed exactly like `find_menu`: no options means nothing to press,
+    and a phone told an agent is blocked when it is working is a signal nobody
+    trusts twice.
+
+    Carries EVERY question, not just the first. The TUI shows them as tabs and
+    will not submit until each has an answer, so a surface that renders only
+    `questions[0]` cannot complete the ask no matter which button you press —
+    it was structurally unable to, which is the bug this shape fixes. The
+    top-level `question`/`title`/`options` stay pinned to the first question so
+    an older client renders exactly what it rendered before.
+    """
+    if not isinstance(payload, dict):
+        return None
+    raw_questions = payload.get("questions")
+    if not isinstance(raw_questions, list) or not raw_questions:
+        return None
+
+    questions = []
+    for raw in raw_questions:
+        parsed = _one_question(raw, len(questions))
+        if parsed is None:
+            # One malformed question must not cost the whole dialog its buttons,
+            # but it MUST cost the structured path: submitting a set of answers
+            # positionally against a list with a hole in it would answer the
+            # wrong tab. Fall back to first-question-only rendering.
+            return _legacy_menu(raw_questions)
+        questions.append(parsed)
+
+    first = questions[0]
     remaining = len(questions) - 1
-    body = f"{remaining} more question{'s' if remaining != 1 else ''} after this one." if remaining > 0 else ""
+    body = (f"{remaining} more question{'s' if remaining != 1 else ''} after this one."
+            if remaining > 0 else "")
 
     return {
-        "question": question,
-        "title": header,
+        "question": first["question"],
+        "title": first["header"],
         "body": body,
         # A transcript cannot see which row the cursor is on — that is a
         # property of the rendered screen, not of the tool call.
         "selected": _EMPTY_SELECTED,
-        "options": options,
+        "options": first["options"],
+        "questions": questions,
         # Which half found it. The client must be able to ignore this; it exists
         # so an operator can tell the transcript path from the screen read.
+        "source": "transcript",
+    }
+
+
+def _legacy_menu(raw_questions) -> dict | None:
+    """First-question-only menu, for an ask this module cannot fully model.
+
+    No `questions` key, deliberately: its absence is what tells a client to fall
+    back to single-question rendering rather than trust a partial list.
+    """
+    first = _one_question(raw_questions[0] if raw_questions else None, 0)
+    if first is None:
+        return None
+    remaining = len(raw_questions) - 1
+    return {
+        "question": first["question"],
+        "title": first["header"],
+        "body": (f"{remaining} more question{'s' if remaining != 1 else ''} after this one."
+                 if remaining > 0 else ""),
+        "selected": _EMPTY_SELECTED,
+        "options": first["options"],
         "source": "transcript",
     }
 

--- a/packages/canopy_transcript/tests/test_questions.py
+++ b/packages/canopy_transcript/tests/test_questions.py
@@ -183,10 +183,17 @@ def test_the_menu_says_where_it_came_from():
 def test_the_shape_matches_the_screen_reader_s():
     """One payload shape, whichever half produced it — the client must never
     grow two readers (the rule execute.py's _blocking_dialog_note already
-    follows)."""
+    follows).
+
+    `questions` is the one OPTIONAL member: both producers emit it when they can
+    see the whole ask, and the screen reader cannot when the terminal is showing
+    one tab of several. A client keys off its absence to fall back to the
+    single-question fields, so it must stay additive — never a replacement for
+    anything below.
+    """
     menu = ct.pending_question([_ask()])
-    assert set(menu) == {"question", "title", "body", "selected", "options", "source",
-                         "observed_at"}
+    assert set(menu) - {"questions"} == {
+        "question", "title", "body", "selected", "options", "source", "observed_at"}
     assert menu["selected"] is None      # a transcript cannot see the cursor
 
 
@@ -300,3 +307,74 @@ def test_every_producer_stamps_when_it_looked():
 def test_stamping_is_injectable_so_ages_are_testable():
     assert ct.stamp_observed({"a": 1}, now=123.0) == {"a": 1, "observed_at": 123.0}
     assert ct.stamp_observed(None) is None
+
+
+# --- every question, not just the first -------------------------------------
+#
+# The TUI draws an AskUserQuestion's questions as TABS and refuses to submit
+# until each has an answer. Carrying only questions[0] therefore did not merely
+# under-report the ask — it made it UNANSWERABLE from any surface but the
+# keyboard, because no button on question 1 can reach the Submit behind tab 3.
+# eva, 2026-08-12: a two-question July closeout took a tap, toggled a checkbox,
+# and sat there.
+
+def _multi_ask():
+    return {
+        "questions": [
+            {"question": "Which colors do you want?", "header": "Colors",
+             "multiSelect": True,
+             "options": [{"label": "Red", "description": "warm"},
+                         {"label": "Blue", "description": "cool"}]},
+            {"question": "Which size?", "header": "Size",
+             "options": [{"label": "Small", "description": "compact"},
+                         {"label": "Large", "description": "roomy"}]},
+        ]
+    }
+
+
+def _hook(tool_input):
+    return {"hook_event_name": "PreToolUse", "tool_name": "AskUserQuestion",
+            "tool_input": tool_input}
+
+
+def test_every_question_is_carried_with_its_multi_select_flag():
+    menu = ct.menu_from_hook(_hook(_multi_ask()))
+    assert [q["index"] for q in menu["questions"]] == [0, 1]
+    assert [q["header"] for q in menu["questions"]] == ["Colors", "Size"]
+    assert [q["multi_select"] for q in menu["questions"]] == [True, False]
+    assert [o["label"] for o in menu["questions"][0]["options"]] == ["Red", "Blue"]
+
+
+def test_option_numbers_restart_at_one_per_question():
+    """They are keystrokes on that question's own tab, not a running index."""
+    menu = ct.menu_from_hook(_hook(_multi_ask()))
+    assert [o["number"] for o in menu["questions"][0]["options"]] == [1, 2]
+    assert [o["number"] for o in menu["questions"][1]["options"]] == [1, 2]
+
+
+def test_the_single_question_fields_still_describe_question_one():
+    """An older client reads only these and must render exactly what it did
+    before — the new list is additive."""
+    menu = ct.menu_from_hook(_hook(_multi_ask()))
+    assert menu["question"] == "Which colors do you want?"
+    assert menu["title"] == "Colors"
+    assert [o["label"] for o in menu["options"]] == ["Red", "Blue"]
+
+
+def test_a_malformed_question_drops_the_structured_list_rather_than_shifting_it():
+    """Answers are submitted POSITIONALLY, so a list with a hole in it would
+    answer the wrong tab. Better to fall back to first-question rendering."""
+    broken = {"questions": [
+        {"question": "Which colors?", "options": [{"label": "Red"}]},
+        {"question": "Which size?", "options": []},          # no usable options
+    ]}
+    menu = ct.menu_from_hook(_hook(broken))
+    assert menu is not None
+    assert "questions" not in menu
+    assert menu["question"] == "Which colors?"
+
+
+def test_a_single_question_ask_still_reports_one_question():
+    menu = ct.menu_from_hook(_hook(SPARK_ASK))
+    assert len(menu["questions"]) == 1
+    assert menu["questions"][0]["multi_select"] is False

--- a/runner/canopy_runner/canopy_runner/hooks.py
+++ b/runner/canopy_runner/canopy_runner/hooks.py
@@ -11,6 +11,7 @@ parser, which is what keeps this dependency one-directional."""
 from __future__ import annotations
 
 import logging
+import threading
 import time
 import uuid
 from pathlib import Path
@@ -270,6 +271,7 @@ def read_hook_menu_from(cdp, task: str, *, cdp_port: int = 9222):
 ANSWERED = "answered"
 NO_DIALOG = "no_dialog"          # nothing on screen — already answered, or gone
 NOT_ON_MENU = "not_on_menu"      # stale numbering; the dialog changed under the tap
+UNMODELLED = "unmodelled"        # a tabbed ask we could not match to its questions
 WRONG_PANE = "wrong_pane"        # a shell tab is selected; keys would run in it
 UNREACHABLE = "unreachable"      # CDP/emdash could not be driven at all
 NO_SESSION = "no_session"        # the emdash task is gone — nothing to press a key in
@@ -279,6 +281,8 @@ NO_SESSION = "no_session"        # the emdash task is gone — nothing to press 
 ANSWER_NOTES = {
     NO_DIALOG: "That dialog is no longer on screen — it may already have been answered.",
     NOT_ON_MENU: "The dialog changed before that reached it. Here is what it shows now.",
+    UNMODELLED: "This ask has several questions and they could not be matched to what is "
+                "on screen — answer it in emdash.",
     WRONG_PANE: "A shell tab is selected for this session in emdash. Switch it to the "
                 "Claude tab and tap again.",
     UNREACHABLE: "Could not reach emdash on this runner to press the key.",
@@ -289,17 +293,88 @@ ANSWER_NOTES = {
 
 def _menu_dict(found, *, source: str) -> dict:
     """A parsed screen dialog as the one shape every producer emits."""
-    return transcript_core.stamp_observed({
+    options = [{"number": o.number, "label": o.label} for o in found.options]
+    # NOT named `menu`: that shadows the module of the same name for the whole
+    # function, and the `menu.SUBMIT_TAB` read below then fails on a dict — but
+    # only for a dialog that HAS a tab strip, because the comprehension guarding
+    # it is empty otherwise. Caught by the tabbed round-trip test.
+    payload = {
         "question": found.question,
         "title": found.title,
         "body": found.body,
         "selected": found.selected,
-        "options": [{"number": o.number, "label": o.label} for o in found.options],
+        "options": options,
         "source": source,
-    })
+    }
+    # `questions` only when the screen genuinely holds the WHOLE ask — one
+    # answerable tab. The terminal draws one tab at a time, so with several the
+    # other questions are not on it and any list we built here would be a
+    # truthful-looking lie about a form the client would then let somebody
+    # submit. Its absence is what makes the client fall back and the driver
+    # refuse, which is the correct outcome for a dialog we cannot see all of.
+    answerable = [t for t in found.tabs if t != menu.SUBMIT_TAB]
+    if len(answerable) <= 1 and not found.is_review:
+        payload["questions"] = [{
+            "index": 0,
+            "question": found.question,
+            "header": found.title,
+            "multi_select": found.is_multi_select,
+            "options": options,
+        }]
+    return transcript_core.stamp_observed(payload)
 
 
-def answer_menu_with(cdp, session_key: str, option, *, cdp_port: int = 9222):
+def held_questions(session_key: str) -> list[dict]:
+    """The declared questions of the ask this session is blocked on.
+
+    The SCREEN cannot supply these: it draws one tab at a time, so the questions
+    behind the other tabs are simply not on it. The hook payload carried the
+    whole `AskUserQuestion` input, which is what the client rendered its form
+    from, so driving the tabs means reading the same list back.
+    """
+    listener = _hook_listener
+    if listener is None or not session_key:
+        return []
+    try:
+        for (_project, task), held in listener._pending_menus.items():
+            if task == session_key and isinstance(held, dict):
+                questions = held.get("questions")
+                return questions if isinstance(questions, list) else []
+    except Exception:  # noqa: BLE001 — never cost the wake listener its socket
+        logger.debug("could not read held questions for %s", session_key, exc_info=True)
+    return []
+
+
+def _drive_selections(cdp, session_key, current, questions, selections, cdp_port):
+    """Walk a tabbed / multi-select dialog to a complete, submitted answer.
+
+    One step per screen read (see `menu.plan_step`): press, re-read, decide
+    again. That is what makes answering IDEMPOTENT on a surface whose number
+    keys toggle — pressing the same answer twice converges on the same state
+    instead of undoing it — and it is why the double delivery this system
+    already performs (control frame, then poll tick) is now harmless.
+    """
+    for _ in range(menu.MAX_STEPS):
+        keys = menu.plan_step(current, questions, selections)
+        if keys is None:
+            # Nothing further we can justify pressing. If every question already
+            # reads as answered this is success; otherwise the screen is not the
+            # dialog we were told about.
+            return (ANSWERED, None) if current.is_review else (UNMODELLED, _menu_dict(current, source="screen"))
+        if keys:
+            cdp.send_keys(session_key, keys, port=cdp_port)
+        current = menu.find_menu_settled(
+            lambda: cdp.read_terminal(session_key, port=cdp_port))
+        if current is None:
+            # The dialog is gone, which for this path means it was submitted.
+            return ANSWERED, None
+    logger.warning("gave up driving the dialog on %s after %d steps",
+                   session_key, menu.MAX_STEPS)
+    return UNMODELLED, _menu_dict(current, source="screen") if current else None
+
+
+def answer_menu_with(cdp, session_key: str, option, *, selections=None,
+                     cdp_port: int = 9222):
     """Press a human's answer into `session_key`'s terminal.
 
     Returns `(outcome, screen)` — the verdict, and what the terminal ACTUALLY
@@ -325,6 +400,28 @@ def answer_menu_with(cdp, session_key: str, option, *, cdp_port: int = 9222):
     if current is None:
         logger.info("menu answer for %s ignored — no dialog on screen now", session_key)
         return NO_DIALOG, None
+
+    # A structured answer (one list of chosen option numbers per question) is the
+    # only thing that can complete a multi-select or a multi-question ask: there
+    # the number key toggles a checkbox and the dialog waits on an explicit
+    # Submit, so the single-key recipe below changes state and answers nothing.
+    if selections is not None:
+        questions = held_questions(session_key)
+        if not questions:
+            # Nothing declared to map onto — safe only when the screen itself is
+            # the whole ask, which is exactly the one-question case.
+            if len(selections) != 1:
+                logger.warning("structured answer for %s has %d questions but none are held",
+                               session_key, len(selections))
+                return UNMODELLED, _menu_dict(current, source="screen")
+            questions = [{"index": 0, "question": current.question,
+                          "multi_select": current.is_multi_select}]
+        outcome, screen = _drive_selections(
+            cdp, session_key, current, questions, selections, cdp_port)
+        logger.info("answered the dialog on %s with %s (%s)", session_key,
+                    selections, outcome)
+        return outcome, screen
+
     number = None if option is None else int(option)
     if not current.allows(number):
         logger.warning("menu answer %r for %s is not on the dialog now showing (%d options)",
@@ -346,7 +443,33 @@ def read_hook_menu(cwd: str, *, cdp_port: int):
     return read_hook_menu_from(cdp_control, hook_task_name(cwd), cdp_port=cdp_port)
 
 
-def answer_menu(session_key: str, option, *, cdp_port: int = 9222):
+_answer_locks: dict[str, threading.Lock] = {}
+_answer_locks_guard = threading.Lock()
+
+
+def _answer_lock(session_key: str) -> threading.Lock:
+    """One lock per session, so two deliveries cannot interleave keystrokes.
+
+    Answering used to be a single `send_keys` and was atomic by being tiny.
+    Driving a tabbed dialog is a read-decide-press loop that runs for seconds,
+    and this system delivers every answer TWICE by design — once on the control
+    frame, once from the poll tick that guarantees it survives a dead channel.
+    Those run on different threads. Without this, the second delivery can press
+    Tab into a terminal the first is halfway through toggling, and the two
+    interleave into an answer neither asked for.
+
+    The waiter is not wasted: it re-reads afterwards, finds the boxes already
+    right (or the dialog gone) and presses nothing. That is the whole reason the
+    driver decides from the drawn state rather than from a key program.
+    """
+    with _answer_locks_guard:
+        lock = _answer_locks.get(session_key)
+        if lock is None:
+            lock = _answer_locks[session_key] = threading.Lock()
+        return lock
+
+
+def answer_menu(session_key: str, option, *, selections=None, cdp_port: int = 9222):
     """`answer_menu_with` bound to real CDP, with transport failures classified.
 
     Never raises: this runs on the wake-listener thread, which also carries wake
@@ -354,7 +477,9 @@ def answer_menu(session_key: str, option, *, cdp_port: int = 9222):
     its liveness.
     """
     try:
-        return answer_menu_with(cdp_control, session_key, option, cdp_port=cdp_port)
+        with _answer_lock(session_key):
+            return answer_menu_with(cdp_control, session_key, option,
+                                    selections=selections, cdp_port=cdp_port)
     except Exception as exc:  # noqa: BLE001
         # NOT_A_CLAUDE_PANE is the one refusal a human can act on themselves, and
         # it is the one that actually bit: with a shell tab selected, every tap on

--- a/runner/canopy_runner/canopy_runner/main.py
+++ b/runner/canopy_runner/canopy_runner/main.py
@@ -655,7 +655,7 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def make_control_handler(cfg: Config, waker):
+def make_control_handler(cfg: Config, waker, client=None):
     """The runner's control-frame dispatch, built as a factory so it is testable.
 
     Lifted out of a closure inside `main()` because this dispatch silently LOST a
@@ -712,8 +712,27 @@ def make_control_handler(cfg: Config, waker):
             # tap work?" would wait out the whole heartbeat window.
             session_key = str(msg["session_key"])
             outcome, screen = hooks.answer_menu(session_key, msg.get("option"),
+                                                selections=msg.get("selections"),
                                                 cdp_port=cfg.cdp_port)
             hooks.note_answer_outcome(session_key, outcome, screen)
+            # RETIRE IT. The server holds the answer until a runner reports on it
+            # (that is what makes it survive a dead control channel), so a fast
+            # path that pressed the key and said nothing left the answer queued —
+            # and the very next poll tick pressed it a SECOND time. Harmless on a
+            # permission prompt, destructive on a multi-select, where a number
+            # key toggles: one tap, two presses, box back to where it started.
+            # Observed 2026-08-12 16:49:48 and 16:49:54 on eva's July closeout.
+            # `client` is optional only so the dispatch stays constructible in a
+            # test with no server; in the runner it is always supplied, and
+            # without it the poll tick is still the (double-pressing) backstop.
+            if client is not None:
+                try:
+                    client.post_menu_answer_result(cfg.runner_id,
+                                                   str(msg.get("session_id") or ""),
+                                                   str(msg.get("answer_id") or ""), outcome)
+                except Exception:  # noqa: BLE001 — the poll tick is the backstop
+                    logger.debug("could not retire menu answer from the control frame",
+                                 exc_info=True)
             sessions.request_report_now()
         elif msg.get("type") == "close_session" and msg.get("session_key"):
             # A human closed this session from the web. Runs on the wake-listener
@@ -805,7 +824,7 @@ def main() -> None:
     from .wake import WakeListener
 
     waker = WakeListener(cfg.base_url, cfg.token, cfg.runner_id)
-    waker.on_control = make_control_handler(cfg, waker)
+    waker.on_control = make_control_handler(cfg, waker, client)
     wake_on = waker.start()
     if wake_on:
         logger.info("  wake: WS control channel connected — claims fire on enqueue, not just poll")

--- a/runner/canopy_runner/canopy_runner/menu.py
+++ b/runner/canopy_runner/canopy_runner/menu.py
@@ -52,10 +52,29 @@ _RULE = re.compile(r"^[─━-]{10,}$")
 _WRAP_SLACK = 4
 
 
+# A multi-select row: "[ ] Red" / "[✔] Red". The TUI draws these ONLY for a
+# multiSelect question, which is what makes them the reliable on-screen
+# discriminator — the tool input's `multiSelect` flag is not visible here.
+_CHECKBOX = re.compile(r"^\[([ ✔xX])\]\s*(.*)$")
+
+# The tab strip a multi-question (or any multi-select) ask draws above the
+# question: "←  ☒ Colors  ☐ Size  ✔ Submit  →". A single-question single-select
+# draws a bare "☐ Size" with no arrows and no Submit tab, and needs no submit
+# step — which is exactly why today's number+Enter works there and nowhere else.
+_TAB_MARK = re.compile(r"[☐☒✔]")
+
+# The final tab. Reached with Tab, and a plain numbered menu once there, so the
+# ordinary answer path presses its button.
+_REVIEW = "Ready to submit your answers?"
+SUBMIT_TAB = "Submit"
+
+
 @dataclass
 class Option:
     number: int
     label: str
+    #: True/False on a multi-select row, None when the row has no checkbox.
+    checked: bool | None = None
 
 
 @dataclass
@@ -65,7 +84,37 @@ class Menu:
     title: str = ""
     body: str = ""
     selected: int | None = None
+    #: Tab labels in drawn order, e.g. ["Colors", "Size", "Submit"]. Empty when
+    #: the dialog draws no tab strip (a permission prompt, a trust gate).
+    tabs: list[str] = field(default_factory=list)
     raw: str = field(default="", repr=False)
+
+    @property
+    def is_review(self) -> bool:
+        """The Submit tab, showing the answers back before they are sent."""
+        return _REVIEW in self.raw
+
+    @property
+    def is_multi_select(self) -> bool:
+        """Whether a number key TOGGLES here rather than answering.
+
+        Read off the drawn checkboxes rather than the tool input: this is the
+        screen the keystroke actually lands on, and the runner's whole safety
+        story is that it verifies against the screen before pressing.
+        """
+        return any(o.checked is not None for o in self.options)
+
+    @property
+    def needs_submit(self) -> bool:
+        """Whether answering every question still leaves a Submit to press.
+
+        A single-question single-select draws no Submit tab and completes on the
+        number alone. Everything else has to be walked to the review screen.
+        """
+        return SUBMIT_TAB in self.tabs
+
+    def checked_numbers(self) -> list[int]:
+        return [o.number for o in self.options if o.checked]
 
     def allows(self, number: int | None) -> bool:
         """Whether `number` is actually on this menu.
@@ -102,6 +151,32 @@ def _join_wrapped(lines: list[str]) -> str:
             # Mid-token wrap: the grid split a path or flag, so no separator.
             out += piece
     return out
+
+
+def _parse_tabs(lines: list[str], first_option_line: int) -> tuple[list[str], int | None]:
+    """The tab strip's labels, and the line it was drawn on.
+
+    "←  ☒ Colors  ☐ Size  ✔ Submit  →" -> (["Colors", "Size", "Submit"], i).
+    A single-question single-select draws a bare "☐ Size"; that parses to
+    ["Size"] with no "Submit", which is precisely the distinction the driver
+    needs — no Submit tab means the number key finishes the dialog by itself.
+
+    Searched only ABOVE the options: a checked multi-select row ("[✔] Red")
+    carries the same glyph and would otherwise parse as a tab strip.
+
+    Backwards from the options, so the NEAREST strip wins. A terminal holds the
+    whole scrollback, and an agent that printed a ✔ earlier in the session must
+    not be mistaken for the tab strip of the dialog now on screen.
+    """
+    for i in range(first_option_line - 1, -1, -1):
+        line = lines[i]
+        if not _TAB_MARK.search(line) or _OPTION.match(line):
+            continue
+        stripped = line.strip().strip("←→").strip()
+        labels = [p.strip() for p in _TAB_MARK.split(stripped) if p.strip()]
+        if labels:
+            return labels, i
+    return [], None
 
 
 def _dialog_runs_to_the_bottom(lines: list[str], selected: int | None) -> bool:
@@ -177,6 +252,14 @@ def find_menu(text: str) -> Menu | None:
         number, label = int(m.group(1)), m.group(2).strip()
         if _FOOTER.search(label):
             continue
+        # "[ ] Red" -> checked=False, label="Red". Kept off the label because the
+        # label is what a phone renders as a button, and "[ ] Red" reads as a
+        # broken string there while the box state belongs in its own field.
+        checked = None
+        box = _CHECKBOX.match(label)
+        if box:
+            checked = box.group(1) != " "
+            label = box.group(2).strip()
         # Options are consecutive from 1; anything else is prose that happens to
         # be numbered.
         if not options and number != 1:
@@ -185,7 +268,7 @@ def find_menu(text: str) -> Menu | None:
             continue
         if not options:
             first_option_line = i
-        options.append(Option(number, label))
+        options.append(Option(number, label, checked))
         if CURSOR in line:
             selected = number
 
@@ -243,12 +326,29 @@ def find_menu(text: str) -> Menu | None:
         if _RULE.match(lines[i].strip()):
             start = i + 1
             break
-    block = [l for l in lines[start:question_line] if l.strip()]
-    title = block[0].strip() if block else ""
+    tabs, tab_line = _parse_tabs(lines, first_option_line)
+
+    # The tab strip sits inside the subject block and is NOT subject: rendered as
+    # a title it reaches a phone as "← ☒ Close July ☒ Aug goals ✔ Submit →",
+    # which is chrome from a terminal nobody is looking at. It has its own field
+    # now, so drop it here.
+    block = [lines[i].strip() for i in range(start, question_line)
+             if lines[i].strip() and i != tab_line]
+    title = block[0] if block else ""
+    if not title:
+        # The tab strip was the whole subject block, which is the normal shape of
+        # an AskUserQuestion — it draws its header there and nothing else. With
+        # one question that header IS the dialog's label, so keep using it (minus
+        # the ☐ chrome, which meant nothing away from the terminal). With several
+        # we cannot tell which tab is current from the strip alone, and a label
+        # naming the wrong question is worse than none: the client has the real
+        # per-question headers in `questions`.
+        answerable = [t for t in tabs if t != SUBMIT_TAB]
+        title = answerable[0] if len(answerable) == 1 else ""
     body = _join_wrapped(block[1:]) if len(block) > 1 else ""
 
     return Menu(question=question, options=options, title=title, body=body,
-                selected=selected, raw=text)
+                selected=selected, tabs=tabs, raw=text)
 
 
 def find_menu_settled(read_screen, *, attempts: int = 3, delay: float = 0.8):
@@ -273,7 +373,7 @@ def find_menu_settled(read_screen, *, attempts: int = 3, delay: float = 0.8):
 
 
 def answer_keys(option: int | None) -> list[str]:
-    """The keystrokes that answer a dialog.
+    """The keystrokes that answer a SINGLE-select dialog.
 
     `None` means refuse, and sends Escape rather than a number — the one answer
     that is safe when the numbering is not what we think it is. Every dialog
@@ -281,7 +381,103 @@ def answer_keys(option: int | None) -> list[str]:
 
     Roundtrip-verified: '1' + Enter on a real Bash-permission dialog ran the
     command.
+
+    NOT sufficient for a multi-select or a multi-question ask: there the number
+    key toggles a checkbox and the trailing Enter answers nothing, so the dialog
+    stays up having silently changed state. `plan_step` drives those.
     """
     if option is None:
         return ["\x1b"]
     return [str(option), "\r"]
+
+
+TAB = "\t"
+SUBMIT_ANSWERS = "Submit answers"
+
+# Bound on the drive loop. Each question costs at most (toggles + one Tab), so
+# this is generous for any real ask while still terminating if the screen stops
+# responding the way we read it — a loop pressing keys into a terminal forever
+# is the one failure mode worse than a dropped answer.
+MAX_STEPS = 60
+
+
+def normalise(text: str) -> str:
+    return " ".join((text or "").split()).casefold()
+
+
+def question_index(menu: "Menu", questions: list[dict]) -> int | None:
+    """Which declared question the screen is currently showing, or None.
+
+    Matched on the question TEXT rather than the tab strip, because the strip
+    marks which tabs are answered but not which one you are on — the current tab
+    is distinguished by colour, and colour does not survive the read.
+
+    Prefix-tolerant: a long question is word-wrapped and can be rejoined with
+    slightly different spacing than the tool input carried.
+    """
+    shown = normalise(menu.question)
+    if not shown:
+        return None
+    best = None
+    for q in questions:
+        want = normalise(q.get("question") or q.get("header") or "")
+        if not want:
+            continue
+        if want == shown:
+            return q.get("index", questions.index(q))
+        if (want.startswith(shown) or shown.startswith(want)) and len(shown) >= 12:
+            # Longest match wins: two questions can share an opening clause.
+            if best is None or len(want) > best[1]:
+                best = (q.get("index", questions.index(q)), len(want))
+    return best[0] if best else None
+
+
+def plan_step(menu: "Menu", questions: list[dict], selections: list[list[int]]) -> list[str] | None:
+    """The NEXT keystrokes for this screen, or None when there is nothing left.
+
+    Deliberately one step at a time, re-reading between steps, rather than one
+    computed key program. Three reasons, all observed on a real TUI:
+
+    * A checkbox press is a TOGGLE, so a replayed answer un-answers it. Driving
+      from the drawn state makes the whole operation idempotent — which is what
+      makes the double-delivery this system already has (WS frame plus poll
+      tick) harmless instead of destructive.
+    * A single-select question AUTO-ADVANCES to the next tab when answered, and
+      a multi-select does not, so the tab you are on after a keypress is not
+      something a blind program can know.
+    * The dialog can change under us. Every step re-verifies before pressing,
+      which is the existing safety property, kept.
+
+    Returns [] to mean "press nothing, but we are not done" — never used, but
+    the distinction from None matters to the caller's loop.
+    """
+    if menu.is_review:
+        for option in menu.options:
+            if normalise(option.label).startswith(normalise(SUBMIT_ANSWERS)):
+                return [str(option.number), "\r"]
+        return None  # a review screen we do not recognise: refuse to guess
+
+    index = question_index(menu, questions)
+    if index is None or index >= len(selections):
+        return None
+    want = sorted(selections[index])
+
+    if menu.is_multi_select:
+        # Toggle only the DIFFERENCES, so re-running this against a screen that
+        # already matches presses nothing at all.
+        have = set(menu.checked_numbers())
+        differing = [n for n in menu.options
+                     if (n.number in want) != (n.number in have)]
+        if differing:
+            return [str(o.number) for o in differing]
+        # This tab is right; move on. Tab clamps at the review screen rather
+        # than wrapping, so over-pressing it cannot walk us back round.
+        return [TAB] if menu.needs_submit else None
+
+    # Single-select: pressing the number both answers and advances.
+    if not want:
+        return [TAB] if menu.needs_submit else None
+    number = want[0]
+    if not menu.allows(number):
+        return None
+    return [str(number)] if menu.needs_submit else [str(number), "\r"]

--- a/runner/canopy_runner/canopy_runner/streams.py
+++ b/runner/canopy_runner/canopy_runner/streams.py
@@ -199,6 +199,7 @@ def drain_menu_answers(cfg: Config, client: Client) -> None:
         if not (session_key and answer_id):
             continue
         outcome, screen = hooks.answer_menu(session_key, a.get("option"),
+                                            selections=a.get("selections"),
                                             cdp_port=cfg.cdp_port)
         hooks.note_answer_outcome(session_key, outcome, screen)
         try:

--- a/runner/canopy_runner/tests/test_menu.py
+++ b/runner/canopy_runner/tests/test_menu.py
@@ -300,7 +300,11 @@ def test_a_word_wrapped_question_is_rejoined():
     assert menu is not None
     assert menu.question.startswith("Ada is blocked on")
     assert menu.question.endswith("so which answer should I press into that session?")
-    assert menu.title == "\u2610 Unstick ada"
+    # The \u2610 is the tab strip's own chrome and now parses into `tabs`. The label
+    # still reaches the phone as the title \u2014 a single-question ask has exactly
+    # one answerable tab, and its header is the dialog's name.
+    assert menu.tabs == ["Unstick ada"]
+    assert menu.title == "Unstick ada"
 
 
 def test_a_subject_line_is_never_swallowed_into_the_question():
@@ -310,3 +314,203 @@ def test_a_subject_line_is_never_swallowed_into_the_question():
     menu = find_menu(PERMISSION)
     assert menu.question == "Do you want to proceed?"
     assert "Delete target.txt and verify" not in menu.question
+
+
+# --- Tabbed / multi-select asks --------------------------------------------
+#
+# Captured the same way as everything above: `claude` driven in a real PTY with
+# an AskUserQuestion carrying two questions, the first `multiSelect: true`, and
+# the rendered grid taken verbatim at each step. The keystroke semantics these
+# assert were established by pressing the keys and watching the screen, on
+# 2026-08-12 — a number TOGGLES a checkbox, Tab moves tab, and the dialog is not
+# submitted until the review tab's own button is pressed.
+
+RULE = "─" * 150
+
+TABBED_MULTI = f"""\
+{RULE}
+←  ☐ Colors  ☐ Size  ✔ Submit  →
+
+Which colors do you want?
+
+❯ 1. [ ] Red
+  Warm and energetic
+  2. [ ] Green
+  Natural and balanced
+  3. [ ] Blue
+  Calm and trustworthy
+  4. [ ] Type something
+     Next
+{RULE}
+  5. Chat about this
+
+Enter to select · Tab/Arrow keys to navigate · Esc to cancel
+"""
+
+TABBED_MULTI_TWO_CHECKED = TABBED_MULTI.replace("1. [ ] Red", "1. [✔] Red").replace(
+    "3. [ ] Blue", "3. [✔] Blue"
+).replace("☐ Colors", "☒ Colors")
+
+TABBED_SINGLE = f"""\
+{RULE}
+←  ☒ Colors  ☐ Size  ✔ Submit  →
+
+Which size?
+
+❯ 1. Small
+     Compact and efficient
+  2. Large
+     Spacious and generous
+  3. Type something.
+{RULE}
+  4. Chat about this
+
+Enter to select · Tab/Arrow keys to navigate · Esc to cancel
+"""
+
+REVIEW = f"""\
+{RULE}
+←  ☒ Colors  ☒ Size  ✔ Submit  →
+
+Review your answers
+
+ ● Which colors do you want?
+   → Red, Blue
+ ● Which size?
+   → Large
+
+Ready to submit your answers?
+
+❯ 1. Submit answers
+  2. Cancel
+"""
+
+# One question, single-select: NO tab strip arrows and no Submit tab. This is the
+# shape a lone number key has always finished, and it must keep working.
+LONE_SINGLE = f"""\
+{RULE}
+ ☐ Size
+
+Which size?
+
+❯ 1. Small
+     Compact option with minimal footprint.
+  2. Large
+     Expanded option with full capacity.
+  3. Type something.
+{RULE}
+  4. Chat about this
+
+Enter to select · ↑/↓ to navigate · Esc to cancel
+"""
+
+QUESTIONS = [
+    {"index": 0, "question": "Which colors do you want?", "header": "Colors",
+     "multi_select": True,
+     "options": [{"number": 1, "label": "Red"}, {"number": 2, "label": "Green"},
+                 {"number": 3, "label": "Blue"}]},
+    {"index": 1, "question": "Which size?", "header": "Size", "multi_select": False,
+     "options": [{"number": 1, "label": "Small"}, {"number": 2, "label": "Large"}]},
+]
+
+
+def test_a_checkbox_row_parses_its_box_separately_from_its_label():
+    """"[ ] Red" reaching a phone as a button label is the string a human reads;
+    the box state belongs in a field the driver can compare against."""
+    menu = find_menu(TABBED_MULTI)
+    assert menu is not None
+    assert [o.label for o in menu.options][:3] == ["Red", "Green", "Blue"]
+    assert [o.checked for o in menu.options][:3] == [False, False, False]
+    assert menu.is_multi_select
+    assert find_menu(TABBED_MULTI_TWO_CHECKED).checked_numbers() == [1, 3]
+
+
+def test_the_tab_strip_parses_and_stays_out_of_the_title():
+    menu = find_menu(TABBED_MULTI)
+    assert menu.tabs == ["Colors", "Size", "Submit"]
+    assert menu.needs_submit
+    # Two answerable tabs: we cannot tell which is current from the strip, and a
+    # title naming the wrong question is worse than none.
+    assert menu.title == ""
+
+
+def test_a_lone_single_select_needs_no_submit_step():
+    """The one shape today's number+Enter actually finishes."""
+    menu = find_menu(LONE_SINGLE)
+    assert menu is not None
+    assert menu.tabs == ["Size"]
+    assert not menu.needs_submit
+    assert not menu.is_multi_select
+    assert menu.title == "Size"
+
+
+def test_a_single_select_question_is_not_read_as_multi_select():
+    menu = find_menu(TABBED_SINGLE)
+    assert not menu.is_multi_select
+    assert all(o.checked is None for o in menu.options)
+    assert menu.needs_submit
+
+
+def test_the_review_screen_is_recognised():
+    menu = find_menu(REVIEW)
+    assert menu is not None
+    assert menu.is_review
+    assert [o.label for o in menu.options] == ["Submit answers", "Cancel"]
+
+
+# --- Driving ----------------------------------------------------------------
+
+
+def test_it_presses_only_the_boxes_that_differ():
+    """The whole idempotence story. A number TOGGLES, so replaying an answer that
+    has already landed must press nothing rather than undo it — which is what
+    makes the control-frame/poll-tick double delivery survivable."""
+    from canopy_runner.menu import plan_step
+
+    fresh = find_menu(TABBED_MULTI)
+    assert plan_step(fresh, QUESTIONS, [[1, 3], [2]]) == ["1", "3"]
+
+    already = find_menu(TABBED_MULTI_TWO_CHECKED)
+    # Boxes already right: nothing to toggle, so move to the next tab.
+    assert plan_step(already, QUESTIONS, [[1, 3], [2]]) == ["\t"]
+
+
+def test_it_unchecks_a_box_the_answer_does_not_want():
+    from canopy_runner.menu import plan_step
+
+    menu = find_menu(TABBED_MULTI_TWO_CHECKED)
+    assert plan_step(menu, QUESTIONS, [[1], [2]]) == ["3"]
+
+
+def test_a_single_select_tab_is_answered_by_its_number_alone():
+    """It auto-advances, so no Enter here — an Enter would land on whatever the
+    next tab drew."""
+    from canopy_runner.menu import plan_step
+
+    menu = find_menu(TABBED_SINGLE)
+    assert plan_step(menu, QUESTIONS, [[1, 3], [2]]) == ["2"]
+
+
+def test_a_lone_single_select_still_gets_number_and_enter():
+    from canopy_runner.menu import plan_step
+
+    menu = find_menu(LONE_SINGLE)
+    lone = [{"index": 0, "question": "Which size?", "multi_select": False,
+             "options": [{"number": 1, "label": "Small"}]}]
+    assert plan_step(menu, lone, [[2]]) == ["2", "\r"]
+
+
+def test_the_review_screen_presses_submit():
+    from canopy_runner.menu import plan_step
+
+    assert plan_step(find_menu(REVIEW), QUESTIONS, [[1, 3], [2]]) == ["1", "\r"]
+
+
+def test_an_unrecognised_question_presses_nothing():
+    """A dialog that is not the one we were told about must cost a dropped tap,
+    never a guessed keystroke."""
+    from canopy_runner.menu import plan_step
+
+    other = [{"index": 0, "question": "Something else entirely?",
+              "multi_select": True, "options": [{"number": 1, "label": "x"}]}]
+    assert plan_step(find_menu(TABBED_MULTI), other, [[1]]) is None

--- a/runner/canopy_runner/tests/test_wake.py
+++ b/runner/canopy_runner/tests/test_wake.py
@@ -101,3 +101,73 @@ def test_a_malformed_frame_never_reaches_a_branch_that_raises():
     on_control({"type": "check_inbox"})         # no mailbox
     on_control({"type": "menu_answer"})         # no session_key
     on_control({"type": "close_session"})       # no session_key
+
+
+# --- the control frame must RETIRE the answer it just pressed ---------------
+
+
+class _RecordingClient:
+    def __init__(self):
+        self.retired = []
+
+    def post_menu_answer_result(self, runner_id, session_id, answer_id, outcome):
+        self.retired.append((session_id, answer_id, outcome))
+
+
+def _menu_handler(monkeypatch, client):
+    from canopy_runner import hooks, sessions
+
+    pressed = []
+    monkeypatch.setattr(hooks, "answer_menu",
+                        lambda key, option, **kw: (pressed.append((key, option, kw)),
+                                                   ("answered", None))[1])
+    monkeypatch.setattr(hooks, "note_answer_outcome", lambda *a, **k: None)
+    monkeypatch.setattr(sessions, "request_report_now", lambda: None)
+
+    waker = WakeListener("http://x", "t", "r1")
+    cfg = types.SimpleNamespace(cdp_port=9222, runner_id="r1", base_url="http://x",
+                                token="t", state_path=None)
+    return make_control_handler(cfg, waker, client), pressed
+
+
+def test_the_control_frame_retires_the_answer_it_pressed(monkeypatch):
+    """REGRESSION, eva 2026-08-12. The server holds an answer until a runner
+    REPORTS on it — that is what makes it survive a dead control channel. This
+    fast path pressed the key and reported nothing, so the answer stayed queued
+    and the next poll tick (5s later) pressed it a SECOND time:
+
+        16:49:48 answered the dialog on eva-… with option 1
+        16:49:54 answered the dialog on eva-… with option 1
+        16:49:55 menu answer for eva-… applied from the poll tick (answered)
+
+    Harmless on a permission prompt, destructive on a multi-select, where a
+    number key toggles: one tap, two presses, checkbox back where it started.
+    """
+    client = _RecordingClient()
+    on_control, pressed = _menu_handler(monkeypatch, client)
+    on_control({"type": "menu_answer", "session_key": "k", "option": 1,
+                "session_id": "s-1", "answer_id": "a-1"})
+    assert len(pressed) == 1
+    assert client.retired == [("s-1", "a-1", "answered")]
+
+
+def test_selections_reach_the_runner_from_the_control_frame(monkeypatch):
+    """A multi-select answer cannot be expressed as one option, so the frame's
+    `selections` has to survive the dispatch or the whole feature is inert."""
+    on_control, pressed = _menu_handler(monkeypatch, _RecordingClient())
+    on_control({"type": "menu_answer", "session_key": "k", "option": 1,
+                "selections": [[1, 3], [2]], "session_id": "s", "answer_id": "a"})
+    assert pressed[0][2]["selections"] == [[1, 3], [2]]
+
+
+def test_a_failed_retire_does_not_cost_the_socket(monkeypatch):
+    """The poll tick is the backstop; a raise here would take down wake and
+    cancel with it."""
+    class _Boom:
+        def post_menu_answer_result(self, *a, **k):
+            raise RuntimeError("server down")
+
+    on_control, pressed = _menu_handler(monkeypatch, _Boom())
+    on_control({"type": "menu_answer", "session_key": "k", "option": 1,
+                "session_id": "s", "answer_id": "a"})
+    assert len(pressed) == 1

--- a/tests/test_menu_roundtrip_e2e.py
+++ b/tests/test_menu_roundtrip_e2e.py
@@ -143,3 +143,205 @@ def test_an_option_the_dialog_does_not_offer_is_never_pressed():
     emdash, _frames = _run_hook_to_frames(SCREEN)
     runner_hooks.answer_menu_with(emdash, "agent-task", 9)
     assert emdash.sent == []
+
+
+# --- the tabbed / multi-select ask, across the same seams -------------------
+#
+# Captured from a live `claude` on 2026-08-12 driving a two-question
+# AskUserQuestion with `multiSelect` on the first. The keystroke expectations
+# below were verified against that real TUI, not reasoned about: a number
+# TOGGLES a checkbox, Tab moves tab, a single-select tab auto-advances, and
+# nothing is submitted until the review tab's own button is pressed.
+#
+# Until this shape was driven properly it was UNANSWERABLE from the web. The tap
+# landed, toggled one box, and the dialog sat waiting on a Submit no phone could
+# reach — eva's July closeout, blocked exactly this way.
+
+_RULE = "─" * 120
+
+TABBED_SCREENS = {
+    "colors": f"""\
+{_RULE}
+←  ☐ Colors  ☐ Size  ✔ Submit  →
+
+Which colors do you want?
+
+❯ 1. [ ] Red
+  2. [ ] Green
+  3. [ ] Blue
+  4. [ ] Type something
+     Next
+{_RULE}
+  5. Chat about this
+
+Enter to select · Tab/Arrow keys to navigate · Esc to cancel
+""",
+    "colors_done": f"""\
+{_RULE}
+←  ☒ Colors  ☐ Size  ✔ Submit  →
+
+Which colors do you want?
+
+❯ 1. [✔] Red
+  2. [ ] Green
+  3. [✔] Blue
+  4. [ ] Type something
+     Next
+{_RULE}
+  5. Chat about this
+
+Enter to select · Tab/Arrow keys to navigate · Esc to cancel
+""",
+    "size": f"""\
+{_RULE}
+←  ☒ Colors  ☐ Size  ✔ Submit  →
+
+Which size?
+
+❯ 1. Small
+  2. Large
+  3. Type something.
+{_RULE}
+  4. Chat about this
+
+Enter to select · Tab/Arrow keys to navigate · Esc to cancel
+""",
+    "review": f"""\
+{_RULE}
+←  ☒ Colors  ☒ Size  ✔ Submit  →
+
+Review your answers
+
+ ● Which colors do you want?
+   → Red, Blue
+ ● Which size?
+   → Large
+
+Ready to submit your answers?
+
+❯ 1. Submit answers
+  2. Cancel
+""",
+    "gone": "⏺ GOT=Red, Blue|Large\n\n❯\n  ⏵⏵ bypass permissions on\n",
+}
+
+TABBED_INPUT = {
+    "questions": [
+        {"question": "Which colors do you want?", "header": "Colors",
+         "multiSelect": True,
+         "options": [{"label": "Red", "description": "warm"},
+                     {"label": "Green", "description": "natural"},
+                     {"label": "Blue", "description": "cool"}]},
+        {"question": "Which size?", "header": "Size", "multiSelect": False,
+         "options": [{"label": "Small", "description": "compact"},
+                     {"label": "Large", "description": "roomy"}]},
+    ]
+}
+
+
+class FakeTabbedEmdash:
+    """A terminal that responds to keys the way the real TUI was observed to.
+
+    Not a mock of our own expectations: each transition below was reproduced
+    against a live `claude` before being written down.
+    """
+
+    def __init__(self):
+        self.state = "colors"
+        self.checked: set[int] = set()
+        self.sent: list = []
+
+    @property
+    def screen(self):
+        if self.state == "colors" and self.checked == {1, 3}:
+            return TABBED_SCREENS["colors_done"]
+        return TABBED_SCREENS[self.state]
+
+    def read_terminal(self, task, *, port=9222):
+        return self.screen
+
+    def send_keys(self, task, keys, *, port=9222):
+        self.sent.append((task, list(keys)))
+        for key in keys:
+            if self.state == "colors":
+                if key == "\t":
+                    self.state = "size"
+                elif key.isdigit():
+                    n = int(key)
+                    self.checked ^= {n}          # a number TOGGLES
+            elif self.state == "size":
+                if key.isdigit():
+                    self.state = "review"        # single-select auto-advances
+                elif key == "\t":
+                    self.state = "review"
+            elif self.state == "review":
+                if key == "1":
+                    self.state = "gone"
+        return {"ok": True}
+
+
+def _hook_menu(tool_input):
+    from canopy_transcript import menu_from_hook
+
+    return menu_from_hook({"hook_event_name": "PreToolUse",
+                           "tool_name": "AskUserQuestion",
+                           "tool_input": tool_input})
+
+
+def test_the_browser_receives_every_question_with_its_multi_select_flag():
+    """The client renders its form from this. Carrying only question 1 is what
+    made the ask unanswerable — no button on it can reach tab 2's Submit."""
+    menu = _hook_menu(TABBED_INPUT)
+    assert [q["header"] for q in menu["questions"]] == ["Colors", "Size"]
+    assert [q["multi_select"] for q in menu["questions"]] == [True, False]
+    # …and an older client still sees exactly what it saw before.
+    assert menu["question"] == "Which colors do you want?"
+    assert [o["label"] for o in menu["options"]] == ["Red", "Green", "Blue"]
+
+
+def test_a_tabbed_multi_select_answer_becomes_the_right_keystrokes():
+    emdash = FakeTabbedEmdash()
+    questions = _hook_menu(TABBED_INPUT)["questions"]
+    current = runner_hooks.menu.find_menu(emdash.screen)
+
+    outcome, _screen = runner_hooks._drive_selections(
+        emdash, "agent-task", current, questions, [[1, 3], [2]], 9222)
+
+    assert outcome == runner_hooks.ANSWERED
+    assert [keys for _task, keys in emdash.sent] == [["1", "3"], ["\t"], ["2"], ["1", "\r"]]
+    assert emdash.state == "gone"
+
+
+def test_replaying_the_same_answer_does_not_undo_it():
+    """The system delivers every answer TWICE by design — control frame, then
+    poll tick. On a surface whose number keys TOGGLE, a blind replay would
+    un-check what the first delivery checked. Driving from the drawn state makes
+    the second pass a no-op instead."""
+    emdash = FakeTabbedEmdash()
+    questions = _hook_menu(TABBED_INPUT)["questions"]
+
+    # First delivery gets as far as filling in the colours, then stops.
+    emdash.send_keys("agent-task", ["1", "3"])
+    assert emdash.checked == {1, 3}
+    emdash.sent.clear()
+
+    # Second delivery, same answer, from whatever is now on screen.
+    current = runner_hooks.menu.find_menu(emdash.screen)
+    runner_hooks._drive_selections(
+        emdash, "agent-task", current, questions, [[1, 3], [2]], 9222)
+
+    assert emdash.checked == {1, 3}              # not toggled back off
+    assert [keys for _t, keys in emdash.sent] == [["\t"], ["2"], ["1", "\r"]]
+
+
+def test_a_dialog_that_is_not_the_declared_ask_is_never_guessed_at():
+    emdash = FakeTabbedEmdash()
+    current = runner_hooks.menu.find_menu(emdash.screen)
+    other = [{"index": 0, "question": "Something else?", "multi_select": True,
+              "options": [{"number": 1, "label": "x"}]}]
+
+    outcome, _screen = runner_hooks._drive_selections(
+        emdash, "agent-task", current, other, [[1]], 9222)
+
+    assert outcome == runner_hooks.UNMODELLED
+    assert emdash.sent == []


### PR DESCRIPTION
## The bug

An `AskUserQuestion` with several questions, or one that takes several answers, could not be answered from the phone at all — not awkwardly, *structurally*:

- The TUI draws the questions as **tabs** and will not submit until each has an answer, but the menu payload carried only `questions[0]`. No button on that surface could reach the Submit behind tab 2.
- On a multi-select the number key **toggles a checkbox**. The runner's one recipe was `<number> + Enter`, which checked a box and answered nothing — leaving the dialog up in a state the person who tapped could not see.

eva's July closeout, 2026-08-12: a tap landed, checked one box, and the session sat on a dialog nobody could finish from the phone.

## Behaviour, established against a live TUI

Driven in a pty through a terminal emulator and observed — not reasoned about. Every fixture in the tests is a verbatim capture.

| shape | tab strip | a number key | completion |
|---|---|---|---|
| 1 question, single-select | `☐ Size`, no arrows | selects **and completes** | immediate (today's path) |
| 1 question, multi-select | `← ☐ Colors ✔ Submit →` | **toggles** | Tab → review → `1`+Enter |
| N questions | `← ☐ A ☐ B ✔ Submit →` | toggles / selects+auto-advances | Tab per tab → review → `1`+Enter |

Tab is the universal advance and **clamps** at the review screen rather than wrapping, so over-pressing it is safe.

## The change

The answer is **driven, not fired**: read the screen, decide one step, press, re-read. That is what makes it idempotent on a surface whose keys toggle — and idempotence is what this system needs, because it delivers every answer twice on purpose (control frame, then the poll tick that makes an answer survive a dead channel).

- `canopy_transcript` carries every question with its `multi_select` flag. The top-level `question`/`options` stay pinned to question 1, so an older client renders exactly what it did before.
- `MenuPrompt` grows a form — all questions at once, checkboxes or radios, one Send. Deliberately *not* a tab strip mirroring the terminal's: the thing that went wrong was somebody answering what looked like the whole ask and it being tab 1 of 2.
- `selections` (one list of option numbers per question) travels endpoint → `pending_answer` → both delivery paths.

## Two defects found on the way

- **The control frame never retired the answer it pressed**, so the poll tick pressed it again ~6s later (`16:49:48` and `16:49:54` in the runner log). Harmless on a permission prompt; on a checkbox it undoes itself.
- **Nothing serialised the two deliveries.** Answering used to be one `send_keys` and atomic by being tiny; driving a dialog runs for seconds, so they could interleave keystrokes into one terminal. Now one lock per session — the waiter re-reads, finds the boxes already right, and presses nothing.

## Compatibility

`option` still rides alongside `selections`, set to the first pick. It is the only field an older runner reads, and sending it `null` there would read as "refuse" and cancel the dialog outright. So an un-updated runner keeps doing exactly what it does today — no regression, no Escape.

## Verification

- Full suites green: **2111** server, **446** runner, **70** canopy_transcript; `ruff --select F` clean; `npm run build` (tsc -b) clean.
- **Live round trip through the production path** — `hooks._drive_selections` against a real Claude Code dialog, only the CDP transport swapped for a pty:

```
outcome: answered
keystrokes: [['1', '3'], ['\t'], ['2'], ['1', '\r']]
⏺ GOT=Red, Blue|Large
```

A cross-seam test reproduces that same transition table in `tests/test_menu_roundtrip_e2e.py`, including the replay case (second delivery presses nothing rather than un-checking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)