### PR TITLE
fix(runner): a network blip after the session launched marked the turn failed

### DIFF
--- a/runner/canopy_runner/canopy_runner/client.py
+++ b/runner/canopy_runner/canopy_runner/client.py
@@ -2,15 +2,38 @@
 from __future__ import annotations
 
 import json
+import logging
 import pathlib
+import time
 import urllib.error
 import urllib.request
 
 TIMEOUT = 10
 
+# A transient fault gets a few short attempts before it's allowed to fail a turn.
+# Sized against what it guards, not tuned for its own sake: these calls run AFTER
+# an emdash session has already launched, so the whole point is to outlive a blip
+# (the labs network routinely produces `[Errno 54] Connection reset by peer` and
+# SSL-handshake timeouts). Three attempts at 0.5s/1.0s adds at most ~1.5s to a
+# failing call — cheap next to burning the turn, and bounded so a struggling
+# server is never hammered.
+RETRY_ATTEMPTS = 3
+RETRY_BACKOFF = 0.5
+
+logger = logging.getLogger("canopy_runner.client")
+
 
 class ClientError(Exception):
-    pass
+    """A control-plane call failed.
+
+    ``transient`` marks the faults worth re-sending — a 5xx, or a network fault
+    (DNS, reset, handshake timeout) — as opposed to a 4xx, which will fail
+    identically however many times it is sent.
+    """
+
+    def __init__(self, message: str, *, transient: bool = False):
+        super().__init__(message)
+        self.transient = transient
 
 
 class Client:
@@ -18,15 +41,46 @@ class Client:
         self.base_url = base_url.rstrip("/")
         self.token = token
 
