### PR TITLE
perf(agent-runs): list_runs took 1+2N sequential Drive calls; make it 2

### DIFF
--- a/packages/canopy_agent_runs/canopy_agent_runs/drive/store.py
+++ b/packages/canopy_agent_runs/canopy_agent_runs/drive/store.py
@@ -824,18 +824,81 @@ class DriveRunStore:
         )
         return run.with_derived_status()
 
+    def _state_files_by_parent(self, run_folders: list[DriveFile]) -> dict[str, DriveFile]:
+        """{run_folder_id: run_state.yaml DriveFile} for every run that has one.
+
+        Uses the client's `find_in_folders` when offered — one query instead of
+        one list_folder per run. Falls back to the per-folder listing so a
+        client without it behaves exactly as before.
+        """
+        finder = getattr(self.client, "find_in_folders", None)
+        if callable(finder):
+            found = finder([f.id for f in run_folders], "run_state.yaml")
+            return {parent: file for parent, file in found.items() if file is not None}
+        out: dict[str, DriveFile] = {}
+        for child in run_folders:
+            state_file = _find_state_file(self.client.list_folder(child.id))
+            if state_file is not None:
+                out[child.id] = state_file
+        return out
+
+    def _read_states_bulk(self, files: list[DriveFile]) -> dict[str, dict]:
+        """{file_id: parsed run_state} — concurrently when the client can."""
+        bulk = getattr(self.client, "get_contents", None)
+        if callable(bulk) and files:
+            raw = bulk([(f.id, f.mime_type) for f in files])
+        else:
+            raw = {}
+            for f in files:
+                try:
+                    raw[f.id] = _read_text(self.client, f)
+                except Exception:  # noqa: BLE001 - one bad file must not sink the list
+                    log.warning("could not read run_state for %s", f.id)
+        out: dict[str, dict] = {}
+        for file_id, text in raw.items():
+            if text is None:
+                continue
+            try:
+                data = yaml.safe_load(text) or {}
+            except yaml.YAMLError:
+                log.warning("run_state.yaml is not valid YAML (%s)", file_id)
+                data = {}
+            out[file_id] = data if isinstance(data, dict) else {}
+        return out
+
     def list_runs(self, agent: str) -> list[RunSummary]:
         runs_id = self._runs_folder_id()
         if runs_id is None:
             return []
+        run_folders = [c for c in self.client.list_folder(runs_id) if _is_folder(c)]
+        if not run_folders:
+            return []
+
+        # ── Why this is not a plain loop ────────────────────────────────────
+        # The obvious shape — for each run: list its folder, then download
+        # run_state.yaml — costs 1 + 2N Drive round-trips, SEQUENTIALLY. On a
+        # real opp (12 runs) that measured ~25 calls and 30-50 s of wall clock,
+        # behind a 30 s content cache that a 50 s load can never populate. So
+        # every page view paid full price.
+        #
+        # Two optional fast paths, both negotiated off the client so any
+        # implementation that lacks them still works:
+        #   find_in_folders  — one query for run_state.yaml across ALL run
+        #                      folders, replacing N list_folder calls.
+        #   get_contents     — the N downloads concurrently. Kept on the client
+        #                      because thread-safety is the client's business:
+        #                      googleapiclient's service object is not
+        #                      thread-safe and only the implementation knows
+        #                      how to hand each worker its own transport.
+        state_by_parent = self._state_files_by_parent(run_folders)
+        contents = self._read_states_bulk(list(state_by_parent.values()))
+
         summaries: list[RunSummary] = []
-        for child in self.client.list_folder(runs_id):
-            if not _is_folder(child):
-                continue
-            run_children = self.client.list_folder(child.id)
-            state_data, state_file = self._read_state(run_children)
+        for child in run_folders:
+            state_file = state_by_parent.get(child.id)
             if state_file is None:
                 continue  # half-initialized run folder
