### PR TITLE
Activate the Next/Submit row after committing free text

### DIFF
--- a/runner/canopy_runner/canopy_runner/menu.py
+++ b/runner/canopy_runner/canopy_runner/menu.py
@@ -455,8 +455,12 @@ def _free_text_step(menu: "Menu", text: str) -> list[str] | None:
     # guess at. On a single-select the row below is "Chat about this", so ↓ there
     # would park the cursor on something that opens a chat; Enter is the verified
     # commit for that shape (it produced `GOT=Medium` from a real agent).
-    commit = DOWN if menu.is_multi_select else "\r"
-    return walk + [TEXT_PREFIX + text, commit]
+    # ↓ then Enter, because ↓ lands the cursor ON that action row and Enter is
+    # what activates it. Tab is NOT the way off: measured live, Tab from there
+    # left the screen identical and the driver stopped on its no-progress guard
+    # with the text committed but the tab never advanced.
+    commit = [DOWN, "\r"] if menu.is_multi_select else ["\r"]
+    return walk + [TEXT_PREFIX + text] + commit
 
 # Bound on the drive loop. Each question costs at most (toggles + one Tab), so
 # this is generous for any real ask while still terminating if the screen stops

--- a/runner/canopy_runner/tests/test_menu.py
+++ b/runner/canopy_runner/tests/test_menu.py
@@ -627,7 +627,9 @@ def test_a_multi_select_toggles_boxes_before_typing():
     # Multi-select commits with ↓: the row below is the dialog's Next/Submit
     # action, so stepping off banks the text and leaves the cursor somewhere
     # the grid can show — no hidden edit state to guess at.
-    assert step == [DOWN, DOWN, DOWN, TEXT_PREFIX + "Teal", DOWN]
+    # ↓ steps off the field onto the dialog's Next/Submit row; Enter activates
+    # it. Tab from there does nothing at all (measured live).
+    assert step == [DOWN, DOWN, DOWN, TEXT_PREFIX + "Teal", DOWN, "\r"]
     # Text entered too -> move on to the next tab.
     assert plan_step(find_menu(TABBED_MULTI_TYPED), QUESTIONS, [[1, 3], [2]], ["Teal", None]) == ["\t"]
 

--- a/tests/test_menu_roundtrip_e2e.py
+++ b/tests/test_menu_roundtrip_e2e.py
@@ -410,7 +410,7 @@ def test_free_text_commits_differently_on_each_kind_of_question():
     multi = find_menu(TABBED_SCREENS["colors"])
     assert multi.is_multi_select
     step = plan_step(multi, _hook_menu(TABBED_INPUT)["questions"], [[], []], ["Teal", None])
-    assert step[-1] == DOWN and TEXT_PREFIX + "Teal" in step
+    assert step[-2:] == [DOWN, "\r"] and TEXT_PREFIX + "Teal" in step
 
     single = find_menu(TABBED_SCREENS["size"])
     assert not single.is_multi_select


### PR DESCRIPTION
↓ steps off the text field onto the dialog's own **Next/Submit** row, and **Enter** is what activates it. Tab is not — measured live, Tab from that row left the screen byte-identical, so the driver stopped on its no-progress guard with the text committed and the tab never advanced:

```
Red ✓, Teal ✓        ← both banked correctly
…then Tab            ← nothing
stopped responding (state repeated)
```

This matches the pty capture that worked end to end: ↓ then Enter reaches `Ready to submit your answers?`, which the driver already knows how to finish.

466 runner / 2120 server tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)