### PR TITLE
fix(sessions): an emdash task NAME is not an identity — the project is half the key

### DIFF
--- a/apps/canopy_sessions/migrations/0021_runnerbinding_emdash_project.py
+++ b/apps/canopy_sessions/migrations/0021_runnerbinding_emdash_project.py
@@ -1,0 +1,87 @@
+"""Make the emdash PROJECT half of a binding's key, instead of the name alone.
+
+`RunnerBinding.session_key` is an emdash task NAME, and names are scoped to a
+project — `issues` under `ace` and `issues` under `connect-labs` are two different
+conversations. The report loop's upsert nevertheless keyed on the bare name, and
+`one_binding_per_runner_session_key` enforced that reading, so the two collapsed
+onto one row: the survivor kept whichever project claimed the name FIRST, and (worse)
+the report deduplicated by name before upserting, so a concurrently-open namesake was
+dropped from the report entirely — no row, no error.
+
+Measured on labs 2026-08-27: session `f6f5efc0` reported `project: "ace"` while
+serving a connect-labs transcript, because an `ace` task called `issues` had claimed
+the name on 2026-08-14. Everything downstream already keys on the PAIR — the runner
+resolves a transcript by (project, task), which is why `get_session_streams` ships
+`session.emdash_project` alongside `session_key`. Only the binding didn't.
+
+Three steps, in this order:
+
+  1. add `emdash_project`, blank by default;
+  2. backfill it from `session.emdash_project` (`project`, or the agent's slug for an
+     agent chat) — so that on the first report after deploy every existing row is
+     found by the new exact-match lookup and nothing forks;
+  3. widen the unique constraint to (runner, emdash_project, session_key).
+
+Step 3 can never fail on existing data: adding a column to a unique key only makes it
+more permissive.
+
+Rows already fused before this ran are NOT repaired here, because nothing in the
+database says which project a fused row's history actually belongs to — the label and
+the transcript disagree and only the runner knows which is right. They split on the
+next report instead: the live conversation is recognised as new under its real
+project and gets its own row, and the mislabelled remnant stops being reported and
+retires on the normal staleness clock.
+"""
+from django.db import migrations, models
+
+
+def backfill_emdash_project(apps, schema_editor):
+    """Copy `Session.emdash_project` onto every binding.
+
+    The property cannot be used (historical models carry no methods), so its rule is
+    restated: `project`, or the agent's slug when the session is an agent chat, whose
+    worktree lives under the agent's own repo. A session with neither keeps a blank,
+    which the lookup's legacy branch still recognises.
+    """
+    RunnerBinding = apps.get_model("canopy_sessions", "RunnerBinding")
+
+    qs = RunnerBinding.objects.select_related("session", "session__agent")
+    for binding in qs.iterator():
+        session = binding.session
+        value = session.project or (session.agent.slug if session.agent_id else "")
+        if value:
+            binding.emdash_project = value[:100]
+            binding.save(update_fields=["emdash_project"])
+
+
+def noop(apps, schema_editor):
+    """Reversible by dropping the column, which the schema step below already does.
+    The data pass has nothing to undo: it only fills blanks."""
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("canopy_sessions", "0020_runnerbinding_transcript_id"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="runnerbinding",
+            name="emdash_project",
+            field=models.CharField(blank=True, default="", max_length=100),
+        ),
+        migrations.RunPython(backfill_emdash_project, noop),
+        migrations.RemoveConstraint(
+            model_name="runnerbinding",
+            name="one_binding_per_runner_session_key",
+        ),
+        migrations.AddConstraint(
+            model_name="runnerbinding",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(("runner__isnull", False), models.Q(("session_key", ""), _negated=True)),
+                fields=("runner", "emdash_project", "session_key"),
+                name="one_binding_per_runner_project_session_key",
+            ),
+        ),
+    ]

--- a/apps/canopy_sessions/models.py
+++ b/apps/canopy_sessions/models.py
@@ -200,6 +200,29 @@ class RunnerBinding(models.Model):
     )
     # Engine-agnostic handle the runner uses to resume/inject (was emdash_task).
     session_key = models.CharField(max_length=255, blank=True, default="")