-    def _call(self, method: str, path: str, body: dict | None = None) -> tuple[int, dict | None]:
-        return self._call_api(f"/harness{path}", method=method, body=body, label=path)
+    def _call(self, method: str, path: str, body: dict | None = None, *,
+              retry: bool = True) -> tuple[int, dict | None]:
+        return self._call_api(f"/harness{path}", method=method, body=body, label=path,
+                              retry=retry)
 
     def _call_api(self, path: str, *, method: str, body: dict | None = None,
-                  label: str = "") -> tuple[int, dict | None]:
+                  label: str = "", retry: bool = True) -> tuple[int, dict | None]:
         """Same transport as ``_call`` but rooted at ``/api`` rather than
         ``/api/harness`` — for the handful of runner calls that live in another
-        app's namespace (the Gmail watch report is in ``apps/inbound``)."""
+        app's namespace (the Gmail watch report is in ``apps/inbound``).
+
+        Retries transient faults by default. Pass ``retry=False`` for a call that
+        is NOT safe to re-send: today that is `claim` alone, which is not
+        idempotent — a retry after the server already claimed a turn would risk a
+        double-claim. Everything else is either a pure state transition
+        (`start`/`finish`/`fail_turn`), an upsert (`record_session`), a level
+        report (`heartbeat`), or idempotency-keyed (`enqueue_turn`,
+        `fire_schedule`).
+        """
         label = label or path
+        attempts = RETRY_ATTEMPTS if retry else 1
+        for attempt in range(1, attempts + 1):
+            try:
+                return self._attempt(path, method=method, body=body, label=label)
+            except ClientError as exc:
+                # The final iteration always re-raises, so this loop cannot fall
+                # through — every path either returns a response or raises.
+                if not exc.transient or attempt == attempts:
+                    raise
+                delay = RETRY_BACKOFF * (2 ** (attempt - 1))
+                logger.warning(
+                    "transient fault on %s %s (attempt %d/%d), retrying in %.1fs: %s",
+                    method, label, attempt, attempts, delay, exc,
+                )
+                time.sleep(delay)
+
+    def _attempt(self, path: str, *, method: str, body: dict | None,
+                 label: str) -> tuple[int, dict | None]:
+        """One HTTP round trip. Classifies its own failure as transient or not so
+        the retry policy above stays a policy and not a second parser of errors."""
         url = f"{self.base_url}/api{path}"
         data = json.dumps(body).encode() if body is not None else None
         req = urllib.request.Request(url, data=data, method=method)
@@ -38,13 +92,22 @@ class Client:
                 status = resp.status
                 raw = resp.read()
         except urllib.error.HTTPError as exc:
+            # Checked before URLError — HTTPError subclasses it. A 5xx is the
+            # server having a bad moment; a 4xx is us being wrong, and re-sending
+            # it just spends the same error again.
             try:
                 error_body = exc.read()[:200]
             except Exception:
                 error_body = b"(could not read error body)"
-            raise ClientError(f"{method} {label} -> {exc.code}: {error_body!r}") from exc
+            raise ClientError(f"{method} {label} -> {exc.code}: {error_body!r}",
+                              transient=exc.code >= 500) from exc
         except urllib.error.URLError as exc:
-            raise ClientError(f"{method} {label} -> {exc.reason}") from exc
+            raise ClientError(f"{method} {label} -> {exc.reason}", transient=True) from exc
+        except (TimeoutError, ConnectionError) as exc:
+            # Siblings of URLError under OSError, not subclasses — a read timeout
+            # on urlopen(timeout=) surfaces as a bare TimeoutError and would
+            # otherwise escape this handler entirely.
+            raise ClientError(f"{method} {label} -> {exc}", transient=True) from exc
         if status == 204 or not raw:
             return status, None
         return status, json.loads(raw)
@@ -210,7 +273,11 @@ class Client:
         if paused_agents:
             from urllib.parse import urlencode
             path += "?" + urlencode({"paused": ",".join(sorted(paused_agents))})
-        status, payload = self._call("POST", path)
+        # retry=False — THE non-idempotent call. A 5xx here may mean the server
+        # claimed a turn and then failed to tell us; re-sending would risk a
+        # second claim. Losing a claim is free (the next tick, ~5s away, claims
+        # it again); double-claiming is not.
+        status, payload = self._call("POST", path, retry=False)
         return payload if status == 200 else None
 
     def post_events(self, turn_id: str, events: list[dict]) -> None:

--- a/runner/canopy_runner/canopy_runner/execute.py
+++ b/runner/canopy_runner/canopy_runner/execute.py
@@ -26,9 +26,29 @@ import time
 from pathlib import Path
 
 from . import cdp_control, chat_bridge, dialog, emdash, hooks, readiness, transcript
+from .client import ClientError
 from .tail import TailReader
 
 logger = logging.getLogger("canopy_runner.execute")
+
+
+def _post_events_best_effort(client, turn_id: str, events: list[dict]) -> None:
+    """Post informational status events WITHOUT letting them fail the turn.
+
+    Only for the success tails, where the emdash session is already live and doing
+    the work. There, a status event is pure narration: if the control plane is
+    unreachable for it, the correct outcome is a quieter turn, not a turn reported
+    as `failed` while its session runs on. `Client._call` already retries transient
+    faults; this is what covers a fault that outlasts them.
+
+    Deliberately NOT applied to the pre-launch call sites — before `create_task`
+    nothing is running yet, so a control-plane failure there SHOULD fail the turn.
+    """
+    try:
+        client.post_events(turn_id, events)
+    except ClientError as exc:
+        logger.warning("post_events failed for turn=%s after retries; the session is "
+                       "live and the turn stands — %s", turn_id, exc)
 
 
 def _target(turn: dict) -> str:
@@ -145,7 +165,7 @@ def _deliver_to_existing(cfg, client, runner_id, turn, task, state, work_prompt)
     # Delivered — either the empty-line fast path, or a cleared-then-sent collision.
     logger.info("REUSE  turn=%s agent=%s thread=%s -> existing session '%s' (no new claude session)",
                 turn_id, agent, thread_key, task)
-    client.post_events(turn_id, [{"kind": "status",
+    _post_events_best_effort(client, turn_id, [{"kind": "status",
         "payload": {"status": "reused_session", "task": task, "thread_key": thread_key}}])
     client.record_session(runner_id, turn.get("agent_slug") or "", thread_key,
                           project=turn.get("project") or "",
@@ -459,7 +479,7 @@ def execute_turn(cfg, client, runner_id: str, turn: dict, cancel_check=None) -> 
     task = res.get("task") or ""
     logger.info("CREATE turn=%s agent=%s thread=%s -> new session '%s' rehydrated=%s "
                 "(NEW claude session = tokens)", turn_id, agent, thread_key, task, bool(summary))
-    client.post_events(turn_id, [{"kind": "status",
+    _post_events_best_effort(client, turn_id, [{"kind": "status",
         "payload": {"status": "created_session", "task": task, "thread_key": thread_key,
                     "rehydrated": bool(summary)}}])
     client.record_session(

--- a/runner/canopy_runner/tests/test_client.py
+++ b/runner/canopy_runner/tests/test_client.py
@@ -4,13 +4,22 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 
 import pytest
 
-from canopy_runner.client import Client, ClientError
+from canopy_runner import client as client_mod
+from canopy_runner.client import RETRY_ATTEMPTS, Client, ClientError
 
 
 class _Handler(BaseHTTPRequestHandler):
     # Records the (path, body) of the last schedule call so the tests can pin the
     # exact wire format against the server contract (apps/harness/api.py).
     last_fire = None
+
+    # Retry-policy fixtures. `attempts` counts every hit on a retry-exercising
+    # path; the handler serves `fail_status` for the first `fail_times` of them
+    # and succeeds after — which is what lets a test distinguish "recovered on
+    # attempt 3" from "never retried at all".
+    attempts = 0
+    fail_times = 0
+    fail_status = 500
 
     def do_GET(self):
         assert self.headers["Authorization"] == "Bearer tok"
@@ -41,7 +50,19 @@ class _Handler(BaseHTTPRequestHandler):
             self.end_headers()
             self.wfile.write(b'{"id": "turn-9", "status": "queued"}')
             return
+        if self.path.endswith("/retry-probe"):
+            _Handler.attempts += 1
+            if _Handler.attempts <= _Handler.fail_times:
+                self.send_response(_Handler.fail_status); self.end_headers(); return
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(b'{"ok": true}')
+            return
         if self.path.endswith("/claim"):
+            _Handler.attempts += 1
+            if _Handler.attempts <= _Handler.fail_times:
+                self.send_response(_Handler.fail_status); self.end_headers(); return
             if _Handler.claim_empty:
                 self.send_response(204); self.end_headers(); return
             body = json.dumps({"id": "t-1", "status": "claimed"}).encode()
@@ -65,11 +86,21 @@ class _Handler(BaseHTTPRequestHandler):
 @pytest.fixture()
 def server():
     _Handler.claim_empty = False
+    _Handler.attempts = 0
+    _Handler.fail_times = 0
+    _Handler.fail_status = 500
     srv = HTTPServer(("127.0.0.1", 0), _Handler)
     t = threading.Thread(target=srv.serve_forever, daemon=True)
     t.start()
     yield f"http://127.0.0.1:{srv.server_port}"
     srv.shutdown()
+
+
+@pytest.fixture(autouse=True)
+def _no_retry_sleep(monkeypatch):
+    """Keep the backoff's SHAPE (attempt counts, give-up point) while removing its
+    wall-clock cost — otherwise every 5xx test would spend the real 0.5s + 1.0s."""
+    monkeypatch.setattr(client_mod, "RETRY_BACKOFF", 0)
 
 
 def test_claim_returns_turn(server):
@@ -105,3 +136,56 @@ def test_fire_schedule_posts_slot_with_runner_id(server):
     path, body = _Handler.last_fire
     assert path == "/api/harness/schedules/7/fire?runner_id=r-1"
     assert body == {"slot": "2026-07-10T13:00:00+00:00"}
+
+
+# --- transient-fault retry (issue #281) ------------------------------------
+# These calls run AFTER an emdash session has launched, so a one-off 5xx or
+# network blip used to mark a turn `failed` while its work was already running.
+
+
+def test_transient_5xx_is_retried_then_succeeds(server):
+    _Handler.fail_times = 2
+    c = Client(server, "tok")
+    status, payload = c._call("POST", "/retry-probe")
+    assert (status, payload) == (200, {"ok": True})
+    # Recovered on the third attempt — not "the first one happened to work".
+    assert _Handler.attempts == 3
+
+
+def test_retries_are_bounded_then_raise(server):
+    _Handler.fail_times = 99          # never recovers
+    c = Client(server, "tok")
+    with pytest.raises(ClientError) as exc:
+        c._call("POST", "/retry-probe")
+    assert exc.value.transient is True
+    assert _Handler.attempts == RETRY_ATTEMPTS   # bounded — no hammering
+
+
+def test_4xx_is_not_retried(server):
+    _Handler.fail_times = 99
+    _Handler.fail_status = 404
+    c = Client(server, "tok")
+    with pytest.raises(ClientError) as exc:
+        c._call("POST", "/retry-probe")
+    # A 404 fails the same way however often it is sent; re-sending buys nothing.
+    assert exc.value.transient is False
+    assert _Handler.attempts == 1
+
+
+def test_claim_is_never_retried(server):
+    """The one non-idempotent call: a retry after the server already claimed a
+    turn risks a double-claim. Losing a claim is free — the next tick re-claims."""
+    _Handler.fail_times = 99
+    c = Client(server, "tok")
+    with pytest.raises(ClientError):
+        c.claim("r-1")
+    assert _Handler.attempts == 1
+
+
+def test_network_fault_is_transient(server):
+    # Nothing listening on this port -> URLError, the `[Errno 54] Connection
+    # reset` / DNS / handshake-timeout class seen routinely in runner.log.
+    c = Client("http://127.0.0.1:1", "tok")
+    with pytest.raises(ClientError) as exc:
+        c._call("POST", "/retry-probe")
+    assert exc.value.transient is True

--- a/runner/canopy_runner/tests/test_execute.py
+++ b/runner/canopy_runner/tests/test_execute.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 import pytest
 
 from canopy_runner import cdp_control, dialog, emdash, execute
+from canopy_runner.client import ClientError
 
 
 def _cfg():
@@ -224,6 +225,42 @@ def test_finish_reports_the_emdash_session_as_the_close_out_join_key(monkeypatch
     client = FakeClient({"reuse": False, "new_thread": True, "summary": ""})
     execute.execute_turn(_cfg(), client, "r-1", _turn())
     assert client.finished_tasks == ["hal-api-df02-0810-0805"]
+
+
+def test_launched_turn_survives_a_dead_post_events(monkeypatch):
+    """issue #281 — the session is already live, so a control-plane blip on a purely
+    informational status event must not turn a working turn into a `failed` one.
+    Before this, the ClientError propagated to main._claim_and_execute's
+    `except Exception` and the turn was reported failed while its work ran on."""
+    monkeypatch.setattr(cdp_control, "create_task",
+                        lambda project, prompt, task_name="", port=9222: {"task": "fresh"})
+    client = FakeClient({"reuse": False, "new_thread": True, "summary": ""})
+
+    def dead(turn_id, events):
+        raise ClientError("POST /turns/t-1/events -> 503", transient=True)
+    client.post_events = dead
+
+    result = execute.execute_turn(_cfg(), client, "r-1", _turn())
+    assert result == "created:t-1:fresh"
+    assert client.failed == []                  # never marked failed
+    assert client.finished                      # and it still closed out normally
+
+
+def test_reused_turn_survives_a_dead_post_events(monkeypatch):
+    """Same guarantee on the reuse tail — the prompt has already been delivered
+    into a live session by the time this event is posted."""
+    monkeypatch.setattr(cdp_control, "open_and_send",
+                        lambda task, text, port=9222: {"ok": True})
+    client = FakeClient({"reuse": True, "emdash_task_id": "etask-A", "summary": ""})
+
+    def dead(turn_id, events):
+        raise ClientError("POST /turns/t-1/events -> 503", transient=True)
+    client.post_events = dead
+
+    result = execute.execute_turn(_cfg(), client, "r-1", _turn())
+    assert result == "reused:t-1"
+    assert client.failed == []
+    assert client.finished
 
 
 def test_create_failure_fails_the_turn(monkeypatch):


### PR DESCRIPTION
Closes #281.

## The bug

`Client._call_api` did **no retry**, so one transient fault — a 5xx, or the `[Errno 54] Connection reset` / DNS-failure / SSL-handshake-timeout class `~/.canopy/runner.log` shows routinely — was one hard `ClientError`.

Where those calls sit is what makes it expensive. In `execute_turn`, `post_events` / `record_session` / `finish` run **after** `cdp_control.create_task` has already launched the emdash session, and are guarded only against `cdp_control.CDPError`, not `ClientError`. The error propagated to `main._claim_and_execute`'s `except Exception` → `fail_turn`. **Net: session live and working, turn reported `failed`.** `_deliver_to_existing` has the same shape.

Re-validated against `main` @e8ccf0e before starting. The issue's paths had moved (`packages/canopy_runner/…` → `runner/canopy_runner/…`); the defect was unchanged.

## The fix

**1. Bounded retry on transient faults only** (`client.py`). 5xx and network errors, 3 attempts at 0.5s/1.0s — at most ~1.5s added to a failing call. A 4xx is never retried: it fails identically however often it is sent. `ClientError.transient` carries the classification at the point the error is raised, so the retry policy stays a policy rather than a second parser of error strings.

**2. `claim` opts out** (`retry=False`) — the one non-idempotent call. A retry after the server already claimed a turn risks a double-claim; losing a claim costs nothing, since the next tick (~5s) re-claims it. Called out explicitly at the call site, and pinned by a test.

**3. A backstop for a fault that outlives the retries.** On the two success tails the informational status event is now best-effort. A turn whose session is already live should never be reported failed because a narration POST didn't land. Deliberately **not** applied to the pre-launch call sites — before `create_task` nothing is running, so a control-plane failure there *should* fail the turn.

## One correction to the issue's framing

The issue implies an unfinished turn is a hazard. Reading the server: `sweep_expired_leases` (`apps/harness/services.py:178`) marks it `LOST`, which is **terminal** — it is never re-queued, so there is no duplicate-session risk in the fallback path.

Related: this is also why I did **not** make `finish` itself swallow-on-failure. If `finish` fails after retries, the subsequent `fail_turn` posts to the *same* endpoint (`/turns/<id>/finish`) and fails too, so `main` already falls through to `except ClientError: pass` and the turn is swept `LOST`. Changing it would add nothing; the retry is the real fix there.

## Two things this does NOT cover

- **Append-only POSTs can duplicate.** Retrying `post_events` / `post_session_stream` after a 5xx could re-send an event the server had already committed before erroring. Consequence is a duplicate status event; judged clearly preferable to burning a turn. Flagging it rather than leaving it implicit.
- **`download_attachment` is unchanged.** It has its own transport (raw bytes, not `_call_api`) and is out of scope here — it is *not* protected by this retry.

## Tests

New, and each verified to **fail** without the fix:

| test | pins |
|---|---|
| `test_transient_5xx_is_retried_then_succeeds` | recovers on attempt 3 (not "the first one worked") |
| `test_retries_are_bounded_then_raise` | gives up at exactly `RETRY_ATTEMPTS` |
| `test_4xx_is_not_retried` | a 404 is sent once |
| `test_claim_is_never_retried` | no double-claim |
| `test_network_fault_is_transient` | `URLError` classified transient |
| `test_launched_turn_survives_a_dead_post_events` | created-session tail: never `failed` |
| `test_reused_turn_survives_a_dead_post_events` | reuse tail: never `failed` |

## CI gates run locally — all green

Every gate in `ci.yml` that this change can reach, each confirmed by its own output rather than an exit code:

- `ruff check . --select F --ignore F403,F405` → `All checks passed!`
- `manage.py makemigrations --check --dry-run` → `No changes detected`
- `manage.py check` → `System check identified no issues`
- `uv run pytest` (root) → **2117 passed, 1 skipped**
- `canopy_runner` suite → **459 passed**

Frontend build/vitest and `regen-openapi` are untouched by this diff (no frontend files, no `apps/**/api.py|schemas.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)