### PR TITLE
Let texts carry a hole for an unanswered question

### DIFF
--- a/apps/canopy_sessions/api.py
+++ b/apps/canopy_sessions/api.py
@@ -394,7 +394,8 @@ def answer_menu(request: HttpRequest, session_id: uuid.UUID, payload: MenuAnswer
     """
     session = _session_or_404(request, session_id)
     outcome = services.answer_menu(session=session, option=payload.option,
-                                   selections=payload.selections)
+                                   selections=payload.selections,
+                                   texts=payload.texts)
     return {"ok": outcome == "sent", "reason": "" if outcome == "sent" else outcome}
 
 

--- a/apps/canopy_sessions/schemas.py
+++ b/apps/canopy_sessions/schemas.py
@@ -209,4 +209,7 @@ class MenuAnswerIn(Schema):
     #: Free text per question, for the answer that is not on the menu — the
     #: TUI appends a "Type something" row to every question and it is often
     #: where the real answer goes. Empty string = no free text.
-    texts: list[str] | None = None
+    #: `None` for a question left unanswered — the list is POSITIONAL against
+    #: the declared questions, so a hole has to be expressible or every later
+    #: answer shifts onto the wrong question.
+    texts: list[str | None] | None = None

--- a/apps/canopy_sessions/schemas.py
+++ b/apps/canopy_sessions/schemas.py
@@ -206,3 +206,7 @@ class MenuAnswerIn(Schema):
     """
     option: int | None = None
     selections: list[list[int]] | None = None
+    #: Free text per question, for the answer that is not on the menu — the
+    #: TUI appends a "Type something" row to every question and it is often
+    #: where the real answer goes. Empty string = no free text.
+    texts: list[str] | None = None

--- a/apps/canopy_sessions/services.py
+++ b/apps/canopy_sessions/services.py
@@ -1002,7 +1002,8 @@ def project_events(turn: Turn, rows) -> int:
 
 
 def answer_menu(*, session: Session, option: int | None,
-                selections: list[list[int]] | None = None) -> str:
+                selections: list[list[int]] | None = None,
+                texts: list[str] | None = None) -> str:
     """Answer the dialog an agent is blocked on, from the web.
 
     `selections` is the whole answer: one list of chosen option numbers per
@@ -1042,7 +1043,8 @@ def answer_menu(*, session: Session, option: int | None,
     # in silence when the control channel is down — see RunnerBinding.pending_answer.
     answer_id = str(uuid.uuid4())
     binding.pending_answer = {"id": answer_id, "option": option,
-                              "selections": selections, "at": time.time()}
+                              "selections": selections, "texts": texts,
+                              "at": time.time()}
     binding.save(update_fields=["pending_answer"])
 
     from apps.realtime import groups
@@ -1052,6 +1054,7 @@ def answer_menu(*, session: Session, option: int | None,
         "session_key": binding.session_key,
         "option": option,
         "selections": selections,
+        "texts": texts,
         "answer_id": answer_id,
     })
     return "sent"

--- a/apps/canopy_sessions/services.py
+++ b/apps/canopy_sessions/services.py
@@ -1003,7 +1003,7 @@ def project_events(turn: Turn, rows) -> int:
 
 def answer_menu(*, session: Session, option: int | None,
                 selections: list[list[int]] | None = None,
-                texts: list[str] | None = None) -> str:
+                texts: list[str | None] | None = None) -> str:
     """Answer the dialog an agent is blocked on, from the web.
 
     `selections` is the whole answer: one list of chosen option numbers per

--- a/apps/harness/api.py
+++ b/apps/harness/api.py
@@ -871,7 +871,8 @@ def list_menu_answers(request: HttpRequest, runner_id: uuid.UUID):
         {"session_id": str(b.session_id), "session_key": b.session_key,
          "answer_id": (b.pending_answer or {}).get("id") or "",
          "option": (b.pending_answer or {}).get("option"),
-         "selections": (b.pending_answer or {}).get("selections")}
+         "selections": (b.pending_answer or {}).get("selections"),
+         "texts": (b.pending_answer or {}).get("texts")}
         for b in bindings
     ]}
 