+    # The other half of that handle: the emdash PROJECT the task lives under, i.e.
+    # a cache of `session.emdash_project` (`project`, or the agent's slug for an
+    # agent chat). It is here because `session_key` alone is NOT an identity —
+    # emdash task names are scoped to a project, and the same name in two projects
+    # is two different conversations.
+    #
+    # Every OTHER part of the system already keys on the pair: the runner resolves a
+    # transcript by (project, task), which is why `get_session_streams` ships
+    # `session.emdash_project` alongside `session_key`. Only the report loop's own
+    # upsert keyed on the bare name, so the two collapsed into one row — and because
+    # the report deduplicates before it upserts, the loser was not merely mislabelled
+    # but dropped from the report entirely, invisible on the web with no error
+    # anywhere. Measured on labs 2026-08-27: a session titled "issues" reported
+    # `project: "ace"` while serving a connect-labs transcript (its live tail was
+    # `gh issue close 1195 -R dimagi-internal/connect-labs`), because an `issues`
+    # task under `ace` on 2026-08-14 had claimed the name first.
+    #
+    # Denormalised rather than joined because it is half of a UNIQUE constraint, and
+    # a constraint cannot span tables. Backfilled from `session.emdash_project` in
+    # 0021; written by the report loop and by `record_session` thereafter. Blank is a
+    # real value (a runner that sends no project), and blanks match each other, so a
+    # deployment that never reports a project degrades to exactly today's behaviour.
+    emdash_project = models.CharField(max_length=100, blank=True, default="")
     # Durable thread identity (absorbed from SessionLink). For a chat session this
     # is str(session.id); for a phone/agent/project thread it's the topic key
     # (e.g. "phone:jj:canopy-web" or "<target>:<turn_id>"). The reuse lookup keys on
@@ -213,10 +236,13 @@ class RunnerBinding(models.Model):
     # WHICH transcript this session's Message rows were derived from — the Claude
     # session uuid (the .jsonl stem), reported by the runner on every ship.
     #
-    # `session_key` is the emdash task NAME, and names are reused: close a task
-    # called "bednet" and start another, and this binding is re-pointed at the new
-    # conversation while the old one's rows stay attached. That alone renders one
-    # session as another; worse, `turn_index` is a PER-FILE ordinal, so the
+    # `session_key` is the emdash task NAME, and names are reused. `emdash_project`
+    # above settles the CROSS-project half of that (two live `issues` tasks in two
+    # repos are now two rows); this field owns the half no key can settle — reuse
+    # within one project OVER TIME. Close a task called "bednet" and start another
+    # under the same name in the same repo and this binding is legitimately
+    # re-pointed at the new conversation, while the old one's rows stay attached.
+    # That alone renders one session as another; worse, `turn_index` is a PER-FILE ordinal, so the
     # first_index/last_index markers computed off the old file are meaningless
     # against the new one. Measured on prod 2026-08-14 (issue #615): a 593-record
     # predecessor left last_index=37,696 against a live 384-record transcript whose
@@ -308,10 +334,14 @@ class RunnerBinding(models.Model):
     class Meta:
         ordering = ["-last_interacted_at"]
         constraints = [
+            # (runner, emdash_project, session_key) — NOT (runner, session_key).
+            # See `emdash_project` above: the bare name is not an identity, and a
+            # constraint on it forces two projects' same-named tasks to share one
+            # binding. Widening the key can never break an existing row.
             models.UniqueConstraint(
-                fields=["runner", "session_key"],
+                fields=["runner", "emdash_project", "session_key"],
                 condition=models.Q(runner__isnull=False) & ~models.Q(session_key=""),
-                name="one_binding_per_runner_session_key",
+                name="one_binding_per_runner_project_session_key",
             ),
         ]
 

