### PR TITLE
feat(agents,workspaces): DELETE endpoints — creation was a one-way door

### DIFF
--- a/apps/agents/api.py
+++ b/apps/agents/api.py
@@ -143,6 +143,39 @@ def get_agent(request: HttpRequest, slug: str) -> AgentDetailOut:
     return AgentDetailOut.model_validate(services.agent_detail(agent))
 
 
+@router.delete("/{slug}/", response={204: None}, summary="Delete an agent (editor/owner)",
+               openapi_extra={"x-mcp-expose": True})
+def delete_agent(request: HttpRequest, slug: str):
+    """Remove an agent and everything hanging off it.
+
+    Registration (`POST /`) was a one-way door until this existed: an agent
+    created by mistake — a typo'd slug, a scaffold someone was only trying
+    out, a test — was permanent and fleet-visible to every member of its
+    workspace, because the only way back was a shell on the box. That made
+    *rehearsing* the onboarding path impossible: you could not walk a new
+    operator's steps end to end without leaving a fake agent behind forever.
+
+    Gated one step ABOVE creation deliberately. Any member may upsert an
+    agent; deleting one requires editor or owner, so a viewer cannot destroy
+    a fleet member's board. `_get_agent_or_404` runs first, so a non-member
+    gets 404 (no existence leak) rather than 403.
+
+    Every FK into Agent is CASCADE or SET_NULL (runs, turns, tasks, skills,
+    syncs, work products, schedules, items, runner assignments/drills), so
+    this is a real delete rather than a soft flag — nothing is left dangling
+    and nothing blocks it.
+    """
+    agent = _get_agent_or_404(request, slug)
+    membership = wsvc.WorkspaceMembership.objects.filter(
+        user=request.user, workspace_id=agent.workspace_id
+    ).first()
+    allowed = {wsvc.WorkspaceMembership.OWNER, wsvc.WorkspaceMembership.EDITOR}
+    if membership is None or membership.role not in allowed:
+        raise HttpError(403, "deleting an agent requires the editor or owner role")
+    agent.delete()
+    return Status(204, None)
+
+
 @router.patch("/{slug}/runner-preference", response=AgentDetailOut,
               summary="Set an agent's ordered runner-kind preference")
 def set_runner_preference(request: HttpRequest, slug: str, payload: RunnerPreferenceIn) -> AgentDetailOut:

--- a/apps/workspaces/api.py
+++ b/apps/workspaces/api.py
@@ -140,6 +140,43 @@ def get_workspace(request: HttpRequest, slug: str) -> WorkspaceOut:
     return _out(m.workspace, m.role)
 
 
+@router.delete("/{slug}/", response={204: None}, summary="Delete a workspace (owner-only)",
+               openapi_extra={"x-mcp-expose": True})
+def delete_workspace(request: HttpRequest, slug: str):
+    """Delete an empty workspace. Owner-only, and never one that still owns agents.
+
+    Creation (`POST /`) was a one-way door: a workspace made with a typo'd
+    slug was permanent, and the slug appears in every URL its team uses. That
+    is a bad property for a self-serve create endpoint, and it made the
+    onboarding path un-rehearsable for the same reason agent creation was.
+
+    Two guards, both deliberate:
+
+    - **Owner-only**, matching the rest of workspace administration (invites,
+      member roles). An editor may act *within* a tenant; removing the tenant
+      itself is an owner's call.
+    - **Refuses while any agent still lives here.** `Agent.workspace` is
+      PROTECT precisely so a tenant cannot be pulled out from under its
+      agents, and Django would raise ProtectedError — a 500. Checking first
+      turns that into an actionable 409 naming what is in the way, so the
+      caller deletes the agents (or moves them) and retries. Memberships and
+      invites are the workspace's own bookkeeping and cascade with it.
+    """
+    _require_role(request.user, slug, WorkspaceMembership.OWNER)
+    ws = Workspace.objects.filter(slug=slug).first()
+    if ws is None:
+        raise HttpError(404, f"workspace '{slug}' not found")
+    agent_slugs = sorted(ws.agents.values_list("slug", flat=True))
+    if agent_slugs:
+        raise HttpError(
+            409,
+            f"workspace '{slug}' still owns {len(agent_slugs)} agent(s): "
+            f"{', '.join(agent_slugs)}. Delete or move them first.",
+        )
+    ws.delete()
+    return Status(204, None)
+
+
 # ---- members ----
 @router.get("/{slug}/members/", response=list[MemberOut], summary="List members (member-only)",
             openapi_extra={"x-mcp-expose": True})

