### PR TITLE
fix(items): show what's waiting on a human, not every card ever posted

### DIFF
--- a/frontend/e2e/backend.sh
+++ b/frontend/e2e/backend.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Boots a local API on :8000 backed by SQLite, no OAuth wall, seeded + a minted
+# Boots a local API on :$E2E_API_PORT (default 8000) backed by SQLite, no OAuth wall, seeded + a minted
 # session (frontend/e2e/.auth/session.txt). Run by Playwright's webServer.
 set -e
 cd "$(dirname "$0")/../.."   # repo root
@@ -8,7 +8,11 @@ export REQUIRE_AUTH=False
 export DEBUG=True
 export SECRET_KEY="e2e-secret-key"
 export ALLOWED_HOSTS="localhost,127.0.0.1"
+# Port is overridable: on a shared machine :8000 is often already taken by
+# another account's dev server, and a hardcoded port makes the suite simply
+# unrunnable there rather than failing with anything actionable.
+E2E_API_PORT="${E2E_API_PORT:-8000}"
 rm -f e2e.sqlite3 frontend/e2e/.auth/session.txt
 uv run python manage.py migrate --noinput >/tmp/e2e-migrate.log 2>&1
 uv run python manage.py shell -c "exec(open('frontend/e2e/seed.py').read())"
-exec uv run uvicorn config.asgi:application --host 127.0.0.1 --port 8000
+exec uv run uvicorn config.asgi:application --host 127.0.0.1 --port "$E2E_API_PORT"

