### PR TITLE
fix(drive): read `forked_from` tolerantly so one run can't 500 a whole opp

### DIFF
--- a/packages/canopy_agent_runs/canopy_agent_runs/drive/store.py
+++ b/packages/canopy_agent_runs/canopy_agent_runs/drive/store.py
@@ -358,6 +358,30 @@ _CANONICAL_TO_SCHEMA_STATUS: dict[str, str] = {
 }
 
 
+def _coerce_forked_from(value: Any) -> str | None:
+    """Coerce a run_state ``forked_from`` to the source run id.
+
+    The read model declares ``forked_from: str | None``, but Drive carries
+    two shapes in the wild: the bare run-id string this store writes, and a
+    lineage BLOCK (``{run_id, phase, forked_at}``) that ace-web's opp_forker
+    wrote for months on the reasoning that nothing read the field. A dict
+    reaching pydantic raises ValidationError inside ``list_runs`` — which
+    fails the whole opp's listing, not just the one forked run, and so 500s
+    every uncached read of that opp.
+
+    Anything we cannot reduce to an id degrades to ``None``: lineage is
+    informational, and losing it must never cost the caller the run list.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value.strip() or None
+    if isinstance(value, dict):
+        run_id = value.get("run_id")
+        return str(run_id).strip() or None if run_id else None
+    return None
+
+
 def _coerce_dt(value: Any) -> dt.datetime | None:
     """Coerce a YAML scalar to a datetime. PyYAML auto-parses many ISO-8601
     timestamps to ``datetime`` already; strings (incl. trailing ``Z``) are
@@ -762,7 +786,7 @@ class DriveRunStore:
             "current_step": str(
                 state_data.get("current_step") or state_data.get("step") or ""
             ),
