### PR TITLE
fix(chat): one producer per session for chat rows — stop every reply rendering twice

### DIFF
--- a/apps/realtime/signals.py
+++ b/apps/realtime/signals.py
@@ -26,6 +26,50 @@ from apps.workspaces.services import workspace_member_ids
 
 from . import groups
 
+# Ledger kinds that ALSO arrive on the session's transcript stream. Everything a
+# runner tails out of the .jsonl — see stream_map.turn_event_to_frames for the
+# aliases — as opposed to turn-lifecycle kinds (status / error / cancel), which
+# no transcript ever contains.
+TRANSCRIPT_ROW_KINDS = frozenset(
+    {"user", "assistant", "tool_start", "tool_use", "tool_end", "tool_result"}
+)
+
+
+def _session_chat_events(turn, events):
+    """The ledger events that still belong on the SESSION group.
+
+    On a transcript-sourced session the chat rows are the transcript tailer's
+    to ship: `/session-stream` sends every conversational record keyed by its
+    durable composite ordinal, and the ledger's own copy of the same assistant
+    text is a SECOND delivery under an id the client cannot reconcile with the
+    first (`seq:<ordinal>` from the tailer vs `<turn8>:<ledger seq>` here,
+    because a transcript-sourced session never projects Messages from a Turn,
+    so `_resolve_message_id_sync` falls back to a synthetic id).
+
+    The other row kinds survive that on their own — tool rows reconcile on
+    `tool_use_id` and user rows on their text — but an assistant row has no
+    correlation key at all, so both copies render and every reply doubles on
+    screen while a reload shows it once. Observed live 2026-08-27 on the
+    `targeting` session: four assistant lines, each on screen twice.
+
+    Both runners have shipped `/session-stream` since the transcript became the
+    durable source (spec 2026-07-24; runner/ec2 `_sync_session_streams` mirrors
+    runner/canopy_runner `sync_session_streams`), which is what made the ledger
+    copy redundant rather than merely noisy — nobody switched it off then.
+
+    Ledger-sourced sessions (the dev stub, and pre-unification sessions that
+    have not been reset) have no transcript to tail, so for them the ledger IS
+    the only producer and every event goes through untouched.
+    """
+    # Function-local: keeps the chat app out of this module's import graph, as
+    # the receiver below has always done.
+    from apps.canopy_sessions.services import transcript_sourced
+
+    session = turn.chat_session
+    if session is None or not transcript_sourced(session):
+        return events
+    return [e for e in events if e.get("kind") not in TRANSCRIPT_ROW_KINDS]
+
 
 @receiver(turn_events_appended, dispatch_uid="realtime_turn_events")
 def _on_turn_events(sender, turn, rows, **kwargs):
@@ -34,12 +78,11 @@ def _on_turn_events(sender, turn, rows, **kwargs):
     for event in events:
         groups.publish(group, {"type": "turn.event", "event": event})
     # A session turn also fans out to the per-session multiplayer group (SP3), so
-    # every participant on the session socket sees the streamed response. Uses the
-    # field only (turn.chat_session_id) — no chat-app import here.
+    # every participant on the session socket sees the streamed response.
     if turn.chat_session_id:
         sgroup = groups.session_group(turn.chat_session_id)
         turn_id = str(turn.id)
-        for event in events:
+        for event in _session_chat_events(turn, events):
             groups.publish(sgroup, {"type": "chat.turn_event", "event": event, "turn_id": turn_id})
 
 

