### PR TITLE
feat(runner): Windows support — Task Scheduler alongside launchd

### DIFF
--- a/runner/canopy_runner/README.md
+++ b/runner/canopy_runner/README.md
@@ -130,6 +130,9 @@ them together would make the two modules import each other.
      within 30 minutes. `launchctl bootout gui/$(id -u)/com.canopy.runner.updater`
      first, or install with `--no-auto-update`.
 
+   **On Windows, run `scripts/install-runner.ps1` instead** — same steps, Task
+   Scheduler in place of launchd. See "Windows" below.
+
    The timer runs `~/.canopy/canopy-runner-update` (a copy of this script placed
    there by the install) rather than the script in your checkout — macOS names
    background items after the executable, so pointing at the repo made canopy's
@@ -215,3 +218,61 @@ python3 -m canopy_runner.main verify-emdash --config ~/.canopy/runner.json
   `READ_SCHEMA` (the allowlist these reads are checked against) to match.
 - the DB itself can't be read → exit 2 (bad `emdash_db` path, or emdash not
   installed).
+
+## Windows
+
+The runner is **not** macOS-only, and never mostly was. Everything it does is
+portable — `inbox.py` and `schedules.py` shell out to `gog` and do date math,
+`cdp_control` drives emdash through `node`, `transcript`/`tail` are pure
+pathlib, and emdash itself ships `emdash-x64.exe` / `.msi`. What was macOS-only
+was the **supervision**: two launchd jobs, and one inline `launchctl kickstart`.
+
+That split now has exactly two homes:
+
+| | macOS | Windows |
+|---|---|---|
+| installer | `scripts/install-runner.sh` | `scripts/install-runner.ps1` |
+| supervisor | launchd | Task Scheduler |
+| runner job | `com.canopy.runner` | `\Canopy\canopy-runner` |
+| updater job | `com.canopy.runner.updater` | `\Canopy\canopy-runner-updater` |
+| run-now verb | `launchctl kickstart gui/<uid>/<label>` | `schtasks /Run /TN <task>` |
+| in-process split | `canopy_runner/platform_jobs.py` | same file, other branch |
+
+Setup mirrors the macOS steps above:
+
+```powershell
+# 1. emdash with its debug port (the CDP equivalent of the "Emdash CDP" app):
+#    make a shortcut to emdash.exe whose Target ends with
+#    --remote-debugging-port=9222
+# 2. pair the runner (same POST as above), then write %USERPROFILE%\.canopy\runner.json
+#    — note the Windows emdash DB path:
+#      "emdash_db": "C:\\Users\\<you>\\AppData\\Roaming\\Emdash\\emdash4.db"
+# 3. install:
+.\runner\canopy_runner\scripts\install-runner.ps1
+```
+
+`-NoTasks`, `-NoAutoUpdate`, `-Ref` and `-IfStale` mean what `--no-launchd`,
+`--no-auto-update`, `--ref` and `--if-stale` mean for the bash installer.
+
+Three Windows differences that are behaviour, not cosmetics:
+
+- **Task Scheduler has no `StandardOutPath`.** launchd redirects a job's stdout
+  for free; Task Scheduler does not. Both jobs are wrapped in
+  `cmd.exe /c "... >> log 2>&1"` so `~\.canopy\runner.log` and `updater.log`
+  exist exactly as on macOS. Without that wrapper the logs are empty — which
+  looks identical to a healthy quiet runner.
+- **`KeepAlive` becomes restart-on-failure**, plus `ExecutionTimeLimit 0`.
+  Task Scheduler otherwise stops a task after three days by default, which
+  would read as a runner that mysteriously goes dark midweek.
+- **Same session boundary.** The tasks are registered for the interactive user,
+  not as a Windows service, because the runner drives emdash's real UI over CDP
+  and needs a desktop session. Logging out stops both jobs together — the same
+  limit the updater plist documents, with the same countermeasure (the
+  supervisor's dark-runner banner).
+
+**What is verified, and what is not.** `platform_jobs` is unit-tested on both
+branches from either host (`tests/test_platform_jobs.py`), and the installer is
+parse- and PSScriptAnalyzer-clean. It has **not** been executed on a Windows
+box — there is none in the fleet yet. Treat the first Windows install as a
+bring-up: run it with `-NoTasks` first, confirm `canopy-runner update-check`
+answers, then register the tasks.

--- a/runner/canopy_runner/canopy_runner/platform_jobs.py
+++ b/runner/canopy_runner/canopy_runner/platform_jobs.py
@@ -1,0 +1,61 @@
+"""The ONE place the runner knows which OS supervises it.
+
+Everything else in `canopy_runner` is already platform-neutral — the producers
+(`inbox.py`, `schedules.py`) shell out to `gog` and do date math, `cdp_control`
+drives emdash through `node`, and the transcript/tail layer is pure pathlib. The
+only genuinely OS-specific thing the runner does is **ask its supervisor to run
+the updater job now**, and that was written inline against `launchctl`, which
+made the whole daemon look macOS-only when one function was.
+
+So the split lives here rather than as `if sys.platform` scattered at call
+sites: a second OS is a new branch in one function with one test, not an audit.
+
+| | macOS | Windows |
+|---|---|---|
+| supervisor | launchd | Task Scheduler |
+| runner job | `com.canopy.runner` | `\\Canopy\\canopy-runner` |
+| updater job | `com.canopy.runner.updater` | `\\Canopy\\canopy-runner-updater` |
+| run-now verb | `launchctl kickstart gui/<uid>/<label>` | `schtasks /Run /TN <task>` |
+
+`os.getuid()` does not exist on Windows, which is why it is referenced only
+inside the POSIX branch — a module-level `os.getuid()` would make this module
+unimportable there, and the import happens long before any kickstart.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+
+#: launchd labels (macOS). Also the filenames of the two plist templates.
+UPDATER_LABEL = "com.canopy.runner.updater"
+RUNNER_LABEL = "com.canopy.runner"
+
+#: Task Scheduler paths (Windows). Backslash-prefixed = the task folder, so both
+#: jobs group under a "Canopy" folder in taskschd.msc rather than littering root.
+WINDOWS_UPDATER_TASK = r"\Canopy\canopy-runner-updater"
+WINDOWS_RUNNER_TASK = r"\Canopy\canopy-runner"
+
+
+def is_windows() -> bool:
+    """`os.name`, not `sys.platform`: the question is 'does this box have
+    launchctl or schtasks', which is exactly the posix/nt split."""
+    return os.name == "nt"
+
+
+def updater_job_name() -> str:
+    """What the updater job is called on THIS box — for log lines and errors."""
+    return WINDOWS_UPDATER_TASK if is_windows() else UPDATER_LABEL
+
+
+def kickstart_updater(*, runner=subprocess.run) -> None:
+    """Ask the supervisor to run the updater job NOW.
+
+    Raises on failure (CalledProcessError / OSError / TimeoutExpired); the sole
+    caller, `update.nudge`, swallows and logs it, because this runs on the wake
+    listener thread that also carries cancel and wake frames.
+    """
+    if is_windows():
+        cmd = ["schtasks", "/Run", "/TN", WINDOWS_UPDATER_TASK]
+    else:
+        cmd = ["launchctl", "kickstart", f"gui/{os.getuid()}/{UPDATER_LABEL}"]
+    runner(cmd, capture_output=True, timeout=15, check=True)

--- a/runner/canopy_runner/canopy_runner/update.py
+++ b/runner/canopy_runner/canopy_runner/update.py
@@ -35,6 +35,10 @@ import logging
 import time
 from pathlib import Path
 
+from . import platform_jobs
+# Re-exported so existing callers and tests keep importing it from here.
+from .platform_jobs import UPDATER_LABEL  # noqa: F401
+
 logger = logging.getLogger("canopy_runner.update")
 
 CURRENT = "current"
@@ -89,17 +93,8 @@ def in_flight(cfg, *, now: float | None = None) -> int | None:
 NUDGE_MIN_SECONDS = 600.0
 _last_nudge_at = 0.0
 
-UPDATER_LABEL = "com.canopy.runner.updater"
-
-
 def _kickstart_updater() -> None:
-    import os
-    import subprocess
-
-    subprocess.run(
-        ["launchctl", "kickstart", f"gui/{os.getuid()}/{UPDATER_LABEL}"],
-        capture_output=True, timeout=15, check=True,
-    )
+    platform_jobs.kickstart_updater()
 
 
 def nudge(cfg, expected_sha: str, *, now: float | None = None) -> bool:
@@ -124,17 +119,18 @@ def nudge(cfg, expected_sha: str, *, now: float | None = None) -> bool:
         return False
     if now - _last_nudge_at < NUDGE_MIN_SECONDS:
         return False
-    # Advance the throttle on the ATTEMPT, not the success: a broken launchctl
-    # would otherwise warn on every ~10s heartbeat, and the 30-min timer is the
-    # rescue for that case regardless.
+    # Advance the throttle on the ATTEMPT, not the success: a broken supervisor
+    # call would otherwise warn on every ~10s heartbeat, and the 30-min timer is
+    # the rescue for that case regardless.
     _last_nudge_at = now
+    job = platform_jobs.updater_job_name()   # launchd label, or Task Scheduler path
     try:
         _kickstart_updater()
-    except Exception as exc:  # noqa: BLE001 — a launchctl hiccup must not cost the socket
-        logger.warning("update nudge: could not kickstart %s: %s", UPDATER_LABEL, exc)
+    except Exception as exc:  # noqa: BLE001 — a supervisor hiccup must not cost the socket
+        logger.warning("update nudge: could not kickstart %s: %s", job, exc)
         return False
     logger.info("update nudge: kickstarted %s (expected %s, installed %s)",
-                UPDATER_LABEL, expected[:12], installed[:12])
+                job, expected[:12], installed[:12])
     return True
 
 

