### PR TITLE
Do not offer free text where it cannot be delivered

### DIFF
--- a/frontend/packages/canopy-ui/src/chat/MenuPrompt.tsx
+++ b/frontend/packages/canopy-ui/src/chat/MenuPrompt.tsx
@@ -188,15 +188,20 @@ function AnswerForm({
             {/* The answer that is not on the menu. The terminal offers this on
                 every question ("Type something"), and it is where the real
                 answer often goes, so a phone without it can only pick from what
-                the agent happened to guess. */}
-            <input
+                the agent happened to guess.
+
+                Not offered on a pick-any question: the runner cannot commit it
+                there (the row's Enter toggles its checkbox instead of
+                confirming), so the box would take an answer that never lands.
+                Better to not offer it than to swallow it. */}
+            {q.multi_select ? null : <input
               type="text"
               value={typed[q.index] ?? ""}
               disabled={busy}
               onChange={(e) => write(q, e.target.value)}
               placeholder="…or type your own answer"
               className="mt-0.5 rounded border border-input bg-card px-2.5 py-2 text-[13px] text-foreground placeholder:text-muted-foreground disabled:opacity-50"
-            />
+            />}
           </div>
         </div>
       ))}

--- a/runner/canopy_runner/canopy_runner/hooks.py
+++ b/runner/canopy_runner/canopy_runner/hooks.py
@@ -272,6 +272,7 @@ ANSWERED = "answered"
 NO_DIALOG = "no_dialog"          # nothing on screen — already answered, or gone
 NOT_ON_MENU = "not_on_menu"      # stale numbering; the dialog changed under the tap
 UNMODELLED = "unmodelled"        # a tabbed ask we could not match to its questions
+FREE_TEXT_UNSUPPORTED = "free_text_unsupported"   # typed answer on a multi-select
 WRONG_PANE = "wrong_pane"        # a shell tab is selected; keys would run in it
 UNREACHABLE = "unreachable"      # CDP/emdash could not be driven at all
 NO_SESSION = "no_session"        # the emdash task is gone — nothing to press a key in
