### PR TITLE
fix(mobile): the answer box on a question card was invisible, and nothing could tap it

### DIFF
--- a/frontend/e2e/agents.spec.ts
+++ b/frontend/e2e/agents.spec.ts
@@ -21,37 +21,52 @@ test('workspace rail exposes the sections', async ({ page }) => {
   await expect(page.locator('a[href$="/agents/echo/skills"]')).toBeVisible()
 })
 
-test('needs-you is the default landing with typed, ranked actionable items', async ({ page }) => {
-  await page.goto('/w/dimagi/agents/echo')
-  await expect(page).toHaveURL(/\/agents\/echo\/needs-you$/)
-  await expect(page.getByRole('heading', { name: 'Needs you' })).toBeVisible()
-  // review band: a suggested task awaiting validate/decline
-  await expect(page.getByTestId('needsyou-band-review')).toContainText('ZEGCAWIS polio AFP story')
-  // question band: the in-progress task blocked on a human
-  await expect(page.getByTestId('needsyou-band-question')).toContainText('PRIDE cholera story')
-  // needs-you is action-only (#273 dropped the FYI 'notify' band — syncs like
-  // "Manager sync 1" no longer surface here). Only review + question bands remain.
-  await expect(page.getByTestId('needsyou-band-notify')).toHaveCount(0)
-  // nothing Echo is actively working appears in the inbox
-  await expect(page.getByText('Ideas backlog upkeep')).toHaveCount(0)
-  // the badge counts the gated items only (t1 + t2 suggested, t3 waiting = 3)
-  await expect(page.getByText(/3 waiting on you/)).toBeVisible()
+test('the inbox is the default landing, banded by kind, with actionable items', async ({
+  page,
+}) => {
+  // Rewritten for the post-#304 inbox. It used to assert echo's TASK-derived bands
+  // (`needsyou-band-*` at /needs-you, with Accept/Decline on suggested tasks). That
+  // aggregation was deleted deliberately: the inbox is a pure Item query now, the
+  // route is /inbox, and the testids are `inbox-band-*`. So the assertions move to
+  // ada, who has Items — echo's five tasks correctly no longer surface here.
+  await page.goto('/w/dimagi/agents/ada')
+  await expect(page).toHaveURL(/\/agents\/ada\/inbox$/)
+  await expect(page.getByRole('heading', { name: 'Inbox' }).first()).toBeVisible()
+
+  // review band: a decision awaiting implement/skip/defer
+  await expect(page.getByTestId('inbox-band-review')).toContainText(
+    'hal: discard 81 junk/stale unread emails',
+  )
+  // The FYI 'notify' band stays gone (#273) — the inbox is action-only.
+  await expect(page.getByTestId('inbox-band-notify')).toHaveCount(0)
+  await expect(page.getByText(/waiting on you/)).toBeVisible()
 })
 
-test('needs-you cards are the actionable board card, not a bounce link', async ({ page }) => {
-  await page.goto('/w/dimagi/agents/echo/needs-you')
-  const review = page.getByTestId('needsyou-band-review')
-  // The real board card (rationale + inline Accept/Decline), so you act here...
-  await expect(review.getByText(/Why:/).first()).toBeVisible()
-  await expect(review.getByRole('button', { name: /^Accept$/ }).first()).toBeVisible()
-  await expect(review.getByRole('button', { name: /^Decline$/ }).first()).toBeVisible()
+test('an agent with nothing open says so instead of showing its task list', async ({ page }) => {
+  // The other half of the #304 change, and the reason the old test could not simply
+  // be renamed: echo has five seeded tasks and zero Items, and the inbox is now
+  // Items-only — so the correct rendering is the empty state, not those tasks.
+  await page.goto('/w/dimagi/agents/echo/inbox')
+  await expect(page.getByText(/Nothing needs you right now/)).toBeVisible()
+  await expect(page.getByText('Ideas backlog upkeep')).toHaveCount(0)
+})
+
+test('inbox cards are the actionable board card, not a bounce link', async ({ page }) => {
+  await page.goto('/w/dimagi/agents/ada/inbox')
+  const review = page.getByTestId('inbox-band-review')
+  // The real card — you decide here, in place. Matched on testid, not button text:
+  // the labels render lowercase and are capitalised in CSS, so an accessible-name
+  // match on /^Implement$/ silently finds nothing.
+  await expect(review.locator('[data-testid^="item-implement-"]').first()).toBeVisible()
+  await expect(review.locator('[data-testid^="item-skip-"]').first()).toBeVisible()
+  await expect(review.locator('[data-testid^="item-defer-"]').first()).toBeVisible()
   // ...and NOT a bare link that dumps you to the generic board.
   await expect(review.locator('a[href$="/tasks"]')).toHaveCount(0)
 })
 
-test('the rail exposes the Needs you inbox', async ({ page }) => {
+test('the rail exposes the inbox', async ({ page }) => {
   await page.goto('/w/dimagi/agents/echo/tasks')
-  await expect(page.locator('a[href$="/agents/echo/needs-you"]')).toBeVisible()
+  await expect(page.locator('a[href$="/agents/echo/inbox"]')).toBeVisible()
 })
 
 test('overview shows the latest sync', async ({ page }) => {

--- a/frontend/e2e/items.spec.ts
+++ b/frontend/e2e/items.spec.ts
@@ -39,12 +39,15 @@ test('an open item shows in the agent inbox and the fleet supervisor', async ({ 
   await expect(page.getByText('hal: discard 81 junk/stale unread emails')).toBeVisible()
 
   await page.goto('/supervisor')
-  await expect(page.getByTestId('waiting-on-you')).toContainText(
+  // `item-inbox` (was `waiting-on-you`): the supervisor's queue became a plain
+  // Item list when the needs_you aggregation was deleted, and the testid moved
+  // with it. The spec kept asserting the old name and had been red ever since.
+  await expect(page.getByTestId('item-inbox')).toContainText(
     'hal: discard 81 junk/stale unread emails',
   )
   // The inbox row names where implementing sends the work — Ada's fan-out,
   // visible without opening the item.
-  await expect(page.getByTestId('waiting-on-you')).toContainText('dispatches to hal')
+  await expect(page.getByTestId('item-inbox')).toContainText('dispatches to hal')
 })
 
 test('the unfiltered queue shows only what is still waiting; settled cards collapse', async ({

--- a/frontend/e2e/mobile-a11y.spec.ts
+++ b/frontend/e2e/mobile-a11y.spec.ts
@@ -1,0 +1,101 @@
+import { test, expect } from '@playwright/test'
+
+// Guards for two defects found by driving the DEPLOYED app as an installed PWA on a
+// Pixel 7 — neither of which any existing check could see, because both are about
+// COMPUTED style rather than markup.
+//
+// Runs on the mobile project (see playwright.config testMatch).
+
+const SURFACES = ['/supervisor', '/w/dimagi/agents/ada/items', '/w/dimagi/agents/ada/inbox']
+
+test.describe('mobile', () => {
+  // The gate is 2.0, and that is deliberately BELOW the 3:1 this should reach.
+  //
+  // What was shipped: four inputs used `bg-input placeholder:text-foreground-subtle`,
+  // and those two tokens are the SAME oklch value in dark mode — contrast 1.00, the
+  // hint literally unreadable. A fifth set no placeholder colour at all and inherited
+  // the browser default: 1.08. Those are the bug this catches, and they are fixed.
+  //
+  // Moving to `--muted-foreground` gets dark mode to 2.15 (light mode is already 3.21,
+  // same token on a light `--input`). Clearing 3:1 in dark needs a placeholder colour
+  // around oklch(0.64) — which means a new per-theme token, because no single value
+  // clears 3:1 against BOTH a dark `--input` (0.374) and a light one (0.869). That is a
+  // palette decision, not a test decision, so it is raised rather than smuggled in here.
+  // Raise this constant to 3 when that token lands.
+  const MIN_CONTRAST = 2.0
+
+  test('no invisible placeholders', async ({ page }) => {
+    // `--foreground-subtle` and `--input` are the SAME oklch value in dark mode, so
+    // `bg-input placeholder:text-foreground-subtle` rendered the answer box on a
+    // question card as a dead grey blob: contrast 1.00, the hint literally unreadable.
+    // Four inputs shipped that combination. This fails if any comes back.
+    for (const path of SURFACES) {
+      await page.goto(path)
+      await page.waitForTimeout(1500)
+      const bad = await page.evaluate((MIN_CONTRAST) => {
+        // Resolve ANY CSS colour (this theme is authored in oklch, which
+        // getComputedStyle returns verbatim) to sRGB by letting the canvas
+        // rasterise it. Parsing the string by hand silently mis-reads oklch
+        // components as RGB — which is exactly how the first version of this
+        // test produced meaningless ratios.
+        const cvs = document.createElement('canvas')
+        cvs.width = cvs.height = 1
+        const ctx = cvs.getContext('2d')!
+        const rgb = (c: string) => {
+          ctx.clearRect(0, 0, 1, 1)
+          ctx.fillStyle = '#000'
+          ctx.fillStyle = c
+          ctx.fillRect(0, 0, 1, 1)
+          const [r, g, b] = ctx.getImageData(0, 0, 1, 1).data
+          return [r, g, b]
+        }
+        const lum = (c: string) => {
+          const [r, g, b] = rgb(c).map((v) => {
+            const x = v / 255
+            return x <= 0.03928 ? x / 12.92 : ((x + 0.055) / 1.055) ** 2.4
+          })
+          return 0.2126 * r + 0.7152 * g + 0.0722 * b
+        }
+        const out: string[] = []
+        document.querySelectorAll('input[placeholder], textarea[placeholder]').forEach((el) => {
+          const ph = getComputedStyle(el, '::placeholder').color
+          let n: Element | null = el
+          let bg = getComputedStyle(document.body).backgroundColor
+          while (n) {
+            const c = getComputedStyle(n).backgroundColor
+            if (c && !/rgba\(0, 0, 0, 0\)/.test(c) && c !== 'transparent') { bg = c; break }
+            n = n.parentElement
+          }
+          const a = lum(ph), b = lum(bg)
+          const ratio = (Math.max(a, b) + 0.05) / (Math.min(a, b) + 0.05)
+          if (ratio < MIN_CONTRAST) {
+            out.push(`"${el.getAttribute('placeholder')}" ${ph} on ${bg} = ${ratio.toFixed(2)}`)
+          }
+        })
+        return out
+      }, MIN_CONTRAST)
+      expect(bad, `unreadable placeholder(s) on ${path}`).toEqual([])
+    }
+  })
+
+  test('decision controls are thumb-sized', async ({ page }) => {
+    // Measured 25-27px tall on the deployed app — the implement/skip/defer/answer row
+    // is the surface the product exists for and was the least tappable thing on it.
+    // 44px is the floor Apple and Google both publish.
+    await page.goto('/w/dimagi/agents/ada/items')
+    await page.waitForTimeout(1500)
+    const small = await page.evaluate(() => {
+      const out: string[] = []
+      document
+        .querySelectorAll('[data-testid^="item-implement-"], [data-testid^="item-skip-"], [data-testid^="item-defer-"], [data-testid^="item-answer-"]')
+        .forEach((el) => {
+          const r = el.getBoundingClientRect()
+          if (r.height > 0 && r.height < 44) {
+            out.push(`${el.getAttribute('data-testid')} ${Math.round(r.width)}x${Math.round(r.height)}`)
+          }
+        })
+      return out
+    })
+    expect(small, 'decision controls under 44px on a phone').toEqual([])
+  })
+})

--- a/frontend/e2e/seed.py
+++ b/frontend/e2e/seed.py
@@ -157,6 +157,16 @@ Item.objects.create(
     body="A real person who never got an answer.",
     dispatch=[{"target_agent": "hal", "prompt": "/hal:turn --thread lily", "origin": "email"}],
 )
+# A QUESTION item — the other kind. Its card is the only thing that renders the
+# answer input, and without one seeded the placeholder-contrast guard had nothing
+# to inspect and passed while the bug was live. (Verified: reintroducing the
+# invisible-placeholder class now turns that test red.)
+Item.objects.create(
+    agent=ada_agent, kind="question", origin="api", batch_key=FLEET_AUDIT_BATCH,
+    idempotency_key="fa-question", title="hal: should the 81 be archived or deleted?",
+    body="Archiving is reversible; deleting is not.",
+    dispatch=[{"target_agent": "hal", "prompt": "/hal:turn", "origin": "email"}],
+)
 # A settled card from an OLDER sitting. Items are never deleted, so this is what
 # accumulates: the unfiltered view must keep it out of the way of the open ones.
 # Deliberately in a different batch, so the batch-permalink tests don't see it.

--- a/frontend/e2e/supervisor.spec.ts
+++ b/frontend/e2e/supervisor.spec.ts
@@ -1,7 +1,10 @@
 import { test, expect } from '@playwright/test'
 
 // Reach a tab's content. Inbox is the default landing; Sessions/Agents need a click.
-async function openTab(page: import('@playwright/test').Page, tab: 'inbox' | 'sessions' | 'agents') {
+async function openTab(
+  page: import('@playwright/test').Page,
+  tab: 'inbox' | 'sessions' | 'agents' | 'runners',
+) {
   if (tab !== 'inbox') await page.getByTestId(`tab-${tab}`).click()
 }
 
@@ -9,7 +12,7 @@ test.describe('/supervisor', () => {
   test('renders without horizontal scroll on every tab', async ({ page }) => {
     await page.goto('/supervisor')
     await expect(page.getByTestId('supervisor-page')).toBeVisible()
-    for (const tab of ['inbox', 'sessions', 'agents'] as const) {
+    for (const tab of ['inbox', 'sessions', 'agents', 'runners'] as const) {
       await openTab(page, tab)
       const overflow = await page.evaluate(
         () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
@@ -22,30 +25,52 @@ test.describe('/supervisor', () => {
     // Default landing (what push drops you into) is Inbox: the waiting queue is
     // visible and the other tabs' content is not.
     await page.goto('/supervisor')
-    await expect(page.getByTestId('waiting-on-you').or(page.getByTestId('waiting-empty'))).toBeVisible()
-    await expect(page.getByTestId('open-sessions').or(page.getByTestId('sessions-empty'))).toBeHidden()
+    // `item-inbox`/`inbox-empty` (were `waiting-on-you`/`waiting-empty`) — renamed when
+    // the needs_you aggregation was deleted and the queue became a plain Item list.
+    await expect(page.getByTestId('item-inbox').or(page.getByTestId('inbox-empty'))).toBeVisible()
+    // The Sessions tab is now ChatSessionsPanel; the composer's `open-sessions` is gone.
+    await expect(page.getByTestId('sessions-panel')).toBeHidden()
 
     // Deep-link straight to Agents.
+    // Runners split out of the Agents tab into their own.
     await page.goto('/supervisor?tab=agents')
-    await expect(page.getByTestId('runner-status').or(page.getByText('No runner paired'))).toBeVisible()
+    await expect(page.locator('[data-testid^="agent-card-"]').first()).toBeVisible()
   })
 
-  test('waiting-on-you is above the fold', async ({ page }) => {
+  test('the inbox is above the fold', async ({ page }) => {
     await page.goto('/supervisor')
-    const inbox = page.getByTestId('waiting-on-you').or(page.getByTestId('waiting-empty'))
+    const inbox = page.getByTestId('item-inbox').or(page.getByTestId('inbox-empty'))
     await expect(inbox).toBeInViewport()
   })
 
   test('one failed call does not blank the page', async ({ page }) => {
-    await page.route('**/api/agents/needs-you', (r) => r.abort())
+    // Abort the call the Inbox ACTUALLY makes. This used to abort
+    // `/api/agents/needs-you`, deleted with the aggregation — so the route never
+    // matched, nothing failed, and the test proved nothing while passing for it.
+    await page.route('**/api/items/**', (r) => r.abort())
     await page.goto('/supervisor')
     await expect(page.getByTestId('supervisor-page')).toBeVisible()
-    // Runners (Agents tab) still render despite the Inbox fetch failing.
-    await openTab(page, 'agents')
+    // Runners still render despite the Inbox fetch failing.
+    await openTab(page, 'runners')
     await expect(page.getByTestId('runner-status').or(page.getByText('No runner paired'))).toBeVisible()
   })
 
-  test('the composer dispatches a launchable command', async ({ page }) => {
+  // ---------------------------------------------------------------------------
+  // The three tests below drive the supervisor COMPOSER (`composer`,
+  // `composer-agent`, `composer-skill`, `composer-mode-repo`, `composer-workspace`)
+  // and the composer-era session list (`open-sessions`, `session-cloud-runner`).
+  // None of those testids exist in the source any more: the Sessions tab was
+  // rewritten around ChatSessionsPanel, whose creation entry point is "New chat
+  // with <agent> or project".
+  //
+  // They are marked fixme rather than deleted because the BEHAVIOUR they pin is
+  // still worth pinning — dispatching a launchable skill, a repo dispatch pinning
+  // its workspace to the tenant endpoint, and continuing into an existing session.
+  // Porting them needs the new panel's UX contract, which is not mine to invent.
+  // Deleting them would quietly drop that coverage, which is how this file rotted
+  // to 8/8 red without anyone noticing.
+  // ---------------------------------------------------------------------------
+  test.fixme('the composer dispatches a launchable command', async ({ page }) => {
     await page.goto('/supervisor')
     await openTab(page, 'sessions')
     const composer = page.getByTestId('composer')
@@ -84,7 +109,7 @@ test.describe('/supervisor', () => {
     expect(posted).toMatchObject({ agent_slug: 'echo', prompt: '/echo:story-ideation bednets' })
   })
 
-  test('a repo dispatch pins its workspace and routes to the tenant endpoint', async ({ page }) => {
+  test.fixme('a repo dispatch pins its workspace and routes to the tenant endpoint', async ({ page }) => {
     await page.goto('/supervisor')
     await openTab(page, 'sessions')
     await page.getByTestId('composer-mode-repo').click()
@@ -128,7 +153,7 @@ test.describe('/supervisor', () => {
     expect(headers['x-canopy-workspace']).toBeUndefined()
   })
 
-  test('open sessions list and continue dispatches into that exact task', async ({ page }) => {
+  test.fixme('open sessions list and continue dispatches into that exact task', async ({ page }) => {
     await page.goto('/supervisor')
     await openTab(page, 'sessions')
     await expect(page.getByTestId('open-sessions')).toBeVisible()
@@ -155,7 +180,7 @@ test.describe('/supervisor', () => {
   })
 
   test('a runner shows not-ready and opens a detail view with the reason', async ({ page }) => {
-    await page.goto('/supervisor?tab=agents')
+    await page.goto('/supervisor?tab=runners')
     // the seeded runner is not-ready → the list shows the marker
     const notReady = page.locator('[data-testid^="runner-notready-"]').first()
     await expect(notReady).toBeVisible()

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -22,7 +22,11 @@ export default defineConfig({
   // an installed PWA, so a layout regression has to fail CI before that lands.
   projects: [
     { name: 'desktop', use: { ...devices['Desktop Chrome'] } },
-    { name: 'mobile', use: { ...devices['Pixel 7'] }, testMatch: /supervisor\.spec\.ts/ },
+    {
+      name: 'mobile',
+      use: { ...devices['Pixel 7'] },
+      testMatch: /(supervisor|mobile-a11y)\.spec\.ts/,
+    },
   ],
   webServer: [
     { command: 'bash e2e/backend.sh', url: `http://127.0.0.1:${API_PORT}/health/`, timeout: 120_000, reuseExistingServer: false },

--- a/frontend/src/components/AppLayout/AppLayout.tsx
+++ b/frontend/src/components/AppLayout/AppLayout.tsx
@@ -301,10 +301,24 @@ function AppShell() {
           )}
           <div className="flex min-w-0 items-center gap-2 xl:gap-3">
             {/* Full inline nav only once all items fit (~xl); below that it
-                overflows the viewport, so we collapse it into the menu below. */}
-            <nav className="hidden min-w-0 xl:flex gap-0.5">
+                collapses into the menu below.
+
+                `overflow-x-auto` because "all items fit at xl" stopped being true:
+                the nav grew to 15 items and at exactly 1280px (Tailwind's xl, and
+                Desktop Chrome's default) it ran 6px past the viewport, giving EVERY
+                page a horizontal scrollbar. Scrolling within the nav keeps that
+                contained instead of pushing the document wide, and it does not
+                regress as the next item is added — raising the breakpoint instead
+                would have hidden the whole nav on 1280–1440px laptops, which is most
+                of them. `min-w-0` is what lets this flex child shrink far enough for
+                the overflow to apply. */}
+            <nav className="hidden min-w-0 overflow-x-auto xl:flex gap-0.5">
               {navItems.map((item) => (
-                <Link key={item.path} to={item.path} className={navLinkClass(item.path, false)}>
+                <Link
+                  key={item.path}
+                  to={item.path}
+                  className={`${navLinkClass(item.path, false)} shrink-0`}
+                >
                   {item.label}
                 </Link>
               ))}

--- a/frontend/src/components/chat/ChatSessionsPanel.tsx
+++ b/frontend/src/components/chat/ChatSessionsPanel.tsx
@@ -255,7 +255,10 @@ export function ChatSessionsPanel({
   const waitingCount = sessions.filter((s) => s.waiting_on_you).length
 
   return (
-    <div className="flex min-h-0 flex-col">
+    // Named so a test can assert this tab is (or is not) showing. The supervisor
+    // spec used to reach for `open-sessions`, which belonged to the composer UI
+    // this panel replaced.
+    <div className="flex min-h-0 flex-col" data-testid="sessions-panel">
       <div className="flex items-center justify-between gap-2 pb-2">
         <h2 className="flex items-center gap-1.5 text-sm font-semibold text-foreground">
           {heading}

--- a/frontend/src/components/items/ItemCard.tsx
+++ b/frontend/src/components/items/ItemCard.tsx
@@ -14,6 +14,11 @@ import { ItemAge } from '@/components/items/ItemAge'
 // — we surface that inline rather than let the tap look like it worked. A second
 // decision 409s (already decided elsewhere); we refetch via onActed.
 
+// `min-h-11 sm:min-h-0` on every control below: measured on a Pixel 7 against the
+// deployed app, the decision row rendered 25-27px tall — well under the 44px both
+// Apple and Google publish as the minimum. This is the surface the whole product
+// exists for (implement / skip / defer / answer), and it was the least tappable
+// thing on the page. Desktop keeps the compact size from `sm:` up.
 const REVIEW_DECISIONS: ItemDecision[] = ['implement', 'skip', 'defer']
 
 /** Where implementing sends the work — the one place Ada's cross-agent fan-out is
@@ -79,14 +84,14 @@ export function ItemCard({
             disabled={busy}
             placeholder="Type an answer…"
             onChange={(e) => setAnswer(e.target.value)}
-            className="min-w-0 flex-1 rounded-md border border-input bg-input px-2 py-1 text-[12px] text-foreground placeholder:text-foreground-subtle disabled:opacity-50"
+            className="min-w-0 flex-1 min-h-11 sm:min-h-0 rounded-md border border-input bg-input px-2 py-1 text-[12px] text-foreground placeholder:text-muted-foreground disabled:opacity-50"
             data-testid={`item-answer-${item.id}`}
           />
           <button
             type="button"
             disabled={busy || !answer.trim()}
             onClick={() => act(() => decideItem(item.id, '', answer.trim()))}
-            className="rounded-md border border-border px-3 py-1 text-[12px] text-foreground transition-colors hover:bg-muted disabled:opacity-50"
+            className="min-h-11 sm:min-h-0 rounded-md border border-border px-3 py-1 text-[12px] text-foreground transition-colors hover:bg-muted disabled:opacity-50"
           >
             {(item.dispatch ?? []).length ? 'Answer & run' : 'Answer'}
           </button>
@@ -94,7 +99,7 @@ export function ItemCard({
             type="button"
             disabled={busy}
             onClick={() => act(() => dismissItem(item.id))}
-            className="rounded-md px-2 py-1 text-[12px] text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50"
+            className="min-h-11 sm:min-h-0 rounded-md px-3 py-1 text-[12px] text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50"
           >
             Dismiss
           </button>
@@ -107,7 +112,7 @@ export function ItemCard({
               type="button"
               disabled={busy}
               onClick={() => act(() => decideItem(item.id, d))}
-              className="rounded-md border border-border px-3 py-1 text-[12px] capitalize text-foreground transition-colors hover:bg-muted disabled:opacity-50"
+              className="min-h-11 sm:min-h-0 rounded-md border border-border px-3 py-1 text-[12px] capitalize text-foreground transition-colors hover:bg-muted disabled:opacity-50"
               data-testid={`item-${d}-${item.id}`}
             >
               {d}
@@ -117,7 +122,7 @@ export function ItemCard({
             type="button"
             disabled={busy}
             onClick={() => act(() => dismissItem(item.id))}
-            className="ml-auto rounded-md px-2 py-1 text-[12px] text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50"
+            className="ml-auto min-h-11 sm:min-h-0 rounded-md px-3 py-1 text-[12px] text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50"
           >
             Dismiss
           </button>

--- a/frontend/src/components/storyboard/NoteComposer.tsx
+++ b/frontend/src/components/storyboard/NoteComposer.tsx
@@ -174,7 +174,7 @@ export function NoteComposer({
             ? 'Change the words to what they should say…'
             : 'What’s wrong, missing, or worth saying differently?'
         }
-        className="w-full rounded-md border border-input bg-background px-3 py-2 text-[13px] text-foreground placeholder:text-foreground-subtle focus-visible:outline-2 focus-visible:outline-primary"
+        className="w-full rounded-md border border-input bg-background px-3 py-2 text-[13px] text-foreground placeholder:text-muted-foreground focus-visible:outline-2 focus-visible:outline-primary"
       />
 
       <div className="flex flex-wrap items-center justify-between gap-2">
@@ -186,7 +186,7 @@ export function NoteComposer({
             rememberReviewerName(e.target.value)
           }}
           placeholder="Your name (optional)"
-          className="min-w-0 flex-1 rounded-md border border-input bg-background px-3 py-1.5 text-[12px] text-foreground placeholder:text-foreground-subtle focus-visible:outline-2 focus-visible:outline-primary"
+          className="min-w-0 flex-1 rounded-md border border-input bg-background px-3 py-1.5 text-[12px] text-foreground placeholder:text-muted-foreground focus-visible:outline-2 focus-visible:outline-primary"
         />
         <div className="flex items-center gap-2">
           <button

--- a/frontend/src/components/supervisor/RunnerDetail.tsx
+++ b/frontend/src/components/supervisor/RunnerDetail.tsx
@@ -170,7 +170,7 @@ export function RunnerDetail({
               placeholder="Why? (e.g. token limit on this account)"
               maxLength={200}
               data-testid="runner-pause-note"
-              className="rounded-md border border-input bg-input px-2 py-1 text-[12px] text-foreground placeholder:text-foreground-subtle"
+              className="rounded-md border border-input bg-input px-2 py-1 text-[12px] text-foreground placeholder:text-muted-foreground"
             />
           )}
           {pauseErr && <p className="text-[12px] text-destructive" data-testid="runner-pause-error">{pauseErr}</p>}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -90,6 +90,10 @@
     --muted: oklch(0.268 0.007 34.3);            /* ~stone-800 */
     --muted-foreground: oklch(0.553 0.013 58.07);/* ~stone-500 */
     --foreground-secondary: oklch(0.809 0.005 56.0); /* ~stone-300 — secondary text */
+    /* NOTE: identical to --input below. Faint text placed ON an input is therefore
+       INVISIBLE in dark mode (contrast 1.00) — use --muted-foreground for anything
+       sitting on an input surface, e.g. placeholders. Guarded by the
+       'no invisible placeholders' e2e test. */
     --foreground-subtle: oklch(0.374 0.01 67.56);    /* ~stone-700 — faint text */
     --accent: oklch(0.268 0.007 34.3);
     --accent-foreground: oklch(0.923 0.003 48.72);

--- a/frontend/src/pages/agents/ItemsSection.tsx
+++ b/frontend/src/pages/agents/ItemsSection.tsx
@@ -82,7 +82,7 @@ function ItemCard({
             value={comment}
             onChange={(e) => setComment(e.target.value)}
             placeholder="Comment (optional) — what to change, or why skip…"
-            className="mt-3 w-full rounded-md border border-input bg-input p-2 text-[13px] text-foreground"
+            className="mt-3 w-full rounded-md border border-input bg-input p-2 text-[13px] text-foreground placeholder:text-muted-foreground"
             rows={2}
           />
           <div className="mt-2 flex gap-2">


### PR DESCRIPTION
Found by driving the **deployed** app as an installed PWA on a Pixel 7. Neither defect is visible in markup — one is computed colour, the other is geometry.

## 1. The answer box was invisible

`--foreground-subtle` and `--input` are the **same oklch value** in dark mode, so `bg-input placeholder:text-foreground-subtle` painted the hint in exactly its own background colour.

```
"Type an answer…"  oklch(0.374 0.01 67.56) on oklch(0.374 0.01 67.56) = 1.00
```

On a question card that input is the only way to answer, and it rendered as a dead grey blob with no indication you could type in it. Four inputs shipped that pair; a fifth set no placeholder colour at all and inherited the browser default (1.08). All now use `--muted-foreground`.

## 2. Nothing on the decision row was tappable

The implement / skip / defer / answer row measured **25–27px tall** on a phone — the surface the whole product exists for, and the least tappable thing on the page. 44px is the floor both Apple and Google publish. `min-h-11` on mobile; desktop unchanged from `sm:` up.

## 3. Guards — and the guard that didn't work

New `mobile-a11y.spec.ts` pins both, on the mobile project.

**It is gated at 2.0 contrast, deliberately below the 3:1 this should reach.** `--muted-foreground` gets dark mode to 2.15 (light is already 3.21 on the same token). Clearing 3:1 needs a new per-theme token, because no single value clears it against *both* a dark `--input` (0.374) and a light one (0.869):

| candidate | on dark input | on light input |
|---|---|---|
| `muted-foreground` 0.553 | 2.15 | 3.21 |
| 0.640 | **3.06** | 2.25 |
| 0.680 | 3.57 | 1.93 |

That is a palette decision, so it's raised here rather than smuggled into a test threshold. Raise `MIN_CONTRAST` to 3 when the token lands.

**The guard passed with the bug reintroduced.** No `kind: "question"` item was seeded, so the answer input never rendered and the test had nothing to inspect — it was protecting nothing. Seeded one, then verified the honest way: put the bug back, watched it go red at 1.00, took it out again.

I also had to fix the contrast math itself — `getComputedStyle` returns `oklch()` verbatim for this theme, and the first version parsed those components as RGB and produced confident nonsense. Colours now resolve through a canvas.

## Result

```
41 passed, 6 skipped, 0 failed   — desktop + mobile
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)