### PR TITLE
fix(e2e): green the suite, and fix the nav overflow it was right about

### DIFF
--- a/frontend/e2e/agents.spec.ts
+++ b/frontend/e2e/agents.spec.ts
@@ -21,37 +21,52 @@ test('workspace rail exposes the sections', async ({ page }) => {
   await expect(page.locator('a[href$="/agents/echo/skills"]')).toBeVisible()
 })
 
-test('needs-you is the default landing with typed, ranked actionable items', async ({ page }) => {
-  await page.goto('/w/dimagi/agents/echo')
-  await expect(page).toHaveURL(/\/agents\/echo\/needs-you$/)
-  await expect(page.getByRole('heading', { name: 'Needs you' })).toBeVisible()
-  // review band: a suggested task awaiting validate/decline
-  await expect(page.getByTestId('needsyou-band-review')).toContainText('ZEGCAWIS polio AFP story')
-  // question band: the in-progress task blocked on a human
-  await expect(page.getByTestId('needsyou-band-question')).toContainText('PRIDE cholera story')
-  // needs-you is action-only (#273 dropped the FYI 'notify' band — syncs like
-  // "Manager sync 1" no longer surface here). Only review + question bands remain.
-  await expect(page.getByTestId('needsyou-band-notify')).toHaveCount(0)
-  // nothing Echo is actively working appears in the inbox
-  await expect(page.getByText('Ideas backlog upkeep')).toHaveCount(0)
-  // the badge counts the gated items only (t1 + t2 suggested, t3 waiting = 3)
-  await expect(page.getByText(/3 waiting on you/)).toBeVisible()
+test('the inbox is the default landing, banded by kind, with actionable items', async ({
+  page,
+}) => {
+  // Rewritten for the post-#304 inbox. It used to assert echo's TASK-derived bands
+  // (`needsyou-band-*` at /needs-you, with Accept/Decline on suggested tasks). That
+  // aggregation was deleted deliberately: the inbox is a pure Item query now, the
+  // route is /inbox, and the testids are `inbox-band-*`. So the assertions move to
+  // ada, who has Items — echo's five tasks correctly no longer surface here.
+  await page.goto('/w/dimagi/agents/ada')
+  await expect(page).toHaveURL(/\/agents\/ada\/inbox$/)
+  await expect(page.getByRole('heading', { name: 'Inbox' }).first()).toBeVisible()
+
+  // review band: a decision awaiting implement/skip/defer
+  await expect(page.getByTestId('inbox-band-review')).toContainText(
+    'hal: discard 81 junk/stale unread emails',
+  )
+  // The FYI 'notify' band stays gone (#273) — the inbox is action-only.
+  await expect(page.getByTestId('inbox-band-notify')).toHaveCount(0)
+  await expect(page.getByText(/waiting on you/)).toBeVisible()
 })
 
-test('needs-you cards are the actionable board card, not a bounce link', async ({ page }) => {
-  await page.goto('/w/dimagi/agents/echo/needs-you')
-  const review = page.getByTestId('needsyou-band-review')
-  // The real board card (rationale + inline Accept/Decline), so you act here...
-  await expect(review.getByText(/Why:/).first()).toBeVisible()
-  await expect(review.getByRole('button', { name: /^Accept$/ }).first()).toBeVisible()
-  await expect(review.getByRole('button', { name: /^Decline$/ }).first()).toBeVisible()
+test('an agent with nothing open says so instead of showing its task list', async ({ page }) => {
+  // The other half of the #304 change, and the reason the old test could not simply
+  // be renamed: echo has five seeded tasks and zero Items, and the inbox is now
+  // Items-only — so the correct rendering is the empty state, not those tasks.
+  await page.goto('/w/dimagi/agents/echo/inbox')
+  await expect(page.getByText(/Nothing needs you right now/)).toBeVisible()
+  await expect(page.getByText('Ideas backlog upkeep')).toHaveCount(0)
+})
+
+test('inbox cards are the actionable board card, not a bounce link', async ({ page }) => {
+  await page.goto('/w/dimagi/agents/ada/inbox')
+  const review = page.getByTestId('inbox-band-review')
+  // The real card — you decide here, in place. Matched on testid, not button text:
+  // the labels render lowercase and are capitalised in CSS, so an accessible-name
+  // match on /^Implement$/ silently finds nothing.
+  await expect(review.locator('[data-testid^="item-implement-"]').first()).toBeVisible()
+  await expect(review.locator('[data-testid^="item-skip-"]').first()).toBeVisible()
+  await expect(review.locator('[data-testid^="item-defer-"]').first()).toBeVisible()
   // ...and NOT a bare link that dumps you to the generic board.
   await expect(review.locator('a[href$="/tasks"]')).toHaveCount(0)
 })
 
-test('the rail exposes the Needs you inbox', async ({ page }) => {
+test('the rail exposes the inbox', async ({ page }) => {
   await page.goto('/w/dimagi/agents/echo/tasks')
-  await expect(page.locator('a[href$="/agents/echo/needs-you"]')).toBeVisible()
+  await expect(page.locator('a[href$="/agents/echo/inbox"]')).toBeVisible()
 })
 
 test('overview shows the latest sync', async ({ page }) => {

--- a/frontend/e2e/items.spec.ts
+++ b/frontend/e2e/items.spec.ts
@@ -39,12 +39,15 @@ test('an open item shows in the agent inbox and the fleet supervisor', async ({ 
   await expect(page.getByText('hal: discard 81 junk/stale unread emails')).toBeVisible()
 
   await page.goto('/supervisor')
-  await expect(page.getByTestId('waiting-on-you')).toContainText(
+  // `item-inbox` (was `waiting-on-you`): the supervisor's queue became a plain
+  // Item list when the needs_you aggregation was deleted, and the testid moved
+  // with it. The spec kept asserting the old name and had been red ever since.
+  await expect(page.getByTestId('item-inbox')).toContainText(
     'hal: discard 81 junk/stale unread emails',
   )
   // The inbox row names where implementing sends the work — Ada's fan-out,
   // visible without opening the item.
-  await expect(page.getByTestId('waiting-on-you')).toContainText('dispatches to hal')
+  await expect(page.getByTestId('item-inbox')).toContainText('dispatches to hal')
 })
 
 test('the unfiltered queue shows only what is still waiting; settled cards collapse', async ({

--- a/frontend/e2e/supervisor.spec.ts
+++ b/frontend/e2e/supervisor.spec.ts
@@ -1,7 +1,10 @@
 import { test, expect } from '@playwright/test'
 
 // Reach a tab's content. Inbox is the default landing; Sessions/Agents need a click.
-async function openTab(page: import('@playwright/test').Page, tab: 'inbox' | 'sessions' | 'agents') {
+async function openTab(
+  page: import('@playwright/test').Page,
+  tab: 'inbox' | 'sessions' | 'agents' | 'runners',
+) {
   if (tab !== 'inbox') await page.getByTestId(`tab-${tab}`).click()
 }
 
@@ -9,7 +12,7 @@ test.describe('/supervisor', () => {
   test('renders without horizontal scroll on every tab', async ({ page }) => {
     await page.goto('/supervisor')
     await expect(page.getByTestId('supervisor-page')).toBeVisible()
-    for (const tab of ['inbox', 'sessions', 'agents'] as const) {
+    for (const tab of ['inbox', 'sessions', 'agents', 'runners'] as const) {
       await openTab(page, tab)
       const overflow = await page.evaluate(
         () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
@@ -22,30 +25,52 @@ test.describe('/supervisor', () => {
     // Default landing (what push drops you into) is Inbox: the waiting queue is
     // visible and the other tabs' content is not.
     await page.goto('/supervisor')
-    await expect(page.getByTestId('waiting-on-you').or(page.getByTestId('waiting-empty'))).toBeVisible()
-    await expect(page.getByTestId('open-sessions').or(page.getByTestId('sessions-empty'))).toBeHidden()
+    // `item-inbox`/`inbox-empty` (were `waiting-on-you`/`waiting-empty`) — renamed when
+    // the needs_you aggregation was deleted and the queue became a plain Item list.
+    await expect(page.getByTestId('item-inbox').or(page.getByTestId('inbox-empty'))).toBeVisible()
+    // The Sessions tab is now ChatSessionsPanel; the composer's `open-sessions` is gone.
+    await expect(page.getByTestId('sessions-panel')).toBeHidden()
 
     // Deep-link straight to Agents.
+    // Runners split out of the Agents tab into their own.
     await page.goto('/supervisor?tab=agents')
-    await expect(page.getByTestId('runner-status').or(page.getByText('No runner paired'))).toBeVisible()
+    await expect(page.locator('[data-testid^="agent-card-"]').first()).toBeVisible()
   })
 
-  test('waiting-on-you is above the fold', async ({ page }) => {
+  test('the inbox is above the fold', async ({ page }) => {
     await page.goto('/supervisor')
-    const inbox = page.getByTestId('waiting-on-you').or(page.getByTestId('waiting-empty'))
+    const inbox = page.getByTestId('item-inbox').or(page.getByTestId('inbox-empty'))
     await expect(inbox).toBeInViewport()
   })
 
   test('one failed call does not blank the page', async ({ page }) => {
-    await page.route('**/api/agents/needs-you', (r) => r.abort())
+    // Abort the call the Inbox ACTUALLY makes. This used to abort
+    // `/api/agents/needs-you`, deleted with the aggregation — so the route never
+    // matched, nothing failed, and the test proved nothing while passing for it.
+    await page.route('**/api/items/**', (r) => r.abort())
     await page.goto('/supervisor')
     await expect(page.getByTestId('supervisor-page')).toBeVisible()
-    // Runners (Agents tab) still render despite the Inbox fetch failing.
-    await openTab(page, 'agents')
+    // Runners still render despite the Inbox fetch failing.
+    await openTab(page, 'runners')
     await expect(page.getByTestId('runner-status').or(page.getByText('No runner paired'))).toBeVisible()
   })
 
-  test('the composer dispatches a launchable command', async ({ page }) => {
+  // ---------------------------------------------------------------------------
+  // The three tests below drive the supervisor COMPOSER (`composer`,
+  // `composer-agent`, `composer-skill`, `composer-mode-repo`, `composer-workspace`)
+  // and the composer-era session list (`open-sessions`, `session-cloud-runner`).
+  // None of those testids exist in the source any more: the Sessions tab was
+  // rewritten around ChatSessionsPanel, whose creation entry point is "New chat
+  // with <agent> or project".
+  //
+  // They are marked fixme rather than deleted because the BEHAVIOUR they pin is
+  // still worth pinning — dispatching a launchable skill, a repo dispatch pinning
+  // its workspace to the tenant endpoint, and continuing into an existing session.
+  // Porting them needs the new panel's UX contract, which is not mine to invent.
+  // Deleting them would quietly drop that coverage, which is how this file rotted
+  // to 8/8 red without anyone noticing.
+  // ---------------------------------------------------------------------------
+  test.fixme('the composer dispatches a launchable command', async ({ page }) => {
     await page.goto('/supervisor')
     await openTab(page, 'sessions')
     const composer = page.getByTestId('composer')
@@ -84,7 +109,7 @@ test.describe('/supervisor', () => {
     expect(posted).toMatchObject({ agent_slug: 'echo', prompt: '/echo:story-ideation bednets' })
   })
 
-  test('a repo dispatch pins its workspace and routes to the tenant endpoint', async ({ page }) => {
+  test.fixme('a repo dispatch pins its workspace and routes to the tenant endpoint', async ({ page }) => {
     await page.goto('/supervisor')
     await openTab(page, 'sessions')
     await page.getByTestId('composer-mode-repo').click()
@@ -128,7 +153,7 @@ test.describe('/supervisor', () => {
     expect(headers['x-canopy-workspace']).toBeUndefined()
   })
 
-  test('open sessions list and continue dispatches into that exact task', async ({ page }) => {
+  test.fixme('open sessions list and continue dispatches into that exact task', async ({ page }) => {
     await page.goto('/supervisor')
     await openTab(page, 'sessions')
     await expect(page.getByTestId('open-sessions')).toBeVisible()
@@ -155,7 +180,7 @@ test.describe('/supervisor', () => {
   })
 
   test('a runner shows not-ready and opens a detail view with the reason', async ({ page }) => {
-    await page.goto('/supervisor?tab=agents')
+    await page.goto('/supervisor?tab=runners')
     // the seeded runner is not-ready → the list shows the marker
     const notReady = page.locator('[data-testid^="runner-notready-"]').first()
     await expect(notReady).toBeVisible()

--- a/frontend/src/components/AppLayout/AppLayout.tsx
+++ b/frontend/src/components/AppLayout/AppLayout.tsx
@@ -301,10 +301,24 @@ function AppShell() {
           )}
           <div className="flex min-w-0 items-center gap-2 xl:gap-3">
             {/* Full inline nav only once all items fit (~xl); below that it
-                overflows the viewport, so we collapse it into the menu below. */}
-            <nav className="hidden min-w-0 xl:flex gap-0.5">
+                collapses into the menu below.
+
+                `overflow-x-auto` because "all items fit at xl" stopped being true:
+                the nav grew to 15 items and at exactly 1280px (Tailwind's xl, and
+                Desktop Chrome's default) it ran 6px past the viewport, giving EVERY
+                page a horizontal scrollbar. Scrolling within the nav keeps that
+                contained instead of pushing the document wide, and it does not
+                regress as the next item is added — raising the breakpoint instead
+                would have hidden the whole nav on 1280–1440px laptops, which is most
+                of them. `min-w-0` is what lets this flex child shrink far enough for
+                the overflow to apply. */}
+            <nav className="hidden min-w-0 overflow-x-auto xl:flex gap-0.5">
               {navItems.map((item) => (
-                <Link key={item.path} to={item.path} className={navLinkClass(item.path, false)}>
+                <Link
+                  key={item.path}
+                  to={item.path}
+                  className={`${navLinkClass(item.path, false)} shrink-0`}
+                >
                   {item.label}
                 </Link>
               ))}

--- a/frontend/src/components/chat/ChatSessionsPanel.tsx
+++ b/frontend/src/components/chat/ChatSessionsPanel.tsx
@@ -255,7 +255,10 @@ export function ChatSessionsPanel({
   const waitingCount = sessions.filter((s) => s.waiting_on_you).length
 
   return (
-    <div className="flex min-h-0 flex-col">
+    // Named so a test can assert this tab is (or is not) showing. The supervisor
+    // spec used to reach for `open-sessions`, which belonged to the composer UI
+    // this panel replaced.
+    <div className="flex min-h-0 flex-col" data-testid="sessions-panel">
       <div className="flex items-center justify-between gap-2 pb-2">
         <h2 className="flex items-center gap-1.5 text-sm font-semibold text-foreground">
           {heading}


### PR DESCRIPTION
## Scope

I flagged one failing test in #604. It was **nine**, across three specs — plus a real layout bug the suite was correctly catching. All of it is fallout from the `needs_you` → `Item` migration (#304) landing while the e2e suite couldn't boot.

## The app bug — every page had a horizontal scrollbar

`renders without horizontal scroll on every tab` was failing because **the app was wrong**, not the test.

The header nav grew to 15 items and no longer fits at Tailwind's `xl` (1280px) — exactly the width Desktop Chrome uses. It ran **6px past the viewport on every page**. The component's own comment said *"Full inline nav only once all items fit (~xl)"*; that stopped being true and nothing caught it.

Fixed with `overflow-x-auto` on the inline nav. I deliberately did **not** raise the breakpoint to `2xl` — that would have hidden the entire nav on 1280–1440px laptops, which is most of them.

| width | overflow | inline nav links |
|---|---|---|
| 1280 | 0 | 15 |
| 1366 | 0 | 15 |
| 1440 | 0 | 15 |
| 1536 | 0 | 15 |
| 1920 | 0 | 15 |

## Stale testids, renamed by #304 and never updated

```
waiting-on-you  -> item-inbox         needsyou-band-* -> inbox-band-*
waiting-empty   -> inbox-empty        /needs-you      -> /inbox
```
Runners also split out of the Agents tab into their own tab.

## A test that proved nothing while passing for it

`one failed call does not blank the page` aborted `/api/agents/needs-you` — an endpoint deleted with the aggregation. **The route never matched, so no call ever failed**, and the test asserted resilience it never exercised. Now aborts `/api/items/**`, which the Inbox actually calls.

## Rewritten, not renamed

The three `agents.spec` inbox tests asserted echo's **task-derived** bands with Accept/Decline. That aggregation is deliberately gone — the inbox is Items-only, so echo's five seeded tasks correctly don't appear. Moved to `ada` (who has Items), and added the case pinning the other half: an agent with nothing open renders the empty state **instead of** its task list.

## Marked `fixme`, not deleted

Three supervisor tests drive the composer (`composer-agent`, `composer-skill`, `composer-mode-repo`, `composer-workspace`) and its session list. That UI was replaced by `ChatSessionsPanel`; none of those testids exist. The behaviour is still worth pinning — dispatching a launchable skill, a repo dispatch pinning its workspace, continuing into an existing session — but porting needs the new panel's UX contract, which isn't mine to invent. Deleting them would quietly drop the coverage, which is how this file reached 8/8 red unnoticed.

Also added `data-testid="sessions-panel"` so the Sessions tab is assertable at all.

## Result

```
37 passed, 6 skipped (3 fixme x 2 projects), 0 failed   — desktop + mobile
```

**The suite is still not wired into any CI workflow.** That is the root cause of everything above, and now that it's green, enabling it is cheap. Worth doing as a follow-up — it's a call about per-PR runtime, so I've left it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)