-            "forked_from": state_data.get("forked_from"),
+            "forked_from": _coerce_forked_from(state_data.get("forked_from")),
             "session_link": str(state_data.get("session_link") or ""),
             "created_at": _coerce_dt(
                 state_data.get("started_at") or state_data.get("created")

--- a/packages/canopy_agent_runs/tests/test_drive_forked_from_shapes.py
+++ b/packages/canopy_agent_runs/tests/test_drive_forked_from_shapes.py
@@ -14,7 +14,6 @@ tolerantly. Every sibling header field is already coerced (``str(...)``,
 ``_coerce_dt(...)``); ``forked_from`` was the one read raw.
 """
 
-import pytest
 import yaml
 
 from canopy_agent_runs.drive.store import DriveRunStore, SkillMeta

--- a/packages/canopy_agent_runs/tests/test_drive_forked_from_shapes.py
+++ b/packages/canopy_agent_runs/tests/test_drive_forked_from_shapes.py
@@ -1,0 +1,81 @@
+"""``forked_from`` on Drive is not always a bare run-id string.
+
+ace-web's opp_forker wrote it as a dict block
+(``{run_id, phase, forked_at}``) for a long time, on the reasoning that
+the plugin didn't read the field. The framework read model DOES read it
+(``RunSummary.forked_from: str | None``), so those runs raised
+pydantic ValidationError inside ``list_runs`` — which 500s every
+uncached read of the whole opp, not just the forked run.
+
+Measured 2026-08-14: 10 of 51 run_state.yaml under the ACE Drive root
+carry the dict, across 3 opps. The rows live in Google Docs holding live
+run state, so rewriting them in place is riskier than reading them
+tolerantly. Every sibling header field is already coerced (``str(...)``,
+``_coerce_dt(...)``); ``forked_from`` was the one read raw.
+"""
+
+import pytest
+import yaml
+
+from canopy_agent_runs.drive.store import DriveRunStore, SkillMeta
+from canopy_agent_runs.schemas import RunSummary
+from tests.fixtures.fake_drive import FakeDriveClient
+
+AGENT = "goofy-geese"
+RUN_ID = "20260101-1000"
+SOURCE_RUN = "20251231-0900"
+
+REGISTRY = [SkillMeta("idea-to-pdd", "1-design", 1)]
+
+_BASE_STATE = {
+    "mode": "review",
+    "started_at": "2026-01-01T10:00:00Z",
+    "current_step": "idea-to-pdd",
+    "phases": {"1-design": {"status": "complete",
+                            "steps": {"idea-to-pdd": {"status": "done"}}}},
+}
+
+
+def _store(forked_from) -> DriveRunStore:
+    state = dict(_BASE_STATE)
+    if forked_from is not None:
+        state["forked_from"] = forked_from
+    tree = {"agents": {AGENT: {
+        "opp.yaml": "display_name: Goofy Geese Demo\nslug: goofy-geese\n",
+        "runs": {RUN_ID: {"run_state.yaml": yaml.safe_dump(state)}},
+    }}}
+    client = FakeDriveClient.from_tree(tree)
+    return DriveRunStore(client, client.folder_id(f"agents/{AGENT}"),
+                         agent_slug=AGENT, manifest=[], skill_registry=REGISTRY)
+
+
+def _only(summaries) -> RunSummary:
+    assert len(summaries) == 1
+    return summaries[0]
+
+
+def test_string_forked_from_is_preserved():
+    assert _only(_store(SOURCE_RUN).list_runs(AGENT)).forked_from == SOURCE_RUN
+
+
+def test_dict_forked_from_is_reduced_to_the_source_run_id():
+    """The shape that was 500ing prod (ace-web opp_forker's lineage block)."""
+    block = {"run_id": SOURCE_RUN, "phase": "commcare-setup",
+             "forked_at": "2026-07-27T18:50:43Z"}
+    assert _only(_store(block).list_runs(AGENT)).forked_from == SOURCE_RUN
+
+
+def test_absent_forked_from_stays_none():
+    assert _only(_store(None).list_runs(AGENT)).forked_from is None
+
+
+def test_unusable_forked_from_degrades_to_none_rather_than_raising():
+    """A shape we can't read must not take down the whole opp's listing."""
+    assert _only(_store({"phase": "commcare-setup"}).list_runs(AGENT)).forked_from is None
+    assert _only(_store([SOURCE_RUN]).list_runs(AGENT)).forked_from is None
+
+
+def test_get_run_agrees_with_list_runs():
+    block = {"run_id": SOURCE_RUN, "phase": "commcare-setup"}
+    store = _store(block)
+    assert store.get_run(AGENT, RUN_ID).forked_from == SOURCE_RUN


### PR DESCRIPTION
## The bug

`_run_header_fields` passed `forked_from` straight from `run_state.yaml` into the read model, which declares `RunSummary.forked_from: str | None`. It was **the only header field read raw** — every sibling is already coerced (`str(...)`, `_coerce_dt(...)`):

```python
"current_phase": str(state_data.get("current_phase") or ""),
"forked_from": state_data.get("forked_from"),      # ← raw
"created_at": _coerce_dt(state_data.get("started_at") or …),
```

Drive carries two shapes in the wild. This store writes the bare run-id string its own docstring specifies:

> `forked_from` is written as a top-level STRING (the source run id) so the read model's `Run.forked_from: str | None` validates

…but ace-web's `opp_forker` wrote a lineage **block** (`{run_id, phase, forked_at}`) for months, on the reasoning that *"the plugin doesn't read this field but humans will"* — true when written, made false by the framework-reader migration.

## Why it matters more than it looks

A dict raises `ValidationError` inside `list_runs`, and `list_runs` builds the summaries for **every run in the opp**. So one forked run takes down the entire opp listing, and every uncached `load_opp` 500s with it.

In ace-web that surfaced as a dead artifact pane. Its step listing still worked *only* because it was served from a snapshot cache — on expiry the whole workbench for that opp would have followed.

```
canopy_agent_runs/drive/store.py:826  RunSummary(…)
ValidationError: forked_from
  Input should be a valid string [input_value={'run_id': '20260724-1622'…}, input_type=dict]
```

## Why tolerate rather than repair the data

Measured against the ACE Drive root on 2026-08-14: **10 of 51** `run_state.yaml` carry the dict, across 3 opps — 2 of them written that same day. Those rows are Google Docs holding **live run state**, so a repair would mean round-tripping active runs through a `text/plain` Doc export. Reading them tolerantly is materially safer and fixes all 10 without mutating a byte.

Anything that can't be reduced to an id degrades to `None` rather than raising — lineage is informational, and losing it must never cost the caller the run list.

## Testing

New `tests/test_drive_forked_from_shapes.py` covers string / dict / absent / unusable across **both** read paths (`list_runs` and `get_run` — the bug hit both). The dict case reproduced the exact production `ValidationError` before the fix.

`147 passed` on the full package suite.

## Related

Writer side: dimagi-internal/ace-web#709 — now emits the string plus sibling `forked_from_phase` / `forked_at` keys. That stops new bad rows; **this** change repairs the ones already on Drive. ace-web pins `canopy-agent-runs` by tag, so it needs a new tag + repin to pick this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)