--- a/apps/harness/services.py
+++ b/apps/harness/services.py
@@ -1352,6 +1352,11 @@ def record_session(
         binding.runner = runner
         binding.host = runner.host
         binding.session_key = emdash_task_id
+        # The other half of the runner-side key (see RunnerBinding.emdash_project).
+        # Mirrors what `Session.emdash_project` derives, from the arguments this
+        # path already has: a project thread carries its repo, an agent thread its
+        # agent's slug — which is the repo emdash actually runs it under.
+        binding.emdash_project = project or (agent.slug if agent else "")
         # Name the row after the emdash task the human actually sees.
         # _thread_session titles a BRAND-NEW session with the raw thread_key,
         # which for an agent turn is an opaque hash (a real one leaked into the
@@ -1407,6 +1412,21 @@ def _title_is_derived(session, thread_key: str) -> bool:
     return title == " ".join(first.split())[:TITLE_MAX]
 
 
+def _reported_project(s) -> str:
+    """The emdash PROJECT of a reported session, normalised to a string.
+
+    getattr rather than attribute access for the same reason `agent_status` and
+    `question` use it below: lightweight session objects also reach this service,
+    and half of an identity must never be the reason a liveness report 500s.
+
+    This is the value `Session.emdash_project` answers with on the way back out
+    (`get_session_streams` ships it next to `session_key`), so a laptop-reported
+    agent chat lines up: emdash runs it under the agent's own repo, which is the
+    same string `emdash_project` derives from `agent.slug`.
+    """
+    return getattr(s, "project", "") or ""
+
+
 def replace_reported_sessions(
     runner: Runner, workspace, sessions: list, archived: list[str] | None = None
 ) -> int:
@@ -1451,14 +1471,27 @@ def replace_reported_sessions(
     # duplicates before upserting; the runner sends newest-first, so the first
     # occurrence is the live session and an older namesake is stale and correctly
     # dropped (observed 2026-07-20 with two "mobile" tasks).
+    #
+    # Keyed on (PROJECT, name), not the bare name. A name is only reused-and-stale
+    # within ONE project; the same name in two projects is two live conversations,
+    # and collapsing those dropped the second from the report ENTIRELY — no row, no
+    # error, invisible on the web. That is the more expensive half of the collision
+    # this key fixes, because a mislabelled session is at least visible.
     deduped, seen = [], set()
     for s in sessions:
-        if s.emdash_task in seen:
+        ident = (_reported_project(s), s.emdash_task)
+        if ident in seen:
             continue
-        seen.add(s.emdash_task)
+        seen.add(ident)
         deduped.append(s)
 
     now_keys = {s.emdash_task for s in deduped}
+    # The bindings this report actually touched. Identity by ROW, not by name: the
+    # reconciliation below (un-archive, stale menus, unsatisfied closes) has to say
+    # "this exact session was in the report", and `session_key__in=now_keys` cannot
+    # — it would revive a project's archived namesake because a DIFFERENT project's
+    # task of the same name is alive.
+    touched_ids: list = []
     # (session_id, menu|None) for every session whose dialog appeared or went
     # away in THIS report — pushed after commit so an open chat updates without
     # a reload. Only the edges: the report repeats every ~10s and republishing
@@ -1490,20 +1523,35 @@ def replace_reported_sessions(
             # un-heartbeated runners would fuse). `runner=runner` still covers a
             # host="" binding this runner currently owns, so that case is unaffected.
             host_match = Q(runner__isnull=True) & Q(host=runner.host) & ~Q(host="")
-            binding = (
+            project = _reported_project(s)
+            by_key = (
                 RunnerBinding.objects.select_for_update()
                 .filter(session_key=s.emdash_task)
                 .filter(Q(runner=runner) | host_match)
-                .first()
             )
+            # The project is HALF THE KEY, not a detail carried alongside it (see
+            # RunnerBinding.emdash_project). Matching on the name alone fused two
+            # repos' same-named tasks into one row.
+            #
+            # The second lookup is the legacy branch, and it is what makes this
+            # deploy a no-op for every row that already exists: a binding written
+            # before 0021 backfilled the column — or by a runner that reports no
+            # project at all — carries a blank, and must still be recognised and
+            # then FILLED, exactly as `host` and `thread_key` are below. It cannot
+            # re-open the hole it closes: a blank is adopted once and is no longer
+            # blank, and a binding carrying a DIFFERENT project is never matched.
+            binding = by_key.filter(emdash_project=project).first()
+            if binding is None and project:
+                binding = by_key.filter(emdash_project="").first()
             if binding is None:
                 session = Session.objects.create(
                     workspace=workspace,
                     origin=Session.ORIGIN_RUNNER,
-                    project=s.project or "",
+                    project=project,
                     title=s.emdash_task,
                 )
                 binding = RunnerBinding(session=session, session_key=s.emdash_task)
+                binding.emdash_project = project
                 binding.thread_key = f"emdash:{s.emdash_task}"
                 binding.host = runner.host
             else:
@@ -1543,6 +1591,30 @@ def replace_reported_sessions(
                     binding.thread_key = f"emdash:{s.emdash_task}"
                 if not binding.host:
                     binding.host = runner.host
+                # Fill the legacy blank matched above, so the row is keyed properly
+                # from here on. Same fill-if-empty shape, and same reason.
+                if not binding.emdash_project:
+                    binding.emdash_project = project
+                # And repair the LABEL on the session itself. `project` was only
+                # ever written at creation, so a row that got the wrong one — from
+                # the name-only fusion this change removes, or from a blank adopted
+                # just above — displayed it forever with nothing to correct it.
+                # Guarded on `agent`: an agent chat identifies by its agent and
+                # carries a deliberately blank `project` (the model's own
+                # chat_session_not_agent_and_project constraint forbids both), so
+                # writing one here would violate it.
+                #
+                # Cosmetic, so isolated like the retitle above: a label must never
+                # cost liveness.
+                try:
+                    sess = binding.session
+                    if project and sess.agent_id is None and sess.project != project:
+                        with transaction.atomic():
+                            sess.project = project
+                            sess.save(update_fields=["project"])
+                except Exception:  # noqa: BLE001 — a label must never cost liveness
+                    logger.warning("could not repair project on session %s to %r",
+                                   binding.session_id, project, exc_info=True)
             binding.runner = runner
             binding.status = s.status or ""
             # The engine's own liveness flag, written through EVERY report including
@@ -1572,19 +1644,26 @@ def replace_reported_sessions(
             if was_asking != binding.pending_question:
                 menu_changes.append((binding.session_id, binding.pending_question))
             binding.save()
+            touched_ids.append(binding.pk)
 
     # Un-archive anything re-reported as open. The DERIVED staleness half of
     # `state=active` recomputes on every read, but this WRITTEN half does not heal
     # itself — without this, a task you reopened in emdash stays archived forever.
-    if now_keys:
+    if touched_ids:
         Session.objects.filter(
-            runner_binding__runner=runner,
-            runner_binding__session_key__in=now_keys,
+            runner_binding__id__in=touched_ids,
             status=Session.ARCHIVED,
         ).update(status=Session.ACTIVE)
 
     # Apply the closing signal. `now_keys` wins over `archived`: emdash task names are
     # not unique, so an open task must never be retired by an archived namesake.
+    #
+    # Still keyed on the NAME, unlike everything above, because that is all the wire
+    # carries — `ReportSessionsIn.archived` is a list of strings with no project. So
+    # the name-level guard stays: an archived `issues` under one repo cannot retire a
+    # live `issues` under another, at the cost of not retiring it either. Erring
+    # towards leaving a row open is the safe direction (staleness retires it on its
+    # own clock); erring the other way deletes a live session from the web.
     closed = [k for k in (archived or []) if k and k not in now_keys]
     if closed:
         Session.objects.filter(
@@ -1610,11 +1689,11 @@ def replace_reported_sessions(
     # from this wholesale report means. Clearing it here (rather than on a runner
     # ack) keeps one source of truth: the report already decides what is open.
     RunnerBinding.objects.filter(runner=runner, close_requested=True).exclude(
-        session_key__in=now_keys).update(close_requested=False)
+        id__in=touched_ids).update(close_requested=False)
 
     stale_menus = RunnerBinding.objects.filter(runner=runner).exclude(
         pending_question__isnull=True,
-    ).exclude(session_key__in=now_keys)
+    ).exclude(id__in=touched_ids)
     for binding in stale_menus:
         menu_changes.append((binding.session_id, None))
     stale_menus.update(pending_question=None)

--- a/tests/test_report_bindings.py
+++ b/tests/test_report_bindings.py
@@ -17,9 +17,9 @@ from apps.workspaces.models import Workspace
 pytestmark = pytest.mark.django_db
 
 
-def _reported(task, msgs):
+def _reported(task, msgs, project="canopy-web"):
     return SimpleNamespace(
-        emdash_task=task, project="canopy-web", status="running",
+        emdash_task=task, project=project, status="running",
         last_interacted_at=None, recent_messages=msgs,
     )
 
@@ -158,3 +158,161 @@ def test_list_visible_sessions_maps_to_wire_shape():
     assert r.emdash_task == "feat-x"
     assert r.recent_messages == [{"role": "assistant", "text": "hi"}]
     assert r.runner_name == "laptop"
+
+
+# --- the project is half the key -------------------------------------------
+#
+# An emdash task name is scoped to a project, so `issues` under `ace` and `issues`
+# under `connect-labs` are two conversations. Keying the binding on the bare name
+# fused them; see RunnerBinding.emdash_project.
+
+
+def _ws_runner():
+    jj = _user()
+    ws = Workspace.objects.create(slug="w1", display_name="W1", created_by=jj)
+    runner = Runner.objects.create(
+        name="laptop", workspace=ws, location=Runner.LOCAL, host="jj@air"
+    )
+    return ws, runner
+
+
+def test_same_name_in_two_projects_is_two_sessions():
+    """The expensive half: the report DEDUPLICATES before it upserts, so a
+    concurrently-open namesake in another repo was not merely mislabelled — it was
+    dropped from the report entirely, with no row and no error."""
+    ws, runner = _ws_runner()
+
+    replace_reported_sessions(runner, ws, [
+        _reported("issues", [{"role": "user", "text": "ace"}], project="ace"),
+        _reported("issues", [{"role": "user", "text": "labs"}], project="connect-labs"),
+    ])
+
+    bindings = {b.emdash_project: b for b in RunnerBinding.objects.all()}
+    assert set(bindings) == {"ace", "connect-labs"}
+    assert bindings["ace"].session_id != bindings["connect-labs"].session_id
+    assert bindings["ace"].session.project == "ace"
+    assert bindings["connect-labs"].session.project == "connect-labs"
+    assert bindings["connect-labs"].tail == [{"role": "user", "text": "labs"}]
+
+
+def test_a_name_reused_in_another_project_does_not_inherit_the_first_session():
+    """Labs 2026-08-27: an `ace` task called `issues` claimed the name on 08-14; a
+    connect-labs task of the same name three weeks later was served under it, so the
+    session reported `project: "ace"` while running `gh ... -R .../connect-labs`."""
+    ws, runner = _ws_runner()
+
+    replace_reported_sessions(runner, ws, [_reported("issues", [], project="ace")])
+    ace_session = RunnerBinding.objects.get(emdash_project="ace").session_id
+
+    replace_reported_sessions(runner, ws, [])  # the ace task is closed and deleted
+    replace_reported_sessions(runner, ws, [_reported("issues", [], project="connect-labs")])
+
+    labs = RunnerBinding.objects.get(emdash_project="connect-labs")
+    assert labs.session_id != ace_session
+    assert labs.session.project == "connect-labs"
+    assert Session.objects.get(pk=ace_session).project == "ace", "the old row is not relabelled"
+
+
+def test_a_legacy_binding_with_no_project_is_adopted_and_filled():
+    """Rows written before the column existed carry a blank. They must still be
+    recognised on the first report after deploy — a miss would fork a duplicate
+    session for every live conversation at once — and then filled, so the hole
+    closes behind them."""
+    ws, runner = _ws_runner()
+    replace_reported_sessions(runner, ws, [_reported("feat-x", [], project="canopy-web")])
+    RunnerBinding.objects.update(emdash_project="")
+    Session.objects.update(project="")
+    before = RunnerBinding.objects.get().pk
+
+    replace_reported_sessions(runner, ws, [_reported("feat-x", [], project="canopy-web")])
+
+    binding = RunnerBinding.objects.get()
+    assert binding.pk == before, "adopted, not forked"
+    assert binding.emdash_project == "canopy-web"
+    assert binding.session.project == "canopy-web", "and the stale label is repaired"
+
+
+def test_an_agent_chat_keeps_its_blank_project():
+    """`Session.project` is blank for an agent chat by constraint (you chat WITH an
+    agent or IN a project, never both). The label repair must not violate that even
+    though emdash runs the task under the agent's own repo."""
+    from apps.agents.models import Agent
+
+    ws, runner = _ws_runner()
+    agent = Agent.objects.create(slug="hal", name="Hal", workspace=ws)
+    session = Session.objects.create(
+        workspace=ws, agent=agent, origin=Session.ORIGIN_RUNNER, title="chat"
+    )
+    RunnerBinding.objects.create(
+        session=session, runner=runner, host=runner.host,
+        session_key="chat", emdash_project="hal",
+    )
+
+    replace_reported_sessions(runner, ws, [_reported("chat", [], project="hal")])
+
+    session.refresh_from_db()
+    assert session.project == ""
+    assert session.agent_id == agent.id
+    assert RunnerBinding.objects.count() == 1
+
+
+def test_reporting_one_project_does_not_revive_anothers_archived_namesake():
+    """The un-archive step keyed on `session_key__in=now_keys`, which a namesake in
+    a different project satisfies."""
+    ws, runner = _ws_runner()
+    replace_reported_sessions(runner, ws, [_reported("issues", [], project="ace")])
+    ace = RunnerBinding.objects.get(emdash_project="ace").session
+    Session.objects.filter(pk=ace.pk).update(status=Session.ARCHIVED)
+
+    replace_reported_sessions(runner, ws, [_reported("issues", [], project="connect-labs")])
+
+    ace.refresh_from_db()
+    assert ace.status == Session.ARCHIVED
+
+
+
+def test_the_0021_backfill_copies_the_project_off_the_session():
+    """The backfill is what makes the deploy a no-op: without it every live binding
+    carries a blank on the first report, the exact-match lookup misses, and every
+    conversation on the box forks a duplicate session at once.
+
+    Driven through the real models (the migration module is imported by path — its
+    name starts with a digit, so it is not importable as an identifier). The pass
+    reads only fields a historical model also has.
+    """
+    import importlib.util
+    from pathlib import Path
+
+    from apps.agents.models import Agent
+
+    import apps.canopy_sessions as pkg
+
+    path = Path(pkg.__file__).parent / "migrations" / "0021_runnerbinding_emdash_project.py"
+    spec = importlib.util.spec_from_file_location("m0021", path)
+    m0021 = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m0021)
+
+    ws, runner = _ws_runner()
+    agent = Agent.objects.create(slug="hal", name="Hal", workspace=ws)
+    repo_session = Session.objects.create(
+        workspace=ws, project="connect-labs", origin=Session.ORIGIN_RUNNER, title="issues"
+    )
+    agent_session = Session.objects.create(
+        workspace=ws, agent=agent, origin=Session.ORIGIN_RUNNER, title="chat"
+    )
+    bare_session = Session.objects.create(workspace=ws, origin=Session.ORIGIN_WEB, title="web")
+    for session, key in ((repo_session, "issues"), (agent_session, "chat"), (bare_session, "web")):
+        RunnerBinding.objects.create(
+            session=session, runner=runner, host=runner.host, session_key=key
+        )
+
+    class _Apps:
+        def get_model(self, app_label, model_name):
+            return {"RunnerBinding": RunnerBinding}[model_name]
+
+    m0021.backfill_emdash_project(_Apps(), None)
+
+    by_key = {b.session_key: b.emdash_project for b in RunnerBinding.objects.all()}
+    assert by_key["issues"] == "connect-labs"
+    assert by_key["chat"] == "hal", "an agent chat's worktree lives under the agent's own repo"
+    assert by_key["web"] == "", "neither agent nor project — the legacy branch still finds it"


### PR DESCRIPTION
## The bug, as reported

> the "issues" session looks like its under ace on my canopy-web but under connect-labs on my emdash

emdash was right. The session lives in
`~/emdash/worktrees/connect-labs/emdash/issues-xrpza`, branched from
`dimagi-internal/connect-labs`, and its live tail on prod was
`gh issue close 1195 -R dimagi-internal/connect-labs`. canopy-web served it as
`project: "ace"` anyway.

## Root cause

`RunnerBinding.session_key` is an emdash task **name**, and names are scoped to a
project — `issues` under `ace` and `issues` under `connect-labs` are two different
conversations. The report loop's upsert nevertheless keyed on the bare name:

```python
binding = (RunnerBinding.objects.select_for_update()
    .filter(session_key=s.emdash_task)      # <- name only; s.project is on the wire, unused
    .filter(Q(runner=runner) | host_match)
    .first())
```

…and `one_binding_per_runner_session_key` enforced that reading, so the two
collapsed onto one row. `project` was only ever written on the create branch, so
whichever project claimed the name first kept the label forever.

Session `f6f5efc0` was created 2026-08-14 for an `ace` task called `issues`. That
task is gone from emdash; a new `issues` under `connect-labs` was created
2026-08-27 02:44, matched the name, and inherited the row. All 299 of its
messages are now the connect-labs conversation — #615's `transcript_id` check
correctly dropped and re-derived them — under an `ace` nameplate.

**The label is the visible half.** The expensive half is the dedup that runs
*before* the upsert:

```python
for s in sessions:
    if s.emdash_task in seen: continue    # <- name only
```

Two concurrently-open namesakes in different repos meant the second was dropped
from the report **entirely** — no row, no error, nothing on the web to notice.

Everything downstream already keys on the pair: the runner resolves a transcript
by `(project, task)`, which is exactly why `get_session_streams` ships
`session.emdash_project` next to `session_key`. Only the binding's own upsert
didn't.

## The fix

- **`RunnerBinding.emdash_project`** — a cache of `session.emdash_project`
  (`project`, or the agent's slug for an agent chat). Denormalised rather than
  joined because it is half of a UNIQUE constraint, and a constraint cannot span
  tables. The key widens to `(runner, emdash_project, session_key)`; widening a
  unique key can never break an existing row.
- **The report loop dedupes and looks up on `(project, name)`.** A binding
  carrying a **blank** project is still adopted and then filled — that legacy
  branch is what makes this deploy a no-op for every row that already exists,
  and it cannot re-open the hole it closes (a blank is adopted once; a binding
  carrying a *different* project is never matched).
- **`Session.project` is repaired on an existing binding**, not written only at
  creation. Guarded on `agent`: an agent chat carries a deliberately blank
  project by the model's own `chat_session_not_agent_and_project` constraint.
- **Reconciliation keys on the row ids the report touched**, not
  `session_key__in=now_keys`. Reporting one project's `issues` was reviving
  another project's *archived* namesake, and was protecting its stale menu from
  being cleared.
- **`0021`** adds the column, backfills it from `session.emdash_project`, and
  swaps the constraint — in that order, so the first report after deploy finds
  every existing row by exact match.

### Deliberately not changed

`archived` stays name-keyed. It is a bare `list[str]` on the wire with no
project, so the existing "an open namesake protects its archived twin" guard
stays too — erring towards leaving a row open (staleness retires it on its own
clock) rather than retiring a live one.

### Rows already fused are not repaired

Nothing in the database says which project a fused row's history belongs to —
the label and the transcript disagree and only the runner knows which is right.
They split on the next report instead: the live conversation is recognised as
new under its real project and gets its own row, and the mislabelled remnant
stops being reported and retires on the staleness clock. `f6f5efc0` is the one
known instance.

### Follow-up worth having

The durable key is emdash's task **UUID**, not `(project, name)` — that would
close the sequential-reuse case too, which `transcript_id` currently patches
after the fact. It needs a wire change on both the runner and the server, so
it's out of scope here.

Fixes the other half of #615, which fixed name reuse for message *derivation*
and left session *identity* keyed on the name.

## Verification

- `pytest` — **2171 passed, 1 skipped**, exit 0
- `ruff check . --select F --ignore F403,F405` — All checks passed
- `manage.py makemigrations --check --dry-run` — No changes detected
- `manage.py check` — no issues
- 6 new tests in `tests/test_report_bindings.py`: two projects' same-named tasks
  are two sessions; a name reused in another project does not inherit the first
  session; a legacy blank binding is adopted and filled and its label repaired;
  an agent chat keeps its blank project; reporting one project does not revive
  another's archived namesake; and the 0021 backfill copies the project off the
  session (repo / agent / neither).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UCvRiYiDBy9j2gJHvgUXfn
