### PR TITLE
Commit free text with the key the layout dictates, not with Enter

### DIFF
--- a/frontend/packages/canopy-ui/src/chat/MenuPrompt.tsx
+++ b/frontend/packages/canopy-ui/src/chat/MenuPrompt.tsx
@@ -189,19 +189,15 @@ function AnswerForm({
                 every question ("Type something"), and it is where the real
                 answer often goes, so a phone without it can only pick from what
                 the agent happened to guess.
-
-                Not offered on a pick-any question: the runner cannot commit it
-                there (the row's Enter toggles its checkbox instead of
-                confirming), so the box would take an answer that never lands.
-                Better to not offer it than to swallow it. */}
-            {q.multi_select ? null : <input
+ */}
+            <input
               type="text"
               value={typed[q.index] ?? ""}
               disabled={busy}
               onChange={(e) => write(q, e.target.value)}
               placeholder="…or type your own answer"
               className="mt-0.5 rounded border border-input bg-card px-2.5 py-2 text-[13px] text-foreground placeholder:text-muted-foreground disabled:opacity-50"
-            />}
+            />
           </div>
         </div>
       ))}

--- a/runner/canopy_runner/canopy_runner/hooks.py
+++ b/runner/canopy_runner/canopy_runner/hooks.py
@@ -272,7 +272,6 @@ ANSWERED = "answered"
 NO_DIALOG = "no_dialog"          # nothing on screen — already answered, or gone
 NOT_ON_MENU = "not_on_menu"      # stale numbering; the dialog changed under the tap
 UNMODELLED = "unmodelled"        # a tabbed ask we could not match to its questions
-FREE_TEXT_UNSUPPORTED = "free_text_unsupported"   # typed answer on a multi-select
 WRONG_PANE = "wrong_pane"        # a shell tab is selected; keys would run in it
 UNREACHABLE = "unreachable"      # CDP/emdash could not be driven at all
 NO_SESSION = "no_session"        # the emdash task is gone — nothing to press a key in