--- a/tests/test_session_ledger_fanout.py
+++ b/tests/test_session_ledger_fanout.py
@@ -1,0 +1,132 @@
+"""One producer per session for chat ROWS.
+
+A transcript-sourced session has two things tailing the same .jsonl: the
+per-turn `chat_bridge`, which posts each assistant text as an `assistant`
+TurnEvent, and the per-session transcript tailer, which posts every
+conversational record to `/session-stream` with its durable composite ordinal.
+Both fan out to the same session group, so every assistant reply arrived twice
+— once as `seq:<ordinal>`, once as `<turn8>:<ledger seq>` — and the client has
+no way to reconcile those (tool rows dedupe on `tool_use_id`, user rows on
+their text, an assistant row on nothing). Observed live 2026-08-27 on the
+`targeting` session: every reply on screen twice, and once on reload.
+
+So the ledger stops fanning chat rows for a session whose transcript is the
+durable source, and keeps fanning turn-lifecycle events, which no transcript
+contains. A ledger-sourced session has no transcript to tail and is untouched.
+"""
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth.models import User
+
+from apps.canopy_sessions.models import Session
+from apps.canopy_sessions.services import TRANSCRIPT_SOURCED
+from apps.harness import services
+from apps.harness.models import Turn
+from apps.workspaces.models import Workspace, WorkspaceMembership
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+
+def _ctx():
+    user = User.objects.create_user("jj", "jj@dimagi.com", "pw")
+    ws = Workspace.objects.create(slug="w1", display_name="W1", created_by=user)
+    WorkspaceMembership.objects.create(user=user, workspace=ws, role=WorkspaceMembership.OWNER)
+    return user, ws
+
+
+def _turn(session):
+    return Turn.objects.create(
+        chat_session=session, origin=Turn.ORIGIN_API,
+        idempotency_key=f"k-{session.id}",
+    )
+
+
+def _session_frames(published, session):
+    """Just the frames aimed at the per-session group."""
+    return [m for g, m in published if g.endswith(session.id.hex)]
+
+
+def _capture(monkeypatch):
+    published: list[tuple[str, dict]] = []
+    monkeypatch.setattr("apps.realtime.groups.publish",
+                        lambda g, m: published.append((g, m)))
+    return published
+
+
+ROWS_AND_LIFECYCLE = [
+    {"kind": "assistant", "payload": {"text": "hi"}},
+    {"kind": "user", "payload": {"text": "yo"}},
+    {"kind": "tool_start", "payload": {"id": "toolu_1", "name": "Bash"}},
+    {"kind": "tool_end", "payload": {"tool_use_id": "toolu_1"}},
+    {"kind": "status", "payload": {"status": Turn.RUNNING}},
+    {"kind": "error", "payload": {"detail": "boom"}},
+]
+
+
+def test_transcript_sourced_session_does_not_get_the_ledgers_copy_of_chat_rows(monkeypatch):
+    """The tailer owns the rows; the ledger keeps the lifecycle.
+
+    This is the whole bug: without the filter, `assistant` goes out here AND
+    over /session-stream, under two irreconcilable ids, and the reply doubles.
+    """
+    _user, ws = _ctx()
+    # ORIGIN_RUNNER is transcript-sourced by definition — discovered in emdash,
+    # the transcript is all there ever was.
+    session = Session.objects.create(workspace=ws, origin=Session.ORIGIN_RUNNER, title="a")
+    turn = _turn(session)
+    published = _capture(monkeypatch)
+
+    services.append_events(turn, ROWS_AND_LIFECYCLE)
+
+    kinds = [f["event"]["kind"] for f in _session_frames(published, session)]
+    assert kinds == ["status", "error"]
+
+
+def test_web_created_session_marked_transcript_sourced_is_filtered_too(monkeypatch):
+    """Where a chat STARTED says nothing about where its record lives — a web
+    composer session driven by a runner writes the same transcript, so it has
+    the same two producers and needs the same filter."""
+    _user, ws = _ctx()
+    session = Session.objects.create(
+        workspace=ws, origin=Session.ORIGIN_WEB, title="a",
+        metadata={TRANSCRIPT_SOURCED: True},
+    )
+    turn = _turn(session)
+    published = _capture(monkeypatch)
+
+    services.append_events(turn, ROWS_AND_LIFECYCLE)
+
+    kinds = [f["event"]["kind"] for f in _session_frames(published, session)]
+    assert kinds == ["status", "error"]
+
+
+def test_ledger_sourced_session_still_gets_every_event(monkeypatch):
+    """The dev stub and pre-unification sessions have no transcript to tail, so
+    the ledger is the ONLY producer and dropping its rows would blank the chat."""
+    _user, ws = _ctx()
+    session = Session.objects.create(workspace=ws, origin=Session.ORIGIN_WEB, title="a")
+    turn = _turn(session)
+    published = _capture(monkeypatch)
+
+    services.append_events(turn, ROWS_AND_LIFECYCLE)
+
+    kinds = [f["event"]["kind"] for f in _session_frames(published, session)]
+    assert kinds == [e["kind"] for e in ROWS_AND_LIFECYCLE]
+
+
+def test_the_turn_group_keeps_every_event_either_way(monkeypatch):
+    """The filter is about the SESSION group only. `turn.{id}` is the turn's own
+    ledger feed — the run view reads it, and it must stay complete."""
+    _user, ws = _ctx()
+    session = Session.objects.create(workspace=ws, origin=Session.ORIGIN_RUNNER, title="a")
+    turn = _turn(session)
+    published = _capture(monkeypatch)
+
+    services.append_events(turn, ROWS_AND_LIFECYCLE)
+
+    turn_kinds = [
+        m["event"]["kind"] for g, m in published
+        if m.get("type") == "turn.event"
+    ]
+    assert turn_kinds == [e["kind"] for e in ROWS_AND_LIFECYCLE]


