### PR TITLE
Commit free text with Enter — Tab is swallowed while the row is edited

### DIFF
--- a/runner/canopy_runner/canopy_runner/menu.py
+++ b/runner/canopy_runner/canopy_runner/menu.py
@@ -433,14 +433,22 @@ def _free_text_step(menu: "Menu", text: str) -> list[str] | None:
     something", un-ticked the box the previous step had ticked, and the driver
     oscillated until it hit its step cap.
 
-    No trailing Enter: typing alone fills the row in (it auto-ticks and takes the
-    text as its label). Enter here was what cleared the earlier selection.
+    Enter COMMITS the text, and on a tabbed ask also advances to the next tab.
+    It is not optional: while the row is being edited the dialog swallows Tab
+    entirely, so without it the driver pressed Tab at a screen that could not
+    respond and stopped (correctly) on its no-progress guard, answer unsent.
+    Measured live — Tab alone left the screen byte-identical, Enter moved it on.
+
+    Removed once, for the right reason and the wrong case: an Enter that follows
+    a NUMBER press cleared the earlier pick, because the number had toggled the
+    wrong row. Following a cursor-walk it is correct and required.
     """
     number = type_something_number(menu)
     if number is None:
         entered = any(option.label.strip() == text.strip() for option in menu.options)
         return [] if entered else None
-    return [DOWN] * max(0, number - (menu.selected or 1)) + [TEXT_PREFIX + text]
+    return ([DOWN] * max(0, number - (menu.selected or 1))
+            + [TEXT_PREFIX + text, "\r"])
 
 # Bound on the drive loop. Each question costs at most (toggles + one Tab), so
 # this is generous for any real ask while still terminating if the screen stops

--- a/runner/canopy_runner/tests/test_menu.py
+++ b/runner/canopy_runner/tests/test_menu.py
@@ -584,7 +584,8 @@ def test_free_text_walks_the_cursor_to_the_row_then_types():
     step = plan_step(find_menu(LONE_SINGLE), lone, [[]], ["Medium, actually"])
     # Cursor on row 1, "Type something" is row 3. No trailing Enter: typing alone
     # fills the row in, and an Enter here cleared the earlier selection.
-    assert step == [DOWN, DOWN, TEXT_PREFIX + "Medium, actually"]
+    # Enter commits: while the row is being edited the dialog swallows Tab.
+    assert step == [DOWN, DOWN, TEXT_PREFIX + "Medium, actually", "\r"]
 
 
 def test_free_text_replaces_a_single_select_pick():
@@ -595,7 +596,7 @@ def test_free_text_replaces_a_single_select_pick():
     lone = [{"index": 0, "question": "Which size?", "multi_select": False,
              "options": [{"number": 1, "label": "Small"}]}]
     step = plan_step(find_menu(LONE_SINGLE), lone, [[1]], ["Medium"])
-    assert step[-1] == TEXT_PREFIX + "Medium" and "1" not in step
+    assert TEXT_PREFIX + "Medium" in step and "1" not in step
 
 
 def test_text_already_entered_is_not_typed_again():
@@ -620,7 +621,7 @@ def test_a_multi_select_toggles_boxes_before_typing():
     # Boxes right -> walk the cursor to row 4 and type. Verified against a live
     # multi-select: the row auto-ticks and takes the text as its label.
     step = plan_step(find_menu(TABBED_MULTI_TWO_CHECKED), QUESTIONS, [[1, 3], [2]], ["Teal", None])
-    assert step == [DOWN, DOWN, DOWN, TEXT_PREFIX + "Teal"]
+    assert step == [DOWN, DOWN, DOWN, TEXT_PREFIX + "Teal", "\r"]
     # Text entered too -> move on to the next tab.
     assert plan_step(find_menu(TABBED_MULTI_TYPED), QUESTIONS, [[1, 3], [2]], ["Teal", None]) == ["\t"]
 


### PR DESCRIPTION
Follow-up to #600, measured live on the deployed stack.

With the cursor in the text row, **Tab leaves the screen byte-identical** — the dialog swallows it while the row is being edited. So the driver's next step pressed Tab at a screen that could not respond and stopped on the no-progress guard: correct behaviour, answer unsent.

```
before:          opts=[(1,'Red',True), (4,'Teal',True)]
after TAB:       opts=[(1,'Red',True), (4,'Teal',True)]   ← nothing
after Enter:     q='Which size?'                          ← committed AND advanced
after Enter+TAB: q='Ready to submit your answers?'
```

Enter both commits the text and advances to the next tab, so it goes back into the recipe. It was removed in #600 for the right reason and the wrong case: an Enter that follows a **number** press cleared the earlier pick, because the number had toggled the wrong row. Following a cursor-walk it is correct and required.

## End-to-end result

Driving this same answer through to submission on the live site produced:

```
GOT=Red, Teal|NONE
```

Free text (`Teal`, not on the menu) alongside a picked option, and question 2 deliberately left blank — both features working through the real browser → server → runner → terminal chain.

466 runner tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)