### PR TITLE
Let texts carry a hole for an unanswered question

### DIFF
--- a/apps/canopy_sessions/schemas.py
+++ b/apps/canopy_sessions/schemas.py
@@ -209,4 +209,7 @@ class MenuAnswerIn(Schema):
     #: Free text per question, for the answer that is not on the menu — the
     #: TUI appends a "Type something" row to every question and it is often
     #: where the real answer goes. Empty string = no free text.
-    texts: list[str] | None = None
+    #: `None` for a question left unanswered — the list is POSITIONAL against
+    #: the declared questions, so a hole has to be expressible or every later
+    #: answer shifts onto the wrong question.
+    texts: list[str | None] | None = None

--- a/apps/canopy_sessions/services.py
+++ b/apps/canopy_sessions/services.py
@@ -1003,7 +1003,7 @@ def project_events(turn: Turn, rows) -> int:
 
 def answer_menu(*, session: Session, option: int | None,
                 selections: list[list[int]] | None = None,
-                texts: list[str] | None = None) -> str:
+                texts: list[str | None] | None = None) -> str:
     """Answer the dialog an agent is blocked on, from the web.
 
     `selections` is the whole answer: one list of chosen option numbers per

--- a/apps/harness/schemas.py
+++ b/apps/harness/schemas.py
@@ -823,7 +823,7 @@ class MenuAnswerOut(Schema):
     #: does today — so the poll tick never gets WORSE than the current
     #: behaviour on an ask this shape cannot express.
     selections: list[list[int]] | None = None
-    texts: list[str] | None = None
+    texts: list[str | None] | None = None
 
 
 class MenuAnswerSyncOut(Schema):

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -8562,7 +8562,7 @@ export interface components {
             /** Selections */
             readonly selections?: readonly (readonly number[])[] | null;
             /** Texts */
-            readonly texts?: readonly string[] | null;
+            readonly texts?: readonly (string | null)[] | null;
         };
         /** MenuAnswerSyncOut */
         readonly MenuAnswerSyncOut: {
@@ -9118,7 +9118,7 @@ export interface components {
             /** Selections */
             readonly selections?: readonly (readonly number[])[] | null;
             /** Texts */
-            readonly texts?: readonly string[] | null;
+            readonly texts?: readonly (string | null)[] | null;
         };
         /**
          * StreamStateOut

--- a/tests/test_menu_roundtrip_e2e.py
+++ b/tests/test_menu_roundtrip_e2e.py
@@ -345,3 +345,20 @@ def test_a_dialog_that_is_not_the_declared_ask_is_never_guessed_at():
 
     assert outcome == runner_hooks.UNMODELLED
     assert emdash.sent == []
+
+
+def test_the_schema_accepts_the_exact_body_the_browser_sends():
+    """REGRESSION, 2026-08-13. `texts` was typed `list[str]`, so a PARTIAL answer
+    — the whole point of the partial-submit change — was rejected 422 by the API
+    the moment it reached the live site. The list is POSITIONAL against the
+    declared questions, so a hole has to be expressible: without None the runner
+    would have to guess which question a shorter list belonged to.
+
+    Captured verbatim from a browser POST.
+    """
+    from apps.canopy_sessions.schemas import MenuAnswerIn
+
+    payload = MenuAnswerIn(**{"option": 1, "selections": [[1], []],
+                              "texts": ["Teal", None]})
+    assert payload.texts == ["Teal", None]
+    assert payload.selections == [[1], []]


### PR DESCRIPTION
Regression found on the live site the moment partial submit was actually exercised.

`texts` was typed `list[str]`, so the browser's real body was rejected **422** — the partial-submit change could not submit anything partial:

```
posted: {"option":1,"selections":[[1],[]],"texts":["Teal",null]}  ->  422
```

The list is **positional** against the declared questions, so a hole has to be expressible. Without `None` a shorter list would leave the runner guessing which question each answer belonged to — the same class of bug as a missing `selections` entry.

The test carries the verbatim browser body, so the schema can't drift from what the form sends.

The form itself behaved correctly throughout, which is why only a live click caught this:

```
nothing answered -> Send disabled: True
partial-submit hint: 1 unanswered — will send anyway
one answered  -> Send enabled: True
```

(Supersedes #596/#597 — both were branched before the #595 squash and were unmergeable, so CI never ran on them.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)