+            state_data = contents.get(state_file.id, {})
             # Cheap status: synthesize steps from run_state alone (no tree walk).
             snaps = _build_steps(
                 self.skill_registry,

--- a/packages/canopy_agent_runs/tests/test_drive_list_runs_fastpath.py
+++ b/packages/canopy_agent_runs/tests/test_drive_list_runs_fastpath.py
@@ -1,0 +1,146 @@
+"""`list_runs` fast paths: one query for the state files, concurrent reads.
+
+The shape this replaces cost 1 + 2N Drive round-trips SEQUENTIALLY — for each
+run, list its folder, then download run_state.yaml. Measured on a real opp
+(12 runs): ~25 calls, 30-50s of wall clock, behind a 30s content cache that a
+50s load can never populate, so every page view paid full price.
+
+Both fast paths are negotiated off the client (`find_in_folders`,
+`get_contents`), so a client offering neither still works. These tests pin
+three things: the fast path is USED when offered, the fallback still works
+when it isn't, and both produce the SAME read model.
+"""
+import pytest
+
+from canopy_agent_runs.drive.store import DriveRunStore, SkillMeta
+from tests.fixtures.fake_drive import FakeDriveClient
+
+AGENT = "goofy-geese"
+REGISTRY = [SkillMeta("idea-to-pdd", "1-design", 1)]
+
+STATE = """
+opportunity: goofy-geese
+mode: default
+phases:
+  1-design:
+    status: done
+    steps:
+      idea-to-pdd:
+        status: done
+"""
+
+
+def _tree(run_ids: list[str]) -> dict:
+    return {
+        "goofy-geese": {
+            "runs": {rid: {"run_state.yaml": STATE} for rid in run_ids},
+        }
+    }
+
+
+class _CountingClient:
+    """Wraps FakeDriveClient and counts calls, so a test can assert the fast
+    path actually eliminated the per-run work rather than merely producing the
+    same answer more slowly."""
+
+    def __init__(self, inner, *, offer_find=False, offer_bulk=False):
+        self._inner = inner
+        self.list_folder_calls = 0
+        self.get_content_calls = 0
+        self.find_calls = 0
+        self.bulk_calls = 0
+        if offer_find:
+            self.find_in_folders = self._find_in_folders
+        if offer_bulk:
+            self.get_contents = self._get_contents
+
+    def __getattr__(self, name):
+        return getattr(self._inner, name)
+
+    def list_folder(self, folder_id):
+        self.list_folder_calls += 1
+        return self._inner.list_folder(folder_id)
+
+    def get_content(self, file_id, mime_type):
+        self.get_content_calls += 1
+        return self._inner.get_content(file_id, mime_type)
+
+    def _find_in_folders(self, parent_ids, name):
+        self.find_calls += 1
+        out = {}
+        for pid in parent_ids:
+            match = next(
+                (f for f in self._inner.list_folder(pid) if f.name == name), None
+            )
+            out[pid] = match
+        return out
+
+    def _get_contents(self, specs):
+        self.bulk_calls += 1
+        return {
+            fid: self._inner.get_content(fid, mime).content for fid, mime in specs
+        }
+
+
+def _store(client, root):
+    return DriveRunStore(client=client, root_folder_id=root, skill_registry=REGISTRY)
+
+
+RUN_IDS = ["20260101-0100", "20260102-0200", "20260103-0300"]
+
+
+@pytest.fixture
+def seeded():
+    inner = FakeDriveClient.from_tree(_tree(RUN_IDS))
+    return inner, inner.folder_id("goofy-geese")
+
+
+def test_fallback_client_still_works(seeded):
+    inner, root = seeded
+    c = _CountingClient(inner)
+    runs = _store(c, root).list_runs(AGENT)
+    assert sorted(r.id for r in runs) == RUN_IDS
+    # 1 root + 1 runs/ + one per run
+    assert c.list_folder_calls >= 3
+    assert c.get_content_calls == 3
+
+
+def test_fast_paths_are_used_when_offered(seeded):
+    inner, root = seeded
+    c = _CountingClient(inner, offer_find=True, offer_bulk=True)
+    runs = _store(c, root).list_runs(AGENT)
+    assert sorted(r.id for r in runs) == RUN_IDS
+    assert c.find_calls == 1, "the per-run folder listing should collapse to one query"
+    assert c.bulk_calls == 1, "the per-run downloads should collapse to one bulk call"
+    assert c.get_content_calls == 0, "no sequential per-run download should remain"
+
+
+def test_both_paths_produce_the_same_read_model(seeded):
+    inner, root = seeded
+    slow = _store(_CountingClient(inner), root).list_runs(AGENT)
+    fast = _store(
+        _CountingClient(inner, offer_find=True, offer_bulk=True), root
+    ).list_runs(AGENT)
+    assert [r.model_dump() for r in slow] == [r.model_dump() for r in fast]
+
+
+def test_a_half_initialised_run_folder_is_skipped_on_both_paths():
+    tree = _tree(RUN_IDS)
+    tree["goofy-geese"]["runs"]["20260104-0400"] = {}  # no run_state.yaml
+    inner = FakeDriveClient.from_tree(tree)
+    root = inner.folder_id("goofy-geese")
+    for c in (
+        _CountingClient(inner),
+        _CountingClient(inner, offer_find=True, offer_bulk=True),
+    ):
+        ids = [r.id for r in _store(c, root).list_runs(AGENT)]
+        assert "20260104-0400" not in ids
+        assert len(ids) == 3
+
+
+def test_an_opp_with_no_runs_folder_returns_empty():
+    inner = FakeDriveClient.from_tree({"empty-opp": {}})
+    root = inner.folder_id("empty-opp")
+    c = _CountingClient(inner, offer_find=True, offer_bulk=True)
+    assert _store(c, root).list_runs(AGENT) == []
+    assert c.find_calls == 0, "no runs means no query at all"

--- a/packages/canopy_agent_runs/uv.lock
+++ b/packages/canopy_agent_runs/uv.lock
@@ -17,7 +17,7 @@ wheels = [
 
 [[package]]
 name = "canopy-agent-runs"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Measured on a real 12-run opp: **~25 Drive round-trips, sequentially, 30–50s of wall clock.** The content cache in front of it has a 30s TTL, so a 50s cold load can never populate it usefully — every page view paid full price. The ace-web Runs tab that reads this took **49.7s**.

The shape was: for each run, `list_folder` to find `run_state.yaml`, then download it. Both halves are per-run; both are avoidable.

## Two optional fast paths

Negotiated off the client with `getattr()`, so any `DriveClient` lacking them behaves exactly as before:

- **`find_in_folders(parent_ids, name)`** — one query for `run_state.yaml` across *all* run folders, replacing N `list_folder` calls.
- **`get_contents(specs)`** — the N downloads together.

`get_contents` is deliberately on the **client**, not here: thread-safety is the implementation's business. googleapiclient's service object isn't thread-safe, and only the client knows how to hand each worker its own transport. Keeping concurrency behind the Protocol leaves this module synchronous and testable with a plain fake.

Also hardened the fallback: one unreadable `run_state` now costs that row, not the whole listing.

## Tests

Three things that matter, all pinned with a call-counting fake client:

1. the fast path is actually **used** when offered — 1 find + 1 bulk, **zero** per-run calls;
2. the **fallback** still works when it isn't;
3. both produce an **identical** read model.

Plus: a half-initialised run folder is skipped on both paths, and an opp with no runs issues no query at all.

Package suite: **152 passed**.

## Follow-up

ace-web implements both methods and bumps its `canopy-agent-runs` pin; that's where the wall-clock win gets measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018b93KcsWmTziiq1Sk3kUPK