--- a/frontend/e2e/items.spec.ts
+++ b/frontend/e2e/items.spec.ts
@@ -46,3 +46,38 @@ test('an open item shows in the agent inbox and the fleet supervisor', async ({ 
   // visible without opening the item.
   await expect(page.getByTestId('waiting-on-you')).toContainText('dispatches to hal')
 })
+
+test('the unfiltered queue shows only what is still waiting; settled cards collapse', async ({
+  page,
+}) => {
+  // The rot this guards against: Items are never deleted, only settled, so the
+  // page grew to 32 cards — 30 of them decided or dismissed — and the 2 that
+  // actually wanted an answer were buried in weeks of history.
+  //
+  // Asserted on the two items whose state is fixed regardless of what ran before:
+  // fa-hal-inbox is never decided by another test, fa-old-settled is seeded
+  // dismissed. Counting cards here would couple this to test order.
+  await page.goto('/w/dimagi/agents/ada/items')
+
+  await expect(page.getByText('hal: discard 81 junk/stale unread emails')).toBeVisible()
+  await expect(page.getByText('waiting on you')).toBeVisible()
+
+  // The settled card is present but tucked away, not competing for attention.
+  const settled = page.getByTestId('items-settled')
+  await expect(settled).toContainText('settled')
+  await expect(
+    page.getByText('hal: an old finding nobody needs to see again'),
+  ).not.toBeVisible()
+
+  await settled.getByText(/\d+ settled/).click()
+  await expect(page.getByText('hal: an old finding nobody needs to see again')).toBeVisible()
+})
+
+test('a batch permalink still shows everything it decided', async ({ page }) => {
+  // The deliberate exception: ?batch= names one sitting and is usually opened to
+  // read back what was decided, so it must NOT hide settled cards.
+  await page.goto('/w/dimagi/agents/ada/items?batch=fleet-audit-2026-06-30')
+
+  await expect(page.getByText('hal: an old finding nobody needs to see again')).toBeVisible()
+  await expect(page.getByTestId('items-settled')).toHaveCount(0)
+})

--- a/frontend/e2e/seed.py
+++ b/frontend/e2e/seed.py
@@ -85,15 +85,25 @@ AgentSkill.objects.create(
 
 # An open emdash session the runner reported — drives /supervisor's Open sessions
 # section. status ONLINE + a fresh heartbeat so GET /api/harness/sessions includes it.
-from apps.harness.models import Runner, EmdashSession
+from apps.harness.models import Runner
+from apps.canopy_sessions.models import Session as CanopySession, RunnerBinding
 from django.utils import timezone as _tz
 _runner = Runner.objects.create(
     name="e2e-mbp", kind=Runner.EMDASH, host="e2e-host", paired_by=user, workspace=ws,
     status=Runner.ONLINE, last_heartbeat_at=_tz.now(), capabilities={"projects": ["canopy-web"]},
     ready=False, ready_note="emdash CDP unreachable",
 )
-EmdashSession.objects.create(
-    runner=_runner, workspace=ws, emdash_task="cloud-runner", project="canopy-web",
+# harness.EmdashSession was absorbed into canopy_sessions: the session itself, plus a
+# RunnerBinding holding the live runner pointer (`emdash_task` → `session_key`). This
+# seed still imported the deleted model, which raised at import time and took the WHOLE
+# e2e suite down — every spec, not just the supervisor one. That is why nothing caught
+# the items view growing to 32 cards.
+_session = CanopySession.objects.create(
+    workspace=ws, project="canopy-web",
+    status=CanopySession.ACTIVE, origin=CanopySession.ORIGIN_RUNNER,
+)
+RunnerBinding.objects.create(
+    session=_session, runner=_runner, session_key="cloud-runner",
     status="in_progress", last_interacted_at=_tz.now(),
 )
 
@@ -146,6 +156,14 @@ Item.objects.create(
     idempotency_key="fa-lily", title="hal: ONE buried HUMAN email — Lily Olson",
     body="A real person who never got an answer.",
     dispatch=[{"target_agent": "hal", "prompt": "/hal:turn --thread lily", "origin": "email"}],
+)
+# A settled card from an OLDER sitting. Items are never deleted, so this is what
+# accumulates: the unfiltered view must keep it out of the way of the open ones.
+# Deliberately in a different batch, so the batch-permalink tests don't see it.
+Item.objects.create(
+    agent=ada_agent, kind="review", origin="api", batch_key="fleet-audit-2026-06-30",
+    idempotency_key="fa-old-settled", title="hal: an old finding nobody needs to see again",
+    body="Long since dismissed.", state=Item.DISMISSED,
 )
 
 session = SessionStore()

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,5 +1,9 @@
 import { defineConfig, devices } from '@playwright/test'
 
+// Overridable so the suite can run on a machine where :8000 is already taken
+// (a shared Mac with a second account's dev server on it).
+const API_PORT = process.env.E2E_API_PORT ?? '8000'
+
 export default defineConfig({
   testDir: './e2e',
   timeout: 30_000,
@@ -21,7 +25,7 @@ export default defineConfig({
     { name: 'mobile', use: { ...devices['Pixel 7'] }, testMatch: /supervisor\.spec\.ts/ },
   ],
   webServer: [
-    { command: 'bash e2e/backend.sh', url: 'http://127.0.0.1:8000/health/', timeout: 120_000, reuseExistingServer: false },
+    { command: 'bash e2e/backend.sh', url: `http://127.0.0.1:${API_PORT}/health/`, timeout: 120_000, reuseExistingServer: false },
     { command: 'npm run dev', url: 'http://localhost:3000', timeout: 60_000, reuseExistingServer: false },
   ],
 })

--- a/frontend/src/pages/agents/ItemsSection.tsx
+++ b/frontend/src/pages/agents/ItemsSection.tsx
@@ -140,30 +140,52 @@ export function ItemsSection(): JSX.Element {
   if (error) return <p className="p-4 text-[13px] text-destructive">{error}</p>
   if (!items) return <p className="p-4 text-[13px] text-muted-foreground">Loading…</p>
 
-  const open = items.filter((i) => i.state === 'open').length
+  // This surface exists to ask a human for a decision, so what is still UNDECIDED is
+  // the whole content and everything else is archive. Items are never deleted — only
+  // moved to `decided`/`dismissed` — so rendering every state made the page grow
+  // without bound: it reached 32 cards, 30 of them settled, and the 2 that actually
+  // wanted an answer were buried in weeks of history. Settled cards now collapse
+  // behind a disclosure. A `?batch=` permalink is the deliberate exception: it names
+  // one sitting and is usually opened precisely to read back what was decided.
+  const open = items.filter((i) => i.state === 'open')
+  const settled = items.filter((i) => i.state !== 'open')
+  const showAll = Boolean(batch)
+  const primary = showAll ? items : open
+
+  const renderCard = (i: ItemOut): JSX.Element => (
+    <ItemCard
+      key={i.id}
+      item={i}
+      onDecided={(updated) =>
+        setItems((prev) => (prev ?? []).map((p) => (p.id === updated.id ? updated : p)))
+      }
+    />
+  )
 
   return (
     <div className="flex flex-col gap-3 p-4" data-testid="items-batch">
       <header>
         <h2 className="text-base font-semibold text-foreground">{batch || 'Items'}</h2>
         <p className="text-[11px] text-muted-foreground">
-          {items.length} item{items.length === 1 ? '' : 's'} · {open} open
+          {showAll
+            ? `${items.length} item${items.length === 1 ? '' : 's'} · ${open.length} open`
+            : `${open.length} waiting on you`}
         </p>
       </header>
-      {items.length === 0 ? (
+      {primary.length === 0 ? (
         <p className="rounded-lg border border-border bg-card p-3 text-[13px] text-muted-foreground">
-          Nothing here.
+          {showAll || settled.length === 0 ? 'Nothing here.' : 'Nothing waiting on you.'}
         </p>
       ) : (
-        items.map((i) => (
-          <ItemCard
-            key={i.id}
-            item={i}
-            onDecided={(updated) =>
-              setItems((prev) => (prev ?? []).map((p) => (p.id === updated.id ? updated : p)))
-            }
-          />
-        ))
+        primary.map(renderCard)
+      )}
+      {!showAll && settled.length > 0 && (
+        <details data-testid="items-settled">
+          <summary className="cursor-pointer text-[11px] text-muted-foreground">
+            {settled.length} settled
+          </summary>
+          <div className="mt-3 flex flex-col gap-3">{settled.map(renderCard)}</div>
+        </details>
       )}
     </div>
   )

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -9,6 +9,9 @@ import {
   NAVIGATE_FALLBACK_DENYLIST,
 } from './src/pwa/navigation-fallback'
 
+// Same override as playwright.config/backend.sh — see E2E_API_PORT there.
+const API_ORIGIN = `http://localhost:${process.env.E2E_API_PORT ?? '8000'}`
+
 export default defineConfig({
   // Path prefix when deployed as a labs tenant (labs.connect.dimagi.com/canopy).
   // Drives import.meta.env.BASE_URL, which the router basename + API client
@@ -87,15 +90,15 @@ export default defineConfig({
   server: {
     port: 3000,
     proxy: {
-      '/api': 'http://localhost:8000',
+      '/api': API_ORIGIN,
       // WebSocket control channels (realtime supervisor/turn tails, chat). Without
       // this, NO ws feature works under `vite dev` — the socket would hit :3000,
       // which has no /ws handler. ws:true upgrades the proxied connection.
-      '/ws': { target: 'ws://localhost:8000', ws: true },
-      '/health': 'http://localhost:8000',
-      '/accounts': 'http://localhost:8000',
-      '/admin': 'http://localhost:8000',
-      '/static': 'http://localhost:8000',
+      '/ws': { target: API_ORIGIN.replace('http', 'ws'), ws: true },
+      '/health': API_ORIGIN,
+      '/accounts': API_ORIGIN,
+      '/admin': API_ORIGIN,
+      '/static': API_ORIGIN,
     },
   },
 })


### PR DESCRIPTION
## The report

> "this is a great example of rot. Why are there so many cards on that screen and why are there dismiss cards showing up? Things that require my action or intervention should be extremely clear, limited"

Ada's board: **32 cards — 25 dismissed, 5 decided, 2 open.** The two that wanted an answer were buried under weeks of history, and retiring a card left it on screen, so cleanup made the page worse.

## Cause

`ItemsSection` called `listItems(slug, batch ? { batch } : {})` — **no state filter** — and rendered every row with its full body markdown. Items are never deleted, only moved to `decided`/`dismissed`, so the view could only grow. The component already had a comment admitting it "mixes open cards with long-decided ones"; this acts on it.

## Change

- Settled cards collapse behind a `N settled` disclosure; the header reads **"N waiting on you"** rather than a total.
- **`?batch=` is the deliberate exception** — it names one sitting and is usually opened to read back what was decided, so it still shows everything. The three existing specs all use `?batch=`, and all still pass unchanged.

## The reason nobody caught it: the e2e suite has been dead

`frontend/e2e/seed.py` imported `harness.EmdashSession`, which was deleted when it was absorbed into `canopy_sessions` (`Session` + `RunnerBinding`). It raised **at import**, taking down every spec — not just the one that used it. Repaired here.

Also made the API port overridable (`E2E_API_PORT`): on a shared Mac `:8000` is routinely held by another account's dev server, and a hardcoded port made the suite unrunnable rather than failing usefully. That is a second reason it stayed dark.

## Verification

```
4 passed, 1 failed
✓ a batch renders its items with their dispatch targets
✓ implementing an item decides it and dispatches its work
✗ an open item shows in the agent inbox and the fleet supervisor   <-- pre-existing
✓ the unfiltered queue shows only what is still waiting; settled cards collapse
✓ a batch permalink still shows everything it decided
```

The failure is **not caused by this change**: `/supervisor` no longer renders a `waiting-on-you` testid. Verified by reverting `ItemsSection.tsx` to `origin/main` and re-running — it fails identically. It decayed while the suite was dark. **e2e is not wired into any CI workflow**, which is the root of all of the above and is worth fixing separately.

`npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)