### PR TITLE
fix(mobile): stop making the phone scroll past the navigation, and finish the placeholder fix

### DIFF
--- a/frontend/e2e/mobile-a11y.spec.ts
+++ b/frontend/e2e/mobile-a11y.spec.ts
@@ -9,20 +9,17 @@ import { test, expect } from '@playwright/test'
 const SURFACES = ['/supervisor', '/w/dimagi/agents/ada/items', '/w/dimagi/agents/ada/inbox']
 
 test.describe('mobile', () => {
-  // The gate is 2.0, and that is deliberately BELOW the 3:1 this should reach.
+  // Gate is the real 3:1 bar.
   //
-  // What was shipped: four inputs used `bg-input placeholder:text-foreground-subtle`,
-  // and those two tokens are the SAME oklch value in dark mode — contrast 1.00, the
-  // hint literally unreadable. A fifth set no placeholder colour at all and inherited
-  // the browser default: 1.08. Those are the bug this catches, and they are fixed.
+  // What shipped before this: four inputs used `bg-input placeholder:text-foreground-subtle`,
+  // and those two tokens are the SAME oklch value in dark mode — contrast 1.00, the hint
+  // literally unreadable. A fifth set no placeholder colour and inherited the browser
+  // default: 1.08.
   //
-  // Moving to `--muted-foreground` gets dark mode to 2.15 (light mode is already 3.21,
-  // same token on a light `--input`). Clearing 3:1 in dark needs a placeholder colour
-  // around oklch(0.64) — which means a new per-theme token, because no single value
-  // clears 3:1 against BOTH a dark `--input` (0.374) and a light one (0.869). That is a
-  // palette decision, not a test decision, so it is raised rather than smuggled in here.
-  // Raise this constant to 3 when that token lands.
-  const MIN_CONTRAST = 2.0
+  // `--muted-foreground` alone only reached 2.15 in dark, because no single value clears
+  // 3:1 against BOTH a dark `--input` (0.374) and a light one (0.869). Dark now uses
+  // `--foreground-secondary` via the `dark:` variant: 5.68 dark, 3.21 light.
+  const MIN_CONTRAST = 3.0
 
   test('no invisible placeholders', async ({ page }) => {
     // `--foreground-subtle` and `--input` are the SAME oklch value in dark mode, so

--- a/frontend/src/components/agents/AgentLeftNav.tsx
+++ b/frontend/src/components/agents/AgentLeftNav.tsx
@@ -70,10 +70,15 @@ export function AgentLeftNav({ agent }: { agent: AgentDetailOut }) {
 
   return (
     <WorkbenchRail header={header}>
+      {/* Phone: a horizontal, scrollable strip — the same shape /supervisor already
+          uses for its tabs. Stacked vertically it ran to nine rows, and with the
+          identity header above it that pushed the actual content to 55% down the
+          first screen: you scrolled past the navigation to reach what you opened.
+          Desktop is unchanged from md up. */}
       <nav className="px-2 py-3">
-        <div className="flex flex-col gap-0.5">
+        <div className="flex gap-0.5 overflow-x-auto md:flex-col md:overflow-x-visible">
           {items.map((item) => (
-            <NavLink key={item.to} to={item.to} end={item.to === 'overview'}>
+            <NavLink key={item.to} to={item.to} end={item.to === 'overview'} className="shrink-0 md:shrink">
               {({ isActive }) => (
                 <WorkbenchNavItem active={isActive} count={item.count}>
                   {item.label}

--- a/frontend/src/components/items/ItemCard.tsx
+++ b/frontend/src/components/items/ItemCard.tsx
@@ -84,7 +84,7 @@ export function ItemCard({
             disabled={busy}
             placeholder="Type an answer…"
             onChange={(e) => setAnswer(e.target.value)}
-            className="min-w-0 flex-1 min-h-11 sm:min-h-0 rounded-md border border-input bg-input px-2 py-1 text-[12px] text-foreground placeholder:text-muted-foreground disabled:opacity-50"
+            className="min-w-0 flex-1 min-h-11 sm:min-h-0 rounded-md border border-input bg-input px-2 py-1 text-[12px] text-foreground placeholder:text-muted-foreground dark:placeholder:text-foreground-secondary disabled:opacity-50"
             data-testid={`item-answer-${item.id}`}
           />
           <button

--- a/frontend/src/components/storyboard/NoteComposer.tsx
+++ b/frontend/src/components/storyboard/NoteComposer.tsx
@@ -174,7 +174,7 @@ export function NoteComposer({
             ? 'Change the words to what they should say…'
             : 'What’s wrong, missing, or worth saying differently?'
         }
-        className="w-full rounded-md border border-input bg-background px-3 py-2 text-[13px] text-foreground placeholder:text-muted-foreground focus-visible:outline-2 focus-visible:outline-primary"
+        className="w-full rounded-md border border-input bg-background px-3 py-2 text-[13px] text-foreground placeholder:text-muted-foreground dark:placeholder:text-foreground-secondary focus-visible:outline-2 focus-visible:outline-primary"
       />
 
       <div className="flex flex-wrap items-center justify-between gap-2">
@@ -186,7 +186,7 @@ export function NoteComposer({
             rememberReviewerName(e.target.value)
           }}
           placeholder="Your name (optional)"
-          className="min-w-0 flex-1 rounded-md border border-input bg-background px-3 py-1.5 text-[12px] text-foreground placeholder:text-muted-foreground focus-visible:outline-2 focus-visible:outline-primary"
+          className="min-w-0 flex-1 rounded-md border border-input bg-background px-3 py-1.5 text-[12px] text-foreground placeholder:text-muted-foreground dark:placeholder:text-foreground-secondary focus-visible:outline-2 focus-visible:outline-primary"
         />
         <div className="flex items-center gap-2">
           <button

--- a/frontend/src/components/supervisor/RunnerDetail.tsx
+++ b/frontend/src/components/supervisor/RunnerDetail.tsx
@@ -170,7 +170,7 @@ export function RunnerDetail({
               placeholder="Why? (e.g. token limit on this account)"
               maxLength={200}
               data-testid="runner-pause-note"
-              className="rounded-md border border-input bg-input px-2 py-1 text-[12px] text-foreground placeholder:text-muted-foreground"
+              className="rounded-md border border-input bg-input px-2 py-1 text-[12px] text-foreground placeholder:text-muted-foreground dark:placeholder:text-foreground-secondary"
             />
           )}
           {pauseErr && <p className="text-[12px] text-destructive" data-testid="runner-pause-error">{pauseErr}</p>}

--- a/frontend/src/pages/agents/ItemsSection.tsx
+++ b/frontend/src/pages/agents/ItemsSection.tsx
@@ -82,7 +82,7 @@ function ItemCard({
             value={comment}
             onChange={(e) => setComment(e.target.value)}
             placeholder="Comment (optional) — what to change, or why skip…"
-            className="mt-3 w-full rounded-md border border-input bg-input p-2 text-[13px] text-foreground placeholder:text-muted-foreground"
+            className="mt-3 w-full rounded-md border border-input bg-input p-2 text-[13px] text-foreground placeholder:text-muted-foreground dark:placeholder:text-foreground-secondary"
             rows={2}
           />
           <div className="mt-2 flex gap-2">


### PR DESCRIPTION
Two follow-ups from dogfooding the deployed app on a Pixel 7. I had framed both as decisions to hand over; neither was — they're repo-internal, so here they are done, with numbers.

## 1. The agent page made you scroll past its own navigation

The rail stacks nine entries vertically under the identity header. On a phone the content you opened the page for started **461px down an 839px viewport — 55% navigation before anything else.**

The rail already had a mobile accommodation (`max-h-[42vh]`), which capped the damage without fixing it.

It's now a horizontal scrollable strip on phones — the same shape `/supervisor` already uses for its tabs. Desktop unchanged from `md` up.

| | content starts at | share of first screen |
|---|---|---|
| before | 461px | **55%** |
| after | 277px | **33%** |

Two full decision cards now fit on the first screen instead of most of one.

## 2. Placeholders now clear the real 3:1 bar

#608 took them from 1.00 (invisible — `--foreground-subtle` and `--input` are the same oklch value in dark mode) to 2.15, and I flagged the remainder as needing a palette decision.

It didn't. `@custom-variant dark (&:is(.dark *))` is already defined in `index.css`, so dark mode can take `--foreground-secondary` while light keeps `--muted-foreground` — no new token, no change to the shared `canopy-ui` preset that ace-web also imports.

| | dark | light |
|---|---|---|
| before (#608) | 2.15 | 3.21 |
| after | **5.68** | 3.21 |

The guard in `mobile-a11y.spec.ts` goes from the interim 2.0 to the real 3.0.

## Result

```
41 passed, 6 skipped, 0 failed   — desktop + mobile
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)