### PR DESCRIPTION
## The bug

Every assistant reply renders **twice** in a live chat, and once on reload.

Reproduced on the `targeting` session (`6a033065`) on 2026-08-27 by driving the
page in Playwright as `hal@dimagi-ai.com` and recording the socket for four
minutes: four assistant lines arrived, all four rendered as two identical
bubbles. The REST transcript held each of them exactly once, which is why a
reload "fixes" it.

## Why

A transcript-sourced session has **two** things tailing the same `.jsonl`, and
both fan out to the session group:

| producer | scope | frame | client message id |
|---|---|---|---|
| `chat_bridge` → ledger → `apps/realtime/signals` | per **turn** | `chat.turn_event`, `turn_id` set | `<turn8>:<ledger seq>` |
| transcript tailer → `POST /session-stream` | per **session** | `chat.turn_event`, `turn_id` None | `seq:<composite ordinal>` |

Straight off the wire, same text, two ids, two turn_index values:

```
10 chat.stream_start    mid=seq:73792      ti=73792
11 chat.stream_complete mid=seq:73792      'The `ancestors()` fallback only reaches ADM0…'
17 chat.stream_start    mid=68371c3f:17    ti=17
18 chat.stream_complete mid=68371c3f:17    'The `ancestors()` fallback only reaches ADM0…'
```

`_resolve_message_id_sync` produces the synthetic `<turn8>:<seq>` because a
transcript-sourced session never projects `Message` rows from a `Turn`, so
there is nothing with `content__source_seq=17` to key on.

The reducer's other two branches already survive this dual delivery — tool rows
reconcile on `tool_use_id` (and the same frames show that working: each tool
call arrives as `seq:<ordinal>` **and** `seq:-1` and collapses to one row), and
`chat.user_message` has an explicit same-text fallback added for exactly this
symptom. `chat.stream_start` upserts on `message_id` alone, and an assistant row
carries no correlation key, so both copies land.

## The fix

The tailer is the producer with the durable ordinal, and **both** runners have
shipped `/session-stream` since the transcript became the durable source (spec
2026-07-24 — `runner/ec2` `_sync_session_streams` mirrors `runner/canopy_runner`
`sync_session_streams`). That is what made the ledger's copy redundant rather
than merely noisy; nobody switched it off at the time. This does.

On a transcript-sourced session the ledger stops fanning the row kinds the
tailer also ships (`user`, `assistant`, `tool_start`/`tool_use`,
`tool_end`/`tool_result`) to the **session** group. Everything else is
untouched:

- turn-lifecycle events (`status`, `error`, `cancel_requested`) have no
  transcript counterpart and keep flowing;
- the turn's own `turn.{id}` feed still gets every event, complete;
- ledger-sourced sessions (the dev stub, and pre-unification sessions not yet
  reset) have no transcript to tail, so the ledger stays their only producer and
  nothing changes for them.

## Verification

- `tests/test_session_ledger_fanout.py` — 4 cases. Red on `origin/main`
  (2 failed), green with the fix.
- Full backend suite: **1557 passed, 1 skipped**.
- `hal-ci-gates`: `CI [ci.yml]` is the only gate that fires on this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