--- a/runner/canopy_runner/scripts/install-runner.ps1
+++ b/runner/canopy_runner/scripts/install-runner.ps1
@@ -1,0 +1,292 @@
+<#
+.SYNOPSIS
+  Install (or update) the canopy laptop runner on Windows -- the Task Scheduler
+  counterpart to install-runner.sh's launchd path.
+
+.DESCRIPTION
+  The runner's Python is already platform-neutral: the producers (inbox.py,
+  schedules.py) shell out to `gog` and do date math, cdp_control drives emdash
+  through `node`, and the transcript layer is pure pathlib. What made the daemon
+  macOS-only was its SUPERVISION -- two launchd jobs and a `launchctl kickstart`.
+  This script provides the other half of that split (see canopy_runner/
+  platform_jobs.py for the in-process half).
+
+  It mirrors install-runner.sh step for step, deliberately:
+
+    fetch ref -> resolve the runner-source sha -> `git archive` to a temp tree
+    -> stamp _build_info.py -> build the three wheels -> `uv tool install`
+    -> provision the CDP sidecar -> register two Scheduled Tasks
+
+  Why a SNAPSHOT and not the working tree: the daemon must not be able to change
+  what it runs because someone did a `git checkout` in their clone. Building from
+  `git archive <ref>` makes installing a branch an act rather than a slip.
+
+  THE TWO JOBS, and why they are two (unchanged from the launchd design): if the
+  runner updated itself, a build that crash-loops on startup could never update
+  again -- it never heartbeats, never learns it is behind, and the box stays
+  bricked. An independent timer keeps checking whatever state the runner is in.
+
+    \Canopy\canopy-runner           AtLogOn + restart-on-failure   (launchd KeepAlive)
+    \Canopy\canopy-runner-updater   every 30 min                   (launchd StartInterval)
+
+  WINDOWS DIFFERENCES worth knowing, none of them cosmetic:
+
+  - **Task Scheduler has no StandardOutPath.** launchd redirects the job's stdout
+    and stderr for you; Task Scheduler does not. Both jobs are therefore wrapped
+    in `cmd.exe /c "... >> log 2>&1"` so ~/.canopy/runner.log and updater.log
+    exist on Windows exactly as they do on macOS. Without the wrapper the logs
+    are simply empty, which looks identical to a healthy quiet runner.
+  - **No PATH stanza.** launchd starts with a stripped PATH (hence the Homebrew
+    entries in the plists); a Scheduled Task running as the logged-in user
+    inherits the user's PATH, so `gog`, `node`, `npm`, `git` and `uv` resolve as
+    they do in that user's shell. If they do not, they are not on the user's PATH
+    either and that is the thing to fix.
+  - **Session-bound, same as a LaunchAgent.** These are registered for the
+    interactive user, not as a service, because the runner drives emdash's real
+    UI over CDP and genuinely needs a desktop session. Logging out stops both
+    jobs together -- the same boundary the updater plist documents, and the same
+    countermeasure applies (the supervisor's dark-runner banner).
+
+.PARAMETER Ref          git ref to install (default: origin/main)
+.PARAMETER Repo         canopy-web checkout to build from (default: $env:CANOPY_WEB_REPO or ~\emdash-projects\canopy-web)
+.PARAMETER Config       runner config path (default: ~\.canopy\runner.json)
+.PARAMETER IfStale      auto-update mode: install only if the control plane says this box is behind
+.PARAMETER NoTasks      install the package but do not touch the Scheduled Tasks
+.PARAMETER NoAutoUpdate skip registering the updater task
+
+.EXAMPLE
+  .\install-runner.ps1
+.EXAMPLE
+  .\install-runner.ps1 -Ref my-branch -NoTasks
+#>
+[CmdletBinding()]
+# Write-Host is deliberate. PSAvoidUsingWriteHost targets modules and functions
+# whose output a caller may want to capture; this is an installer whose output is
+# diagnostic narration for a human, mirroring the bash installer's `echo`. It
+# still reaches ~/.canopy/*.log: the Scheduled Task wraps the script in
+# `cmd.exe /c ... >> log`, and PowerShell renders that stream to stdout.
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '')]
+param(
+    [string] $Ref    = "origin/main",
+    [string] $Repo   = $(if ($env:CANOPY_WEB_REPO) { $env:CANOPY_WEB_REPO } else { Join-Path $HOME "emdash-projects\canopy-web" }),
+    [string] $Config = $(Join-Path $HOME ".canopy\runner.json"),
+    [switch] $IfStale,
+    [switch] $NoTasks,
+    [switch] $NoAutoUpdate
+)
+
+# Write-Host is deliberate and suppressed below. PSAvoidUsingWriteHost targets
+# modules and functions whose output a caller may want to capture; this is an
+# installer whose output is diagnostic narration for a human, mirroring the
+# bash installer's `echo`. It still reaches ~/.canopy/*.log: the Scheduled Task
+# wraps the script in `cmd.exe /c ... >> log`, and PowerShell renders the
+# information stream to stdout, which that redirect captures.
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$RUNNER_SRC   = "runner/canopy_runner/canopy_runner"
+$TASK_FOLDER  = "\Canopy"
+$RUNNER_TASK  = "canopy-runner"
+$UPDATER_TASK = "canopy-runner-updater"
+$CanopyDir    = Join-Path $HOME ".canopy"
+
+function Fail($msg) { Write-Error $msg; exit 1 }
+function Info($msg) { Write-Host "==> $msg" }
+function Stamp { (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ") }
+
+# --- preflight ---------------------------------------------------------------
+foreach ($tool in @("git", "uv")) {
+    if (-not (Get-Command $tool -ErrorAction SilentlyContinue)) {
+        Fail "$tool not found on PATH. uv: https://docs.astral.sh/uv/"
+    }
+}
+# `rev-parse`, not `Test-Path $Repo\.git`: in a git WORKTREE .git is a FILE, and
+# the directory test would reject a perfectly good checkout.
+& git -C $Repo rev-parse --git-dir *> $null
+if ($LASTEXITCODE -ne 0) { Fail "not a git checkout: $Repo (set CANOPY_WEB_REPO)" }
+New-Item -ItemType Directory -Force -Path $CanopyDir | Out-Null
+
+# --- auto-update mode --------------------------------------------------------
+# Ask the INSTALLED runner whether this box should update, and PIN to the sha the
+# control plane expects. This must NOT track origin/main: the expected sha is the
+# runner source in the DEPLOYED image, already through CI and a deploy. Installing
+# main would run undeployed code AND leave code_sha != expected_code_sha forever,
+# so the staleness banner would fire permanently on correctly-updating boxes.
+if ($IfStale) {
+    $binDir   = (& uv tool dir --bin 2>$null)
+    $checkBin = if ($binDir) { Join-Path $binDir "canopy-runner.exe" } else { $null }
+    if (-not ($checkBin -and (Test-Path $checkBin))) {
+        $cmd = Get-Command canopy-runner -ErrorAction SilentlyContinue
+        $checkBin = if ($cmd) { $cmd.Source } else { $null }
+    }
+    if (-not $checkBin) { Write-Host "$(Stamp) -IfStale: no installed runner to check."; exit 0 }
+    if (-not (Test-Path $Config)) { Write-Host "$(Stamp) -IfStale: no config at $Config."; exit 0 }
+
+    $answer = (& $checkBin update-check --config $Config 2>&1 | Select-Object -Last 1)
+    $parts  = "$answer".Trim() -split '\s+'
+    $status = $parts[0]
+    $expected = if ($parts.Count -gt 1) { $parts[1] } else { "" }
+    switch ($status) {
+        "stale" {
+            $short = if ($expected.Length -ge 12) { $expected.Substring(0,12) } else { $expected }
+            Write-Host "$(Stamp) -IfStale: behind -- installing $short"
+            $Ref = $expected
+        }
+        # All "do nothing", and all exit 0: this runs on a timer, so a non-zero
+        # exit for the ordinary case would train everyone to ignore the log.
+        { $_ -in @("current","busy","unknown") } {
+            Write-Host "$(Stamp) -IfStale: $status -- nothing to do."; exit 0
+        }
+        default {
+            # The installed runner does not understand `update-check`, i.e. it
+            # predates auto-update. Say so -- "nothing to do" forever would
+            # otherwise look exactly like a healthy up-to-date box.
+            Write-Warning "$(Stamp) -IfStale: update-check unavailable from $checkBin (answered: '$answer')."
+            Write-Warning "    This runner predates auto-update; run install-runner.ps1 once by hand."
+            exit 0
+        }
+    }
+}
+
+# --- resolve the ref + the runner-source provenance --------------------------
+Info "fetching $Repo"
+& git -C $Repo fetch --quiet origin
+if ($LASTEXITCODE -ne 0) { Write-Host "    (fetch failed -- using local refs)" }
+
+& git -C $Repo rev-parse --verify --quiet "$Ref^{commit}" *> $null
+if ($LASTEXITCODE -ne 0) {
+    if ($IfStale) { Write-Host "    ref $Ref not in this clone yet; will retry."; exit 0 }
+    Fail "no such ref: $Ref"
+}
+
+# The provenance the runner reports and the server compares against: the last
+# commit that touched the runner's OWN source, NOT the repo HEAD (which moves on
+# every canopy-web commit and would mark every runner stale on a CSS change).
+$RunnerSha   = (& git -C $Repo log -1 --format=%H $Ref -- $RUNNER_SRC).Trim()
+$CommittedAt = (& git -C $Repo log -1 --format=%ct $Ref -- $RUNNER_SRC).Trim()
+$BuiltAt     = Stamp
+if ($RunnerSha) {
+    Info "ref $Ref | runner source at $($RunnerSha.Substring(0,12))"
+} else {
+    # Say so rather than installing an anonymous runner: empty is fail-safe (the
+    # supervisor stays silent) but silence is indistinguishable from working.
+    Write-Warning "could not resolve the runner source sha (shallow clone?). This runner will"
+    Write-Warning "report unknown provenance and the staleness alert will never fire for it."
+}
+
+$Tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("canopy-runner-" + [guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Force -Path $Tmp | Out-Null
+try {
+    Info "exporting $Ref"
+    $tar = Join-Path $Tmp "src.tar"
+    & git -C $Repo archive --output $tar $Ref
+    if ($LASTEXITCODE -ne 0) { Fail "git archive failed" }
+    # bsdtar ships in Windows 10 1803+ as tar.exe.
+    & tar -x -f $tar -C $Tmp
+    if ($LASTEXITCODE -ne 0) { Fail "tar extraction failed (is tar.exe present? Windows 10 1803+)" }
+
+    # Stamp build provenance into the TEMP tree only -- never the working checkout.
+    $buildInfo = @"
+"""Build provenance, stamped by install-runner.ps1. Generated -- do not edit."""
+from __future__ import annotations
+
+SHA = "$RunnerSha"
+BUILT_AT = "$BuiltAt"
+COMMITTED_AT = $(if ($CommittedAt) { $CommittedAt } else { 0 })
+"@
+    Set-Content -Path (Join-Path $Tmp "$RUNNER_SRC/_build_info.py") -Value $buildInfo -Encoding UTF8
+
+    Info "building wheels"
+    $dist = Join-Path $Tmp "dist"
+    foreach ($pkg in @("packages/canopy_cron", "packages/canopy_transcript", "runner/canopy_runner")) {
+        & uv build --quiet --wheel -o $dist (Join-Path $Tmp $pkg)
+        if ($LASTEXITCODE -ne 0) { Fail "wheel build failed for $pkg" }
+    }
+
+    $wheel = Get-ChildItem -Path $dist -Filter "canopy_runner-*.whl" | Select-Object -First 1
+    if (-not $wheel) { Fail "no canopy_runner wheel produced in $dist" }
+    Info "installing $($wheel.Name)"
+    # --find-links supplies canopy-cron / canopy-transcript while the real index
+    # still serves croniter and the realtime extra's websocket-client. The runner
+    # itself is named by direct file:// URL so no index can shadow it.
+    $uri = "file:///" + ($wheel.FullName -replace '\\','/')
+    & uv tool install --force --find-links $dist "canopy-runner[realtime] @ $uri"
+    if ($LASTEXITCODE -ne 0) { Fail "uv tool install failed" }
+} finally {
+    Remove-Item -Recurse -Force $Tmp -ErrorAction SilentlyContinue
+}
+
+# Ask uv where it PUT the executable rather than trusting PATH order -- an older
+# canopy-runner earlier on PATH would otherwise be what the task points at, and
+# the daemon would keep running the version this script just replaced.
+$binDir = (& uv tool dir --bin 2>$null)
+$Bin = if ($binDir) { Join-Path $binDir "canopy-runner.exe" } else { $null }
+if (-not ($Bin -and (Test-Path $Bin))) {
+    $cmd = Get-Command canopy-runner -ErrorAction SilentlyContinue
+    $Bin = if ($cmd) { $cmd.Source } else { $null }
+}
+if (-not ($Bin -and (Test-Path $Bin))) { Fail "installed, but the canopy-runner executable was not found" }
+
+Info "provisioning the CDP sidecar's node deps"
+& $Bin install-sidecar
+if ($LASTEXITCODE -ne 0) { Write-Warning "install-sidecar failed -- emdash control will not work until node/npm are available" }
+
+if ($NoTasks) { Info "done (Scheduled Tasks untouched)"; exit 0 }
+
+# --- Scheduled Tasks ---------------------------------------------------------
+# Register-ScheduledTask is idempotent via -Force, which replaces an existing
+# definition in place. That is the Task Scheduler analogue of the plist's
+# bootout/bootstrap cycle -- and unlike that cycle it has no window in which the
+# job is unregistered, so a failure cannot leave the box with NO runner task.
+function Register-CanopyTask {
+    param(
+        [Parameter(Mandatory)] [string]   $Name,
+        [Parameter(Mandatory)] [string]   $CommandLine,   # passed to cmd.exe /c
+        [Parameter(Mandatory)] [object[]] $Triggers,
+        [switch] $RestartOnFailure
+    )
+    # cmd.exe wrapper: Task Scheduler has no StandardOutPath, so without this the
+    # logs macOS gets for free simply never exist on Windows.
+    $action = New-ScheduledTaskAction -Execute "cmd.exe" -Argument "/c `"$CommandLine`""
+    $principal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -LogonType Interactive -RunLevel Limited
+    $settings = if ($RestartOnFailure) {
+        # The KeepAlive analogue. ExecutionTimeLimit 0 = never kill a long-running
+        # daemon; without it Task Scheduler stops the task after 3 days by default.
+        New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries `
+            -RestartCount 999 -RestartInterval (New-TimeSpan -Minutes 1) `
+            -ExecutionTimeLimit (New-TimeSpan -Seconds 0) -MultipleInstances IgnoreNew
+    } else {
+        New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries `
+            -MultipleInstances IgnoreNew
+    }
+    Register-ScheduledTask -TaskName $Name -TaskPath $TASK_FOLDER -Action $action `
+        -Trigger $Triggers -Principal $principal -Settings $settings -Force | Out-Null
+    Info "registered $TASK_FOLDER\$Name"
+}
+
+$runnerLog  = Join-Path $CanopyDir "runner.log"
+$updaterLog = Join-Path $CanopyDir "updater.log"
+
+Register-CanopyTask -Name $RUNNER_TASK -RestartOnFailure `
+    -CommandLine "`"$Bin`" run --config `"$Config`" >> `"$runnerLog`" 2>&1" `
+    -Triggers @(New-ScheduledTaskTrigger -AtLogOn)
+
+if (-not $NoAutoUpdate) {
+    # A COPY of this installer, frozen at the last install -- so a stray
+    # `git checkout` in the repo cannot change the script this timer runs. The
+    # repo remains the source of the BUILD (-Repo, for `git archive`).
+    $stage2 = Join-Path $CanopyDir "canopy-runner-update.ps1"
+    Copy-Item -Path $PSCommandPath -Destination $stage2 -Force
+
+    # Not AtLogOn: the installer restarts the runner, and login is not a moment
+    # to bounce a working daemon. Repetition runs for the life of the session.
+    $trigger = New-ScheduledTaskTrigger -Once -At (Get-Date).AddMinutes(30) `
+        -RepetitionInterval (New-TimeSpan -Minutes 30)
+    $ps = (Get-Command powershell.exe).Source
+    Register-CanopyTask -Name $UPDATER_TASK -Triggers @($trigger) `
+        -CommandLine "`"$ps`" -NoProfile -ExecutionPolicy Bypass -File `"$stage2`" -IfStale -Repo `"$Repo`" >> `"$updaterLog`" 2>&1"
+}
+
+# Start the runner now so a first install does not wait for the next logon.
+& schtasks /Run /TN "$TASK_FOLDER\$RUNNER_TASK" *> $null
+Info "done -- logs at $runnerLog"

--- a/runner/canopy_runner/tests/test_platform_jobs.py
+++ b/runner/canopy_runner/tests/test_platform_jobs.py
@@ -1,0 +1,109 @@
+"""The supervisor split: launchd on macOS, Task Scheduler on Windows.
+
+The runner was macOS-only for one reason — it asked `launchctl` to run the
+updater job, inline, with `os.getuid()` in the argv. Everything else in the
+package is platform-neutral. These tests pin BOTH branches from either host, so
+the Windows path cannot rot untested on a fleet of Macs:
+
+- the command is built for the right supervisor,
+- `os.getuid()` is never touched on the Windows branch (it does not exist
+  there, so a stray reference would raise at kickstart time — and the sole
+  caller swallows exceptions, so it would surface as a runner that silently
+  never auto-updates rather than as a crash),
+- the job NAME the log line reports matches the platform it ran on.
+
+They flip `platform_jobs.is_windows`, NOT `os.name`. Patching `os.name` globally
+is what a first cut did, and it breaks the interpreter under the test: `pathlib`
+selects WindowsPath/PosixPath off `os.name`, so pytest's own cachedir handling
+dies with "cannot instantiate 'WindowsPath' on your system" before any assertion
+runs. The seam is the function.
+"""
+from __future__ import annotations
+
+import pytest
+
+from canopy_runner import platform_jobs
+
+
+@pytest.fixture
+def calls():
+    seen = []
+
+    def fake(cmd, **kw):
+        seen.append((cmd, kw))
+
+    return seen, fake
+
+
+@pytest.fixture
+def on_windows(monkeypatch):
+    monkeypatch.setattr(platform_jobs, "is_windows", lambda: True)
+
+
+@pytest.fixture
+def on_posix(monkeypatch):
+    monkeypatch.setattr(platform_jobs, "is_windows", lambda: False)
+    monkeypatch.setattr(platform_jobs.os, "getuid", lambda: 501, raising=False)
+
+
+def test_posix_kickstart_uses_launchctl_with_the_gui_domain(on_posix, calls):
+    seen, fake = calls
+    platform_jobs.kickstart_updater(runner=fake)
+
+    (cmd, kw), = seen
+    assert cmd == ["launchctl", "kickstart", "gui/501/com.canopy.runner.updater"]
+    assert kw["check"] is True and kw["timeout"] == 15
+
+
+def test_windows_kickstart_uses_schtasks(on_windows, calls):
+    seen, fake = calls
+    platform_jobs.kickstart_updater(runner=fake)
+
+    (cmd, kw), = seen
+    assert cmd == ["schtasks", "/Run", "/TN", r"\Canopy\canopy-runner-updater"]
+    assert kw["check"] is True and kw["timeout"] == 15
+
+
+def test_windows_branch_never_calls_getuid(on_windows, monkeypatch, calls):
+    """`os.getuid` is absent on Windows. Deleting it reproduces that, so a
+    regression that hoists the uid out of the POSIX branch fails loudly."""
+    seen, fake = calls
+    monkeypatch.delattr(platform_jobs.os, "getuid", raising=False)
+
+    platform_jobs.kickstart_updater(runner=fake)  # must not raise
+
+    assert seen[0][0][0] == "schtasks"
+
+
+def test_updater_job_name_on_windows(on_windows):
+    assert platform_jobs.updater_job_name() == r"\Canopy\canopy-runner-updater"
+
+
+def test_updater_job_name_on_posix(on_posix):
+    assert platform_jobs.updater_job_name() == "com.canopy.runner.updater"
+
+
+def test_is_windows_reads_os_name():
+    """The real predicate, unpatched — posix/nt is exactly the launchctl/schtasks
+    split, which is why it is `os.name` and not `sys.platform`."""
+    import os
+
+    assert platform_jobs.is_windows() is (os.name == "nt")
+
+
+def test_nudge_reports_the_platform_job_name(on_windows, monkeypatch, tmp_path, caplog):
+    """End of the wire: `update.nudge` logs the Windows task path on Windows,
+    not the launchd label it used to hardcode."""
+    import logging
+
+    from canopy_runner import provenance, update
+
+    monkeypatch.setattr(provenance, "code_sha", lambda: "a" * 40)
+    monkeypatch.setattr(update, "_kickstart_updater", lambda: None)
+    monkeypatch.setattr(update, "_last_nudge_at", 0.0)
+
+    cfg = type("Cfg", (), {"state_dir": tmp_path})()
+    with caplog.at_level(logging.INFO, logger="canopy_runner.update"):
+        assert update.nudge(cfg, "b" * 40, now=10_000.0) is True
+
+    assert any(r"\Canopy\canopy-runner-updater" in m for m in caplog.messages)


### PR DESCRIPTION
## Why this, and not "just use the cloud runner"

Email and schedule triggering are the runner's job, and **both producers live
only in the laptop runner**. `runner/ec2/cloud_runner.py` has zero references to
inbox, gmail, mailbox or schedules — it claims Turns that something *else*
queued. So pointing a Windows operator at the cloud runner gives them a box that
executes turns and never *triggers* any.

If a Windows teammate needs email-triggered and scheduled turns, the laptop
runner has to run on Windows.

## It nearly already did

The macOS coupling was never the runner's logic — it was its **supervision**:

| Portable already | Verified how |
|---|---|
| `inbox.py`, `schedules.py` | shell out to `gog`; stdlib + date math |
| `cdp_control.py` | drives emdash via `node`/`npm`, no platform paths |
| `transcript.py` / `tail.py` | pure pathlib |
| emdash itself | ships `emdash-x64.exe` + `.msi` in stable |

The entire macOS-only surface was two launchd plists and **one inline
`launchctl kickstart`** carrying `os.getuid()` — a function that does not exist
on Windows.

## What's here

- **`canopy_runner/platform_jobs.py`** — the one place the runner knows which OS
  supervises it (`launchctl kickstart` vs `schtasks /Run`). `os.getuid()` is
  referenced *only* inside the POSIX branch, so the module stays importable on
  Windows. `update.nudge` now logs the job name for the platform it ran on
  instead of the launchd label unconditionally.
- **`scripts/install-runner.ps1`** — the Task Scheduler counterpart, mirroring
  the bash installer step for step: snapshot via `git archive`, stamped
  `_build_info.py`, three wheels, `uv tool install`, sidecar, two jobs.

Three Windows differences that are behaviour, not cosmetics — all documented in
the script:

1. **Task Scheduler has no `StandardOutPath`.** Both jobs are wrapped in
   `cmd.exe /c "... >> log 2>&1"`, or the logs macOS gets for free simply never
   exist — which looks identical to a healthy quiet runner.
2. **`KeepAlive` → restart-on-failure + `ExecutionTimeLimit 0`.** Task Scheduler
   otherwise stops a task after three days by default.
3. **Pure ASCII on purpose.** Windows PowerShell 5.1 is the default on Windows
   and reads a BOM-less file as ANSI; non-ASCII punctuation would arrive mangled.

## Verification

| Gate / check | Result |
|---|---|
| `canopy_runner` suite (`uv run --with pytest pytest`, as CI runs it) | **502 passed** |
| `cloud_runner` suite | 144 passed |
| Backend pytest | 2178 passed, 1 skipped |
| ruff / `makemigrations --check` / `manage.py check` | clean / `No changes detected` / no issues |
| `npm run build` / `npm run test` | built / **645 passed** |
| `install-runner.ps1` under pwsh 7.5.2 | **parse-clean**, PSScriptAnalyzer **CLEAN** |

`tests/test_platform_jobs.py` pins **both** branches from either host — including
that the Windows branch never touches `os.getuid` — by flipping the
`is_windows()` seam rather than `os.name` (patching `os.name` globally breaks
`pathlib`, which selects WindowsPath off it, and kills pytest before any
assertion runs).

**Not executed on a Windows box** — there is none in the fleet yet. The README
says so plainly and prescribes a `-NoTasks` bring-up for the first install
rather than pretending this is proven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8F73DxK16xijAAwcDeJ6n