### PR TITLE
Free text on a multi-select: walk the cursor, and stop thrashing

### DIFF
--- a/runner/canopy_runner/canopy_runner/cdp/emdash_control.mjs
+++ b/runner/canopy_runner/canopy_runner/cdp/emdash_control.mjs
@@ -529,7 +529,9 @@ try {
     // right after its first tab (observed live 2026-08-12). It survived a PTY
     // harness because that writes the raw byte and a terminal interprets it;
     // this transport does not.
-    const NAMED_KEYS = { '\r': 'Enter', '\n': 'Enter', '\u001b': 'Escape', '\t': 'Tab' };
+    const NAMED_KEYS = { '\r': 'Enter', '\n': 'Enter', '\u001b': 'Escape', '\t': 'Tab',
+                         '\u001b[A': 'ArrowUp', '\u001b[B': 'ArrowDown',
+                         '\u001b[C': 'ArrowRight', '\u001b[D': 'ArrowLeft' };
     // "text:..." means TYPE this, not press it — the answer to a question whose
     // real answer is not on the menu ("Type something"). keyboard.press takes one
     // key and would reject a sentence outright, and pressing it character by

--- a/runner/canopy_runner/canopy_runner/hooks.py
+++ b/runner/canopy_runner/canopy_runner/hooks.py
@@ -355,7 +355,21 @@ def _drive_selections(cdp, session_key, current, questions, selections, cdp_port
     instead of undoing it — and it is why the double delivery this system
     already performs (control frame, then poll tick) is now harmless.
     """
+    seen: set = set()
     for _ in range(menu.MAX_STEPS):
+        # A step that pressed keys and changed NOTHING means our model of this
+        # screen is wrong, and repeating it just thrashes. Observed live: a
+        # free-text step that silently missed its row left the driver toggling a
+        # checkbox on and off until the step cap — 60 presses into somebody's
+        # terminal to accomplish nothing. Stopping on a repeat state turns that
+        # into one wasted press and an honest refusal.
+        state = menu.screen_state(current)
+        if state in seen:
+            logger.warning("the dialog on %s stopped responding to the answer "
+                           "(state repeated) — refusing to press further", session_key)
+            return UNMODELLED, _menu_dict(current, source="screen")
+        seen.add(state)
+
         keys = menu.plan_step(current, questions, selections, texts)
         if keys is None:
             # Nothing further we can justify pressing. If every question already

--- a/runner/canopy_runner/canopy_runner/menu.py
+++ b/runner/canopy_runner/canopy_runner/menu.py
@@ -415,22 +415,32 @@ def type_something_number(menu: "Menu") -> int | None:
     return None
 
 
+DOWN = "\x1b[B"
+
+
 def _free_text_step(menu: "Menu", text: str) -> list[str] | None:
     """Keystrokes to put `text` into this question, or [] if it is already there.
 
     None means we cannot: the row is gone and nothing on screen carries the text,
     so typing would land somewhere unpredictable. Refusing costs the answer and
     says so; guessing types a sentence into whatever has focus.
+
+    Typing goes to whatever row the CURSOR is on, so the cursor has to be walked
+    there with arrow keys. A number key will not do it on a multi-select: there a
+    number TOGGLES a checkbox and leaves the cursor where it was, so the text
+    lands on the wrong row and the tick is spurious. Observed live — pressing the
+    row's number, typing and pressing Enter left the label reading "Type
+    something", un-ticked the box the previous step had ticked, and the driver
+    oscillated until it hit its step cap.
+
+    No trailing Enter: typing alone fills the row in (it auto-ticks and takes the
+    text as its label). Enter here was what cleared the earlier selection.
     """
     number = type_something_number(menu)
     if number is None:
         entered = any(option.label.strip() == text.strip() for option in menu.options)
         return [] if entered else None
-    # Pressing the number MOVES the cursor to that row and opens its edit field —
-    # it does NOT answer, unlike a declared option's number. Verified against a
-    # live TUI: the footer gains "ctrl+g to edit in Vim" and the label becomes
-    # whatever you type.
-    return [str(number), TEXT_PREFIX + text, "\r"]
+    return [DOWN] * max(0, number - (menu.selected or 1)) + [TEXT_PREFIX + text]
 
 # Bound on the drive loop. Each question costs at most (toggles + one Tab), so
 # this is generous for any real ask while still terminating if the screen stops
@@ -468,6 +478,21 @@ def question_index(menu: "Menu", questions: list[dict]) -> int | None:
             if best is None or len(want) > best[1]:
                 best = (q.get("index", questions.index(q)), len(want))
     return best[0] if best else None
+
+
+def screen_state(menu: "Menu") -> tuple:
+    """What this screen IS, for spotting a step that changed nothing.
+
+    Question plus every row's number, label and tick — the only things the driver
+    reacts to, so two screens equal under this are two screens it would treat
+    identically and therefore answer identically. Comparing raw text instead
+    would make a spinner or a clock look like progress.
+    """
+    return (
+        menu.question,
+        menu.is_review,
+        tuple((o.number, o.label, o.checked) for o in menu.options),
+    )
 
 
 def plan_step(menu: "Menu", questions: list[dict], selections: list[list[int]],
@@ -519,8 +544,8 @@ def plan_step(menu: "Menu", questions: list[dict], selections: list[list[int]],
         if differing:
             return [str(o.number) for o in differing]
         if text:
-            # After the boxes, never before: typing moves focus to the text row,
-            # and a number pressed from there edits the text instead of toggling.
+            # After the boxes, never before: the cursor ends up on the text row,
+            # and a number pressed from there would toggle the wrong thing.
             step = _free_text_step(menu, text)
             if step is None:
                 return None
@@ -539,7 +564,10 @@ def plan_step(menu: "Menu", questions: list[dict], selections: list[list[int]],
             return None
         if step:
             return step
-        return [TAB] if menu.needs_submit else None
+        # Entered. A dialog with a Submit tab is finished from there; one without
+        # (a lone question) is confirmed with Enter, exactly as picking an option
+        # would have been.
+        return [TAB] if menu.needs_submit else ["\r"]
 
     # Single-select: pressing the number both answers and advances.
     if not want:

--- a/runner/canopy_runner/tests/test_menu.py
+++ b/runner/canopy_runner/tests/test_menu.py
@@ -540,8 +540,10 @@ def test_every_control_key_the_driver_emits_is_named_for_the_real_transport():
     mapped = set(re.findall(r"'((?:\\u[0-9a-fA-F]{4}|\\.|[^'\\])+)'\s*:", named.group(1)))
     mapped = {k.encode().decode("unicode_escape") for k in mapped}
 
-    emitted = {TAB, "\r"} | {k for k in answer_keys(None)}
-    control = {k for k in emitted if len(k) == 1 and not k.isprintable()}
+    from canopy_runner.menu import DOWN
+
+    emitted = {TAB, "\r", DOWN} | {k for k in answer_keys(None)}
+    control = {k for k in emitted if not k.isprintable() or k.startswith('\x1b')}
     assert control <= mapped, f"unmapped control keys: {control - mapped}"
 
 
@@ -569,13 +571,20 @@ def test_the_type_something_row_is_found_by_label_not_by_counting():
     assert type_something_number(find_menu(LONE_SINGLE_TYPED)) is None
 
 
-def test_free_text_presses_the_row_then_types_then_confirms():
-    from canopy_runner.menu import TEXT_PREFIX, plan_step
+def test_free_text_walks_the_cursor_to_the_row_then_types():
+    """The cursor is what receives typing, so it has to be WALKED there. A number
+    key will not do it on a multi-select — there a number toggles a checkbox and
+    leaves the cursor put, so the text lands on the wrong row (observed live: the
+    label stayed "Type something", the previous tick was cleared, and the driver
+    oscillated to its step cap)."""
+    from canopy_runner.menu import DOWN, TEXT_PREFIX, plan_step
 
     lone = [{"index": 0, "question": "Which size?", "multi_select": False,
              "options": [{"number": 1, "label": "Small"}]}]
     step = plan_step(find_menu(LONE_SINGLE), lone, [[]], ["Medium, actually"])
-    assert step == ["3", TEXT_PREFIX + "Medium, actually", "\r"]
+    # Cursor on row 1, "Type something" is row 3. No trailing Enter: typing alone
+    # fills the row in, and an Enter here cleared the earlier selection.
+    assert step == [DOWN, DOWN, TEXT_PREFIX + "Medium, actually"]
 
 
 def test_free_text_replaces_a_single_select_pick():
@@ -586,7 +595,7 @@ def test_free_text_replaces_a_single_select_pick():
     lone = [{"index": 0, "question": "Which size?", "multi_select": False,
              "options": [{"number": 1, "label": "Small"}]}]
     step = plan_step(find_menu(LONE_SINGLE), lone, [[1]], ["Medium"])
-    assert step[0] == "3" and step[1] == TEXT_PREFIX + "Medium"
+    assert step[-1] == TEXT_PREFIX + "Medium" and "1" not in step
 
 
 def test_text_already_entered_is_not_typed_again():
@@ -596,20 +605,22 @@ def test_text_already_entered_is_not_typed_again():
 
     lone = [{"index": 0, "question": "Which size?", "multi_select": False,
              "options": [{"number": 1, "label": "Small"}]}]
-    # No Submit tab on a lone single-select, so "done" is None, not Tab.
-    assert plan_step(find_menu(LONE_SINGLE_TYPED), lone, [[]], ["Medium, actually"]) is None
+    # Entered. A lone dialog has no Submit tab, so it is confirmed with Enter —
+    # exactly as picking an option would have been.
+    assert plan_step(find_menu(LONE_SINGLE_TYPED), lone, [[]], ["Medium, actually"]) == ["\r"]
 
 
 def test_a_multi_select_toggles_boxes_before_typing():
     """Typing moves focus to the text row; a number pressed from there edits the
     text instead of toggling a box."""
-    from canopy_runner.menu import TEXT_PREFIX, plan_step
+    from canopy_runner.menu import DOWN, TEXT_PREFIX, plan_step
 
     # Boxes not yet right -> toggles come first, text is not touched yet.
     assert plan_step(find_menu(TABBED_MULTI), QUESTIONS, [[1, 3], [2]], ["Teal", None]) == ["1", "3"]
-    # Boxes right -> now the text.
+    # Boxes right -> walk the cursor to row 4 and type. Verified against a live
+    # multi-select: the row auto-ticks and takes the text as its label.
     step = plan_step(find_menu(TABBED_MULTI_TWO_CHECKED), QUESTIONS, [[1, 3], [2]], ["Teal", None])
-    assert step == ["4", TEXT_PREFIX + "Teal", "\r"]
+    assert step == [DOWN, DOWN, DOWN, TEXT_PREFIX + "Teal"]
     # Text entered too -> move on to the next tab.
     assert plan_step(find_menu(TABBED_MULTI_TYPED), QUESTIONS, [[1, 3], [2]], ["Teal", None]) == ["\t"]
 

--- a/tests/test_menu_roundtrip_e2e.py
+++ b/tests/test_menu_roundtrip_e2e.py
@@ -362,3 +362,37 @@ def test_the_schema_accepts_the_exact_body_the_browser_sends():
                               "texts": ["Teal", None]})
     assert payload.texts == ["Teal", None]
     assert payload.selections == [[1], []]
+
+
+def test_a_step_that_changes_nothing_stops_instead_of_thrashing():
+    """REGRESSION, 2026-08-13. A free-text step that silently missed its row left
+    the driver toggling a checkbox on and off until its step cap — 60 presses
+    into somebody's terminal to accomplish nothing, and the answer lost anyway.
+
+    A screen the driver has already seen means its model is wrong, and pressing
+    again cannot help. One wasted press and an honest refusal beats sixty.
+    """
+    screens = iter([TABBED_SCREENS["colors"]] * 40)
+
+    class _Stuck:
+        """A terminal that accepts keys and never changes."""
+
+        def __init__(self):
+            self.sent = []
+
+        def read_terminal(self, task, *, port=9222):
+            return next(screens)
+
+        def send_keys(self, task, keys, *, port=9222):
+            self.sent.append(list(keys))
+            return {"ok": True}
+
+    emdash = _Stuck()
+    questions = _hook_menu(TABBED_INPUT)["questions"]
+    current = runner_hooks.menu.find_menu(TABBED_SCREENS["colors"])
+
+    outcome, _screen = runner_hooks._drive_selections(
+        emdash, "agent-task", current, questions, [[1, 3], [2]], 9222)
+
+    assert outcome == runner_hooks.UNMODELLED
+    assert len(emdash.sent) <= 2, f"kept pressing: {emdash.sent}"


### PR DESCRIPTION
The free-text recipe shipped in #595 was verified on a **single-select** question and silently does not work on a **multi-select**. Caught by clicking it on the live site, then replaying the drive step by step against the stuck dialog:

```
step 0: ['1']                    -> Red checked
step 1: ['4','text:Teal','\r']   -> Red UNCHECKED, row 4 ticked,
                                    label still "Type something"
step 2: ['1']                    -> Red checked … forever
```

## Two behaviours behind one number key

| | pressing the "Type something" row's number |
|---|---|
| single-select | moves the cursor there and opens its edit field |
| multi-select | **toggles that row's checkbox**, cursor stays put |

So the text was typed at whatever row had focus, the tick was spurious, and the trailing Enter cleared the selection made a step earlier.

Typing goes to the **cursor**, so the cursor is now walked there with arrow keys — true in both modes. No trailing Enter: typing alone fills the row in, and the Enter was what cleared the earlier pick. A lone dialog (no Submit tab) is still confirmed with Enter once the text is in.

Verified against a live multi-select TUI:

```
  1. [✔] Red        ← toggled by number
❯ 4. [✔] Teal       ← cursor walked down, then typed
```

## And a guard, so this class of bug costs one press instead of sixty

A step that pressed keys and left the screen in a state the driver **has already seen** means our model is wrong, and pressing again cannot help. It now stops and reports instead of oscillating to `MAX_STEPS` — which is what put 60 keystrokes into a terminal to accomplish nothing.

Arrow keys join Tab in the sidecar's named-key map, and the test pinning that map against everything the driver can emit now covers them (verified failing without `ArrowDown`).

466 runner tests; server suite and ruff clean. (Supersedes #599, branched before the #598 squash.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)