### PR TITLE
Relay selections and answer_id on the menu_answer control frame

### DIFF
--- a/apps/realtime/consumers.py
+++ b/apps/realtime/consumers.py
@@ -284,11 +284,27 @@ class RunnerConsumer(AsyncJsonWebsocketConsumer):
         # runner.{id} group_send type="runner.menu_answer" — a human answered, from
         # the web, the dialog an agent is blocked on. The runner presses the key in
         # the session's terminal; the server never touches a terminal itself.
+        # Relayed field by field, so anything added to the published frame has to
+        # be added HERE too or it is silently dropped — which is exactly what
+        # happened to both fields below on 2026-08-12:
+        #
+        #   `selections` missing -> the runner fell back to the single-key
+        #   `option` path and pressed a NUMBER at a multi-select, toggling one
+        #   checkbox and answering nothing.
+        #   `answer_id` missing  -> the runner's retire call carried an empty id,
+        #   the server's id match refused it, the answer stayed queued and the
+        #   poll tick pressed it a second time.
+        #
+        # Both were invisible to the unit tests because those built the frame by
+        # hand. `test_realtime_menu_answer.py` now asserts this relay against
+        # what `answer_menu` actually publishes.
         await self.send_json({
             "type": "menu_answer",
             "session_id": message.get("session_id"),
             "session_key": message.get("session_key"),
             "option": message.get("option"),
+            "selections": message.get("selections"),
+            "answer_id": message.get("answer_id"),
         })
 
     async def runner_close_session(self, message):

--- a/tests/test_realtime_runner_consumer.py
+++ b/tests/test_realtime_runner_consumer.py
@@ -417,3 +417,64 @@ async def test_ws_heartbeat_survives_a_malformed_committed_at():
     assert fresh.code_sha == "abc123"
     assert fresh.code_committed_at == 0
     await comm.disconnect()
+
+
+# --- the menu_answer relay must carry EVERY field it is published with ------
+#
+# REGRESSION, 2026-08-12. `runner_menu_answer` relays field by field, and two
+# fields added to the published frame were never added here, so the socket
+# quietly delivered a frame missing both:
+#
+#   selections  -> the runner fell back to the single-key `option` path and
+#                  pressed a NUMBER at a multi-select, toggling one checkbox
+#                  and answering nothing. Watched happening on screen: the
+#                  checkmark appeared and vanished.
+#   answer_id   -> the runner's retire call carried "", the server's id match
+#                  refused it, and the poll tick pressed the answer again.
+#
+# Every unit test around this built the frame by hand and so agreed with the
+# bug. This one takes what `answer_menu` ACTUALLY publishes and asserts the
+# relay preserves it, so the next added field fails here instead of in a
+# terminal.
+
+def _published_menu_answer_frame(monkeypatch):
+    from apps.canopy_sessions import services as chat_services
+    from apps.realtime import groups
+
+    sent = {}
+    monkeypatch.setattr(groups, "publish",
+                        lambda group, payload: sent.update(payload))
+    return sent, chat_services
+
+
+@pytest.mark.django_db(transaction=True)
+def test_the_relay_forwards_every_published_field(monkeypatch):
+    import asyncio
+
+    from apps.canopy_sessions.models import RunnerBinding, Session
+    from apps.realtime.consumers import RunnerConsumer
+
+    user, ws, agent, runner = _setup()
+    session = Session.objects.create(workspace=ws, created_by=user, agent=agent,
+                                     title="t")
+    RunnerBinding.objects.create(session=session, runner=runner,
+                                 session_key="agent-task")
+
+    sent, chat_services = _published_menu_answer_frame(monkeypatch)
+    chat_services.answer_menu(session=session, option=1, selections=[[1, 3], [2]])
+
+    # What the socket actually writes, for that exact published payload.
+    relayed = {}
+    consumer = RunnerConsumer()
+    consumer.send_json = lambda payload: _noop_store(relayed, payload)
+    asyncio.get_event_loop_policy().new_event_loop().run_until_complete(
+        consumer.runner_menu_answer(sent))
+
+    for field in ("session_id", "session_key", "option", "selections", "answer_id"):
+        assert field in relayed, f"{field} was dropped by the relay"
+    assert relayed["selections"] == [[1, 3], [2]]
+    assert relayed["answer_id"] == sent["answer_id"]
+
+
+async def _noop_store(target, payload):
+    target.update(payload)


### PR DESCRIPTION
## What broke

`RunnerConsumer.runner_menu_answer` relays the control frame **field by field**, and the two fields [#591](https://github.com/dimagi-internal/canopy-web/pull/591) added to the published payload were never added to the relay. So the socket delivered a frame missing both, and #591 was **inert on its fast path**.

Found by watching the terminal during a live end-to-end on the deployed instance — the checkmark appeared and then vanished. The runner log says exactly why:

```
21:09:44  answered the dialog on ada-…-3ee2-… with option 1
21:09:49  structured answer for ada-…-3ee2-… has 2 questions but none are held
21:09:49  menu answer … applied from the poll tick (unmodelled)
```

That first line is the **legacy** log format (`with option 1`, not `with [[1,3],[2]]`).

| dropped field | consequence |
|---|---|
| `selections` | runner took the legacy single-key path and pressed a NUMBER at a multi-select — toggling one checkbox and answering nothing. The precise bug #591 exists to fix. |
| `answer_id` | the retire call carried `""`, the server's id match refused it (correctly — it must not clear a *newer* answer), the answer stayed queued, and the poll tick pressed again. So the double delivery was still happening. |

## Why no test caught it

Every unit test around this path built the frame by hand, so they all agreed with the bug — including the one I added in #591 to prevent exactly this class of thing.

The new test takes what `answer_menu` **actually publishes** and asserts the relay preserves it, so the next field added to that frame fails here instead of in somebody's terminal. Confirmed it fails without the fix:

```
E  assert 'selections' in {'answer_id': …, 'option': 1, 'session_id': …, 'session_key': …}
```

Full suite: 2112 passed, 1 skipped. `ruff --select F` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)