### PR TITLE
fix(runner): the activity clock counted bookkeeping as work

### DIFF
--- a/runner/canopy_runner/canopy_runner/transcript.py
+++ b/runner/canopy_runner/canopy_runner/transcript.py
@@ -210,6 +210,25 @@ def read_recent_messages(path: Path, limit: int = 8) -> list[dict]:
     return msgs[-limit:]
 
 
+# Timestamped record kinds that are NOT the agent doing something. Both were
+# measured writing to a live transcript while its session sat parked at
+# "awaiting-input" (spark, 2026-08-15: last `assistant` record 04:22:40, a
+# `pr-link` at 04:46:16 and `queue-operation`s past 04:46:56). Counting them made
+# `newest_record_time` — and so the chat list's "2m ago" and its running-first
+# sort — say a session parked for 27 minutes had just acted.
+#
+#   queue-operation  a background task's notification entering/leaving the queue,
+#                    which happens while the main loop is parked
+#   pr-link          a PR discovered for the worktree, written long after the turn
+#
+# A DENYLIST rather than an allowlist, deliberately: the failure it leaves is
+# cosmetic (an unknown future bookkeeping kind reads as fresh), where an allowlist
+# would drop an unknown future ACTIVITY kind and freeze the clock mid-turn — which
+# reads as "not running" on a runner with no emdash `agent_status` to fall back on.
+# Fail toward alive.
+_NON_TURN_KINDS = frozenset({"queue-operation", "pr-link"})
+
+
 def newest_record_time(path: Path) -> str | None:
     """ISO-8601 UTC of the newest record IN the transcript, or None.
 
@@ -220,10 +239,10 @@ def newest_record_time(path: Path) -> str | None:
     ahead of their newest record). What the transcript SAYS happened is the only
     signal that can't drift that way.
 
-    Counts every record type, not just conversational ones: a tool call or a
-    subagent turn mid-run is the session working, and a run that is mid-tool-loop
-    is exactly when "is this alive?" is being asked. Reads only the last
-    TAIL_BYTES like the tail reader; a partial first line just fails to parse.
+    Counts every record type EXCEPT the bookkeeping ones (`_NON_TURN_KINDS`): a
+    tool call or a subagent turn mid-run is the session working, and a run that is
+    mid-tool-loop is exactly when "is this alive?" is being asked. Reads only the
+    last TAIL_BYTES like the tail reader; a partial first line just fails to parse.
     Never raises — an unreadable/timestamp-less file yields None, meaning "no
     opinion", and the caller keeps whatever it had.
     """
@@ -244,6 +263,8 @@ def newest_record_time(path: Path) -> str | None:
         except json.JSONDecodeError:
             continue
         if not isinstance(payload, dict):
+            continue
+        if payload.get("type") in _NON_TURN_KINDS:
             continue
         ts = _parse_utc(payload.get("timestamp"))
         if ts and (newest is None or ts > newest):

--- a/runner/canopy_runner/tests/test_transcript.py
+++ b/runner/canopy_runner/tests/test_transcript.py
@@ -371,5 +371,32 @@ def test_newest_record_time_takes_the_max_not_the_last_line(tmp_path):
     assert transcript.newest_record_time(f) == "2026-07-25T12:00:00+00:00"
 
 
+def test_newest_record_time_ignores_bookkeeping_records(tmp_path):
+    # The parked-session shape measured on the fleet (spark, 2026-08-15): the agent
+    # stopped at 12:00 and the transcript kept growing with a PR link and background
+    # task-queue churn. Counting those made a 27-minute-parked session read as
+    # "just acted" in the chat list, and float to the top of its running-first sort.
+    f = tmp_path / "s.jsonl"
+    f.write_text("\n".join(json.dumps(x) for x in [
+        {"type": "assistant", "timestamp": "2026-08-15T12:00:00.000Z"},
+        {"type": "pr-link", "timestamp": "2026-08-15T12:24:00.000Z"},
+        {"type": "queue-operation", "timestamp": "2026-08-15T12:27:00.000Z"},
+    ]), "utf-8")
+    assert transcript.newest_record_time(f) == "2026-08-15T12:00:00+00:00"
+
+
+def test_newest_record_time_still_counts_non_conversational_turn_records(tmp_path):
+    # The opposite guard: an `attachment` or `system` row mid-tool-loop IS the
+    # session working, and is exactly what keeps a long tool call from reading as
+    # dead. Only the bookkeeping kinds were meant to be dropped.
+    f = tmp_path / "s.jsonl"
+    f.write_text("\n".join(json.dumps(x) for x in [
+        {"type": "assistant", "timestamp": "2026-08-15T12:00:00.000Z"},
+        {"type": "attachment", "timestamp": "2026-08-15T12:05:00.000Z"},
+        {"type": "system", "timestamp": "2026-08-15T12:06:00.000Z"},
+    ]), "utf-8")
+    assert transcript.newest_record_time(f) == "2026-08-15T12:06:00+00:00"
+
+
 def test_newest_record_time_of_an_unreadable_file_is_none(tmp_path):
     assert transcript.newest_record_time(tmp_path / "missing.jsonl") is None


### PR DESCRIPTION
## What

`newest_record_time` — the clock behind a session's `last_activity_at`, i.e. the "2m ago" the
chat list shows *in place of* the running pill, and the tiebreak in its running-first sort —
counted every timestamped record in the transcript tail. Two of those kinds are not the agent
working, and they fire while the main loop is parked.

Measured on the fleet 2026-08-15 while chasing "does the list show running when a tool call is
in flight":

| session | last real `assistant` record | what the Web said |
|---|---|---|
| `spark` | 04:22:40 (27 min earlier, emdash `agent_status = awaiting-input`) | **"1m ago"** — from a `pr-link` at 04:46:16 and `queue-operation` pairs past 04:46:56 |

`running` itself was correct the whole time: `is_session_running` asks emdash's `agent_status`
first and only falls back to the 120s window. This fixes the other half of the same signal.

## Why a denylist

An unknown future *bookkeeping* kind then reads as fresh — cosmetic. An allowlist would drop an
unknown future *activity* kind and freeze the clock mid-turn, which reads as "not running" on a
runner with no emdash `agent_status` to fall back on. Fail toward alive.

## Verification

`runner/canopy_runner`: 468 passed, including two new cases — one that a parked session's
`pr-link` / `queue-operation` churn does not move the clock, and its opposite, that `attachment`
and `system` rows mid-tool-loop still do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)