@@ -284,8 +283,6 @@ ANSWER_NOTES = {
     NOT_ON_MENU: "The dialog changed before that reached it. Here is what it shows now.",
     UNMODELLED: "This ask has several questions and they could not be matched to what is "
                 "on screen — answer it in emdash.",
-    FREE_TEXT_UNSUPPORTED: "Typing your own answer to a pick-any question does not work from "
-                           "here yet — pick from the options, or answer it in emdash.",
     WRONG_PANE: "A shell tab is selected for this session in emdash. Switch it to the "
                 "Claude tab and tap again.",
     UNREACHABLE: "Could not reach emdash on this runner to press the key.",
@@ -434,22 +431,6 @@ def answer_menu_with(cdp, session_key: str, option, *, selections=None, texts=No
                 return UNMODELLED, _menu_dict(current, source="screen")
             questions = [{"index": 0, "question": current.question,
                           "multi_select": current.is_multi_select}]
-        # Free text on a MULTI-SELECT question is refused before anything is
-        # pressed. Its commit keystroke could not be pinned down: on the row that
-        # has taken text, Enter was observed advancing the tab once and simply
-        # TOGGLING the row's checkbox on every later attempt, on/off/on/off. The
-        # answer therefore gets typed and never submitted, which leaves exactly
-        # the half-answered dialog this whole surface exists to prevent.
-        #
-        # Single-select free text is verified end to end and stays. Refusing here
-        # costs a trip to the keyboard and says so; pressing hopefully costs a
-        # dialog nobody can see the state of.
-        blocked = menu.free_text_blocked(questions, texts)
-        if blocked:
-            logger.info("refusing free text on multi-select question(s) %s for %s",
-                        blocked, session_key)
-            return FREE_TEXT_UNSUPPORTED, _menu_dict(current, source="screen")
-
         outcome, screen = _drive_selections(
             cdp, session_key, current, questions, selections, cdp_port, texts)
         logger.info("answered the dialog on %s with %s (%s)", session_key,

--- a/runner/canopy_runner/canopy_runner/menu.py
+++ b/runner/canopy_runner/canopy_runner/menu.py
@@ -447,7 +447,16 @@ def _free_text_step(menu: "Menu", text: str) -> list[str] | None:
     if number is None:
         entered = any(option.label.strip() == text.strip() for option in menu.options)
         return [] if entered else None
-    return [DOWN] * max(0, number - (menu.selected or 1)) + [TEXT_PREFIX + text]
+    walk = [DOWN] * max(0, number - (menu.selected or 1))
+    # How the row is COMMITTED differs by mode, because what sits below it does.
+    # On a multi-select the next row is the dialog's own Next/Submit action, so ↓
+    # steps off the field, banks the text (the box stays ticked) and lands the
+    # cursor somewhere the grid can plainly show — no hidden edit state left to
+    # guess at. On a single-select the row below is "Chat about this", so ↓ there
+    # would park the cursor on something that opens a chat; Enter is the verified
+    # commit for that shape (it produced `GOT=Medium` from a real agent).
+    commit = DOWN if menu.is_multi_select else "\r"
+    return walk + [TEXT_PREFIX + text, commit]
 
 # Bound on the drive loop. Each question costs at most (toggles + one Tab), so
 # this is generous for any real ask while still terminating if the screen stops
@@ -485,25 +494,6 @@ def question_index(menu: "Menu", questions: list[dict]) -> int | None:
             if best is None or len(want) > best[1]:
                 best = (q.get("index", questions.index(q)), len(want))
     return best[0] if best else None
-
-
-def free_text_blocked(questions: list[dict], texts) -> list[str]:
-    """Questions whose typed answer this driver cannot deliver, by name.
-
-    Free text on a MULTI-SELECT is the case. Its commit keystroke could not be
-    pinned down: on a row that has taken text, Enter was seen advancing the tab
-    once and simply TOGGLING that row's checkbox on every later attempt —
-    on/off/on/off, measured live. The answer therefore gets typed and never
-    submitted, which leaves exactly the half-answered dialog this surface exists
-    to prevent. Single-select free text is verified end to end and is not here.
-
-    Returned as names so the refusal can say WHICH question to go and answer.
-    """
-    if not texts:
-        return []
-    return [q.get("header") or q.get("question") or f"question {i + 1}"
-            for i, q in enumerate(questions)
-            if q.get("multi_select") and i < len(texts) and texts[i]]
 
 
 def screen_state(menu: "Menu") -> tuple:
@@ -575,12 +565,8 @@ def plan_step(menu: "Menu", questions: list[dict], selections: list[list[int]],
             step = _free_text_step(menu, text)
             if step is None:
                 return None
-            # [] means the text is IN the row but the row is still being edited:
-            # the dialog is on this question and swallowing Tab. Enter commits
-            # (and advances). It is a SEPARATE step so a full screen read sits
-            # between typing and committing — batched behind the text it lands
-            # mid-render and toggles the row off instead.
-            return step or ["\r"]
+            # [] means the text is already in and committed; this tab is done.
+            return step or ([TAB] if menu.needs_submit else None)
         # This tab is right; move on. Tab clamps at the review screen rather
         # than wrapping, so over-pressing it cannot walk us back round.
         return [TAB] if menu.needs_submit else None
@@ -592,8 +578,8 @@ def plan_step(menu: "Menu", questions: list[dict], selections: list[list[int]],
         step = _free_text_step(menu, text)
         if step is None:
             return None
-        # Same two beats as the multi-select above: type, then commit.
-        return step or ["\r"]
+        # Committed already; nothing left for this question.
+        return step or ([TAB] if menu.needs_submit else None)
 
     # Single-select: pressing the number both answers and advances.
     if not want:

--- a/runner/canopy_runner/tests/test_menu.py
+++ b/runner/canopy_runner/tests/test_menu.py
@@ -584,8 +584,10 @@ def test_free_text_walks_the_cursor_to_the_row_then_types():
     step = plan_step(find_menu(LONE_SINGLE), lone, [[]], ["Medium, actually"])
     # Cursor on row 1, "Type something" is row 3. No trailing Enter: typing alone
     # fills the row in, and an Enter here cleared the earlier selection.
-    # Typing only. Enter is a SEPARATE step so a screen read sits between them.
-    assert step == [DOWN, DOWN, TEXT_PREFIX + "Medium, actually"]
+    # Single-select commits with Enter: the row BELOW "Type something" there is
+    # "Chat about this", so a ↓ would park the cursor on something that opens a
+    # chat. Verified live — this produced `GOT=Medium` from a real agent.
+    assert step == [DOWN, DOWN, TEXT_PREFIX + "Medium, actually", "\r"]
 
 
 def test_free_text_replaces_a_single_select_pick():
@@ -608,8 +610,8 @@ def test_text_already_entered_is_not_typed_again():
              "options": [{"number": 1, "label": "Small"}]}]
     # Entered. A lone dialog has no Submit tab, so it is confirmed with Enter —
     # exactly as picking an option would have been.
-    # Text is in the row; the next step is the Enter that commits it.
-    assert plan_step(find_menu(LONE_SINGLE_TYPED), lone, [[]], ["Medium, actually"]) == ["\r"]
+    # Committed already (a lone dialog has no Submit tab), so nothing is left.
+    assert plan_step(find_menu(LONE_SINGLE_TYPED), lone, [[]], ["Medium, actually"]) is None
 
 
 def test_a_multi_select_toggles_boxes_before_typing():
@@ -622,9 +624,12 @@ def test_a_multi_select_toggles_boxes_before_typing():
     # Boxes right -> walk the cursor to row 4 and type. Verified against a live
     # multi-select: the row auto-ticks and takes the text as its label.
     step = plan_step(find_menu(TABBED_MULTI_TWO_CHECKED), QUESTIONS, [[1, 3], [2]], ["Teal", None])
-    assert step == [DOWN, DOWN, DOWN, TEXT_PREFIX + "Teal"]
+    # Multi-select commits with ↓: the row below is the dialog's Next/Submit
+    # action, so stepping off banks the text and leaves the cursor somewhere
+    # the grid can show — no hidden edit state to guess at.
+    assert step == [DOWN, DOWN, DOWN, TEXT_PREFIX + "Teal", DOWN]
     # Text entered too -> move on to the next tab.
-    assert plan_step(find_menu(TABBED_MULTI_TYPED), QUESTIONS, [[1, 3], [2]], ["Teal", None]) == ["\r"]
+    assert plan_step(find_menu(TABBED_MULTI_TYPED), QUESTIONS, [[1, 3], [2]], ["Teal", None]) == ["\t"]
 
 
 def test_text_that_cannot_be_entered_presses_nothing():

--- a/tests/test_menu_roundtrip_e2e.py
+++ b/tests/test_menu_roundtrip_e2e.py
@@ -398,24 +398,24 @@ def test_a_step_that_changes_nothing_stops_instead_of_thrashing():
     assert len(emdash.sent) <= 2, f"kept pressing: {emdash.sent}"
 
 
-def test_free_text_on_a_multi_select_is_refused_rather_than_half_pressed():
-    """Its commit keystroke could not be pinned down: on a row that has taken
-    text, Enter was seen advancing the tab ONCE and simply toggling that row's
-    checkbox on every later attempt — on/off/on/off, measured live. So the answer
-    gets typed and never submitted, leaving exactly the half-answered dialog this
-    surface exists to prevent.
-
-    Refusing costs a trip to the keyboard and SAYS so. Pressing hopefully costs a
-    dialog nobody can see the state of.
+def test_free_text_commits_differently_on_each_kind_of_question():
+    """Established against a live TUI. What sits BELOW the "Type something" row
+    differs by mode, and that is what decides the commit key: on a multi-select
+    it is the dialog's own Next/Submit action (so ↓ steps off and banks the
+    text), on a single-select it is "Chat about this" (so ↓ would park the
+    cursor on something that opens a chat, and Enter is the commit).
     """
-    questions = _hook_menu(TABBED_INPUT)["questions"]
-    assert questions[0]["multi_select"] is True and questions[1]["multi_select"] is False
+    from canopy_runner.menu import DOWN, TEXT_PREFIX, find_menu, plan_step
 
-    # Typed answer on the pick-any question -> named, and refused.
-    assert runner_hooks.menu.free_text_blocked(questions, ["Teal", None]) == ["Colors"]
-    # Typed answer on the single-select one -> fine, that path is verified.
-    assert runner_hooks.menu.free_text_blocked(questions, [None, "Extra large"]) == []
-    # No free text at all -> nothing to block.
-    assert runner_hooks.menu.free_text_blocked(questions, None) == []
+    multi = find_menu(TABBED_SCREENS["colors"])
+    assert multi.is_multi_select
+    step = plan_step(multi, _hook_menu(TABBED_INPUT)["questions"], [[], []], ["Teal", None])
+    assert step[-1] == DOWN and TEXT_PREFIX + "Teal" in step
 
-    assert runner_hooks.ANSWER_NOTES[runner_hooks.FREE_TEXT_UNSUPPORTED]
+    single = find_menu(TABBED_SCREENS["size"])
+    assert not single.is_multi_select
+    step = plan_step(single, [{"index": 0, "question": "Which size?",
+                               "multi_select": False,
+                               "options": [{"number": 1, "label": "Small"}]}],
+                     [[]], ["Extra large"])
+    assert step[-1] == "\r"


### PR DESCRIPTION
Multi-select free text works after all. The commit keystroke is **↓, not Enter** — and the reason is in the layout, not in any hidden state:

```
multi-select                single-select
  4. [ ] Type something       3. Type something.
     Next        <- ↓         ─────────────────
                              4. Chat about this   <- ↓
```

On a multi-select the row below the text field is the dialog's own **Next/Submit** action, so ↓ steps off the field, banks the text (the box stays ticked) and leaves the cursor somewhere the character grid plainly *shows*. On a single-select the row below is "Chat about this", so ↓ would park the cursor on something that opens a chat — Enter stays the commit there, as verified (`GOT=Medium`).

## Why this dissolves the problem rather than working around it

Enter looked non-deterministic — advancing the tab once, then toggling the row's checkbox on eight consecutive presses — because the driver **could not see** whether the row was still being edited. Both states render identically as `4. [✔] Teal` in a character grid.

Stepping off the field with ↓ removes the invisible state instead of trying to detect it. That's the same principle that makes the declared options reliable: answer with a key whose meaning doesn't depend on where the cursor is. Credit where due — this came from being asked why the driver wasn't leaning on numeric/positional keys.

The refusal added in #603 is therefore withdrawn, and the form offers the text box everywhere again.

## Captured live

```
  1. [✔] Red
  4. [✔] Teal
❯    Submit          ← after ↓; Enter here reaches "Ready to submit your answers?"
```

which is the state the driver already finishes.

2120 server / 466 runner tests, ruff + tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)