### PR TITLE
fix(sessions): a turn that hands off to a background subagent is not a finished turn

### DIFF
--- a/apps/canopy_sessions/migrations/0022_runnerbinding_agent_status_stale.py
+++ b/apps/canopy_sessions/migrations/0022_runnerbinding_agent_status_stale.py
@@ -1,0 +1,18 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('canopy_sessions', '0021_runnerbinding_emdash_project'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='runnerbinding',
+            name='agent_status_stale',
+            # Defaults False, which is exactly the pre-existing behaviour: trust the
+            # engine flag outright. Only a runner new enough to dissent sets it.
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/apps/canopy_sessions/models.py
+++ b/apps/canopy_sessions/models.py
@@ -316,6 +316,12 @@ class RunnerBinding(models.Model):
     # drifted schema), NOT "idle": `is_session_running` falls back to activity
     # recency for a blank, and only trusts a non-blank value.
     agent_status = models.CharField(max_length=40, blank=True, default="")
+    # The runner's dissent from `agent_status`: it says "not working", but the session
+    # is still writing. emdash's flag has no way back to "working" without a human
+    # prompt, so a turn that ended only to hand off to a background subagent leaves it
+    # pinned at "completed" for the rest of the session — see
+    # `is_session_running` and canopy_runner.sessions.annotate_engine_staleness.
+    agent_status_stale = models.BooleanField(default=False)
     last_interacted_at = models.DateTimeField(null=True, blank=True)
     live_seen_at = models.DateTimeField(null=True, blank=True)
     # Stamped ONLY by the report loop (apps/harness/services.py::

--- a/apps/canopy_sessions/services.py
+++ b/apps/canopy_sessions/services.py
@@ -116,8 +116,14 @@ def is_session_running(binding) -> bool:
 
     Asks the ENGINE first: emdash sets `agent_status` when it starts and stops driving
     a conversation, so a reported value is an observation of the session's actual state
-    and is trusted outright — including its "not working" answer, which retires the
-    badge the moment a turn ends instead of two minutes later.
+    rather than an inference from writes. Its "not working" answer counts too — that is
+    what retires the badge the moment a turn ends instead of two minutes later — EXCEPT
+    where the runner has explicitly dissented (`agent_status_stale`). emdash reaches
+    "working" only via Claude Code's UserPromptSubmit hook, so nothing short of a human
+    typing can ever move the flag back: a turn that ended only to hand off to a
+    background subagent leaves it pinned at "completed" while the session churns on.
+    The dissent is the runner reporting that the session kept WRITING after the flag
+    said it had stopped, which no genuinely finished turn does.
 
     Only when the runner cannot answer (blank: an older runner, a cloud runner with no
     emdash, a drifted schema) does this fall back to RUNNING_WINDOW, whose false
@@ -135,7 +141,14 @@ def is_session_running(binding) -> bool:
     if binding.runner.live_status != Runner.ONLINE:
         return False
     if binding.agent_status:
-        return binding.agent_status in WORKING_STATUSES
+        if binding.agent_status in WORKING_STATUSES:
+            return True
+        # The flag says stopped and the runner disagrees, having watched the session
+        # keep writing AFTER it said so. Believe the writes: emdash's flag has no path
+        # back to "working" that does not go through a human typing, so a turn that
+        # ended only to hand off to a background subagent stays "completed" for the
+        # rest of the session. See RunnerBinding.agent_status_stale.
+        return bool(binding.agent_status_stale)
     ts = binding.last_interacted_at
     return bool(ts and (timezone.now() - ts) <= RUNNING_WINDOW)
 

--- a/apps/harness/schemas.py
+++ b/apps/harness/schemas.py
@@ -269,6 +269,13 @@ class ReportedSessionIn(Schema):
     # nothing, and the server falls back to its activity-recency heuristic for them
     # (services.is_session_running). Only a runner that actually knows overrides it.
     agent_status: str = ""
+    # The runner's dissent from its OWN `agent_status` above: emdash says this session
+    # is not working, but it is still writing to its transcript (or to a subagent's).
+    # Set only after the runner has watched writes land AFTER the flag went non-working
+    # — see canopy_runner.sessions.annotate_engine_staleness for why that, and not
+    # recency, is the discriminator. Defaulted False so an older runner, which cannot
+    # dissent, keeps the pre-existing "trust the flag outright" behaviour exactly.
+    agent_status_stale: bool = False
     last_interacted_at: dt.datetime | None = None
     recent_messages: list = []  # Phase B populates this; ignored/empty in Phase A
     # The dialog this session is blocked on, read from its transcript, or None

--- a/apps/harness/services.py
+++ b/apps/harness/services.py
@@ -1624,6 +1624,10 @@ def replace_reported_sessions(
             # reason too: lightweight session objects also reach this service, and a
             # display flag must never be why a liveness report fails.
             binding.agent_status = getattr(s, "agent_status", "") or ""
+            # Written through on EVERY report including False, for the same reason
+            # as the flag it qualifies: it is a fresh observation, so "it has gone
+            # quiet" has to be able to clear "it is still writing".
+            binding.agent_status_stale = bool(getattr(s, "agent_status_stale", False))
             binding.last_interacted_at = _aware(s.last_interacted_at)
             binding.live_seen_at = timezone.now()
             # The one write site. See RunnerBinding.reported_at — `close` branches

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -8494,6 +8494,11 @@ export interface components {
              * @default
              */
             readonly agent_status: string;
+            /**
+             * Agent Status Stale
+             * @default false
+             */
+            readonly agent_status_stale: boolean;
             /** Last Interacted At */
             readonly last_interacted_at?: string | null;
             /**

--- a/runner/canopy_runner/canopy_runner/sessions.py
+++ b/runner/canopy_runner/canopy_runner/sessions.py
@@ -91,6 +91,92 @@ def session_changed(cfg: Config, sessions: list[dict]) -> bool:
     return changed
 
 
+# Per-task engine-flag watch: {emdash_task: (flag_value, baseline_mtime | None)}.
+# `None` for the baseline means "settling" — see `annotate_engine_staleness`.
+_ENGINE_FLAG: dict[str, "tuple[str, float | None]"] = {}
+
+# How long after its last write a session that has ALREADY proved its engine flag
+# wrong keeps claiming to be running.
+#
+# This is a de-latch, not a liveness heuristic: without it, a session that woke up
+# from a background hand-off, worked, and then genuinely finished would stay marked
+# running forever, because the second `Stop` writes the SAME flag value ("completed")
+# that is already there and so never re-settles the baseline.
+#
+# Deliberately longer than the server's own 120s fallback window: the only sessions
+# that reach this line have been observed writing after their flag said they were
+# done, so the expensive mistake here is calling a working session finished — the very
+# bug this exists to fix — not leaving a badge up three minutes too long on one that
+# has stopped. A subagent appends to its transcript on every tool call, so real
+# delegated work clears this bar continuously.
+STILL_WRITING_SECONDS = 180
+
+
+def annotate_engine_staleness(
+    cfg: Config, sessions: list[dict], *, now_fn=time.time
+) -> None:
+    """Mark, in place, the sessions whose emdash flag says "not working" while the
+    session is demonstrably STILL WRITING.
+
+    emdash derives `agent_status` from three Claude Code hooks: UserPromptSubmit ->
+    working, Stop -> completed, Notification -> awaiting-input. Claude Code fires
+    `Stop` whenever the MAIN LOOP's turn ends — and a turn that ends only to hand off
+    to a background subagent ends exactly the same way. What wakes the loop back up is
+    a task-notification, not a UserPromptSubmit, so no `start` hook ever fires again:
+    from the first background dispatch onward the flag is pinned at "completed" for
+    the rest of the session. The server trusts a non-blank flag outright (it is
+    normally the BETTER signal — see is_session_running), so a churning session reads
+    as finished.
+
+    Measured 2026-08-27 on `hh4`: background Agent dispatched 12:59:34, wake-ups at
+    13:06 and 13:22, transcript still growing at 13:23:33 — emdash saying "completed"
+    and the API saying running=False the whole time. The control case is fine and must
+    stay fine: through a 200-second SILENT foreground tool call the flag correctly held
+    "working", so this only ever looks at flags that already claim the session stopped.
+
+    The discriminator is not recency — a real turn end is recent too — but writes that
+    land AFTER the flag went non-working. The baseline is snapshotted one tick LATER
+    than the flag change, so the turn's own closing write is inside the baseline rather
+    than mistaken for new work.
+
+    One-directional by construction: this can only ever say "still running", never
+    "not running". A blank flag is left alone (the server has its own fallback for
+    those) and a `working` flag needs no help.
+    """
+    home = Path.home()
+    claude_home = home / ".claude" / "projects"
+    live: set[str] = set()
+    for s in sessions[: cfg.session_tail_count]:
+        task = s.get("emdash_task")
+        if not task:
+            continue
+        live.add(task)
+        status = str(s.get("agent_status") or "").strip()
+        if not status or status == emdash.WORKING:
+            _ENGINE_FLAG.pop(task, None)  # nothing to second-guess
+            continue
+        try:
+            path = transcript.resolve_transcript(
+                s.get("project") or "", task, home=home, claude_home=claude_home
+            )
+        except Exception:  # noqa: BLE001 — a fragile half must not cost us the report
+            path = None
+        wrote_at = transcript.activity_mtime(path)
+        watched = _ENGINE_FLAG.get(task)
+        if watched is None or watched[0] != status:
+            _ENGINE_FLAG[task] = (status, None)  # new flag value: settle one tick
+            continue
+        baseline = watched[1]
+        if baseline is None:
+            _ENGINE_FLAG[task] = (status, wrote_at)  # settled — this is the mark
+            continue
+        if wrote_at > baseline and now_fn() - wrote_at <= STILL_WRITING_SECONDS:
+            s["agent_status_stale"] = True
+    for task in list(_ENGINE_FLAG):  # forget sessions that are gone
+        if task not in live:
+            _ENGINE_FLAG.pop(task, None)
+
+
 def reported_projects(cfg: Config) -> list[str] | None:
     """The repos this box can drive, for the heartbeat to report — or None if we
     could not tell this tick.
@@ -149,6 +235,12 @@ def maybe_report_sessions(cfg: Config, client: Client, now_fn=time.monotonic) ->
     except Exception:  # noqa: BLE001
         logger.debug("session list failed (non-fatal)", exc_info=True)
         return
+    # Every tick, not just reporting ones: the baseline this keeps is a
+    # tick-over-tick comparison, so skipping ticks would coarsen it.
+    try:
+        annotate_engine_staleness(cfg, sessions)
+    except Exception:  # noqa: BLE001
+        logger.debug("engine-staleness annotation failed (non-fatal)", exc_info=True)
     global _REPORT_NOW
     changed = session_changed(cfg, sessions) or bool(_PENDING_CLOSED) or _REPORT_NOW
     _REPORT_NOW = False

--- a/runner/canopy_runner/canopy_runner/transcript.py
+++ b/runner/canopy_runner/canopy_runner/transcript.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import datetime
 import json
 import logging
+import os
 import re
 from pathlib import Path
 
@@ -270,6 +271,48 @@ def newest_record_time(path: Path) -> str | None:
         if ts and (newest is None or ts > newest):
             newest = ts
     return newest.isoformat() if newest else None
+
+
+SUBAGENT_DIRNAME = "subagents"
+
+
+def activity_mtime(path: Path | None) -> float:
+    """Newest mtime across a session's transcript AND its subagents' transcripts.
+
+    A subagent does not write to the session transcript. Its turns go to
+    `<transcript-stem>/subagents/agent-*.jsonl`, so the parent file can sit
+    completely untouched for the whole of a long delegated run — a 22-minute hole
+    in one measured session. Anything that asks "is this session still doing
+    something" from the parent file alone is blind for exactly that window, which
+    is the window we care about.
+
+    mtime rather than record timestamps, because every comparison this feeds is
+    against an EARLIER READING OF ITSELF on this same box — never against another
+    clock — so the cheap stat is both sufficient and immune to a transcript whose
+    newest record is unparseable. 0.0 means "nothing to see" (no path, unreadable
+    dir) and sorts as oldest, so an unreadable session simply never claims to be
+    writing.
+    """
+    if path is None:
+        return 0.0
+    newest = 0.0
+    try:
+        newest = path.stat().st_mtime
+    except OSError:
+        pass
+    try:
+        entries = os.scandir(path.with_suffix("") / SUBAGENT_DIRNAME)
+    except OSError:
+        return newest  # no subagents dir is the common case, not a problem
+    with entries:
+        for entry in entries:
+            if not entry.name.endswith(".jsonl"):
+                continue
+            try:
+                newest = max(newest, entry.stat().st_mtime)
+            except OSError:
+                continue
+    return newest
 
 
 def session_tail(

--- a/runner/canopy_runner/tests/test_engine_flag_staleness.py
+++ b/runner/canopy_runner/tests/test_engine_flag_staleness.py
@@ -1,0 +1,162 @@
+"""The runner's dissent from emdash's `agent_status`.
+
+emdash reaches "working" only through Claude Code's UserPromptSubmit hook, and fires
+`Stop` whenever the MAIN LOOP's turn ends — including a turn that ends only to hand off
+to a background subagent. Nothing fires `start` again (the wake-up is a
+task-notification), so the flag stays "completed" for the rest of the session while the
+session churns on. These pin the discriminator that catches that: writes landing AFTER
+the flag said the session stopped.
+"""
+import os
+
+from canopy_runner import sessions as sessions_mod
+from canopy_runner import transcript
+
+
+class _Cfg:
+    session_tail_count = 30
+
+
+def _touch(path, when):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("x")
+    os.utime(path, (when, when))
+
+
+def _run(sessions, cfg=None, now=1_000_000.0):
+    sessions_mod.annotate_engine_staleness(cfg or _Cfg(), sessions, now_fn=lambda: now)
+
+
+def _session(status, task="t1"):
+    return {"emdash_task": task, "project": "p", "agent_status": status}
+
+
+def _resolve_to(monkeypatch, path):
+    monkeypatch.setattr(transcript, "resolve_transcript", lambda *a, **k: path)
+
+
+def test_subagent_writes_after_stop_override_a_completed_flag(tmp_path, monkeypatch):
+    """The reported bug: a background hand-off pins the flag at "completed" while a
+    subagent works. The subagent writes to its OWN transcript, never the parent's."""
+    sessions_mod._ENGINE_FLAG.clear()
+    parent = tmp_path / "sess.jsonl"
+    _touch(parent, 999_000.0)
+    _resolve_to(monkeypatch, parent)
+
+    s = _session("completed")
+    _run([s])                      # tick 1: new flag value -> settle
+    assert "agent_status_stale" not in s
+    _run([s])                      # tick 2: baseline snapshotted
+    assert "agent_status_stale" not in s
+
+    # A subagent appends to <stem>/subagents/agent-*.jsonl. The parent file is untouched.
+    _touch(tmp_path / "sess" / "subagents" / "agent-abc.jsonl", 999_990.0)
+    s2 = _session("completed")
+    _run([s2])
+    assert s2["agent_status_stale"] is True
+
+
+def test_a_genuinely_finished_turn_is_never_marked_stale(tmp_path, monkeypatch):
+    """The property the engine flag was adopted FOR: the badge retires the moment a
+    turn ends. A real end writes nothing more, so it never clears the bar."""
+    sessions_mod._ENGINE_FLAG.clear()
+    parent = tmp_path / "sess.jsonl"
+    _touch(parent, 999_999.0)      # the turn's own closing write
+    _resolve_to(monkeypatch, parent)
+    for _ in range(5):
+        s = _session("completed")
+        _run([s])
+        assert "agent_status_stale" not in s
+
+
+def test_the_turns_own_closing_write_is_inside_the_baseline(tmp_path, monkeypatch):
+    """Why the baseline is snapshotted a tick LATER than the flag change: Stop fires
+    before the last record is flushed, so a same-instant baseline would read that
+    flush as new work and call every finished session running."""
+    sessions_mod._ENGINE_FLAG.clear()
+    parent = tmp_path / "sess.jsonl"
+    _touch(parent, 999_000.0)
+    _resolve_to(monkeypatch, parent)
+    s = _session("completed")
+    _run([s])                                  # flag change observed; settling
+    _touch(parent, 999_001.0)                  # the closing flush lands now
+    _run([s])                                  # baseline includes it
+    s2 = _session("completed")
+    _run([s2])
+    assert "agent_status_stale" not in s2
+
+
+def test_dissent_de_latches_once_the_writing_stops(tmp_path, monkeypatch):
+    """A second Stop writes the SAME flag value, so the baseline never re-settles.
+    Without the quiet window a session that woke up, worked and then genuinely
+    finished would claim to be running forever."""
+    sessions_mod._ENGINE_FLAG.clear()
+    parent = tmp_path / "sess.jsonl"
+    _touch(parent, 999_000.0)
+    _resolve_to(monkeypatch, parent)
+    s = _session("completed")
+    _run([s]); _run([s])                       # settle + baseline
+    _touch(parent, 999_500.0)                  # woke back up and worked
+    s2 = _session("completed")
+    _run([s2], now=999_600.0)
+    assert s2["agent_status_stale"] is True
+    s3 = _session("completed")
+    _run([s3], now=999_500.0 + sessions_mod.STILL_WRITING_SECONDS + 1)
+    assert "agent_status_stale" not in s3
+
+
+def test_a_working_flag_is_left_alone_and_forgets_its_watch(tmp_path, monkeypatch):
+    """One-directional: this can only ever say "still running". A `working` flag needs
+    no help, and clearing the watch means the next Stop settles a fresh baseline."""
+    sessions_mod._ENGINE_FLAG.clear()
+    parent = tmp_path / "sess.jsonl"
+    _touch(parent, 999_000.0)
+    _resolve_to(monkeypatch, parent)
+    s = _session("completed")
+    _run([s]); _run([s])
+    _run([_session("working")])
+    assert sessions_mod._ENGINE_FLAG == {}
+
+
+def test_a_blank_flag_is_left_to_the_servers_own_fallback(tmp_path, monkeypatch):
+    """"" means the runner could not answer — a cloud runner, a drifted schema. The
+    server falls back to activity recency for those; dissenting would be a guess."""
+    sessions_mod._ENGINE_FLAG.clear()
+    parent = tmp_path / "sess.jsonl"
+    _touch(parent, 999_000.0)
+    _resolve_to(monkeypatch, parent)
+    s = _session("")
+    _run([s]); _touch(parent, 999_900.0); _run([s])
+    assert "agent_status_stale" not in s
+    assert sessions_mod._ENGINE_FLAG == {}
+
+
+def test_an_unresolvable_transcript_never_claims_to_be_writing(tmp_path, monkeypatch):
+    sessions_mod._ENGINE_FLAG.clear()
+    _resolve_to(monkeypatch, None)
+    s = _session("awaiting-input")
+    for _ in range(3):
+        _run([s])
+    assert "agent_status_stale" not in s
+
+
+def test_a_vanished_session_drops_its_watch(tmp_path, monkeypatch):
+    sessions_mod._ENGINE_FLAG.clear()
+    parent = tmp_path / "sess.jsonl"
+    _touch(parent, 999_000.0)
+    _resolve_to(monkeypatch, parent)
+    _run([_session("completed")])
+    assert "t1" in sessions_mod._ENGINE_FLAG
+    _run([])
+    assert sessions_mod._ENGINE_FLAG == {}
+
+
+def test_activity_mtime_takes_the_newest_of_parent_and_subagents(tmp_path):
+    parent = tmp_path / "sess.jsonl"
+    _touch(parent, 500.0)
+    assert transcript.activity_mtime(parent) == 500.0
+    _touch(tmp_path / "sess" / "subagents" / "agent-1.jsonl", 900.0)
+    _touch(tmp_path / "sess" / "subagents" / "agent-2.jsonl", 700.0)
+    assert transcript.activity_mtime(parent) == 900.0
+    assert transcript.activity_mtime(None) == 0.0
+    assert transcript.activity_mtime(tmp_path / "nope.jsonl") == 0.0

--- a/tests/test_session_running_engine_flag.py
+++ b/tests/test_session_running_engine_flag.py
@@ -1,0 +1,101 @@
+"""`running` when emdash's engine flag has gone stale.
+
+emdash derives `agent_status` from three Claude Code hooks, and only UserPromptSubmit
+ever reaches "working". Claude Code fires `Stop` whenever the MAIN LOOP's turn ends —
+including a turn that ends only to hand off to a background subagent — and the wake-up
+afterwards is a task-notification, not a prompt. So from the first background dispatch
+onward the flag is pinned at "completed" while the session churns on, and a server that
+trusts a non-blank flag outright calls a working session finished.
+
+Measured 2026-08-27 on `hh4`: background Agent dispatched 12:59:34, wake-ups at 13:06
+and 13:22, transcript still growing at 13:23:33, API saying running=False throughout.
+"""
+import datetime as dt
+
+import pytest
+from django.contrib.auth.models import User
+from django.test import Client
+from django.utils import timezone
+
+from apps.canopy_sessions.models import RunnerBinding, Session
+from apps.canopy_sessions.services import is_session_running
+from apps.harness.models import Runner
+from apps.workspaces.models import Workspace, WorkspaceMembership
+
+pytestmark = pytest.mark.django_db
+
+
+def _ctx():
+    user = User.objects.create_user("jj", "jj@dimagi.com", "pw")
+    ws = Workspace.objects.create(slug="w1", display_name="W1", created_by=user)
+    WorkspaceMembership.objects.create(user=user, workspace=ws, role=WorkspaceMembership.OWNER)
+    c = Client(); c.force_login(user)
+    return user, ws, c
+
+
+def _binding(user, ws, *, agent_status, stale=False, interacted=None, key="echo-1"):
+    session = Session.objects.create(workspace=ws, origin=Session.ORIGIN_RUNNER, title="disc")
+    runner = Runner.objects.create(name="laptop", workspace=ws, location=Runner.LOCAL,
+                                   status=Runner.ONLINE, last_heartbeat_at=timezone.now(),
+                                   paired_by=user)
+    return session, RunnerBinding.objects.create(
+        session=session, runner=runner, session_key=key,
+        agent_status=agent_status, agent_status_stale=stale,
+        last_interacted_at=interacted or timezone.now(),
+        live_seen_at=timezone.now(),
+    )
+
+
+def test_a_stale_completed_flag_still_reads_as_running():
+    """The reported bug. The flag says the turn ended; the runner has watched the
+    session keep writing since it said so, which no finished turn does."""
+    user, ws, _ = _ctx()
+    # Deliberately also past RUNNING_WINDOW: the recency fallback would say False too,
+    # so nothing but the dissent can carry this.
+    stale_ts = timezone.now() - dt.timedelta(seconds=600)
+    _, binding = _binding(user, ws, agent_status="completed", stale=True, interacted=stale_ts)
+    assert is_session_running(binding) is True
+
+
+def test_a_finished_turn_still_retires_immediately():
+    """The property the engine flag was adopted for must survive: no dissent, so a
+    "completed" flag retires the badge at once even though the write was seconds ago."""
+    user, ws, _ = _ctx()
+    _, binding = _binding(user, ws, agent_status="completed", stale=False)
+    assert is_session_running(binding) is False
+
+
+def test_dissent_cannot_resurrect_an_offline_runner():
+    """A box that is gone is not running whatever it last reported — the offline check
+    comes first and the dissent must not reach past it."""
+    user, ws, _ = _ctx()
+    _, binding = _binding(user, ws, agent_status="completed", stale=True)
+    # live_status is derived from the heartbeat, not the stored column.
+    binding.runner.last_heartbeat_at = timezone.now() - dt.timedelta(hours=2)
+    binding.runner.save(update_fields=["last_heartbeat_at"])
+    assert binding.runner.live_status != Runner.ONLINE
+    assert is_session_running(binding) is False
+
+
+def test_a_working_flag_does_not_need_the_dissent():
+    user, ws, _ = _ctx()
+    _, binding = _binding(user, ws, agent_status="working", stale=False)
+    assert is_session_running(binding) is True
+
+
+def test_a_blank_flag_still_falls_back_to_recency():
+    """An older runner cannot dissent, so blank+False must behave exactly as before."""
+    user, ws, _ = _ctx()
+    _, fresh = _binding(user, ws, agent_status="", stale=False)
+    assert is_session_running(fresh) is True
+    _, old = _binding(user, ws, agent_status="", stale=False, key="echo-2",
+                      interacted=timezone.now() - dt.timedelta(seconds=150))
+    assert is_session_running(old) is False
+
+
+def test_the_api_row_reflects_the_dissent():
+    user, ws, c = _ctx()
+    session, _ = _binding(user, ws, agent_status="completed", stale=True,
+                          interacted=timezone.now() - dt.timedelta(seconds=600))
+    row = next(r for r in c.get("/api/canopy-sessions/").json() if r["id"] == str(session.id))
+    assert row["running"] is True


### PR DESCRIPTION
## The bug

The `running` badge goes dark on sessions that are actively working, and it happens the moment a session hands work to a **background subagent**.

emdash derives `conversations.agent_status` from exactly three Claude Code hooks it writes into each worktree's `.claude/settings.local.json`:

| hook | → agent_status |
|---|---|
| `UserPromptSubmit` | `working` |
| `Stop` | `completed` |
| `Notification` | `awaiting-input` |

Only `UserPromptSubmit` ever reaches `working`. And Claude Code fires `Stop` whenever the **main loop's turn ends** — a turn that ends only to hand off to a background subagent ends exactly the same way (`background_requested` is a normal, non-error stop reason). What wakes the loop back up is a `<task-notification>`, not a prompt, so **`start` never fires again**. Subagent completion fires `SubagentStop`, which emdash does not register.

Net effect: from the first background dispatch onward, the flag is pinned at `completed` for the rest of the session. `is_session_running` trusts a non-blank flag outright — deliberately; it is normally the better signal — so a churning session reads as finished.

### Measured, live

`hh4`, 2026-08-27:

- background `Agent` dispatched at **12:59:34**
- task-notification wake-ups at **13:06:56** and **13:22:16**
- transcript still growing at **13:23:33**
- emdash saying `completed`, `GET /api/canopy-sessions/` saying `running=False` — the whole time

### The control, which has to stay working

Through a **200-second completely silent foreground tool call**, the flag correctly held `working` for all 41 samples and the transcript never grew once. That is exactly the false negative the old 120s recency heuristic had, and the reason the engine flag was adopted in the first place. So this PR does **not** go back to inferring liveness from writes.

## The fix

The runner now watches only the flags that claim a session **stopped**, and reports `agent_status_stale` when the session keeps writing after it said so. Three things make that a fact rather than another heuristic:

- **The discriminator is not recency** — a real turn end is recent too — but writes landing *after* the flag went non-working.
- **The baseline is snapshotted one tick later** than the observed flag change, so the turn's own closing flush lands inside the baseline instead of being read as new work.
- **Activity includes `<transcript-stem>/subagents/agent-*.jsonl`.** A subagent does not write to the session transcript at all, so the parent file can sit untouched for the whole delegated run — a 22-minute hole in one measured session. Anything reading the parent alone is blind for exactly the window that matters.

`is_session_running` gains one branch: a non-working flag still means not running, **unless** the runner has dissented.

### Why this is safe

- **One-directional by construction.** It can say "still running", never "not running".
- **The instant retire survives.** An ordinary turn end never becomes stale, because a finished turn writes nothing more — so the badge still goes dark the moment the turn ends, not two minutes later.
- **A `working` flag needs no help**; a **blank** one (older runner, cloud runner with no emdash, drifted schema) is left to the existing recency fallback.
- **Defaults False**, so a runner too old to dissent behaves exactly as before.
- **It de-latches.** A second `Stop` writes the same `completed` that is already there and so never re-settles the baseline; the quiet window (`STILL_WRITING_SECONDS`) is what stops a session that woke up, worked, and genuinely finished from claiming to run forever.
- **An offline runner is still never running** — that check comes first and the dissent cannot reach past it.

## Tests

- `runner/canopy_runner/tests/test_engine_flag_staleness.py` — 9 tests: subagent writes override a pinned `completed`; a genuinely finished turn is never marked stale; the closing flush is inside the baseline; de-latch; `working`/blank left alone; unresolvable transcript never claims to write; vanished session drops its watch; `activity_mtime` takes the newest of parent and subagents.
- `tests/test_session_running_engine_flag.py` — 6 tests over `is_session_running` and the API row, including that the dissent cannot resurrect an offline runner and that blank+False still falls back to recency.

Full suites green locally: **1553 passed** (server), **495 passed** (runner). `makemigrations --check` clean; `ruff --select F` clean; `generated.ts` regenerated.

## Not in this PR

`uv.lock` still records `canopy-agent-runs 0.1.1` while `packages/canopy_agent_runs` is at `0.1.2` (drift from #626). `uv run` regenerates the one-line fix on every invocation; left out to keep this diff about one thing.

## Upstream

The real root cause is emdash's: the flag has no path back to `working` that does not go through a human typing. Worth reporting — `SubagentStop` is unregistered and `Stop` cannot distinguish "the turn is over" from "the turn handed off". This PR makes canopy-web correct regardless of whether emdash changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxxPZogVQXtW218kVDjMyP