@@ -283,6 +284,8 @@ ANSWER_NOTES = {
     NOT_ON_MENU: "The dialog changed before that reached it. Here is what it shows now.",
     UNMODELLED: "This ask has several questions and they could not be matched to what is "
                 "on screen — answer it in emdash.",
+    FREE_TEXT_UNSUPPORTED: "Typing your own answer to a pick-any question does not work from "
+                           "here yet — pick from the options, or answer it in emdash.",
     WRONG_PANE: "A shell tab is selected for this session in emdash. Switch it to the "
                 "Claude tab and tap again.",
     UNREACHABLE: "Could not reach emdash on this runner to press the key.",
@@ -431,6 +434,22 @@ def answer_menu_with(cdp, session_key: str, option, *, selections=None, texts=No
                 return UNMODELLED, _menu_dict(current, source="screen")
             questions = [{"index": 0, "question": current.question,
                           "multi_select": current.is_multi_select}]
+        # Free text on a MULTI-SELECT question is refused before anything is
+        # pressed. Its commit keystroke could not be pinned down: on the row that
+        # has taken text, Enter was observed advancing the tab once and simply
+        # TOGGLING the row's checkbox on every later attempt, on/off/on/off. The
+        # answer therefore gets typed and never submitted, which leaves exactly
+        # the half-answered dialog this whole surface exists to prevent.
+        #
+        # Single-select free text is verified end to end and stays. Refusing here
+        # costs a trip to the keyboard and says so; pressing hopefully costs a
+        # dialog nobody can see the state of.
+        blocked = menu.free_text_blocked(questions, texts)
+        if blocked:
+            logger.info("refusing free text on multi-select question(s) %s for %s",
+                        blocked, session_key)
+            return FREE_TEXT_UNSUPPORTED, _menu_dict(current, source="screen")
+
         outcome, screen = _drive_selections(
             cdp, session_key, current, questions, selections, cdp_port, texts)
         logger.info("answered the dialog on %s with %s (%s)", session_key,

--- a/runner/canopy_runner/canopy_runner/menu.py
+++ b/runner/canopy_runner/canopy_runner/menu.py
@@ -487,6 +487,25 @@ def question_index(menu: "Menu", questions: list[dict]) -> int | None:
     return best[0] if best else None
 
 
+def free_text_blocked(questions: list[dict], texts) -> list[str]:
+    """Questions whose typed answer this driver cannot deliver, by name.
+
+    Free text on a MULTI-SELECT is the case. Its commit keystroke could not be
+    pinned down: on a row that has taken text, Enter was seen advancing the tab
+    once and simply TOGGLING that row's checkbox on every later attempt —
+    on/off/on/off, measured live. The answer therefore gets typed and never
+    submitted, which leaves exactly the half-answered dialog this surface exists
+    to prevent. Single-select free text is verified end to end and is not here.
+
+    Returned as names so the refusal can say WHICH question to go and answer.
+    """
+    if not texts:
+        return []
+    return [q.get("header") or q.get("question") or f"question {i + 1}"
+            for i, q in enumerate(questions)
+            if q.get("multi_select") and i < len(texts) and texts[i]]
+
+
 def screen_state(menu: "Menu") -> tuple:
     """What this screen IS, for spotting a step that changed nothing.
 

--- a/tests/test_menu_roundtrip_e2e.py
+++ b/tests/test_menu_roundtrip_e2e.py
@@ -396,3 +396,26 @@ def test_a_step_that_changes_nothing_stops_instead_of_thrashing():
 
     assert outcome == runner_hooks.UNMODELLED
     assert len(emdash.sent) <= 2, f"kept pressing: {emdash.sent}"
+
+
+def test_free_text_on_a_multi_select_is_refused_rather_than_half_pressed():
+    """Its commit keystroke could not be pinned down: on a row that has taken
+    text, Enter was seen advancing the tab ONCE and simply toggling that row's
+    checkbox on every later attempt — on/off/on/off, measured live. So the answer
+    gets typed and never submitted, leaving exactly the half-answered dialog this
+    surface exists to prevent.
+
+    Refusing costs a trip to the keyboard and SAYS so. Pressing hopefully costs a
+    dialog nobody can see the state of.
+    """
+    questions = _hook_menu(TABBED_INPUT)["questions"]
+    assert questions[0]["multi_select"] is True and questions[1]["multi_select"] is False
+
+    # Typed answer on the pick-any question -> named, and refused.
+    assert runner_hooks.menu.free_text_blocked(questions, ["Teal", None]) == ["Colors"]
+    # Typed answer on the single-select one -> fine, that path is verified.
+    assert runner_hooks.menu.free_text_blocked(questions, [None, "Extra large"]) == []
+    # No free text at all -> nothing to block.
+    assert runner_hooks.menu.free_text_blocked(questions, None) == []
+
+    assert runner_hooks.ANSWER_NOTES[runner_hooks.FREE_TEXT_UNSUPPORTED]


### PR DESCRIPTION
Free text on a **multi-select** question is now refused before anything is pressed, and the form stops offering the box there.

## Why

Its commit keystroke could not be pinned down. On a row that has taken text, Enter was observed advancing the tab **once**, and then simply **toggling that row's checkbox** on every later attempt — measured live, across eight consecutive presses:

```
step 0: ['\r']  ->  (4,'Teal',False)
step 1: ['\r']  ->  (4,'Teal',True)
step 2: ['\r']  ->  (4,'Teal',False)
step 3: ['\r']  ->  (4,'Teal',True)   … on/off/on/off
```

So the typed answer lands in the row and is never submitted — precisely the half-answered dialog this whole surface exists to prevent.

## What stays

**Single-select free text is verified end to end and is untouched**: typing `Medium, actually` at a real dialog produced `⏺ GOT=Medium` from the agent.

And the full multi-select chain does work when the keystrokes are right — driven by hand it produced `GOT=Red, Teal|NONE`. It is only the automated commit that isn't reliable, so that is the part being withheld.

## How it refuses

Nothing is pressed, so the dialog is exactly as the human left it, and the note beside the menu names the question to go and answer. The rule is a pure function (`menu.free_text_blocked`) so what is and isn't supported is one readable list, and a test asserts the note exists so it can never refuse silently.

2119 server / 466 runner tests, ruff + tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)