### PR TITLE
Let the CDP path actually answer a tabbed dialog: name Tab, and see the dialog

### DIFF
--- a/runner/canopy_runner/canopy_runner/cdp/emdash_control.mjs
+++ b/runner/canopy_runner/canopy_runner/cdp/emdash_control.mjs
@@ -495,17 +495,43 @@ try {
       const term = activeTerm();
       const rows = term && term.querySelector('.xterm-rows');
       const text = rows ? rows.textContent || '' : '';
-      return /[⏺✻⎿]/.test(text) || /esc to interrupt|shift\\+tab to cycle|bypass permissions/i.test(text);
+      // Claude's own chrome: transcript glyphs, or the composer's status line.
+      if (/[⏺✻⎿]/.test(text)) return true;
+      if (/esc to interrupt|shift\\+tab to cycle|bypass permissions/i.test(text)) return true;
+      // A DIALOG's footer. Needed because both tests above look for chrome that a
+      // tall dialog PUSHES OFF THE FRAME: Claude Code draws a dialog where the
+      // composer would be, so a fresh session whose first act is a six-option
+      // AskUserQuestion shows the dialog and nothing else — no glyphs, no status
+      // line. The pane was then unidentifiable exactly when a menu was up, which
+      // is the only time this command is ever called, and every web answer to one
+      // was refused as NOT_A_CLAUDE_PANE (observed live 2026-08-12). These
+      // footers are drawn by Claude Code alone; a shell renders none of them.
+      if (/Enter to select|Enter to confirm|Tab to amend|ctrl\\+e to explain|to navigate · Esc to cancel/i.test(text)) return true;
+      // The dialog's STRUCTURE, for the states that draw no footer at all.
+      // The review tab is one: it shows the tab strip, the answers so far and
+      // "1. Submit answers", and nothing else — so footer matching alone still
+      // could not identify the pane at the exact moment the final Submit had to
+      // be pressed, leaving a fully-filled-in dialog stranded one keypress from
+      // done (observed live 2026-08-12). Ballot-box glyphs and this phrasing are
+      // Claude Code's; a shell draws neither.
+      return /[☐☒]|✔ Submit|Ready to submit your answers/.test(text);
     })(); })()`);
     if (!isClaude) {
       fail(`NOT_A_CLAUDE_PANE: the visible terminal for "${task}" is not a Claude session ` +
            `(a shell tab is probably selected${switched ? ", and selecting the Claude tab did not help" : ""}) ` +
            `— refusing to send keys into it`);
     }
+    // Playwright NAMES its keys; a raw control character is rejected outright
+    // ("Unknown key: \t"). Every control character the answer path can emit has
+    // to be mapped here or the sequence dies part-way — having already pressed
+    // the keys before it, which on a multi-select leaves checkboxes toggled and
+    // nothing submitted. Tab was missing, so answering a TABBED dialog failed
+    // right after its first tab (observed live 2026-08-12). It survived a PTY
+    // harness because that writes the raw byte and a terminal interprets it;
+    // this transport does not.
+    const NAMED_KEYS = { '\r': 'Enter', '\n': 'Enter', '\u001b': 'Escape', '\t': 'Tab' };
     for (const key of keys) {
-      if (key === '\r') await page.keyboard.press('Enter');
-      else if (key === '\u001b') await page.keyboard.press('Escape');
-      else await page.keyboard.press(key);
+      await page.keyboard.press(NAMED_KEYS[key] || key);
       await page.waitForTimeout(120);
     }
     out({ ok: true, task, sent: keys.length });

--- a/runner/canopy_runner/tests/test_menu.py
+++ b/runner/canopy_runner/tests/test_menu.py
@@ -6,7 +6,7 @@ produces for emdash — so what the runner reads over CDP is what these strings
 contain. Verified by roundtrip on 2026-07-28: the dialog below was detected,
 answered with a keystroke, and the file it asked about was actually deleted.
 """
-from canopy_runner.menu import answer_keys, find_menu, find_menu_settled
+from canopy_runner.menu import TAB, answer_keys, find_menu, find_menu_settled
 
 # Verbatim, as a terminal renders it. Note the leading spaces, the box rule, and
 # that option 2's text wraps concerns beyond the tool itself.
@@ -514,3 +514,30 @@ def test_an_unrecognised_question_presses_nothing():
     other = [{"index": 0, "question": "Something else entirely?",
               "multi_select": True, "options": [{"number": 1, "label": "x"}]}]
     assert plan_step(find_menu(TABBED_MULTI), other, [[1]]) is None
+
+
+def test_every_control_key_the_driver_emits_is_named_for_the_real_transport():
+    """REGRESSION, 2026-08-12. The answer path is delivered over CDP, where
+    Playwright NAMES its keys and rejects a raw control character outright
+    ("Unknown key: \\t"). The sidecar mapped Enter and Escape but not Tab, so
+    answering a TABBED dialog died after its first tab — having already toggled
+    checkboxes, leaving the ask half-filled and unsubmitted.
+
+    It survived every test because the PTY harness writes the raw byte and a
+    terminal interprets it. Only the real transport cares, so this asserts the
+    two agree: every control character this module can emit must be named in the
+    sidecar's map.
+    """
+    import re
+    from pathlib import Path
+
+    sidecar = (Path(__file__).resolve().parents[1]
+               / "canopy_runner" / "cdp" / "emdash_control.mjs").read_text()
+    named = re.search(r"const NAMED_KEYS = \{([^}]*)\}", sidecar)
+    assert named, "the sidecar's key map moved — this test cannot see it any more"
+    mapped = set(re.findall(r"'((?:\\u[0-9a-fA-F]{4}|\\.|[^'\\])+)'\s*:", named.group(1)))
+    mapped = {k.encode().decode("unicode_escape") for k in mapped}
+
+    emitted = {TAB, "\r"} | {k for k in answer_keys(None)}
+    control = {k for k in emitted if len(k) == 1 and not k.isprintable()}
+    assert control <= mapped, f"unmapped control keys: {control - mapped}"


### PR DESCRIPTION
Two defects in the emdash sidecar, both found by answering a **real dialog on the deployed site** rather than in a harness. Either alone makes a tabbed / multi-select ask unanswerable from the web — so #591 and #592 were still inert end to end.

## 1. Tab was not a named key

Playwright names its keys and rejects a raw control character outright:

```
CDPError: keyboard.press: Unknown key: "\t"
```

The map had Enter and Escape but not Tab, so the sequence died after the first tab — **having already pressed the toggles before it**, leaving checkboxes set and the ask unsubmitted. Exactly the half-answered state this arc is about.

It survived every existing test because the PTY harness writes the raw byte and a terminal interprets it; only this transport cares. `test_menu.py` now asserts every control character the driver can emit is named in the sidecar's map, and fails without Tab.

## 2. A dialog on screen was not identifiable AS Claude

`send-keys` demands positive identification before pressing (a shell tab selected means a number would *run* something), and looked for transcript glyphs or the composer's status line.

But Claude Code draws a dialog **where the composer would be**. A fresh session whose first act is a six-option AskUserQuestion shows the dialog and nothing else — no glyphs, no status line. So the pane was unidentifiable precisely when a menu was up, which is the only time this command is ever called: every web answer to one was refused as `NOT_A_CLAUDE_PANE`. Eva's dialog only got through because her scrollback still had `⏺`/`⎿` above it.

The review tab is a second, worse case — it draws no footer either, so footer-matching alone still stranded a fully filled-in dialog one keypress from done:

```
←  ☒ Colors  ☒ Size  ✔ Submit  →
 ● Which colors do you want?  → Red, Blue
 ● Which size?                → Large
❯ 1. Submit answers
```

Identification now also accepts the dialog's own footers and its structural chrome (ballot-box glyphs, `✔ Submit`, `Ready to submit your answers`). Checked against captured panes — shells, starship prompts and build output still fail it.

## Verification

On the live site, clicking the form in a browser drove a real emdash session:

```
21:42:26  answered the dialog on ada-canopy-web-chat-a75d-… with [[1, 3], [2]] (answered)
21:42:33  menu answer … ignored — no dialog on screen now
21:42:34  menu answer … applied from the poll tick (no_dialog)
```

and the agent replied **`GOT=Red, Blue|Large`**. The second delivery pressed nothing.

Runner suite: 452 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)