--- a/apps/harness/schemas.py
+++ b/apps/harness/schemas.py
@@ -823,7 +823,7 @@ class MenuAnswerOut(Schema):
     #: does today — so the poll tick never gets WORSE than the current
     #: behaviour on an ask this shape cannot express.
     selections: list[list[int]] | None = None
-    texts: list[str] | None = None
+    texts: list[str | None] | None = None
 
 
 class MenuAnswerSyncOut(Schema):

--- a/apps/harness/schemas.py
+++ b/apps/harness/schemas.py
@@ -823,6 +823,7 @@ class MenuAnswerOut(Schema):
     #: does today — so the poll tick never gets WORSE than the current
     #: behaviour on an ask this shape cannot express.
     selections: list[list[int]] | None = None
+    texts: list[str] | None = None
 
 
 class MenuAnswerSyncOut(Schema):

--- a/apps/realtime/consumers.py
+++ b/apps/realtime/consumers.py
@@ -304,6 +304,7 @@ class RunnerConsumer(AsyncJsonWebsocketConsumer):
             "session_key": message.get("session_key"),
             "option": message.get("option"),
             "selections": message.get("selections"),
+            "texts": message.get("texts"),
             "answer_id": message.get("answer_id"),
         })
 

--- a/frontend/packages/canopy-ui/src/chat/MenuPrompt.tsx
+++ b/frontend/packages/canopy-ui/src/chat/MenuPrompt.tsx
@@ -7,8 +7,17 @@ export interface MenuPromptProps {
   error?: string;
   /** `selections` is the whole answer — one list of chosen option numbers per
    *  question. Omitted for the single-question single-select dialogs that a
-   *  lone `option` has always been able to answer. */
-  onAnswer: (option: number | null, selections?: number[][] | null) => void;
+   *  lone `option` has always been able to answer.
+   *
+   *  `texts` carries the answer that is NOT on the menu, per question. The TUI
+   *  appends a "Type something" row to every question, and it is frequently
+   *  where the real answer goes — the July closeout's notes were all typed, not
+   *  picked. Without it a phone can only choose from what the agent guessed. */
+  onAnswer: (
+    option: number | null,
+    selections?: number[][] | null,
+    texts?: (string | null)[] | null,
+  ) => void;
   /** Injectable for tests; defaults to the wall clock. */
   now?: number;
 }
