### PR TITLE
perf(agent-runs): read opp.yaml once per store, not once per run

### DIFF
--- a/packages/canopy_agent_runs/canopy_agent_runs/drive/store.py
+++ b/packages/canopy_agent_runs/canopy_agent_runs/drive/store.py
@@ -651,6 +651,10 @@ def _build_fork_run_state(
 # ---------------------------------------------------------------------------
 # DriveRunStore
 # ---------------------------------------------------------------------------
+# Distinguishes "not looked yet" from "looked, and there is no name".
+_UNSET = object()
+
+
 class DriveRunStore:
     """A `RunStore` reading ACE-shaped Drive run-folders into the read model.
 
@@ -685,6 +689,8 @@ class DriveRunStore:
         self.skill_registry = list(
             skill_registry if skill_registry is not None else DEFAULT_SKILL_REGISTRY
         )
+        # Per-instance memo for opp.yaml's display_name; see _opp_display_name.
+        self._display_name: object = _UNSET
 
     # -- internal resolution --
     def _registered_skills(self) -> set[str]:
@@ -718,6 +724,26 @@ class DriveRunStore:
         return data, state_file
 
     def _opp_display_name(self) -> str | None:
+        """The opp's display name, read at most ONCE per store instance.
+
+        This is called from `_run_header_fields`, which runs once PER RUN — so
+        without memoisation a 12-run opp did 12 identical `list_folder` +
+        `get_content` round-trips for the same `opp.yaml`. Profiled against a
+        real opp: 12 redundant reads costing 8.7s of a 19s call, which is the
+        single largest item and dwarfs the per-run state reads the batching
+        work targeted. `opp.yaml` cannot change mid-listing, so one read is
+        the correct number.
+
+        `_UNSET` rather than None as the sentinel: None is a legitimate answer
+        (no opp.yaml, or no display_name in it) and caching it must stop the
+        re-read, otherwise the opps that lack the file keep paying full price.
+        """
+        if self._display_name is not _UNSET:
+            return self._display_name
+        self._display_name = self._read_opp_display_name()
+        return self._display_name
+
+    def _read_opp_display_name(self) -> str | None:
         children = self.client.list_folder(self.root_folder_id)
         opp_yaml = _find_child(children, "opp.yaml")
         if opp_yaml is None:

--- a/packages/canopy_agent_runs/pyproject.toml
+++ b/packages/canopy_agent_runs/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canopy-agent-runs"
-version = "0.1.2"
+version = "0.1.3"
 description = "Django-free run-lifecycle core: storage-agnostic read model, RunStore Protocol, in-memory + Drive adapters. Pip-installable into canopy-web / ace-web."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/canopy_agent_runs/tests/test_drive_display_name_once.py
+++ b/packages/canopy_agent_runs/tests/test_drive_display_name_once.py
@@ -10,7 +10,6 @@ The batching made `list_runs` issue 2 Drive calls instead of 25 and the
 endpoint got no faster, because this loop was still there. That is the lesson
 worth keeping: optimise what you MEASURED, not what you assumed.
 """
-import pytest
 
 from canopy_agent_runs.drive.store import DriveRunStore, SkillMeta
 from tests.fixtures.fake_drive import FakeDriveClient

--- a/packages/canopy_agent_runs/tests/test_drive_display_name_once.py
+++ b/packages/canopy_agent_runs/tests/test_drive_display_name_once.py
@@ -1,0 +1,75 @@
+"""`opp.yaml` is read once per store, not once per run.
+
+`_run_header_fields` runs once PER RUN and called `_opp_display_name()`, which
+did a `list_folder` + `get_content` of the same `opp.yaml` every time.
+Profiled against a real 12-run opp: 12 redundant reads costing 8.7s of a 19s
+call — the single largest item, dwarfing the per-run state reads that the
+batching work had targeted.
+
+The batching made `list_runs` issue 2 Drive calls instead of 25 and the
+endpoint got no faster, because this loop was still there. That is the lesson
+worth keeping: optimise what you MEASURED, not what you assumed.
+"""
+import pytest
+
+from canopy_agent_runs.drive.store import DriveRunStore, SkillMeta
+from tests.fixtures.fake_drive import FakeDriveClient
+
+AGENT = "goofy-geese"
+REGISTRY = [SkillMeta("idea-to-pdd", "1-design", 1)]
+STATE = "phases:\n  1-design:\n    status: done\n"
+
+
+class _Counting:
+    def __init__(self, inner):
+        self._inner = inner
+        self.content_reads = 0
+
+    def __getattr__(self, name):
+        return getattr(self._inner, name)
+
+    def get_content(self, file_id, mime_type):
+        self.content_reads += 1
+        return self._inner.get_content(file_id, mime_type)
+
+
+def _tree(runs, *, with_opp_yaml=True):
+    node = {"runs": {r: {"run_state.yaml": STATE} for r in runs}}
+    if with_opp_yaml:
+        node["opp.yaml"] = "display_name: Goofy Geese\n"
+    return {"goofy-geese": node}
+
+
+def _store(client, root):
+    return DriveRunStore(client=client, root_folder_id=root, skill_registry=REGISTRY)
+
+
+def test_opp_yaml_is_read_once_regardless_of_run_count():
+    runs = [f"2026010{i}-0{i}00" for i in range(1, 6)]
+    inner = FakeDriveClient.from_tree(_tree(runs))
+    c = _Counting(inner)
+    store = _store(c, inner.folder_id("goofy-geese"))
+    store.list_runs(AGENT)
+    # 5 run_state bodies + exactly ONE opp.yaml, not one per run.
+    assert c.content_reads == len(runs) + 1
+
+
+def test_the_name_still_reaches_every_run():
+    runs = ["20260101-0100", "20260102-0200"]
+    inner = FakeDriveClient.from_tree(_tree(runs))
+    out = _store(inner, inner.folder_id("goofy-geese")).list_runs(AGENT)
+    assert {r.label for r in out} == {"Goofy Geese"}
+
+
+def test_a_missing_opp_yaml_is_cached_too():
+    """None is a legitimate answer. If it weren't cached, the opps that lack
+    the file would keep paying full price — the exact case the memo exists
+    for."""
+    runs = ["20260101-0100", "20260102-0200", "20260103-0300"]
+    inner = FakeDriveClient.from_tree(_tree(runs, with_opp_yaml=False))
+    c = _Counting(inner)
+    store = _store(c, inner.folder_id("goofy-geese"))
+    out = store.list_runs(AGENT)
+    assert c.content_reads == len(runs), "no opp.yaml means no body reads for it"
+    # Falls back to the agent slug rather than inventing a name.
+    assert {r.label for r in out} == {AGENT}

--- a/packages/canopy_agent_runs/uv.lock
+++ b/packages/canopy_agent_runs/uv.lock
@@ -17,7 +17,7 @@ wheels = [
 
 [[package]]
 name = "canopy-agent-runs"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/packages/canopy_agent_runs/uv.lock
+++ b/packages/canopy_agent_runs/uv.lock
@@ -17,7 +17,7 @@ wheels = [
 
 [[package]]
 name = "canopy-agent-runs"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Batching `list_runs`' Drive calls from ~25 to 2 produced **no measurable improvement**. So I profiled the real path against a real opp instead of guessing a third time:

```
list_opp_runs: 12 runs in 19.52s
  get_content      12 calls   8.73s   <-- the actual bill
  list_folder      17 calls   5.66s
  get_contents      2 calls   3.77s   (the new fast path, working)
  find_in_folders   2 calls   0.90s   (the new fast path, working)
```

Twelve content reads for twelve runs. `_run_header_fields` runs once **per run** and calls `_opp_display_name()`, which did a `list_folder` **plus** a `get_content` of the *same* `opp.yaml` every time.

The batching removed the per-run *state* reads and left this untouched — so the endpoint stayed slow while the part I optimised got 12x faster. That's the lesson: optimise what you measured, not what you assumed.

`opp.yaml` cannot change mid-listing, so once is the correct number.

**`_UNSET` rather than `None` as the memo sentinel.** `None` is a legitimate answer — no `opp.yaml`, or no `display_name` in it — and caching it must also stop the re-read. Otherwise exactly the opps that lack the file keep paying full price, which is the case the memo exists for.

Tests: `opp.yaml` read once regardless of run count (5 runs → 5 state bodies + 1), the name still reaches every run, and a **missing** `opp.yaml` is cached too.

Package suite **155 passed**. Bumped to 0.1.3 for the ace-web pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018b93KcsWmTziiq1Sk3kUPK