### PR TITLE
Type the free text, then commit it as a separate step

### DIFF
--- a/runner/canopy_runner/canopy_runner/cdp/emdash_control.mjs
+++ b/runner/canopy_runner/canopy_runner/cdp/emdash_control.mjs
@@ -540,11 +540,22 @@ try {
     const TEXT_PREFIX = 'text:';
     for (const key of keys) {
       if (typeof key === 'string' && key.startsWith(TEXT_PREFIX)) {
-        await page.keyboard.type(key.slice(TEXT_PREFIX.length));
+        // `delay` matters: at zero the characters arrive faster than the TUI
+        // processes them and the row takes the text WITHOUT ticking itself,
+        // after which Enter neither commits nor advances and the dialog is
+        // stuck. Discrete, paced keys are what a person produces and what the
+        // row's own handler is written for (matches a PTY capture exactly).
+        await page.keyboard.type(key.slice(TEXT_PREFIX.length), { delay: 60 });
+        // Longer than a keypress needs. The TUI re-renders the row it just took
+        // text into, and the Enter that COMMITS that text has to arrive after
+        // that settles — at 120ms it landed mid-render and toggled the row off
+        // instead, leaving the answer typed but unticked and the dialog stuck on
+        // the same tab (observed live 2026-08-13).
+        await page.waitForTimeout(700);
       } else {
         await page.keyboard.press(NAMED_KEYS[key] || key);
+        await page.waitForTimeout(120);
       }
-      await page.waitForTimeout(120);
     }
     out({ ok: true, task, sent: keys.length });
 

--- a/runner/canopy_runner/canopy_runner/menu.py
+++ b/runner/canopy_runner/canopy_runner/menu.py
@@ -447,8 +447,7 @@ def _free_text_step(menu: "Menu", text: str) -> list[str] | None:
     if number is None:
         entered = any(option.label.strip() == text.strip() for option in menu.options)
         return [] if entered else None
-    return ([DOWN] * max(0, number - (menu.selected or 1))
-            + [TEXT_PREFIX + text, "\r"])
+    return [DOWN] * max(0, number - (menu.selected or 1)) + [TEXT_PREFIX + text]
 
 # Bound on the drive loop. Each question costs at most (toggles + one Tab), so
 # this is generous for any real ask while still terminating if the screen stops
@@ -557,8 +556,12 @@ def plan_step(menu: "Menu", questions: list[dict], selections: list[list[int]],
             step = _free_text_step(menu, text)
             if step is None:
                 return None
-            if step:
-                return step
+            # [] means the text is IN the row but the row is still being edited:
+            # the dialog is on this question and swallowing Tab. Enter commits
+            # (and advances). It is a SEPARATE step so a full screen read sits
+            # between typing and committing — batched behind the text it lands
+            # mid-render and toggles the row off instead.
+            return step or ["\r"]
         # This tab is right; move on. Tab clamps at the review screen rather
         # than wrapping, so over-pressing it cannot walk us back round.
         return [TAB] if menu.needs_submit else None
@@ -570,12 +573,8 @@ def plan_step(menu: "Menu", questions: list[dict], selections: list[list[int]],
         step = _free_text_step(menu, text)
         if step is None:
             return None
-        if step:
-            return step
-        # Entered. A dialog with a Submit tab is finished from there; one without
-        # (a lone question) is confirmed with Enter, exactly as picking an option
-        # would have been.
-        return [TAB] if menu.needs_submit else ["\r"]
+        # Same two beats as the multi-select above: type, then commit.
+        return step or ["\r"]
 
     # Single-select: pressing the number both answers and advances.
     if not want:

--- a/runner/canopy_runner/tests/test_menu.py
+++ b/runner/canopy_runner/tests/test_menu.py
@@ -584,8 +584,8 @@ def test_free_text_walks_the_cursor_to_the_row_then_types():
     step = plan_step(find_menu(LONE_SINGLE), lone, [[]], ["Medium, actually"])
     # Cursor on row 1, "Type something" is row 3. No trailing Enter: typing alone
     # fills the row in, and an Enter here cleared the earlier selection.
-    # Enter commits: while the row is being edited the dialog swallows Tab.
-    assert step == [DOWN, DOWN, TEXT_PREFIX + "Medium, actually", "\r"]
+    # Typing only. Enter is a SEPARATE step so a screen read sits between them.
+    assert step == [DOWN, DOWN, TEXT_PREFIX + "Medium, actually"]
 
 
 def test_free_text_replaces_a_single_select_pick():
@@ -608,6 +608,7 @@ def test_text_already_entered_is_not_typed_again():
              "options": [{"number": 1, "label": "Small"}]}]
     # Entered. A lone dialog has no Submit tab, so it is confirmed with Enter —
     # exactly as picking an option would have been.
+    # Text is in the row; the next step is the Enter that commits it.
     assert plan_step(find_menu(LONE_SINGLE_TYPED), lone, [[]], ["Medium, actually"]) == ["\r"]
 
 
@@ -621,9 +622,9 @@ def test_a_multi_select_toggles_boxes_before_typing():
     # Boxes right -> walk the cursor to row 4 and type. Verified against a live
     # multi-select: the row auto-ticks and takes the text as its label.
     step = plan_step(find_menu(TABBED_MULTI_TWO_CHECKED), QUESTIONS, [[1, 3], [2]], ["Teal", None])
-    assert step == [DOWN, DOWN, DOWN, TEXT_PREFIX + "Teal", "\r"]
+    assert step == [DOWN, DOWN, DOWN, TEXT_PREFIX + "Teal"]
     # Text entered too -> move on to the next tab.
-    assert plan_step(find_menu(TABBED_MULTI_TYPED), QUESTIONS, [[1, 3], [2]], ["Teal", None]) == ["\t"]
+    assert plan_step(find_menu(TABBED_MULTI_TYPED), QUESTIONS, [[1, 3], [2]], ["Teal", None]) == ["\r"]
 
 
 def test_text_that_cannot_be_entered_presses_nothing():


### PR DESCRIPTION
Measured on the live stack, from a row that has taken text but not yet been committed:

```
Enter #1 -> advances to the next question   (commits this one)
Enter #2 -> review
Enter #3 -> submitted
```

So one Enter commits and advances — but it has to be **its own step**. Batched directly behind the typing it lands before the TUI has finished re-rendering the row it just took text into, and is swallowed: the answer stays typed, unticked and uncommitted, and the dialog sits on the same tab. Splitting it puts a full screen read between the two, which is what the working manual sequence had.

Also paces the typing itself — at zero delay the characters arrive faster than the row's handler processes them.

This is the last of three keystroke facts that only the real transport could teach:

| fact | where it bit |
|---|---|
| Tab is swallowed while a row is being edited | #601 |
| a number *toggles* on multi-select, it does not open the editor | #600 |
| Enter commits the text, as a separate step | here |

None of them are true of the PTY harness, which passed throughout.

466 runner tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)