@@ -91,6 +100,7 @@ function AnswerForm({
   onAnswer: MenuPromptProps["onAnswer"];
 }) {
   const [picks, setPicks] = useState<Record<number, number[]>>({});
+  const [typed, setTyped] = useState<Record<number, string>>({});
 
   const toggle = (q: MenuQuestion, number: number) => {
     setPicks((prev) => {
@@ -105,9 +115,24 @@ function AnswerForm({
     });
   };
 
+  // Typing your own answer to a SINGLE-select question replaces the pick,
+  // because that is what the TUI does — selecting "Type something" moves the
+  // selection onto the text row. On a multi-select the text is an extra
+  // checkbox, so both can stand.
+  const write = (q: MenuQuestion, value: string) => {
+    setTyped((prev) => ({ ...prev, [q.index]: value }));
+    if (!q.multi_select && value.trim()) {
+      setPicks((prev) => ({ ...prev, [q.index]: [] }));
+    }
+  };
+
+  const answered = (q: MenuQuestion) =>
+    isAnswered(picks[q.index]) || Boolean((typed[q.index] ?? "").trim());
+
   const remaining = useMemo(
-    () => questions.filter((q) => !isAnswered(picks[q.index])).length,
-    [questions, picks],
+    () => questions.filter((q) => !answered(q)).length,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [questions, picks, typed],
   );
 
   const send = () => {
@@ -115,9 +140,10 @@ function AnswerForm({
     // runner walks the tabs in this order, so a missing entry would silently
     // shift every later answer onto the wrong question.
     const selections = questions.map((q) => picks[q.index] ?? []);
+    const texts = questions.map((q) => (typed[q.index] ?? "").trim() || null);
     // `option` is the first pick, for a runner too old to read `selections`.
     // Sending null there would read as "refuse" and cancel the dialog.
-    onAnswer(selections[0]?.[0] ?? null, selections);
+    onAnswer(selections[0]?.[0] ?? null, selections, texts);
   };
 
   return (
@@ -159,13 +185,30 @@ function AnswerForm({
                 </button>
               );
             })}
+            {/* The answer that is not on the menu. The terminal offers this on
+                every question ("Type something"), and it is where the real
+                answer often goes, so a phone without it can only pick from what
+                the agent happened to guess. */}
+            <input
+              type="text"
+              value={typed[q.index] ?? ""}
+              disabled={busy}
+              onChange={(e) => write(q, e.target.value)}
+              placeholder="…or type your own answer"
+              className="mt-0.5 rounded border border-input bg-card px-2.5 py-2 text-[13px] text-foreground placeholder:text-muted-foreground disabled:opacity-50"
+            />
           </div>
         </div>
       ))}
-      <div className="flex items-center gap-2">
+      <div className="flex flex-wrap items-center gap-2">
         <button
           type="button"
-          disabled={busy || remaining > 0}
+          // Sendable as soon as ANYTHING is answered, not only when everything
+          // is. The terminal submits a partly-filled ask and merely warns, and
+          // refusing here made a question you meant to skip unskippable from a
+          // phone. Still not sendable when NOTHING is answered — that is what
+          // Cancel says, and says better.
+          disabled={busy || remaining === questions.length}
           onClick={send}
           className="rounded bg-warning px-3 py-1.5 text-[13px] font-medium text-warning-foreground disabled:opacity-50"
         >
@@ -173,7 +216,9 @@ function AnswerForm({
         </button>
         {remaining > 0 ? (
           <span className="text-[12px] text-muted-foreground">
-            {remaining} question{remaining === 1 ? "" : "s"} still to answer
+            {remaining === questions.length
+              ? "answer at least one to send"
+              : `${remaining} unanswered — will send anyway`}
           </span>
         ) : null}
       </div>

--- a/frontend/src/api/chat.ts
+++ b/frontend/src/api/chat.ts
@@ -277,6 +277,7 @@ export function answerMenu(
   id: string,
   option: number | null,
   selections?: number[][] | null,
+  texts?: (string | null)[] | null,
 ): Promise<{ ok: boolean; reason: string }> {
   return request<{ ok: boolean; reason: string }>(
     `/api/canopy-sessions/${encodeURIComponent(id)}/answer-menu`,
@@ -287,7 +288,7 @@ export function answerMenu(
       // it is the only field a runner older than this understands, and sending
       // it the first pick keeps such a runner doing what it does today instead
       // of reading a null option as "refuse" and pressing Escape.
-      body: JSON.stringify(selections ? { option, selections } : { option }),
+      body: JSON.stringify(selections ? { option, selections, texts } : { option }),
     },
   );
 }

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -8561,6 +8561,8 @@ export interface components {
             readonly option?: number | null;
             /** Selections */
             readonly selections?: readonly (readonly number[])[] | null;
+            /** Texts */
+            readonly texts?: readonly string[] | null;
         };
         /** MenuAnswerSyncOut */
         readonly MenuAnswerSyncOut: {
@@ -9115,6 +9117,8 @@ export interface components {
             readonly option?: number | null;
             /** Selections */
             readonly selections?: readonly (readonly number[])[] | null;
+            /** Texts */
+            readonly texts?: readonly string[] | null;
         };
         /**
          * StreamStateOut

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -8562,7 +8562,7 @@ export interface components {
             /** Selections */
             readonly selections?: readonly (readonly number[])[] | null;
             /** Texts */
-            readonly texts?: readonly string[] | null;
+            readonly texts?: readonly (string | null)[] | null;
         };
         /** MenuAnswerSyncOut */
         readonly MenuAnswerSyncOut: {
@@ -9118,7 +9118,7 @@ export interface components {
             /** Selections */
             readonly selections?: readonly (readonly number[])[] | null;
             /** Texts */
-            readonly texts?: readonly string[] | null;
+            readonly texts?: readonly (string | null)[] | null;
         };
         /**
          * StreamStateOut

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -522,7 +522,8 @@ export function ChatPage() {
   const [answerError, setAnswerError] = useState('')
   const answeredAt = useRef(0)
   const onAnswerMenu = useCallback(
-    async (option: number | null, selections?: number[][] | null) => {
+    async (option: number | null, selections?: number[][] | null,
+           texts?: (string | null)[] | null) => {
       if (!id) return
       setAnswering(true)
       setAnswerError('')
@@ -533,7 +534,7 @@ export function ChatPage() {
       // here, where we know a tap just happened.
       answeredAt.current = Date.now()
       try {
-        const res = await answerMenu(id, option, selections)
+        const res = await answerMenu(id, option, selections, texts)
         if (!res.ok) {
           setAnswerError(
             res.reason === 'unavailable'

--- a/runner/canopy_runner/canopy_runner/cdp/emdash_control.mjs
+++ b/runner/canopy_runner/canopy_runner/cdp/emdash_control.mjs
@@ -530,8 +530,18 @@ try {
     // harness because that writes the raw byte and a terminal interprets it;
     // this transport does not.
     const NAMED_KEYS = { '\r': 'Enter', '\n': 'Enter', '\u001b': 'Escape', '\t': 'Tab' };
+    // "text:..." means TYPE this, not press it — the answer to a question whose
+    // real answer is not on the menu ("Type something"). keyboard.press takes one
+    // key and would reject a sentence outright, and pressing it character by
+    // character gets the shifting wrong on punctuation; keyboard.type is the
+    // primitive for a string.
+    const TEXT_PREFIX = 'text:';
     for (const key of keys) {
-      await page.keyboard.press(NAMED_KEYS[key] || key);
+      if (typeof key === 'string' && key.startsWith(TEXT_PREFIX)) {
+        await page.keyboard.type(key.slice(TEXT_PREFIX.length));
+      } else {
+        await page.keyboard.press(NAMED_KEYS[key] || key);
+      }
       await page.waitForTimeout(120);
     }
     out({ ok: true, task, sent: keys.length });

--- a/runner/canopy_runner/canopy_runner/hooks.py
+++ b/runner/canopy_runner/canopy_runner/hooks.py
@@ -345,7 +345,8 @@ def held_questions(session_key: str) -> list[dict]:
     return []
 
 
-def _drive_selections(cdp, session_key, current, questions, selections, cdp_port):
+def _drive_selections(cdp, session_key, current, questions, selections, cdp_port,
+                      texts=None):
     """Walk a tabbed / multi-select dialog to a complete, submitted answer.
 
     One step per screen read (see `menu.plan_step`): press, re-read, decide
@@ -355,7 +356,7 @@ def _drive_selections(cdp, session_key, current, questions, selections, cdp_port
     already performs (control frame, then poll tick) is now harmless.
     """
     for _ in range(menu.MAX_STEPS):
-        keys = menu.plan_step(current, questions, selections)
+        keys = menu.plan_step(current, questions, selections, texts)
         if keys is None:
             # Nothing further we can justify pressing. If every question already
             # reads as answered this is success; otherwise the screen is not the
@@ -373,7 +374,7 @@ def _drive_selections(cdp, session_key, current, questions, selections, cdp_port
     return UNMODELLED, _menu_dict(current, source="screen") if current else None
 
 
-def answer_menu_with(cdp, session_key: str, option, *, selections=None,
+def answer_menu_with(cdp, session_key: str, option, *, selections=None, texts=None,
                      cdp_port: int = 9222):
     """Press a human's answer into `session_key`'s terminal.
 
@@ -417,7 +418,7 @@ def answer_menu_with(cdp, session_key: str, option, *, selections=None,
             questions = [{"index": 0, "question": current.question,
                           "multi_select": current.is_multi_select}]
         outcome, screen = _drive_selections(
-            cdp, session_key, current, questions, selections, cdp_port)
+            cdp, session_key, current, questions, selections, cdp_port, texts)
         logger.info("answered the dialog on %s with %s (%s)", session_key,
                     selections, outcome)
         return outcome, screen
@@ -469,7 +470,8 @@ def _answer_lock(session_key: str) -> threading.Lock:
         return lock
 
 
-def answer_menu(session_key: str, option, *, selections=None, cdp_port: int = 9222):
+def answer_menu(session_key: str, option, *, selections=None, texts=None,
+                cdp_port: int = 9222):
     """`answer_menu_with` bound to real CDP, with transport failures classified.
 
     Never raises: this runs on the wake-listener thread, which also carries wake
@@ -479,7 +481,8 @@ def answer_menu(session_key: str, option, *, selections=None, cdp_port: int = 92
     try:
         with _answer_lock(session_key):
             return answer_menu_with(cdp_control, session_key, option,
-                                    selections=selections, cdp_port=cdp_port)
+                                    selections=selections, texts=texts,
+                                    cdp_port=cdp_port)
     except Exception as exc:  # noqa: BLE001
         # NOT_A_CLAUDE_PANE is the one refusal a human can act on themselves, and
         # it is the one that actually bit: with a shell tab selected, every tap on

--- a/runner/canopy_runner/canopy_runner/main.py
+++ b/runner/canopy_runner/canopy_runner/main.py
@@ -713,6 +713,7 @@ def make_control_handler(cfg: Config, waker, client=None):
             session_key = str(msg["session_key"])
             outcome, screen = hooks.answer_menu(session_key, msg.get("option"),
                                                 selections=msg.get("selections"),
+                                                texts=msg.get("texts"),
                                                 cdp_port=cfg.cdp_port)
             hooks.note_answer_outcome(session_key, outcome, screen)
             # RETIRE IT. The server holds the answer until a runner reports on it

--- a/runner/canopy_runner/canopy_runner/menu.py
+++ b/runner/canopy_runner/canopy_runner/menu.py
@@ -394,6 +394,44 @@ def answer_keys(option: int | None) -> list[str]:
 TAB = "\t"
 SUBMIT_ANSWERS = "Submit answers"
 
+# An entry in a keystroke list that means TYPE this, rather than press it. The
+# transport tells the two apart by this prefix: a pressed key is one character
+# (or a control character named by the sidecar), and free text is neither.
+TEXT_PREFIX = "text:"
+
+# The option Claude Code appends to every question for an answer that is not on
+# the menu. Its NUMBER is assigned by the TUI, not by the tool input, so it can
+# only be read off the rendered screen — which is why the driver looks for it by
+# label rather than computing len(declared) + 1.
+TYPE_SOMETHING = "type something"
+
+
+def type_something_number(menu: "Menu") -> int | None:
+    """The "Type something" row's number on this screen, or None once it has
+    been filled in — the TUI replaces the label with the text you typed."""
+    for option in menu.options:
+        if option.label.rstrip(".").casefold() == TYPE_SOMETHING:
+            return option.number
+    return None
+
+
+def _free_text_step(menu: "Menu", text: str) -> list[str] | None:
+    """Keystrokes to put `text` into this question, or [] if it is already there.
+
+    None means we cannot: the row is gone and nothing on screen carries the text,
+    so typing would land somewhere unpredictable. Refusing costs the answer and
+    says so; guessing types a sentence into whatever has focus.
+    """
+    number = type_something_number(menu)
+    if number is None:
+        entered = any(option.label.strip() == text.strip() for option in menu.options)
+        return [] if entered else None
+    # Pressing the number MOVES the cursor to that row and opens its edit field —
+    # it does NOT answer, unlike a declared option's number. Verified against a
+    # live TUI: the footer gains "ctrl+g to edit in Vim" and the label becomes
+    # whatever you type.
+    return [str(number), TEXT_PREFIX + text, "\r"]
+
 # Bound on the drive loop. Each question costs at most (toggles + one Tab), so
 # this is generous for any real ask while still terminating if the screen stops
 # responding the way we read it — a loop pressing keys into a terminal forever
@@ -432,7 +470,8 @@ def question_index(menu: "Menu", questions: list[dict]) -> int | None:
     return best[0] if best else None
 
 
-def plan_step(menu: "Menu", questions: list[dict], selections: list[list[int]]) -> list[str] | None:
+def plan_step(menu: "Menu", questions: list[dict], selections: list[list[int]],
+              texts: list[str] | None = None) -> list[str] | None:
     """The NEXT keystrokes for this screen, or None when there is nothing left.
 
     Deliberately one step at a time, re-reading between steps, rather than one
@@ -461,17 +500,45 @@ def plan_step(menu: "Menu", questions: list[dict], selections: list[list[int]]) 
     if index is None or index >= len(selections):
         return None
     want = sorted(selections[index])
+    text = (texts[index] if texts and index < len(texts) else "") or ""
+
+    # The TUI appends its own rows ("Type something", "Chat about this") AFTER
+    # the declared options, and `selections` only ever numbers the declared ones.
+    # So anything past that count is not ours to toggle — and once free text has
+    # been entered its row is CHECKED, so a diff that considered it would untick
+    # it and erase what was typed.
+    declared = len(questions[index].get("options") or []) if index < len(questions) else 0
 
     if menu.is_multi_select:
         # Toggle only the DIFFERENCES, so re-running this against a screen that
         # already matches presses nothing at all.
         have = set(menu.checked_numbers())
         differing = [n for n in menu.options
-                     if (n.number in want) != (n.number in have)]
+                     if (not declared or n.number <= declared)
+                     and (n.number in want) != (n.number in have)]
         if differing:
             return [str(o.number) for o in differing]
+        if text:
+            # After the boxes, never before: typing moves focus to the text row,
+            # and a number pressed from there edits the text instead of toggling.
+            step = _free_text_step(menu, text)
+            if step is None:
+                return None
+            if step:
+                return step
         # This tab is right; move on. Tab clamps at the review screen rather
         # than wrapping, so over-pressing it cannot walk us back round.
+        return [TAB] if menu.needs_submit else None
+
+    if text:
+        # Single-select: free text REPLACES the pick — the TUI moves the
+        # selection onto the text row, so a declared option pressed as well
+        # would simply overwrite it.
+        step = _free_text_step(menu, text)
+        if step is None:
+            return None
+        if step:
+            return step
         return [TAB] if menu.needs_submit else None
 
     # Single-select: pressing the number both answers and advances.

--- a/runner/canopy_runner/canopy_runner/streams.py
+++ b/runner/canopy_runner/canopy_runner/streams.py
@@ -200,6 +200,7 @@ def drain_menu_answers(cfg: Config, client: Client) -> None:
             continue
         outcome, screen = hooks.answer_menu(session_key, a.get("option"),
                                             selections=a.get("selections"),
+                                            texts=a.get("texts"),
                                             cdp_port=cfg.cdp_port)
         hooks.note_answer_outcome(session_key, outcome, screen)
         try:

--- a/runner/canopy_runner/tests/test_menu.py
+++ b/runner/canopy_runner/tests/test_menu.py
@@ -6,6 +6,8 @@ produces for emdash — so what the runner reads over CDP is what these strings
 contain. Verified by roundtrip on 2026-07-28: the dialog below was detected,
 answered with a keystroke, and the file it asked about was actually deleted.
 """
+import pathlib
+
 from canopy_runner.menu import TAB, answer_keys, find_menu, find_menu_settled
 
 # Verbatim, as a terminal renders it. Note the leading spaces, the box rule, and
@@ -541,3 +543,93 @@ def test_every_control_key_the_driver_emits_is_named_for_the_real_transport():
     emitted = {TAB, "\r"} | {k for k in answer_keys(None)}
     control = {k for k in emitted if len(k) == 1 and not k.isprintable()}
     assert control <= mapped, f"unmapped control keys: {control - mapped}"
+
+
+# --- free text ("Type something") -------------------------------------------
+#
+# Recipe established against a live TUI 2026-08-12: pressing this row's number
+# does NOT answer — it moves the cursor there and opens an edit field (the
+# footer gains "ctrl+g to edit in Vim") — then you type and press Enter. The
+# row's NUMBER is appended by the TUI and is absent from the tool input, so it
+# can only be read off the render. Verified end to end: typing "Medium,
+# actually" produced `⏺ GOT=Medium` from the agent.
+
+LONE_SINGLE_TYPED = LONE_SINGLE.replace("3. Type something.", "3. Medium, actually")
+
+TABBED_MULTI_TYPED = TABBED_MULTI_TWO_CHECKED.replace(
+    "4. [ ] Type something", "4. [✔] Teal")
+
+
+def test_the_type_something_row_is_found_by_label_not_by_counting():
+    from canopy_runner.menu import type_something_number
+
+    assert type_something_number(find_menu(LONE_SINGLE)) == 3
+    assert type_something_number(find_menu(TABBED_MULTI)) == 4
+    # Once filled in, the label IS the text, so the row is no longer offered.
+    assert type_something_number(find_menu(LONE_SINGLE_TYPED)) is None
+
+
+def test_free_text_presses_the_row_then_types_then_confirms():
+    from canopy_runner.menu import TEXT_PREFIX, plan_step
+
+    lone = [{"index": 0, "question": "Which size?", "multi_select": False,
+             "options": [{"number": 1, "label": "Small"}]}]
+    step = plan_step(find_menu(LONE_SINGLE), lone, [[]], ["Medium, actually"])
+    assert step == ["3", TEXT_PREFIX + "Medium, actually", "\r"]
+
+
+def test_free_text_replaces_a_single_select_pick():
+    """The TUI moves the selection onto the text row, so pressing a declared
+    option as well would just overwrite what was typed."""
+    from canopy_runner.menu import TEXT_PREFIX, plan_step
+
+    lone = [{"index": 0, "question": "Which size?", "multi_select": False,
+             "options": [{"number": 1, "label": "Small"}]}]
+    step = plan_step(find_menu(LONE_SINGLE), lone, [[1]], ["Medium"])
+    assert step[0] == "3" and step[1] == TEXT_PREFIX + "Medium"
+
+
+def test_text_already_entered_is_not_typed_again():
+    """Same idempotence story as the checkboxes: this system delivers every
+    answer twice, and re-typing would append to what is already there."""
+    from canopy_runner.menu import plan_step
+
+    lone = [{"index": 0, "question": "Which size?", "multi_select": False,
+             "options": [{"number": 1, "label": "Small"}]}]
+    # No Submit tab on a lone single-select, so "done" is None, not Tab.
+    assert plan_step(find_menu(LONE_SINGLE_TYPED), lone, [[]], ["Medium, actually"]) is None
+
+
+def test_a_multi_select_toggles_boxes_before_typing():
+    """Typing moves focus to the text row; a number pressed from there edits the
+    text instead of toggling a box."""
+    from canopy_runner.menu import TEXT_PREFIX, plan_step
+
+    # Boxes not yet right -> toggles come first, text is not touched yet.
+    assert plan_step(find_menu(TABBED_MULTI), QUESTIONS, [[1, 3], [2]], ["Teal", None]) == ["1", "3"]
+    # Boxes right -> now the text.
+    step = plan_step(find_menu(TABBED_MULTI_TWO_CHECKED), QUESTIONS, [[1, 3], [2]], ["Teal", None])
+    assert step == ["4", TEXT_PREFIX + "Teal", "\r"]
+    # Text entered too -> move on to the next tab.
+    assert plan_step(find_menu(TABBED_MULTI_TYPED), QUESTIONS, [[1, 3], [2]], ["Teal", None]) == ["\t"]
+
+
+def test_text_that_cannot_be_entered_presses_nothing():
+    """The row is gone and nothing on screen carries the text, so typing would
+    land somewhere unpredictable. Refusing costs the answer and says so."""
+    from canopy_runner.menu import plan_step
+
+    lone = [{"index": 0, "question": "Which size?", "multi_select": False,
+             "options": [{"number": 1, "label": "Small"}]}]
+    assert plan_step(find_menu(LONE_SINGLE_TYPED), lone, [[]], ["Something else"]) is None
+
+
+def test_the_text_marker_is_distinguishable_from_a_keypress():
+    """The transport tells them apart by this prefix, so it must never collide
+    with a real key: keys are one character, or a control character."""
+    from canopy_runner.menu import TEXT_PREFIX
+
+    assert len(TEXT_PREFIX) > 1 and not TEXT_PREFIX.isdigit()
+    sidecar = (pathlib.Path(__file__).resolve().parents[1]
+               / "canopy_runner" / "cdp" / "emdash_control.mjs").read_text()
+    assert f"'{TEXT_PREFIX}'" in sidecar, "the sidecar does not know the text marker"

--- a/tests/test_menu_roundtrip_e2e.py
+++ b/tests/test_menu_roundtrip_e2e.py
@@ -345,3 +345,20 @@ def test_a_dialog_that_is_not_the_declared_ask_is_never_guessed_at():
 
     assert outcome == runner_hooks.UNMODELLED
     assert emdash.sent == []
+
+
+def test_the_schema_accepts_the_exact_body_the_browser_sends():
+    """REGRESSION, 2026-08-13. `texts` was typed `list[str]`, so a PARTIAL answer
+    — the whole point of the partial-submit change — was rejected 422 by the API
+    the moment it reached the live site. The list is POSITIONAL against the
+    declared questions, so a hole has to be expressible: without None the runner
+    would have to guess which question a shorter list belonged to.
+
+    Captured verbatim from a browser POST.
+    """
+    from apps.canopy_sessions.schemas import MenuAnswerIn
+
+    payload = MenuAnswerIn(**{"option": 1, "selections": [[1], []],
+                              "texts": ["Teal", None]})
+    assert payload.texts == ["Teal", None]
+    assert payload.selections == [[1], []]

--- a/tests/test_realtime_runner_consumer.py
+++ b/tests/test_realtime_runner_consumer.py
@@ -461,7 +461,8 @@ def test_the_relay_forwards_every_published_field(monkeypatch):
                                  session_key="agent-task")
 
     sent, chat_services = _published_menu_answer_frame(monkeypatch)
-    chat_services.answer_menu(session=session, option=1, selections=[[1, 3], [2]])
+    chat_services.answer_menu(session=session, option=1, selections=[[1, 3], [2]],
+                              texts=["Teal", None])
 
     # What the socket actually writes, for that exact published payload.
     relayed = {}
@@ -470,9 +471,11 @@ def test_the_relay_forwards_every_published_field(monkeypatch):
     asyncio.get_event_loop_policy().new_event_loop().run_until_complete(
         consumer.runner_menu_answer(sent))
 
-    for field in ("session_id", "session_key", "option", "selections", "answer_id"):
+    for field in ("session_id", "session_key", "option", "selections", "texts",
+                  "answer_id"):
         assert field in relayed, f"{field} was dropped by the relay"
     assert relayed["selections"] == [[1, 3], [2]]
+    assert relayed["texts"] == ["Teal", None]
     assert relayed["answer_id"] == sent["answer_id"]
 
 


### PR DESCRIPTION
Regression found on the live site the moment partial submit was actually exercised.

`texts` was typed `list[str]`, so the browser's real body was rejected **422** — the partial-submit change could not submit anything partial:

```
posted: {"option":1,"selections":[[1],[]],"texts":["Teal",null]}  ->  422
```

The list is **positional** against the declared questions, so a hole has to be expressible. Without `None` a shorter list would leave the runner guessing which question each answer belonged to — the same class of bug as a missing `selections` entry.

The test carries the verbatim browser body, so the schema can't drift from what the form sends.

The form itself behaved correctly throughout, which is why only a live click caught this:

```
nothing answered -> Send disabled: True
partial-submit hint: 1 unanswered — will send anyway
one answered  -> Send enabled: True
```

2118 server tests, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)