### PR TITLE
chore(agent-runs): 0.1.2 — batched + concurrent list_runs

### DIFF
--- a/packages/canopy_agent_runs/pyproject.toml
+++ b/packages/canopy_agent_runs/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canopy-agent-runs"
-version = "0.1.1"
+version = "0.1.2"
 description = "Django-free run-lifecycle core: storage-agnostic read model, RunStore Protocol, in-memory + Drive adapters. Pip-installable into canopy-web / ace-web."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Version bump so ace-web can pin the #625 perf work by tag (`canopy-agent-runs-v0.1.2`).

#625 replaced `list_runs`'s 1+2N sequential Drive round-trips with two optional client-negotiated fast paths. ace-web implements both; without a new tag it cannot pin them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018b93KcsWmTziiq1Sk3kUPK