--- a/apps/workspaces/tests/test_delete.py
+++ b/apps/workspaces/tests/test_delete.py
@@ -1,0 +1,161 @@
+"""Deleting a workspace, and deleting an agent — the two one-way doors.
+
+Both `POST /api/workspaces/` and `POST /api/agents/` were create-only, so a
+typo'd slug was permanent and fleet-visible. That made the onboarding path
+un-rehearsable: you could not walk a new operator's steps end to end without
+leaving a fake tenant and a fake agent behind forever.
+
+RBAC differs between the two on purpose, and these tests pin that:
+workspace delete is owner-only (it removes a tenant); agent delete needs
+editor or owner — one step above the "any member" bar for creating one.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import Client
+
+from apps.agents.models import Agent
+from apps.workspaces.models import Workspace, WorkspaceMembership
+
+pytestmark = pytest.mark.django_db
+User = get_user_model()
+
+
+def _user(email):
+    return User.objects.create(username=email, email=email)
+
+
+def _client(u):
+    c = Client()
+    c.force_login(u)
+    return c
+
+
+def _post(c, url, data=None):
+    return c.post(url, data=json.dumps(data or {}), content_type="application/json")
+
+
+def _ws(owner, slug="acme"):
+    ws = Workspace.objects.create(slug=slug, display_name=slug.title(), created_by=owner)
+    WorkspaceMembership.objects.create(workspace=ws, user=owner, role=WorkspaceMembership.OWNER)
+    return ws
+
+
+def _agent(ws, owner, slug="scout"):
+    return Agent.objects.create(slug=slug, name=slug.title(), workspace=ws, owner=owner)
+
+
+# ---------------------------------------------------------------- workspaces
+
+def test_owner_can_delete_an_empty_workspace():
+    owner = _user("a@dimagi.com")
+    _ws(owner)
+    r = _client(owner).delete("/api/workspaces/acme/")
+    assert r.status_code == 204
+    assert not Workspace.objects.filter(slug="acme").exists()
+
+
+def test_editor_cannot_delete_a_workspace():
+    owner = _user("a@dimagi.com")
+    ws = _ws(owner)
+    editor = _user("b@dimagi.com")
+    WorkspaceMembership.objects.create(workspace=ws, user=editor, role=WorkspaceMembership.EDITOR)
+
+    r = _client(editor).delete("/api/workspaces/acme/")
+    assert r.status_code == 403
+    assert Workspace.objects.filter(slug="acme").exists()
+
+
+def test_non_member_gets_404_not_403():
+    """No existence leak — a stranger must not learn the workspace is real."""
+    owner = _user("a@dimagi.com")
+    _ws(owner)
+    r = _client(_user("stranger@dimagi.com")).delete("/api/workspaces/acme/")
+    assert r.status_code == 404
+    assert Workspace.objects.filter(slug="acme").exists()
+
+
+def test_workspace_with_agents_is_refused_with_409_naming_them():
+    """`Agent.workspace` is PROTECT, so an unchecked delete would be a 500.
+    The guard turns it into an actionable 409 that names what is in the way."""
+    owner = _user("a@dimagi.com")
+    ws = _ws(owner)
+    _agent(ws, owner, "scout")
+    _agent(ws, owner, "recon")
+
+    r = _client(owner).delete("/api/workspaces/acme/")
+
+    assert r.status_code == 409
+    body = r.json()["detail"] if "detail" in r.json() else json.dumps(r.json())
+    assert "recon" in body and "scout" in body
+    assert Workspace.objects.filter(slug="acme").exists()
+
+
+def test_workspace_delete_succeeds_once_its_agents_are_gone():
+    """The documented recovery path in the 409 actually works."""
+    owner = _user("a@dimagi.com")
+    ws = _ws(owner)
+    _agent(ws, owner, "scout")
+    c = _client(owner)
+
+    assert c.delete("/api/workspaces/acme/").status_code == 409
+    assert c.delete("/api/agents/scout/").status_code == 204
+    assert c.delete("/api/workspaces/acme/").status_code == 204
+
+    assert not Workspace.objects.filter(slug="acme").exists()
+
+
+# -------------------------------------------------------------------- agents
+
+def test_editor_can_delete_an_agent():
+    owner = _user("a@dimagi.com")
+    ws = _ws(owner)
+    editor = _user("b@dimagi.com")
+    WorkspaceMembership.objects.create(workspace=ws, user=editor, role=WorkspaceMembership.EDITOR)
+    _agent(ws, owner)
+
+    r = _client(editor).delete("/api/agents/scout/")
+    assert r.status_code == 204
+    assert not Agent.objects.filter(slug="scout").exists()
+
+
+def test_viewer_cannot_delete_an_agent():
+    """Deleting is gated one step above creating (any member may upsert)."""
+    owner = _user("a@dimagi.com")
+    ws = _ws(owner)
+    viewer = _user("b@dimagi.com")
+    WorkspaceMembership.objects.create(workspace=ws, user=viewer, role=WorkspaceMembership.VIEWER)
+    _agent(ws, owner)
+
+    r = _client(viewer).delete("/api/agents/scout/")
+    assert r.status_code == 403
+    assert Agent.objects.filter(slug="scout").exists()
+
+
+def test_deleting_an_agent_in_another_tenant_is_404():
+    owner = _user("a@dimagi.com")
+    ws = _ws(owner)
+    _agent(ws, owner)
+
+    outsider = _user("b@dimagi.com")
+    _ws(outsider, slug="other")
+
+    r = _client(outsider).delete("/api/agents/scout/")
+    assert r.status_code == 404
+    assert Agent.objects.filter(slug="scout").exists()
+
+
+def test_deleting_an_agent_takes_its_children_with_it():
+    """Every FK into Agent is CASCADE/SET_NULL — a real delete, nothing dangling."""
+    from apps.agents.models import AgentTask
+
+    owner = _user("a@dimagi.com")
+    ws = _ws(owner)
+    agent = _agent(ws, owner)
+    AgentTask.objects.create(agent=agent, ext_id="T1", title="something")
+
+    assert _client(owner).delete("/api/agents/scout/").status_code == 204
+    assert not AgentTask.objects.filter(agent_id=agent.id).exists()

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -1390,7 +1390,28 @@ export interface paths {
         readonly get: operations["apps_agents_api_get_agent"];
         readonly put?: never;
         readonly post?: never;
-        readonly delete?: never;
+        /**
+         * Delete an agent (editor/owner)
+         * @description Remove an agent and everything hanging off it.
+         *
+         *     Registration (`POST /`) was a one-way door until this existed: an agent
+         *     created by mistake — a typo'd slug, a scaffold someone was only trying
+         *     out, a test — was permanent and fleet-visible to every member of its
+         *     workspace, because the only way back was a shell on the box. That made
+         *     *rehearsing* the onboarding path impossible: you could not walk a new
+         *     operator's steps end to end without leaving a fake agent behind forever.
+         *
+         *     Gated one step ABOVE creation deliberately. Any member may upsert an
+         *     agent; deleting one requires editor or owner, so a viewer cannot destroy
+         *     a fleet member's board. `_get_agent_or_404` runs first, so a non-member
+         *     gets 404 (no existence leak) rather than 403.
+         *
+         *     Every FK into Agent is CASCADE or SET_NULL (runs, turns, tasks, skills,
+         *     syncs, work products, schedules, items, runner assignments/drills), so
+         *     this is a real delete rather than a soft flag — nothing is left dangling
+         *     and nothing blocks it.
+         */
+        readonly delete: operations["apps_agents_api_delete_agent"];
         readonly options?: never;
         readonly head?: never;
         readonly patch?: never;
@@ -2045,7 +2066,28 @@ export interface paths {
         readonly get: operations["apps_workspaces_api_get_workspace"];
         readonly put?: never;
         readonly post?: never;
-        readonly delete?: never;
+        /**
+         * Delete a workspace (owner-only)
+         * @description Delete an empty workspace. Owner-only, and never one that still owns agents.
+         *
+         *     Creation (`POST /`) was a one-way door: a workspace made with a typo'd
+         *     slug was permanent, and the slug appears in every URL its team uses. That
+         *     is a bad property for a self-serve create endpoint, and it made the
+         *     onboarding path un-rehearsable for the same reason agent creation was.
+         *
+         *     Two guards, both deliberate:
+         *
+         *     - **Owner-only**, matching the rest of workspace administration (invites,
+         *       member roles). An editor may act *within* a tenant; removing the tenant
+         *       itself is an owner's call.
+         *     - **Refuses while any agent still lives here.** `Agent.workspace` is
+         *       PROTECT precisely so a tenant cannot be pulled out from under its
+         *       agents, and Django would raise ProtectedError — a 500. Checking first
+         *       turns that into an actionable 409 naming what is in the way, so the
+         *       caller deletes the agents (or moves them) and retries. Memberships and
+         *       invites are the workspace's own bookkeeping and cascade with it.
+         */
+        readonly delete: operations["apps_workspaces_api_delete_workspace"];
         readonly options?: never;
         readonly head?: never;
         readonly patch?: never;
@@ -11604,6 +11646,26 @@ export interface operations {
             };
         };
     };
+    readonly apps_agents_api_delete_agent: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path: {
+                readonly slug: string;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description No Content */
+            readonly 204: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
     readonly apps_agents_api_set_runner_preference: {
         readonly parameters: {
             readonly query?: never;
@@ -12733,6 +12795,26 @@ export interface operations {
                 content: {
                     readonly "application/json": components["schemas"]["WorkspaceOut"];
                 };
+            };
+        };
+    };
+    readonly apps_workspaces_api_delete_workspace: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path: {
+                readonly slug: string;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description No Content */
+            readonly 204: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };


### PR DESCRIPTION
## Why

`POST /api/agents/` and `POST /api/workspaces/` were both create-only. A typo'd
slug was **permanent and fleet-visible**, recoverable only with a shell on the
box — and a workspace slug appears in every URL its team uses.

The sharper cost: it made the onboarding path **un-rehearsable**. You could not
walk a new operator's steps end to end without leaving a fake tenant and a fake
agent behind forever, which is exactly what blocked verifying that path for a
new teammate.

## What

| Endpoint | Gate | Notes |
|---|---|---|
| `DELETE /api/agents/{slug}/` | editor **or** owner | One step above the "any member" bar for creating one, so a viewer can't destroy a fleet member's board. Non-member → **404, not 403** (no existence leak). |
| `DELETE /api/workspaces/{slug}/` | owner-only | Matches the rest of workspace admin (invites, member roles). **409 while it still owns agents.** |

Two details worth the review:

- **The 409 is load-bearing.** `Agent.workspace` is `PROTECT`, so an unchecked
  delete raises `ProtectedError` — a 500. The guard turns that into an
  actionable message naming the agents in the way, and a test walks the
  documented recovery (delete agents → workspace delete succeeds).
- **Agent delete is a real delete.** Every FK into `Agent` is CASCADE or
  SET_NULL (runs, turns, tasks, skills, syncs, work products, schedules, items,
  runner assignments/drills) — no soft flag, nothing dangling. Pinned by a test.

## Verification

Both gates that fire on this diff (per `hal-ci-gates`), each confirmed by its own output:

| Gate | Result |
|---|---|
| CI → ruff | `All checks passed!` |
| CI → `makemigrations --check` | `No changes detected` |
| CI → `manage.py check` | `System check identified no issues` |
| CI → backend pytest | `2187 passed, 1 skipped` |
| CI → `npm run build` | built, PWA precache 37 entries |
| CI → `npm run test` | `64 passed (64)` / `645 passed (645)` |
| **OpenAPI types check** | types **were stale**; regenerated via the workflow's own commands and committed |

That last row is the one this repo has been bitten by before (#611) — the gate
fires on `apps/**/schemas.py`-adjacent API changes and its name reads like a
scheduled job. It was run deliberately, not inferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8F73DxK16xijAAwcDeJ6n