### PR TITLE
Show link-shared sessions to everyone, not just their owner

### DIFF
--- a/apps/session_sharing/api.py
+++ b/apps/session_sharing/api.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import tempfile
 from pathlib import Path
 
-from django.db import transaction
+from django.db import models, transaction
 from django.http import HttpRequest
 from django.utils.dateparse import parse_datetime
 from ninja import File, Form, Router, Status
@@ -73,7 +73,13 @@ def _message_payloads(session: Session) -> list[dict]:
 
 
 def _list_payload(session: Session, *, is_owner: bool) -> dict:
-    token = session.active_token() if is_owner else None
+    # A non-owner can only be seeing this row because it's link-visible, and
+    # the link IS the read path — so the token ships to them too.
+    token = (
+        session.active_token()
+        if is_owner or session.visibility == Session.VISIBILITY_LINK
+        else None
+    )
     return {
         "slug": session.slug,
         "title": session.title,
@@ -232,23 +238,33 @@ def upload_session(
 
 
 # ---------------------------------------------------------------------------
-# List (owner's sessions)
+# List — mine (any visibility) + everyone's link-shared.
+# Agents upload under their OWN accounts (the canopy uploader resolves the PAT
+# from the repo it runs in), so an owner-only list hides exactly the shares a
+# human asked their agent to make. Link visibility already means "anyone with
+# the URL"; surfacing those rows to authed teammates grants nothing new.
 # ---------------------------------------------------------------------------
 
 
-@router.get("/", response=list[SessionListItemOut], summary="List my shared sessions")
+@router.get("/", response=list[SessionListItemOut], summary="List shared sessions")
 def list_sessions(
     request: HttpRequest, project: str = ""
 ) -> list[SessionListItemOut]:
     qs = (
         Session.objects.select_related("owner")
-        .filter(owner=request.user)
+        .filter(
+            models.Q(owner=request.user)
+            | models.Q(visibility=Session.VISIBILITY_LINK)
+        )
         .prefetch_related("share_tokens")
     )
     if project:
         qs = qs.filter(project_slug=project)
     return [
-        SessionListItemOut.model_validate(_list_payload(s, is_owner=True)) for s in qs
+        SessionListItemOut.model_validate(
+            _list_payload(s, is_owner=s.owner_id == request.user.id)
+        )
+        for s in qs
     ]
 
 
@@ -260,7 +276,11 @@ def list_sessions(
 
 
 def _arc_list_payload(arc: SessionArc, *, is_owner: bool) -> dict:
-    token = arc.active_token() if is_owner else None
+    token = (
+        arc.active_token()
+        if is_owner or arc.visibility == SessionArc.VISIBILITY_LINK
+        else None
+    )
     return {
         "slug": arc.slug,
         "title": arc.title,
@@ -363,17 +383,24 @@ def create_arc(request: HttpRequest, payload: ArcCreateIn) -> Status:
     )
 
 
-@router.get("/arcs", response=list[ArcListItemOut], summary="List my arcs")
+@router.get("/arcs", response=list[ArcListItemOut], summary="List arcs")
 def list_arcs(request: HttpRequest, project: str = "") -> list[ArcListItemOut]:
+    # Same rule as list_sessions: mine + everyone's link-shared.
     qs = (
         SessionArc.objects.select_related("owner")
-        .filter(owner=request.user)
+        .filter(
+            models.Q(owner=request.user)
+            | models.Q(visibility=SessionArc.VISIBILITY_LINK)
+        )
         .prefetch_related("share_tokens", "items")
     )
     if project:
         qs = qs.filter(project_slug=project)
     return [
-        ArcListItemOut.model_validate(_arc_list_payload(a, is_owner=True)) for a in qs
+        ArcListItemOut.model_validate(
+            _arc_list_payload(a, is_owner=a.owner_id == request.user.id)
+        )
+        for a in qs
     ]
 
 

--- a/apps/session_sharing/tests/test_api.py
+++ b/apps/session_sharing/tests/test_api.py
@@ -113,15 +113,33 @@ def test_reupload_is_idempotent(auth_client):
 
 
 @pytest.mark.django_db
-def test_list_only_returns_my_sessions(auth_client, other):
+def test_list_includes_link_shared_sessions_from_others(auth_client, other):
+    """A session an agent (or teammate) shared must be findable by everyone —
+    the list is "shared with the team", not "uploaded by me". Their PRIVATE
+    sessions stay invisible."""
     _upload(auth_client, _transcript("mine"))
     other_client = Client()
     other_client.force_login(other)
-    _upload(other_client, _transcript("theirs"))
+    _upload(other_client, _transcript("theirs-link"), title="Agent share")
+    _upload(other_client, _transcript("theirs-private"), visibility="private")
 
     rows = auth_client.get("/api/sessions/").json()
-    assert len(rows) == 1
-    assert rows[0]["is_owner"] is True
+    by_title = {r["title"]: r for r in rows}
+    assert len(rows) == 2
+    theirs = by_title["Agent share"]
+    assert theirs["is_owner"] is False
+    assert theirs["owner_email"] == "other@dimagi.com"
+    # A non-owner still needs the link to open it.
+    assert theirs["share_token"]
+    assert Client().get(f"/api/share/{theirs['share_token']}").status_code == 200
+
+
+@pytest.mark.django_db
+def test_list_never_exposes_others_private_sessions(auth_client, other):
+    other_client = Client()
+    other_client.force_login(other)
+    _upload(other_client, _transcript("theirs"), visibility="private")
+    assert auth_client.get("/api/sessions/").json() == []
 
 
 @pytest.mark.django_db
@@ -224,6 +242,20 @@ def test_arc_list_and_detail_owner_only(auth_client, other):
     other_client = Client()
     other_client.force_login(other)
     assert other_client.get(f"/api/sessions/arcs/{slug}").status_code == 403
+
+
+@pytest.mark.django_db
+def test_arc_list_includes_link_shared_arcs_from_others(auth_client, other):
+    s1 = _upload(auth_client, _transcript("v1")).json()["slug"]
+    _create_arc(auth_client, [{"session_slug": s1}], title="Their arc")
+
+    other_client = Client()
+    other_client.force_login(other)
+    rows = other_client.get("/api/sessions/arcs").json()
+    assert len(rows) == 1
+    assert rows[0]["title"] == "Their arc"
+    assert rows[0]["is_owner"] is False
+    assert rows[0]["share_token"]
 
 
 @pytest.mark.django_db

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -1261,7 +1261,7 @@ export interface paths {
             readonly path?: never;
             readonly cookie?: never;
         };
-        /** List my shared sessions */
+        /** List shared sessions */
         readonly get: operations["apps_session_sharing_api_list_sessions"];
         readonly put?: never;
         readonly post?: never;
@@ -1278,7 +1278,7 @@ export interface paths {
             readonly path?: never;
             readonly cookie?: never;
         };
-        /** List my arcs */
+        /** List arcs */
         readonly get: operations["apps_session_sharing_api_list_arcs"];
         readonly put?: never;
         /** Create an arc from owned sessions (ordered) */

--- a/frontend/src/pages/SessionsPage.tsx
+++ b/frontend/src/pages/SessionsPage.tsx
@@ -54,7 +54,7 @@ export function SessionsPage() {
     <div className="mx-auto max-w-4xl px-4 py-8">
       <h1 className="text-2xl font-semibold text-foreground">Shared sessions</h1>
       <p className="mt-1 text-sm text-muted-foreground">
-        Claude Code transcripts you've shared. Run{" "}
+        Claude Code transcripts shared by you, your agents, and teammates. Run{" "}
         <code className="rounded bg-muted px-1">/canopy:share-session</code> to
         add one.
       </p>
@@ -89,6 +89,7 @@ export function SessionsPage() {
                   {s.message_count} messages ·{" "}
                   {new Date(s.created_at).toLocaleString()}
                   {s.project_slug ? ` · ${s.project_slug}` : ""}
+                  {!s.is_owner ? ` · ${s.owner_email}` : ""}
                 </div>
               </div>
               <div className="flex shrink-0 flex-wrap items-center gap-x-3 gap-y-1 text-sm">
@@ -108,27 +109,33 @@ export function SessionsPage() {
                     >
                       {copied === s.share_token ? "Copied!" : "Copy link"}
                     </button>
+                    {s.is_owner && (
+                      <button
+                        className="text-muted-foreground hover:text-foreground"
+                        onClick={() => onRotate(s.slug)}
+                        title="Invalidate the current link and mint a new one"
+                      >
+                        Rotate
+                      </button>
+                    )}
+                  </>
+                )}
+                {s.is_owner && (
+                  <>
                     <button
                       className="text-muted-foreground hover:text-foreground"
-                      onClick={() => onRotate(s.slug)}
-                      title="Invalidate the current link and mint a new one"
+                      onClick={() => onToggle(s)}
                     >
-                      Rotate
+                      {s.visibility === "link" ? "Make private" : "Make link"}
+                    </button>
+                    <button
+                      className="text-destructive hover:text-destructive/80"
+                      onClick={() => onDelete(s.slug)}
+                    >
+                      Delete
                     </button>
                   </>
                 )}
-                <button
-                  className="text-muted-foreground hover:text-foreground"
-                  onClick={() => onToggle(s)}
-                >
-                  {s.visibility === "link" ? "Make private" : "Make link"}
-                </button>
-                <button
-                  className="text-destructive hover:text-destructive/80"
-                  onClick={() => onDelete(s.slug)}
-                >
-                  Delete
-                </button>
               </div>
             </li>
           ))}


### PR DESCRIPTION
## Why

Agents upload session shares under their **own** accounts — the canopy uploader resolves its PAT from the repo it runs in, so a share Echo makes on your behalf is owned by `echo@dimagi-ai.com`. The `/sessions` list filtered `owner=request.user`, which hid exactly those shares: Echo's upload existed and its link worked, but it was findable by nobody (the incident behind this branch). Decision: agent ownership is fine — what must hold is that **you and others can see a session once it's shared**.

## What

- `GET /api/sessions/` (and `/api/sessions/arcs`) now return your own rows (any visibility) **plus everyone's link-visibility rows**. Link visibility already means "anyone with the URL can read", so surfacing those rows — including the share token, which is the read path — to authed teammates grants nothing new.
- Private sessions stay invisible to non-owners; the owner-only detail route and all management routes are untouched.
- `/sessions` page: non-owned rows show the owner's email and offer Open / Copy link only; Rotate / visibility toggle / Delete render only on rows you own.

## Testing

- New contract tests: others' link shares appear (`is_owner: false`, token opens via `/api/share/`), others' private sessions never appear, same for arcs.
- Full backend suite: 2122 passed. `npm run build` clean; `generated.ts` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)