### PR TITLE
chore(canopy-agent-runs): 0.1.1 — tolerant forked_from read

### DIFF
--- a/packages/canopy_agent_runs/pyproject.toml
+++ b/packages/canopy_agent_runs/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canopy-agent-runs"
-version = "0.1.0"
+version = "0.1.1"
 description = "Django-free run-lifecycle core: storage-agnostic read model, RunStore Protocol, in-memory + Drive adapters. Pip-installable into canopy-web / ace-web."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Version bump so #612 can be tagged and pinned.

ace-web pins `canopy-agent-runs` by git tag (`canopy-agent-runs-v0.1.0`), so the `forked_from` ValidationError fix that merged in #612 is unreachable from ace-web until a new tag exists. This bumps the package version; the tag `canopy-agent-runs-v0.1.1` follows on the merge commit, and ace-web repins to it.

No code change — #612 carries the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)