### PR TITLE
Return owner_email on session upload + arc create

### DIFF
--- a/apps/session_sharing/api.py
+++ b/apps/session_sharing/api.py
@@ -178,6 +178,7 @@ def upload_session(
                     message_count=existing.messages.count(),
                     redaction_count=existing.redaction_count,
                     visibility=existing.visibility,
+                    owner_email=existing.owner.email,
                     share_token=token.token if token else None,
                     duplicate=True,
                 ),
@@ -231,6 +232,7 @@ def upload_session(
             message_count=len(rows),
             redaction_count=total_redactions,
             visibility=session.visibility,
+            owner_email=session.owner.email,
             share_token=token.token if token else None,
             duplicate=False,
         ),
@@ -378,6 +380,7 @@ def create_arc(request: HttpRequest, payload: ArcCreateIn) -> Status:
             slug=arc.slug,
             visibility=arc.visibility,
             item_count=len(items),
+            owner_email=arc.owner.email,
             share_token=token.token if token else None,
         ),
     )

--- a/apps/session_sharing/schemas.py
+++ b/apps/session_sharing/schemas.py
@@ -46,12 +46,20 @@ class SharedSessionOut(StrictModel):
 
 
 class SessionUploadOut(StrictModel):
-    """Result of POST /api/sessions/upload."""
+    """Result of POST /api/sessions/upload.
+
+    ``owner_email`` is here because a PRIVATE upload has no share token and no
+    public page, so the only true statement a client can make about it is *who
+    can read it* — and the client cannot know that on its own. Agents upload
+    under their own accounts (the canopy uploader resolves its PAT from the repo
+    it runs in), so the uploader's identity is frequently not the human's.
+    """
 
     slug: str
     message_count: int = Field(ge=0)
     redaction_count: int = Field(ge=0)
     visibility: SessionVisibility
+    owner_email: EmailStr
     share_token: str | None = None
     duplicate: bool = False
 
@@ -122,6 +130,7 @@ class ArcCreateOut(StrictModel):
     slug: str
     visibility: SessionVisibility
     item_count: int = Field(ge=0)
+    owner_email: EmailStr
     share_token: str | None = None
 
 

--- a/apps/session_sharing/tests/test_api.py
+++ b/apps/session_sharing/tests/test_api.py
@@ -113,6 +113,36 @@ def test_reupload_is_idempotent(auth_client):
 
 
 @pytest.mark.django_db
+def test_upload_reports_the_owning_account(auth_client):
+    """A PRIVATE upload has no share token and no public page, so the only true
+    thing a client can say about it is who can read it — and only the server
+    knows that. Agents upload under their OWN accounts, so the uploader is
+    frequently not the human who asked for the share; a client that guesses
+    prints a false promise (dimagi-internal/canopy#484)."""
+    private = _upload(auth_client, _transcript("own-1"), visibility="private").json()
+    assert private["share_token"] is None
+    assert private["owner_email"] == "owner@dimagi.com"
+
+    linked = _upload(auth_client, _transcript("own-2")).json()
+    assert linked["owner_email"] == "owner@dimagi.com"
+
+    # The idempotent re-upload path returns a second, separately-built payload.
+    again = _upload(auth_client, _transcript("own-1"), visibility="private").json()
+    assert again["duplicate"] is True
+    assert again["owner_email"] == "owner@dimagi.com"
+
+
+@pytest.mark.django_db
+def test_arc_create_reports_the_owning_account(auth_client):
+    slug = _upload(auth_client, _transcript("arc-own")).json()["slug"]
+    body = _create_arc(
+        auth_client, [{"session_slug": slug, "heading": "One"}], visibility="private"
+    ).json()
+    assert body["share_token"] is None
+    assert body["owner_email"] == "owner@dimagi.com"
+
+
+@pytest.mark.django_db
 def test_list_includes_link_shared_sessions_from_others(auth_client, other):
     """A session an agent (or teammate) shared must be findable by everyone —
     the list is "shared with the team", not "uploaded by me". Their PRIVATE

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -5792,6 +5792,12 @@ export interface components {
         /**
          * SessionUploadOut
          * @description Result of POST /api/sessions/upload.
+         *
+         *     ``owner_email`` is here because a PRIVATE upload has no share token and no
+         *     public page, so the only true statement a client can make about it is *who
+         *     can read it* — and the client cannot know that on its own. Agents upload
+         *     under their own accounts (the canopy uploader resolves its PAT from the repo
+         *     it runs in), so the uploader's identity is frequently not the human's.
          */
         readonly SessionUploadOut: {
             /** Slug */
@@ -5805,6 +5811,11 @@ export interface components {
              * @enum {string}
              */
             readonly visibility: "private" | "link";
+            /**
+             * Owner Email
+             * Format: email
+             */
+            readonly owner_email: string;
             /** Share Token */
             readonly share_token?: string | null;
             /**
@@ -5864,6 +5875,11 @@ export interface components {
             readonly visibility: "private" | "link";
             /** Item Count */
             readonly item_count: number;
+            /**
+             * Owner Email
+             * Format: email
+             */
+            readonly owner_email: string;
             /** Share Token */
             readonly share_token?: string | null;
         };


### PR DESCRIPTION
## Why

A **private** session upload has no share token and no public page, so the only true statement a client can make about it is *who can read it* — and the client cannot know that on its own. Agents upload under their **own** accounts (the canopy uploader resolves its PAT from the repo it runs in), so the uploader is frequently not the human who asked for the share.

Without this field the canopy uploader had nothing to print but a guess, and the guess it shipped was `View (dimagi login required): <api>/sessions  (slug: …)` — false on both halves. Private is owner-only here:

- `_owned_session` raises `403 Forbidden — owner only` for a non-owner
- `list_sessions` returns `Q(owner=request.user) | Q(visibility=LINK)`

So a private share an agent makes is readable by the agent and nobody else. That is what produced the black screen in [canopy#484](https://github.com/dimagi-internal/canopy/issues/484) — a session Echo shared for Jonathan, owned by `echo@dimagi-ai.com`, invisible to him.

## What

`owner_email` on `SessionUploadOut` and `ArcCreateOut`, populated at all three construction sites (fresh upload, idempotent re-upload, arc create). The list schemas (`SessionListItemOut`, `ArcListItemOut`) already carried it — this is the create/upload responses catching up.

The public `/api/share/<token>` payload is **untouched** and still exposes no owner identity; the existing `assert "owner_email" not in body` test pins that.

The consumer is [canopy#485](https://github.com/dimagi-internal/canopy/pull/485), which degrades gracefully if it's talking to a canopy-web that predates this.

## Verification

Ran every gate `ci.yml` gates on, backend side (no frontend source touched):

| Gate | Result |
|---|---|
| `ruff check . --select F --ignore F403,F405` | All checks passed |
| `manage.py makemigrations --check --dry-run` | No changes detected |
| `manage.py check` | 0 issues |
| `uv run pytest` | **2124 passed**, 1 skipped |
| `pytest apps/session_sharing/tests/` | 34 passed |

New tests: `test_upload_reports_the_owning_account` (private, link, and the idempotent-re-upload path, which builds a separate payload) and `test_arc_create_reports_the_owning_account`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)