### PR TITLE
fix(runner): survive emdash 1.2, and check all four surfaces next time

### DIFF
--- a/packages/canopy_transcript/canopy_transcript/paths.py
+++ b/packages/canopy_transcript/canopy_transcript/paths.py
@@ -49,14 +49,49 @@ def encode_project_dir(worktree: Path | str) -> str:
     return str(worktree).replace("/", "-").replace(".", "-").replace("_", "-")
 
 
+# emdash 1.2 renamed the worktree ROOT as well as the leaf: a task now lives at
+# `worktrees/<repo>-<8 hex>/emdash-<task>-<suffix>` instead of
+# `worktrees/<repo>/emdash/<task>-<suffix>`. The 8-hex tail is per-repo, not
+# per-task, so it cannot be derived from (repo, task) — it has to be read off disk.
+_REPO_DIR_RE = re.compile(r"^(?P<repo>.+)-[0-9a-f]{8}$")
+_FLAT_TASK_PREFIX = "emdash-"
+
+
 def _worktree_bases(repo: str, task: str, home: Path) -> list[Path]:
-    """Candidate worktree paths for (repo, task). Verified against the live fleet
-    (2026-07-20): most agents nest under `<repo>/emdash/<task>`, but some
-    worktrees sit directly at `<repo>/<task>` with no `emdash` segment. Try both;
-    a wrong guess simply doesn't match a project dir and degrades to no
-    transcript."""
+    """Candidate worktree paths for (repo, task), most-specific first.
+
+    Three layouts are live on the fleet, all of them observed rather than guessed:
+
+    * `<repo>/emdash/<task>` — the common pre-1.2 nesting (verified 2026-07-20).
+    * `<repo>/<task>` — some worktrees (e.g. echo's) skip the `emdash` segment.
+    * `<repo>-<8 hex>/emdash-<task>` — **emdash 1.2**. Every worktree created after
+      the 1.2 upgrade uses it (verified 2026-08-28: all four such dirs on the fleet
+      laptop were created minutes after 1.2 first ran, and every older one is the
+      pre-1.2 shape).
+
+    The 1.2 root carries a random per-repo hash, so unlike the other two this
+    candidate cannot be constructed — the worktree root is globbed off disk. That
+    makes the list empty for a repo with no checkout yet, which is correct: a base
+    we cannot name is a base we cannot match.
+
+    A wrong guess simply doesn't match a project dir and degrades to no transcript.
+    """
     root = home / "emdash" / "worktrees" / repo
-    return [root / "emdash" / task, root / task]
+    bases = [root / "emdash" / task, root / task]
+    try:
+        for repo_dir in sorted((home / "emdash" / "worktrees").glob(f"{repo}-*")):
+            if not repo_dir.is_dir():
+                continue
+            hashed = _REPO_DIR_RE.match(repo_dir.name)
+            # The glob is a prefix match, so `canopy-*` also lands on
+            # `canopy-web-05b9fcc4`. Only the repo half of the split may be
+            # trusted: without this, repo `canopy` borrows `canopy-web`'s
+            # transcripts — a wrong session's history, which is worse than none.
+            if hashed and hashed.group("repo") == repo:
+                bases.append(repo_dir / f"{_FLAT_TASK_PREFIX}{task}")
+    except OSError:
+        pass
+    return bases
 
 
 def resolve_emdash_transcript(
@@ -130,10 +165,17 @@ def parse_emdash_worktree(cwd: Path | str, *, home: Path) -> tuple[str, str] | N
 
     A Claude Code hook reports the session's `cwd`, but canopy identifies a
     session by (project, session_key) — so the live path needs to run the
-    convention backwards. Handles both observed layouts
-    (`<repo>/emdash/<task>` and `<repo>/<task>`) and strips emdash's random
-    de-dupe suffix, so `…/canopy-web/emdash/runner-yipnn` resolves to
-    ("canopy-web", "runner").
+    convention backwards. Handles all three observed layouts
+    (`<repo>/emdash/<task>`, `<repo>/<task>`, and emdash 1.2's
+    `<repo>-<8 hex>/emdash-<task>`) and strips emdash's random de-dupe suffix,
+    so `…/canopy-web/emdash/runner-yipnn` resolves to ("canopy-web", "runner").
+
+    The 1.2 shape has to be recognised explicitly rather than falling through to
+    the two-segment case: that case would hand back the hashed dir as the repo
+    (`canopy-web-05b9fcc4`) and the prefixed dir as the task
+    (`emdash-emdash-check-sq69z`), and NEITHER survives `emdash_task_candidates`
+    — so the session matches nothing and the hook silently describes a session
+    canopy does not believe exists.
 
     The suffix strip is ambiguous by construction — a task legitimately named
     `foo-bar` is indistinguishable from task `foo` with suffix `bar`. Both
@@ -149,6 +191,12 @@ def parse_emdash_worktree(cwd: Path | str, *, home: Path) -> tuple[str, str] | N
     if len(parts) >= 3 and parts[1] == "emdash":
         return parts[0], parts[2]
     if len(parts) >= 2:
+        hashed = _REPO_DIR_RE.match(parts[0])
+        if hashed and parts[1].startswith(_FLAT_TASK_PREFIX):
+            # emdash 1.2. The de-dupe suffix is left ON the task, exactly as the
+            # other layouts leave it — `emdash_task_candidates` is the one place
+            # that strips it, and it needs the raw name to offer both readings.
+            return hashed.group("repo"), parts[1][len(_FLAT_TASK_PREFIX):]
         return parts[0], parts[1]
     return None
 

--- a/packages/canopy_transcript/tests/test_paths.py
+++ b/packages/canopy_transcript/tests/test_paths.py
@@ -32,7 +32,11 @@ def test_encoding_collapses_every_separator_it_knows():
 
 import os
 
-from canopy_transcript import resolve_emdash_transcript
+from canopy_transcript import (
+    emdash_task_candidates,
+    parse_emdash_worktree,
+    resolve_emdash_transcript,
+)
 
 
 def _plant(home, claude_home, repo, worktree_name, stem, *, mtime, make_worktree):
@@ -88,3 +92,80 @@ def test_a_sibling_task_is_never_borrowed(tmp_path):
     _plant(home, claude_home, "ace", "bednet-2-tsnn3", "sibling", mtime=9000, make_worktree=True)
 
     assert resolve_emdash_transcript("ace", "bednet", home=home, claude_home=claude_home) is None
+
+
+# --------------------------------------------------------------------------------------
+# emdash 1.2's worktree layout. Both the repo root and the leaf changed shape:
+# `worktrees/<repo>-<8 hex>/emdash-<task>-<suffix>` replaced
+# `worktrees/<repo>/emdash/<task>-<suffix>`. Verified on the fleet laptop 2026-08-28 —
+# every worktree created after 1.2 first ran uses it, every older one does not.
+# --------------------------------------------------------------------------------------
+
+def _plant_v12(home, claude_home, repo, repo_hash, worktree_name, stem, *, make_worktree=True):
+    """A project dir (+ transcript) for emdash 1.2's `<repo>-<hash>/emdash-<name>`."""
+    worktree = home / "emdash" / "worktrees" / f"{repo}-{repo_hash}" / f"emdash-{worktree_name}"
+    if make_worktree:
+        worktree.mkdir(parents=True)
+    proj = claude_home / encode_project_dir(worktree)
+    proj.mkdir(parents=True)
+    jsonl = proj / f"{stem}.jsonl"
+    jsonl.write_text("{}\n")
+    return jsonl
+
+
+def test_the_1_2_layout_resolves(tmp_path):
+    """Before this, every session created on emdash 1.2 resolved to no transcript at
+    all — so it streamed nothing and backfilled nothing, silently, forever."""
+    home, claude_home = tmp_path / "home", tmp_path / "home" / ".claude" / "projects"
+    _plant_v12(home, claude_home, "canopy-web", "05b9fcc4", "emdash-check-sq69z", "live")
+
+    got = resolve_emdash_transcript("canopy-web", "emdash-check", home=home, claude_home=claude_home)
+    assert got is not None and got.stem == "live"
+
+
+def test_the_1_2_layout_does_not_borrow_a_sibling_repo(tmp_path):
+    """`canopy` must not match `canopy-web-05b9fcc4` — the hash is 8 hex characters,
+    so `web-05b9fcc4` is not one and the dir belongs to a different repo."""
+    home, claude_home = tmp_path / "home", tmp_path / "home" / ".claude" / "projects"
+    _plant_v12(home, claude_home, "canopy-web", "05b9fcc4", "emdash-check-sq69z", "other")
+
+    assert resolve_emdash_transcript("canopy", "emdash-check", home=home, claude_home=claude_home) is None
+
+
+def test_the_pre_1_2_layouts_still_resolve(tmp_path):
+    """The three layouts coexist: a fleet mid-upgrade has live worktrees in all of
+    them, so recognising 1.2 must not cost the older two."""
+    home, claude_home = tmp_path / "home", tmp_path / "home" / ".claude" / "projects"
+    _plant(home, claude_home, "ace", "spark-ry12q", "nested", mtime=1000, make_worktree=True)
+
+    got = resolve_emdash_transcript("ace", "spark", home=home, claude_home=claude_home)
+    assert got is not None and got.stem == "nested"
+
+
+# --- the inverse, used by the hook path -------------------------------------------------
+
+def test_parse_reads_the_1_2_layout_back(tmp_path):
+    """A hook reports a cwd; canopy has to turn it back into (repo, task). Falling
+    through to the plain two-segment case yields ("canopy-web-05b9fcc4",
+    "emdash-emdash-check-sq69z") — a repo and a task canopy has never heard of, so the
+    hook describes a session nothing matches."""
+    home = tmp_path / "home"
+    cwd = home / "emdash" / "worktrees" / "canopy-web-05b9fcc4" / "emdash-emdash-check-sq69z"
+    cwd.mkdir(parents=True)
+
+    repo, task = parse_emdash_worktree(cwd, home=home)
+    assert repo == "canopy-web"
+    assert "emdash-check" in emdash_task_candidates(task)
+
+
+def test_parse_leaves_the_older_layouts_alone(tmp_path):
+    home = tmp_path / "home"
+    for parts, want in [
+        (("ace", "emdash", "spark-ry12q"), ("ace", "spark")),
+        (("echo", "thread-abc12"), ("echo", "thread")),
+    ]:
+        cwd = home.joinpath("emdash", "worktrees", *parts)
+        cwd.mkdir(parents=True)
+        repo, task = parse_emdash_worktree(cwd, home=home)
+        assert repo == want[0]
+        assert want[1] in emdash_task_candidates(task)

--- a/runner/canopy_runner/README.md
+++ b/runner/canopy_runner/README.md
@@ -162,8 +162,9 @@ them together would make the two modules import each other.
 - `run` (default when no subcommand is given) — the main watch loop. `--once`
   runs a single iteration (used by cron/tests/launchd health checks);
   `--drain-one` claims + runs exactly one queued turn, then exits.
-- `verify-emdash` — read-only check that emdash's DB still has the columns the
-  reads depend on (run after an emdash update; see below).
+- `verify-emdash` — read-only check that canopy's emdash assumptions still hold
+  — DB columns, worktree layout, DOM contracts, version (run after an emdash
+  update; see below).
 
 ## E2E check
 
@@ -202,22 +203,59 @@ worry about: it surfaces either as a `task_state` false-"unknown" (duplicate
 sessions) or a skipped session report (the phone's list goes stale), with
 nothing else in the log.
 
-`verify-emdash` is the proactive guard against exactly that drift. Run it
-after an emdash update:
+`verify-emdash` is the proactive guard. Run it after every emdash update:
 
 ```bash
 python3 -m canopy_runner.main verify-emdash --config ~/.canopy/runner.json
 ```
 
-- all read columns present → exit 0, `✓ … schema intact`. Nothing else to do —
-  everything else the runner assumes about emdash (it's installed, its CDP port,
-  transcripts) fails LOUDLY and is obvious within a tick.
-- a column drifted → exit 1, naming each missing `table.column`. Reconcile
-  `task_state()` / `list_open_sessions()` / `list_recently_archived_tasks()` in
-  `canopy_runner/emdash.py` against emdash's new schema, then update
-  `READ_SCHEMA` (the allowlist these reads are checked against) to match.
+It checks **four** surfaces, because canopy couples to emdash across four and
+they fail differently:
+
+| surface | what breaks | how it fails |
+|---|---|---|
+| `db schema` | the columns the sqlite reads name | silently — the reads are fail-soft |
+| `transcripts` | the worktree-path convention | silently — a miss returns `None` and every caller `continue`s |
+| `cdp dom` | the aria-labels + xterm selectors | loudly, but not until the next real turn |
+| `version` | nothing — it is the reason to look | n/a |
+
+Every check is **read-only**: it clicks nothing, opens nothing, selects no tab
+and writes no row, so it is safe to run mid-turn on a working box.
+
+- everything intact → exit 0. The version is stamped in
+  `~/.canopy/emdash-verified.json`, so a later run can say "unchanged since the
+  last clean check" and a version bump announces itself.
+- something drifted → exit 1, naming it. A schema drift names each missing
+  `table.column` (reconcile the SQL in `canopy_runner/emdash.py`, then
+  `READ_SCHEMA`). A transcript drift names each session emdash can resolve and
+  we cannot (teach the layout to `_worktree_bases` / `parse_emdash_worktree` in
+  `canopy_transcript/paths.py`). A DOM drift names the contract (reconcile the
+  selectors in `cdp/emdash_control.mjs`).
 - the DB itself can't be read → exit 2 (bad `emdash_db` path, or emdash not
-  installed).
+  installed). Distinct from 1 on purpose: "I could not look" is triaged
+  differently from "I looked and it drifted".
+
+Sections skip rather than fail when they cannot draw a conclusion — emdash not
+running skips the DOM probe, an emdash older than 1.2 skips the transcript
+check (it predates `provider_session_id`, the ground truth that check compares
+against). A check that goes red on a healthy box is a check that gets muted.
+
+### What emdash 1.2 changed
+
+Kept here as the worked example, because it is the release that showed one
+check was not enough. 1.2 moved **three** things at once:
+
+- dropped `conversations.last_interacted_at` (its own migration train copied
+  the values to `last_session_activity_at` first — that successor is emdash's
+  choice, not our guess). The schema check named it immediately.
+- changed the **worktree layout** from `worktrees/<repo>/emdash/<task>-<suffix>`
+  to `worktrees/<repo>-<8 hex>/emdash-<task>-<suffix>`. Nothing was watching
+  this, and nothing would have: sessions on the new layout resolved to no
+  transcript, so they streamed nothing and backfilled nothing, indefinitely,
+  with no error anywhere. This is why the `transcripts` check now exists.
+- added `deleted_at` to `tasks`/`projects`, and asks for live tasks as
+  `and(isNull(archivedAt), isNull(deletedAt))`. Canopy's reads now match that,
+  so a soft-deleted task stops being reported as an open session.
 
 ## Windows
 

--- a/runner/canopy_runner/canopy_runner/cdp/emdash_control.mjs
+++ b/runner/canopy_runner/canopy_runner/cdp/emdash_control.mjs
@@ -559,6 +559,36 @@ try {
     }
     out({ ok: true, task, sent: keys.length });
 
+  } else if (command === 'probe') {
+    // READ-ONLY upgrade probe: does every DOM contract this sidecar depends on still
+    // resolve? Clicks NOTHING and opens NOTHING — an upgrade check that stole focus
+    // or selected a tab would be a check nobody dares run on a working fleet, and
+    // #510 is the record of what a read-on-a-signal costs.
+    //
+    // It reports what it can SEE, so a contract is only meaningful when the UI is
+    // showing that part of itself: with no task open there is no terminal, which is
+    // not a drift. Hence `present` (found it), `absent` (looked, not there) and the
+    // caller deciding which absences matter — see upgrade_check.CDP_CONTRACTS.
+    const data = await page.evaluate(String.raw`(() => { ${ACTIVE_TERM_FN}; return (() => {
+      const labels = [...document.querySelectorAll('button')]
+        .map(b => b.getAttribute('aria-label') || '');
+      const term = activeTerm();
+      const claudeTabs = [...document.querySelectorAll('[role="button"][title]')]
+        .filter(el => /^Claude\s*\(/.test(el.getAttribute('title') || ''));
+      return {
+        open_task_labels:  labels.filter(t => t.startsWith('Open task ')).length,
+        new_task_labels:   labels.filter(t => t.startsWith('New task for ')).length,
+        sidebar_scroller:  document.querySelectorAll('.overflow-y-auto').length,
+        xterm_any:         document.querySelectorAll('.xterm').length,
+        xterm_active:      term ? 1 : 0,
+        xterm_rows:        term && term.querySelector('.xterm-rows') ? 1 : 0,
+        terminal_input:    (term && term.querySelector('.xterm-helper-textarea'))
+                             || document.querySelector('textarea[aria-label="Terminal input"]') ? 1 : 0,
+        claude_tabs:       claudeTabs.length,
+      };
+    })(); })()`);
+    out({ ok: true, ...data });
+
   } else {
     fail(`unknown command: ${command}`);
   }

--- a/runner/canopy_runner/canopy_runner/cdp_control.py
+++ b/runner/canopy_runner/canopy_runner/cdp_control.py
@@ -160,6 +160,20 @@ def list_tasks(*, port: int = 9222) -> dict:
     return _run("list", {"port": port})
 
 
+def probe(*, port: int = 9222) -> dict:
+    """READ-ONLY: a count per DOM contract this module depends on.
+
+    The upgrade counterpart to `verify-emdash`'s schema check, for the half of the
+    coupling that lives in emdash's UI rather than its DB. Clicks nothing and opens
+    nothing, so it is safe to run against a fleet mid-turn.
+
+    Counts rather than booleans because the interesting failures are not binary: a
+    sidebar that renders but exposes no `Open task` labels is a drift, and so is one
+    that suddenly exposes two Claude tabs where `send-keys` requires exactly one.
+    """
+    return _run("probe", {"port": port}, timeout=30)
+
+
 def create_task(project: str, prompt: str, *, task_name: str = "", port: int = 9222) -> dict:
     """Create a NEW emdash task under `project` with `prompt` as the initial message.
     Pass `task_name` for a deterministic, reusable name (recommended — the auto-name

--- a/runner/canopy_runner/canopy_runner/emdash.py
+++ b/runner/canopy_runner/canopy_runner/emdash.py
@@ -17,6 +17,16 @@ emdash renaming a column these queries name — which is why `check_read_schema`
 (surfaced as `canopy_runner verify-emdash`) exists: run it after an emdash update to
 confirm the columns these two functions depend on still exist. Keep `READ_SCHEMA` in
 lockstep with the SQL below — it IS the list of columns the SQL names.
+
+**A row is live only if it is neither archived NOR soft-deleted.** emdash 1.2 added
+`deleted_at` to `tasks` and `projects` and its own queries pair the two —
+`and(isNull(tasks.archivedAt), isNull(tasks.deletedAt))` is how emdash itself asks for
+live tasks. Matching that is not defensive tidiness: filtering on `archived_at` alone
+means canopy reports as OPEN a task emdash no longer shows anywhere, so the supervisor
+grows sessions nobody can click into and `task_state` calls a deleted task "live" and
+hands it to the reuse path. The columns were empty on the fleet laptop when this was
+written (2026-08-28), so the divergence is latent rather than observed — which is the
+point of fixing it now: it starts costing the moment anyone deletes a task.
 """
 from __future__ import annotations
 
@@ -36,13 +46,26 @@ READ_SCHEMA: dict[str, list[str]] = {
         "last_interacted_at",
         "type",
         "project_id",
+        "deleted_at",
     ],
-    "projects": ["id", "name"],
+    "projects": ["id", "name", "deleted_at"],
     # Emdash's OWN liveness flag, per conversation. Read fail-soft (see
     # `_agent_statuses`) but listed here anyway: verify-emdash is where you find
     # out a read drifted, and a degradation that nothing reports is exactly the
     # class this file exists to prevent.
-    "conversations": ["task_id", "agent_status", "last_interacted_at"],
+    #
+    # `last_interacted_at` lived here until emdash 1.2. Its migration train copied
+    # the values into `last_session_activity_at` (0036) and then dropped the legacy
+    # column (0037) — so the successor is emdash's own choice, not our guess. It is
+    # NULLABLE and sparsely populated (10 of 26 rows on the fleet laptop, 2026-08-28),
+    # hence the COALESCE onto `updated_at` in the ORDER BY below rather than a
+    # straight swap: ordering by a mostly-NULL column is not an ordering.
+    "conversations": [
+        "task_id",
+        "agent_status",
+        "last_session_activity_at",
+        "updated_at",
+    ],
 }
 
 # `conversations.agent_status` when emdash is actively driving the agent. The
@@ -133,7 +156,8 @@ def task_state(db_path: str, name: str) -> str:
     try:
         with _db(db_path) as conn:
             row = conn.execute(
-                "SELECT archived_at FROM tasks WHERE name=? ORDER BY created_at DESC LIMIT 1",
+                "SELECT archived_at FROM tasks WHERE name=? AND deleted_at IS NULL "
+                "ORDER BY created_at DESC LIMIT 1",
                 (name,),
             ).fetchone()
     except sqlite3.Error:
@@ -168,7 +192,7 @@ def _agent_statuses(conn: sqlite3.Connection) -> dict[str, str]:
             """
             SELECT task_id, COALESCE(agent_status, '') AS agent_status
             FROM conversations
-            ORDER BY last_interacted_at
+            ORDER BY COALESCE(last_session_activity_at, updated_at)
             """
         ).fetchall()
     except sqlite3.Error:
@@ -213,7 +237,7 @@ def list_open_sessions(db_path: str, limit: int = 30) -> list[dict]:
                        t.last_interacted_at AS last_interacted_at
                 FROM tasks t
                 LEFT JOIN projects p ON p.id = t.project_id
-                WHERE t.archived_at IS NULL AND t.type = 'task'
+                WHERE t.archived_at IS NULL AND t.deleted_at IS NULL AND t.type = 'task'
                 ORDER BY t.last_interacted_at DESC
                 LIMIT ?
                 """,
@@ -264,7 +288,9 @@ def list_projects(db_path: str) -> list[str]:
         return []
     try:
         with _db(db_path) as conn:
-            rows = conn.execute("SELECT name FROM projects ORDER BY name").fetchall()
+            rows = conn.execute(
+                "SELECT name FROM projects WHERE deleted_at IS NULL ORDER BY name"
+            ).fetchall()
     except sqlite3.Error as exc:
         raise EmdashReadError(f"emdash project read failed: {exc}") from exc
     return [r["name"] for r in rows if r["name"]]
@@ -291,7 +317,7 @@ def list_recently_archived_tasks(db_path: str, limit: int = 100) -> list[str]:
                 """
                 SELECT t.name AS emdash_task
                 FROM tasks t
-                WHERE t.archived_at IS NOT NULL AND t.type = 'task'
+                WHERE t.archived_at IS NOT NULL AND t.deleted_at IS NULL AND t.type = 'task'
                 ORDER BY t.archived_at DESC
                 LIMIT ?
                 """,

--- a/runner/canopy_runner/canopy_runner/main.py
+++ b/runner/canopy_runner/canopy_runner/main.py
@@ -652,38 +652,38 @@ def drain_one(cfg: Config, client: Client) -> str:
 
 
 def verify_emdash(cfg_path: Path) -> int:
-    """Read-only check that emdash's DB still has the columns the CDP-path reads
-    depend on. Exit 0 = intact; 1 = drifted (names each missing column); 2 = the
-    DB itself couldn't be read.
+    """Read-only check that canopy's four emdash assumptions still hold. Exit 0 =
+    intact; 1 = something drifted (each one named); 2 = the DB itself couldn't be read.
 
-    This is the ONE emdash assumption that fails SILENTLY. task_state() and
+    Run it after an emdash update. It started life as the schema check alone, because
+    that was the one emdash assumption believed to fail SILENTLY: task_state() and
     list_open_sessions() swallow sqlite errors (a read failure must never be mistaken
-    for "session gone"), so a renamed tasks/projects column doesn't crash — it quietly
-    degrades the runner into spawning duplicate sessions and blanking the supervisor,
-    with nothing in the log. Everything else we assume about emdash fails LOUDLY and is
-    obvious within a tick (emdash not installed → won't launch; CDP down → degraded
-    heartbeat + a WARNING; transcripts unreadable → visible). So this verifies the quiet
-    one. Run it after an emdash update.
+    for "session gone"), so a renamed column doesn't crash — it quietly degrades the
+    runner into spawning duplicate sessions and blanking the supervisor, with nothing
+    in the log.
+
+    emdash 1.2 showed that reasoning was half right. The schema check did its job and
+    named `conversations.last_interacted_at` the moment it went. But the same release
+    also changed the WORKTREE LAYOUT, and that assumption is quieter still: a path we
+    can no longer derive returns None, and every caller treats None as "no transcript
+    yet" — so a session streams nothing and backfills nothing, indefinitely, with no
+    error anywhere. Nothing was watching that, so this now checks it, along with the
+    DOM contracts and the version itself. See `upgrade_check`.
     """
+    from . import upgrade_check
+
     raw = json.loads(Path(cfg_path).read_text())
     db = raw.get("emdash_db")
     if not db:
         print(f"✗ no 'emdash_db' in {cfg_path}"); return 2
-    try:
-        problems = emdash.check_read_schema(db)
-    except emdash.SchemaCheckError as exc:
-        print(f"✗ {exc}"); return 2
-    if problems:
-        print("✗ emdash read schema drifted — the CDP-path reads would SILENTLY degrade:")
-        for p in problems:
-            print(f"    - {p}")
-        print("  fix: reconcile task_state()/list_open_sessions() in canopy_runner/emdash.py")
-        print("       against emdash's new schema, then update READ_SCHEMA to match.")
-        return 1
-    n = sum(len(c) for c in emdash.READ_SCHEMA.values())
-    print(f"✓ emdash read schema intact — all {n} columns across "
-          f"{', '.join(emdash.READ_SCHEMA)} present in {db}")
-    return 0
+    port = int(raw.get("cdp_port") or 9222)
+
+    checks, code = upgrade_check.run(
+        db, port=port, home=Path.home(), claude_home=Path.home() / ".claude" / "projects"
+    )
+    print("emdash upgrade check" + (" — OK" if code == 0 else " — ATTENTION"))
+    print(upgrade_check.render(checks))
+    return code
 
 
 def update_check(cfg_path: Path) -> int:
@@ -772,8 +772,9 @@ def _build_parser() -> argparse.ArgumentParser:
 
     verify_parser = subparsers.add_parser(
         "verify-emdash",
-        help="read-only check that emdash's DB still has the columns the CDP-path "
-             "reads depend on (run after an emdash update)",
+        help="read-only check that canopy's emdash assumptions still hold — DB "
+             "columns, worktree layout, DOM contracts, version (run after an "
+             "emdash update)",
     )
     verify_parser.add_argument("--config", required=True)
 

--- a/runner/canopy_runner/canopy_runner/main.py
+++ b/runner/canopy_runner/canopy_runner/main.py
@@ -36,7 +36,7 @@ import logging
 import time
 from pathlib import Path
 
-from . import chat_bridge, chat_pump, close, emdash, hooks, inbox_due, sessions, streams
+from . import chat_bridge, chat_pump, close, hooks, inbox_due, sessions, streams
 from . import __version__, provenance
 from .cancel import CANCELLED_TURNS
 from .client import Client, ClientError

--- a/runner/canopy_runner/canopy_runner/upgrade_check.py
+++ b/runner/canopy_runner/canopy_runner/upgrade_check.py
@@ -1,0 +1,269 @@
+"""The emdash upgrade check — run it after every emdash update.
+
+Canopy couples to emdash across FOUR surfaces, and they fail in different ways:
+
+    surface        how it breaks                          who noticed, before this
+    -------------  -------------------------------------  ------------------------
+    sqlite reads   silently (reads are fail-soft)          `verify-emdash`
+    worktree paths silently (a miss returns None)          nobody
+    DOM contracts  loudly, but only on the next real turn  nobody, until it mattered
+    app version    not a failure — the reason to look      nobody
+
+Only the first had a check. That asymmetry is why emdash 1.2 was able to change the
+worktree layout and drop `conversations.last_interacted_at` in the same release and
+have exactly one of the two get caught: the schema check named its missing column
+immediately, while every session created on 1.2 resolved to no transcript at all and
+said nothing about it — no error, no log line, just a `continue` on the streams and
+backfills ticks, forever.
+
+So this check asserts all four, and the ordering is deliberate: cheapest and most
+diagnostic first, so a box with no emdash at all reports that rather than a cascade of
+downstream failures caused by it.
+
+**Every check here is READ-ONLY.** Nothing clicks, opens, selects a tab, or writes a
+row. A check that perturbs the fleet is a check nobody runs on the fleet, and the one
+time canopy read emdash's UI on a signal it stole focus from a human (#510). It is
+therefore safe to run mid-turn, on a working box, as often as you like.
+
+Exit codes are the same three `verify-emdash` always used: 0 intact, 1 drifted, 2 the
+DB could not be read at all.
+"""
+from __future__ import annotations
+
+import json
+import plistlib
+import sqlite3
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from . import emdash
+
+# Where macOS keeps the version string. Read from the app bundle rather than asked of
+# a running emdash: the check must work with emdash closed, and — more usefully — the
+# bundle is what a NEXT launch will run, so a replaced-but-not-restarted emdash reports
+# the version the box is about to be on rather than the one it is still executing.
+_INFO_PLIST = Path("/Applications/Emdash.app/Contents/Info.plist")
+
+# The last version this check passed against, so a rerun can say "same version, still
+# fine" vs "this is new, look at the report properly". Advisory only — never a gate.
+_STAMP = Path.home() / ".canopy" / "emdash-verified.json"
+
+# What a healthy `cdp_control.probe()` looks like. A contract is (key, minimum,
+# required) — `required=False` means an absence is only meaningful when the UI is
+# showing that part of itself, so it degrades to a NOTE rather than a drift.
+#
+# `claude_tabs` is deliberately non-required AND unbounded above: `send-keys` needs
+# exactly one VISIBLE Claude tab in the open task, but the probe opens nothing, so
+# what it counts here is whatever happens to be on screen.
+CDP_CONTRACTS: tuple[tuple[str, int, bool], ...] = (
+    ("open_task_labels", 1, False),   # no tasks in the sidebar is a legitimate state
+    ("new_task_labels", 1, True),     # a project list is always rendered
+    ("sidebar_scroller", 1, True),    # `.overflow-y-auto` — the virtualization scan
+    ("xterm_any", 1, False),          # no terminal until a task is open
+    ("xterm_rows", 1, False),
+    ("terminal_input", 1, False),
+    ("claude_tabs", 1, False),
+)
+
+
+@dataclass
+class Check:
+    """One surface's verdict. `notes` carry the evidence a human needs to act."""
+    name: str
+    ok: bool
+    summary: str
+    notes: list[str] = field(default_factory=list)
+    skipped: bool = False
+
+
+def installed_version() -> str | None:
+    """emdash's `CFBundleShortVersionString`, or None if it isn't installed here."""
+    try:
+        with _INFO_PLIST.open("rb") as fh:
+            return plistlib.load(fh).get("CFBundleShortVersionString")
+    except (OSError, ValueError):
+        return None
+
+
+def _last_verified() -> str | None:
+    try:
+        return json.loads(_STAMP.read_text()).get("version")
+    except (OSError, ValueError):
+        return None
+
+
+def record_verified(version: str | None) -> None:
+    """Stamp a clean run. Best-effort: a read-only check must not fail because it
+    could not write its own bookkeeping."""
+    if not version:
+        return
+    try:
+        _STAMP.parent.mkdir(parents=True, exist_ok=True)
+        _STAMP.write_text(json.dumps({"version": version}))
+    except OSError:
+        pass
+
+
+def check_version() -> Check:
+    version = installed_version()
+    if version is None:
+        return Check("version", True, "emdash not installed at /Applications — skipping",
+                     skipped=True)
+    last = _last_verified()
+    if last == version:
+        return Check("version", True, f"emdash {version} (unchanged since the last clean check)")
+    was = f"last verified against {last}" if last else "no previous check recorded"
+    return Check("version", True, f"emdash {version} — NEW ({was})",
+                 notes=["a version bump is the reason to read the rest of this report closely"])
+
+
+def check_schema(db_path: str) -> Check:
+    """The sqlite columns the CDP-path reads name. The pre-existing check, unchanged
+    in behaviour — it is the one surface that was already covered."""
+    try:
+        problems = emdash.check_read_schema(db_path)
+    except emdash.SchemaCheckError as exc:
+        return Check("db schema", False, str(exc))
+    if problems:
+        return Check(
+            "db schema", False,
+            "read schema drifted — the reads would SILENTLY degrade",
+            notes=problems + [
+                "fix: reconcile emdash.py's SQL against emdash's new schema, then "
+                "update READ_SCHEMA to match",
+            ],
+        )
+    n = sum(len(c) for c in emdash.READ_SCHEMA.values())
+    return Check("db schema", True,
+                 f"all {n} columns across {', '.join(emdash.READ_SCHEMA)} present")
+
+
+def check_transcripts(db_path: str, *, home: Path, claude_home: Path) -> Check:
+    """Can we still find the transcript for the sessions emdash says are open?
+
+    This is the check that did not exist, and the reason it now does. It asserts the
+    worktree-path CONVENTION — which emdash owns, has changed twice, and signals in no
+    way — against emdash's own list of open tasks. A miss here is invisible everywhere
+    else: `resolve_emdash_transcript` returns None and its callers `continue`.
+
+    A session with no transcript YET is not a miss, so the check does not demand 100%;
+    it compares our answer against emdash's own `provider_session_id`, which is the
+    ground truth for "a transcript exists at all". Sessions where emdash knows the file
+    and we cannot find it are the drift, and they are named individually.
+    """
+    from canopy_transcript import resolve_emdash_transcript
+
+    try:
+        with sqlite3.connect(f"file:{db_path}?mode=ro", uri=True) as conn:
+            conn.row_factory = sqlite3.Row
+            # `provider_session_id` is the referee, and emdash only started recording
+            # it in 1.2. Its absence means an OLDER emdash, which is a fine thing to be
+            # running — so the check loses its ground truth and says so, rather than
+            # reporting the older emdash as a drift. A check that goes red on a
+            # perfectly healthy box is a check that gets muted.
+            cols = {r["name"] for r in conn.execute("PRAGMA table_info(conversations)")}
+            if "provider_session_id" not in cols:
+                return Check(
+                    "transcripts", True,
+                    "emdash predates provider_session_id — no ground truth to check "
+                    "the worktree layout against, skipping",
+                    skipped=True,
+                )
+            rows = conn.execute(
+                """
+                SELECT t.name AS task, COALESCE(p.name, '') AS repo,
+                       cv.provider_session_id AS sid
+                FROM tasks t
+                LEFT JOIN projects p ON p.id = t.project_id
+                LEFT JOIN conversations cv ON cv.task_id = t.id
+                WHERE t.archived_at IS NULL AND t.type = 'task'
+                """
+            ).fetchall()
+    except sqlite3.Error as exc:
+        return Check("transcripts", False, f"could not list open sessions: {exc}")
+
+    if not rows:
+        return Check("transcripts", True, "no open sessions to check", skipped=True)
+
+    misses: list[str] = []
+    resolved = truth = 0
+    for r in rows:
+        ours = resolve_emdash_transcript(r["repo"], r["task"], home=home, claude_home=claude_home)
+        # emdash 1.2 records the provider's own session id; a matching .jsonl anywhere
+        # under ~/.claude/projects proves a transcript exists independently of any path
+        # convention, which is exactly the neutral referee this check needs.
+        emdash_knows = bool(r["sid"]) and any(claude_home.glob(f"*/{r['sid']}.jsonl"))
+        resolved += bool(ours)
+        truth += emdash_knows
+        if emdash_knows and not ours:
+            misses.append(f"{r['repo']}/{r['task']} — emdash has the transcript, our path convention does not find it")
+
+    if misses:
+        return Check(
+            "transcripts", False,
+            f"worktree layout drifted — {resolved}/{truth} resolvable transcripts found",
+            notes=misses + [
+                "fix: teach _worktree_bases()/parse_emdash_worktree() in "
+                "canopy_transcript/paths.py the new layout",
+            ],
+        )
+    return Check("transcripts", True,
+                 f"{resolved}/{truth} resolvable transcripts found across {len(rows)} open sessions")
+
+
+def check_cdp(*, port: int) -> Check:
+    """The DOM contracts the CDP sidecar depends on. Read-only; nothing is clicked."""
+    from . import cdp_control
+
+    if not cdp_control.cdp_healthy(port=port):
+        return Check("cdp dom", True,
+                     f"emdash not reachable on CDP :{port} — skipping (start emdash to check)",
+                     skipped=True)
+    try:
+        data = cdp_control.probe(port=port)
+    except cdp_control.CDPError as exc:
+        return Check("cdp dom", False, f"probe failed: {exc}")
+
+    broken, notes = [], []
+    for key, minimum, required in CDP_CONTRACTS:
+        got = data.get(key, 0)
+        if got >= minimum:
+            continue
+        if required:
+            broken.append(f"{key}: found {got}, expected >= {minimum}")
+        else:
+            notes.append(f"{key}: 0 — not on screen right now, so not conclusive")
+    if broken:
+        return Check("cdp dom", False, "DOM contract drifted — the CDP path would fail on the next turn",
+                     notes=broken + [
+                         "fix: reconcile the selectors in cdp/emdash_control.mjs against emdash's new UI",
+                     ])
+    seen = ", ".join(f"{k}={data.get(k, 0)}" for k, _, _ in CDP_CONTRACTS)
+    return Check("cdp dom", True, f"all required contracts resolve ({seen})", notes=notes)
+
+
+def run(db_path: str, *, port: int, home: Path, claude_home: Path) -> tuple[list[Check], int]:
+    """Every check, in order. Returns (checks, exit code)."""
+    checks = [check_version(), check_schema(db_path)]
+    # The schema check is the gate for the transcript one: both read the same DB, and
+    # a DB we cannot open would report a second, derivative failure that tells a human
+    # nothing they don't already know from the first.
+    if checks[-1].ok:
+        checks.append(check_transcripts(db_path, home=home, claude_home=claude_home))
+    checks.append(check_cdp(port=port))
+
+    failed = [c for c in checks if not c.ok]
+    if not failed:
+        record_verified(installed_version())
+        return checks, 0
+    # 2 is reserved for "could not read the DB at all" — a setup problem, not a drift.
+    return checks, 2 if not checks[1].ok and "not found" in checks[1].summary else 1
+
+
+def render(checks: list[Check]) -> str:
+    lines = []
+    for c in checks:
+        mark = "-" if c.skipped else ("+" if c.ok else "x")
+        lines.append(f"  {mark} {c.name}: {c.summary}")
+        lines.extend(f"      {n}" for n in c.notes)
+    return "\n".join(lines)

--- a/runner/canopy_runner/tests/test_emdash.py
+++ b/runner/canopy_runner/tests/test_emdash.py
@@ -18,16 +18,17 @@ def _emdash_schema() -> str:
     and list_open_sessions() name. Deliberately a superset-shaped, minimal stand-in
     for emdash's real schema — only the read columns matter here."""
     return """
-        CREATE TABLE projects (id TEXT PRIMARY KEY, name TEXT NOT NULL);
+        CREATE TABLE projects (id TEXT PRIMARY KEY, name TEXT NOT NULL, deleted_at TEXT);
         CREATE TABLE tasks (
           id TEXT PRIMARY KEY, project_id TEXT NOT NULL, name TEXT NOT NULL, status TEXT NOT NULL,
           archived_at TEXT, last_interacted_at TEXT,
           created_at TEXT DEFAULT CURRENT_TIMESTAMP NOT NULL, updated_at TEXT DEFAULT CURRENT_TIMESTAMP NOT NULL,
-          type TEXT DEFAULT 'task' NOT NULL, automation_run_id TEXT
+          type TEXT DEFAULT 'task' NOT NULL, automation_run_id TEXT, deleted_at TEXT
         );
         CREATE TABLE conversations (
           id TEXT PRIMARY KEY, task_id TEXT NOT NULL, agent_status TEXT,
-          last_interacted_at TEXT
+          last_session_activity_at TEXT,
+          updated_at TEXT DEFAULT CURRENT_TIMESTAMP NOT NULL
         );
     """
 
@@ -67,7 +68,7 @@ def test_check_read_schema_reports_a_missing_table(tmp_path):
     conn = sqlite3.connect(path)
     conn.executescript(
         "CREATE TABLE tasks (name TEXT, archived_at TEXT, created_at TEXT, status TEXT, "
-        "last_interacted_at TEXT, type TEXT, project_id TEXT);"
+        "last_interacted_at TEXT, type TEXT, project_id TEXT, deleted_at TEXT);"
     )  # no `projects` table at all
     conn.commit()
     conn.close()
@@ -197,11 +198,14 @@ def test_list_open_sessions_is_fail_soft_on_missing_db(tmp_path):
 # cannot give: a session inside a long tool call is silent, not finished.
 # --------------------------------------------------------------------------------------
 
-def _add_conversation(db, task_id, agent_status, *, at="2026-08-12T23:00:00Z"):
+def _add_conversation(db, task_id, agent_status, *, at="2026-08-12T23:00:00Z", column="last_session_activity_at"):
+    """`column` picks which timestamp carries the ordering. emdash 1.2 populates
+    `last_session_activity_at` sparsely (10 of 26 rows on the fleet laptop), so the
+    read COALESCEs onto the always-present `updated_at` — pass "updated_at" to build
+    the rows that exercise that leg."""
     conn = sqlite3.connect(db)
     conn.execute(
-        "INSERT INTO conversations (id, task_id, agent_status, last_interacted_at) "
-        "VALUES (?, ?, ?, ?)",
+        f"INSERT INTO conversations (id, task_id, agent_status, {column}) VALUES (?, ?, ?, ?)",
         (str(uuid.uuid4()), task_id, agent_status, at),
     )
     conn.commit()
@@ -242,6 +246,21 @@ def test_without_working_the_newest_conversation_answers(db):
     assert row["agent_status"] == "compacting"
 
 
+def test_a_null_activity_stamp_still_orders_by_updated_at(db):
+    """emdash 1.2 dropped `conversations.last_interacted_at` and its migration train
+    (0036) copied the values into `last_session_activity_at` — but that successor is
+    NULLABLE and sparsely written (10 of 26 rows, fleet laptop 2026-08-28). Ordering
+    by it alone is therefore not an ordering: the 16 NULL rows sort together and the
+    newest-wins rule silently picks an arbitrary one. The read COALESCEs onto
+    `updated_at`, which emdash declares NOT NULL, so a row with no activity stamp
+    still sorts where it belongs."""
+    _add_task(db, "sparse", task_id="t-6")
+    _add_conversation(db, "t-6", "idle", at="2026-08-12T22:00:00Z", column="updated_at")
+    _add_conversation(db, "t-6", "awaiting-input", at="2026-08-12T23:00:00Z", column="updated_at")
+    (row,) = list_open_sessions(db)
+    assert row["agent_status"] == "awaiting-input"
+
+
 def test_a_drifted_conversations_table_costs_the_status_not_the_report(db):
     """The asymmetry that matters: this read is an ENRICHMENT. An emdash that cannot
     answer must leave us reporting sessions without the flag — raising here would skip
@@ -258,3 +277,45 @@ def test_a_drifted_conversations_table_costs_the_status_not_the_report(db):
     assert row["agent_status"] == ""
     # ...and verify-emdash is where that degradation becomes visible.
     assert check_read_schema(db) == ["conversations.agent_status missing"]
+
+
+# --------------------------------------------------------------------------------------
+# Soft delete. emdash 1.2 added `deleted_at` to tasks/projects and asks for live tasks as
+# `and(isNull(archivedAt), isNull(deletedAt))`. Matching that is what keeps canopy's idea
+# of "open" the same as emdash's — filtering on archived_at alone reports sessions that
+# emdash no longer shows anywhere, which is a session nobody can click into.
+# --------------------------------------------------------------------------------------
+
+def _soft_delete(db, name):
+    conn = sqlite3.connect(db)
+    conn.execute("UPDATE tasks SET deleted_at = '2026-08-28T06:00:00Z' WHERE name = ?", (name,))
+    conn.commit()
+    conn.close()
+
+
+def test_a_soft_deleted_task_is_not_an_open_session(db):
+    _add_task(db, "kept")
+    _add_task(db, "binned")
+    _soft_delete(db, "binned")
+    assert {r["emdash_task"] for r in list_open_sessions(db)} == {"kept"}
+
+
+def test_a_soft_deleted_task_is_absent_not_live(db):
+    """`task_state` drives the REUSE decision. Calling a deleted task "live" sends the
+    runner to open a task emdash will not find, and the CDP path then fails at a point
+    where it can no longer tell "glitched" from "gone"."""
+    _add_task(db, "binned")
+    _soft_delete(db, "binned")
+    assert task_state(db, "binned") == "absent"
+
+
+def test_a_soft_deleted_task_is_not_reported_as_archived(db):
+    """The archived list is the CLOSING signal — the server un-retires anything absent
+    from it. A deleted task is not something the human archived, and reporting it as
+    such would resurrect it."""
+    from canopy_runner.emdash import list_recently_archived_tasks
+
+    _add_task(db, "really-archived", archived_at="2026-08-27T00:00:00Z")
+    _add_task(db, "binned", archived_at="2026-08-27T00:00:00Z")
+    _soft_delete(db, "binned")
+    assert list_recently_archived_tasks(db) == ["really-archived"]

--- a/runner/canopy_runner/tests/test_emdash_projects.py
+++ b/runner/canopy_runner/tests/test_emdash_projects.py
@@ -22,12 +22,12 @@ def _make_db(path):
     conn = sqlite3.connect(path)
     conn.executescript(
         """
-        CREATE TABLE projects (id TEXT, name TEXT, path TEXT);
+        CREATE TABLE projects (id TEXT, name TEXT, path TEXT, deleted_at TEXT);
         CREATE TABLE tasks (id TEXT, project_id TEXT, name TEXT, status TEXT,
                             archived_at TEXT, last_interacted_at TEXT, type TEXT);
-        INSERT INTO projects VALUES ('p2','canopy-web','/x/canopy-web');
-        INSERT INTO projects VALUES ('p1','canopy','/x/canopy');
-        INSERT INTO projects VALUES ('p3','','/x/nameless');
+        INSERT INTO projects (id, name, path) VALUES ('p2','canopy-web','/x/canopy-web');
+        INSERT INTO projects (id, name, path) VALUES ('p1','canopy','/x/canopy');
+        INSERT INTO projects (id, name, path) VALUES ('p3','','/x/nameless');
         """
     )
     conn.commit()
@@ -62,7 +62,7 @@ def test_an_empty_projects_table_is_a_real_empty_list(tmp_path):
     which is the entire point of raising in that case."""
     db = tmp_path / "empty.db"
     conn = sqlite3.connect(str(db))
-    conn.executescript("CREATE TABLE projects (id TEXT, name TEXT, path TEXT);")
+    conn.executescript("CREATE TABLE projects (id TEXT, name TEXT, path TEXT, deleted_at TEXT);")
     conn.commit()
     conn.close()
     assert emdash.list_projects(str(db)) == []

--- a/runner/canopy_runner/tests/test_emdash_sessions.py
+++ b/runner/canopy_runner/tests/test_emdash_sessions.py
@@ -9,15 +9,16 @@ def _make_db(path):
     conn = sqlite3.connect(path)
     conn.executescript(
         """
-        CREATE TABLE projects (id TEXT, name TEXT, path TEXT);
+        CREATE TABLE projects (id TEXT, name TEXT, path TEXT, deleted_at TEXT);
         CREATE TABLE tasks (id TEXT, project_id TEXT, name TEXT, status TEXT,
-                            archived_at TEXT, last_interacted_at TEXT, type TEXT);
-        INSERT INTO projects VALUES ('p1','canopy-web','/x/canopy-web');
-        INSERT INTO tasks VALUES ('t1','p1','cloud-runner','in_progress',NULL,'2026-07-16T15:52:00','task');
-        INSERT INTO tasks VALUES ('t2','p1','ddd','in_progress',NULL,'2026-07-16T12:41:00','task');
-        INSERT INTO tasks VALUES ('t3','p1','old','done','2026-07-15T00:00:00','2026-07-15T00:00:00','task');
+                            archived_at TEXT, last_interacted_at TEXT, type TEXT,
+                            deleted_at TEXT);
+        INSERT INTO projects (id, name, path) VALUES ('p1','canopy-web','/x/canopy-web');
+        INSERT INTO tasks (id, project_id, name, status, archived_at, last_interacted_at, type) VALUES ('t1','p1','cloud-runner','in_progress',NULL,'2026-07-16T15:52:00','task');
+        INSERT INTO tasks (id, project_id, name, status, archived_at, last_interacted_at, type) VALUES ('t2','p1','ddd','in_progress',NULL,'2026-07-16T12:41:00','task');
+        INSERT INTO tasks (id, project_id, name, status, archived_at, last_interacted_at, type) VALUES ('t3','p1','old','done','2026-07-15T00:00:00','2026-07-15T00:00:00','task');
         -- an un-promoted automation-run: emdash hides it under "Automations", so must NOT show.
-        INSERT INTO tasks VALUES ('t4','p1','plain-keys-rescue','in_progress',NULL,'2026-07-13T15:01:00','automation-run');
+        INSERT INTO tasks (id, project_id, name, status, archived_at, last_interacted_at, type) VALUES ('t4','p1','plain-keys-rescue','in_progress',NULL,'2026-07-13T15:01:00','automation-run');
         """
     )
     conn.commit()
@@ -68,17 +69,17 @@ def test_lists_recently_archived_task_names_newest_first(tmp_path):
     conn.execute("DELETE FROM tasks WHERE name='old'")
     # OLDER-archived row inserted FIRST...
     conn.execute(
-        "INSERT INTO tasks VALUES ('t5','p1','older','done','2026-07-01T00:00:00',"
+        "INSERT INTO tasks (id, project_id, name, status, archived_at, last_interacted_at, type) VALUES ('t5','p1','older','done','2026-07-01T00:00:00',"
         "'2026-07-01T00:00:00','task')"
     )
     # ...NEWER-archived row inserted SECOND — reversed vs. the expected output order.
     conn.execute(
-        "INSERT INTO tasks VALUES ('t3','p1','old','done','2026-07-15T00:00:00',"
+        "INSERT INTO tasks (id, project_id, name, status, archived_at, last_interacted_at, type) VALUES ('t3','p1','old','done','2026-07-15T00:00:00',"
         "'2026-07-15T00:00:00','task')"
     )
     # an archived AUTOMATION-RUN must not leak in either — it was never a session
     conn.execute(
-        "INSERT INTO tasks VALUES ('t6','p1','auto-gone','done','2026-07-20T00:00:00',"
+        "INSERT INTO tasks (id, project_id, name, status, archived_at, last_interacted_at, type) VALUES ('t6','p1','auto-gone','done','2026-07-20T00:00:00',"
         "'2026-07-20T00:00:00','automation-run')"
     )
     conn.commit()

--- a/runner/canopy_runner/tests/test_main.py
+++ b/runner/canopy_runner/tests/test_main.py
@@ -50,11 +50,12 @@ def db(tmp_path: Path) -> str:
     conn = sqlite3.connect(path)
     conn.executescript(
         """
-        CREATE TABLE projects (id TEXT PRIMARY KEY, name TEXT NOT NULL);
+        CREATE TABLE projects (id TEXT PRIMARY KEY, name TEXT NOT NULL, deleted_at TEXT);
         CREATE TABLE tasks (
           id TEXT PRIMARY KEY, project_id TEXT NOT NULL, name TEXT NOT NULL, status TEXT NOT NULL,
           archived_at TEXT, last_interacted_at TEXT,
-          created_at TEXT DEFAULT CURRENT_TIMESTAMP NOT NULL, type TEXT DEFAULT 'task' NOT NULL
+          created_at TEXT DEFAULT CURRENT_TIMESTAMP NOT NULL, type TEXT DEFAULT 'task' NOT NULL,
+          deleted_at TEXT
         );
         """
     )

--- a/runner/canopy_runner/tests/test_reported_projects.py
+++ b/runner/canopy_runner/tests/test_reported_projects.py
@@ -18,9 +18,9 @@ from canopy_runner import sessions
 def _db(tmp_path, *names) -> str:
     path = tmp_path / "emdash4.db"
     conn = sqlite3.connect(str(path))
-    conn.executescript("CREATE TABLE projects (id TEXT, name TEXT, path TEXT);")
+    conn.executescript("CREATE TABLE projects (id TEXT, name TEXT, path TEXT, deleted_at TEXT);")
     for i, n in enumerate(names):
-        conn.execute("INSERT INTO projects VALUES (?,?,?)", (f"p{i}", n, f"/x/{n}"))
+        conn.execute("INSERT INTO projects VALUES (?,?,?,NULL)", (f"p{i}", n, f"/x/{n}"))
     conn.commit()
     conn.close()
     return str(path)

--- a/runner/canopy_runner/tests/test_upgrade_check.py
+++ b/runner/canopy_runner/tests/test_upgrade_check.py
@@ -1,0 +1,225 @@
+"""The emdash upgrade check.
+
+The point of these tests is NOT that the check reports green on a healthy box — that
+proves nothing, and a check that only ever passes is indistinguishable from a check
+that cannot fail. Each one reconstructs a drift emdash has actually shipped and asserts
+the check names it.
+"""
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from canopy_runner import upgrade_check
+
+# emdash 1.2's shape, trimmed to the columns canopy reads.
+_SCHEMA_12 = """
+    CREATE TABLE projects (id TEXT PRIMARY KEY, name TEXT NOT NULL, deleted_at TEXT);
+    CREATE TABLE tasks (
+      id TEXT PRIMARY KEY, project_id TEXT, name TEXT NOT NULL, status TEXT,
+      archived_at TEXT, created_at TEXT, last_interacted_at TEXT,
+      type TEXT DEFAULT 'task' NOT NULL, deleted_at TEXT
+    );
+    CREATE TABLE conversations (
+      id TEXT PRIMARY KEY, task_id TEXT, agent_status TEXT,
+      last_session_activity_at TEXT, updated_at TEXT DEFAULT CURRENT_TIMESTAMP NOT NULL,
+      provider_session_id TEXT
+    );
+"""
+
+
+def _db(tmp_path, schema=_SCHEMA_12):
+    p = tmp_path / "emdash4.db"
+    conn = sqlite3.connect(p)
+    conn.executescript(schema)
+    conn.commit()
+    conn.close()
+    return str(p)
+
+
+def _session(db, *, repo, task, sid=None):
+    conn = sqlite3.connect(db)
+    conn.execute("INSERT OR IGNORE INTO projects (id, name) VALUES (?, ?)", (repo, repo))
+    conn.execute(
+        "INSERT INTO tasks (id, project_id, name, type) VALUES (?, ?, ?, 'task')",
+        (task, repo, task),
+    )
+    conn.execute(
+        "INSERT INTO conversations (id, task_id, provider_session_id) VALUES (?, ?, ?)",
+        (f"c-{task}", task, sid),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _plant_transcript(home, claude_home, *, worktree_rel, sid):
+    """A real worktree + the Claude transcript that belongs to it."""
+    from canopy_transcript import encode_project_dir
+
+    worktree = home / "emdash" / "worktrees" / worktree_rel
+    worktree.mkdir(parents=True)
+    proj = claude_home / encode_project_dir(worktree)
+    proj.mkdir(parents=True)
+    (proj / f"{sid}.jsonl").write_text("{}\n")
+
+
+@pytest.fixture()
+def paths(tmp_path):
+    home = tmp_path / "home"
+    claude_home = home / ".claude" / "projects"
+    claude_home.mkdir(parents=True)
+    return home, claude_home
+
+
+# --- the schema surface (the drift emdash 1.2 actually shipped) -------------------------
+
+def test_a_dropped_column_is_named(tmp_path):
+    """emdash 1.2 dropped `conversations.last_interacted_at`. The check has to say
+    WHICH column: "something drifted" sends a human to read a diff of the whole app."""
+    db = _db(tmp_path)
+    conn = sqlite3.connect(db)
+    conn.execute("ALTER TABLE conversations DROP COLUMN last_session_activity_at")
+    conn.commit()
+    conn.close()
+
+    check = upgrade_check.check_schema(db)
+    assert not check.ok
+    assert any("conversations.last_session_activity_at missing" in n for n in check.notes)
+
+
+def test_a_missing_db_is_not_reported_as_a_drift(tmp_path):
+    """"emdash isn't here" is a setup problem, not a schema change, and conflating the
+    two sends you looking for a column that was never missing."""
+    check = upgrade_check.check_schema(str(tmp_path / "nope.db"))
+    assert not check.ok
+    assert "not found" in check.summary
+
+
+# --- the worktree surface (the drift NOTHING was watching) ------------------------------
+
+def test_an_unknown_worktree_layout_is_caught(paths, tmp_path):
+    """The emdash 1.2 regression this check exists for. emdash knows the transcript —
+    it recorded the provider's own session id — and our path convention cannot find
+    it. Before this check, that state was completely silent: the session simply
+    streamed nothing, forever."""
+    home, claude_home = paths
+    db = _db(tmp_path)
+    _session(db, repo="canopy-web", task="emdash-check", sid="sid-1")
+    # A layout no version of `_worktree_bases` knows about.
+    _plant_transcript(home, claude_home, worktree_rel="totally-new-shape/emdash-check", sid="sid-1")
+
+    check = upgrade_check.check_transcripts(db, home=home, claude_home=claude_home)
+    assert not check.ok
+    assert any("canopy-web/emdash-check" in n for n in check.notes)
+
+
+def test_the_1_2_layout_passes(paths, tmp_path):
+    """The same check, against the layout 1.2 actually uses — this is what pins the
+    fix in place, so a future refactor of the path logic can't quietly undo it."""
+    home, claude_home = paths
+    db = _db(tmp_path)
+    _session(db, repo="canopy-web", task="emdash-check", sid="sid-1")
+    _plant_transcript(
+        home, claude_home,
+        worktree_rel="canopy-web-05b9fcc4/emdash-emdash-check-sq69z", sid="sid-1",
+    )
+
+    check = upgrade_check.check_transcripts(db, home=home, claude_home=claude_home)
+    assert check.ok, check.notes
+
+
+def test_a_session_with_no_transcript_yet_is_not_a_drift(paths, tmp_path):
+    """A brand-new session has written nothing. Counting it as a miss would make the
+    check red on a healthy box every time someone opened a task — and a check that
+    cries wolf gets ignored exactly when it is right."""
+    home, claude_home = paths
+    db = _db(tmp_path)
+    _session(db, repo="ace", task="fresh", sid=None)
+
+    check = upgrade_check.check_transcripts(db, home=home, claude_home=claude_home)
+    assert check.ok, check.notes
+
+
+# --- the DOM surface --------------------------------------------------------------------
+
+def test_a_missing_required_dom_contract_fails(monkeypatch):
+    """A sidebar that renders but exposes no `New task for` labels means the aria-label
+    convention changed — `create` would fail on the next real turn."""
+    from canopy_runner import cdp_control
+
+    monkeypatch.setattr(cdp_control, "cdp_healthy", lambda **_: True)
+    monkeypatch.setattr(cdp_control, "probe", lambda **_: {
+        "ok": True, "open_task_labels": 4, "new_task_labels": 0,
+        "sidebar_scroller": 1, "xterm_any": 1, "xterm_rows": 1,
+        "terminal_input": 1, "claude_tabs": 1,
+    })
+    check = upgrade_check.check_cdp(port=9222)
+    assert not check.ok
+    assert any("new_task_labels" in n for n in check.notes)
+
+
+def test_an_absent_terminal_is_a_note_not_a_failure(monkeypatch):
+    """The probe opens nothing, so with no task on screen there is no terminal. That
+    is the ordinary state of an idle emdash, not a drift — calling it one would make
+    the check unrunnable on exactly the quiet box you want to check before a shift."""
+    from canopy_runner import cdp_control
+
+    monkeypatch.setattr(cdp_control, "cdp_healthy", lambda **_: True)
+    monkeypatch.setattr(cdp_control, "probe", lambda **_: {
+        "ok": True, "open_task_labels": 0, "new_task_labels": 7,
+        "sidebar_scroller": 1, "xterm_any": 0, "xterm_rows": 0,
+        "terminal_input": 0, "claude_tabs": 0,
+    })
+    check = upgrade_check.check_cdp(port=9222)
+    assert check.ok
+    assert any("not conclusive" in n for n in check.notes)
+
+
+def test_emdash_not_running_skips_rather_than_fails(monkeypatch):
+    from canopy_runner import cdp_control
+
+    monkeypatch.setattr(cdp_control, "cdp_healthy", lambda **_: False)
+    check = upgrade_check.check_cdp(port=9222)
+    assert check.ok and check.skipped
+
+
+# --- the whole run ----------------------------------------------------------------------
+
+def test_run_is_red_when_any_surface_drifts(paths, tmp_path, monkeypatch):
+    home, claude_home = paths
+    db = _db(tmp_path)
+    _session(db, repo="canopy-web", task="emdash-check", sid="sid-1")
+    _plant_transcript(home, claude_home, worktree_rel="totally-new-shape/emdash-check", sid="sid-1")
+    monkeypatch.setattr(upgrade_check, "record_verified", lambda *_: None)
+    from canopy_runner import cdp_control
+    monkeypatch.setattr(cdp_control, "cdp_healthy", lambda **_: False)
+
+    checks, code = upgrade_check.run(db, port=9222, home=home, claude_home=claude_home)
+    assert code == 1
+    assert [c.name for c in checks if not c.ok] == ["transcripts"]
+
+
+def test_an_unreadable_db_exits_2_not_1(paths, tmp_path, monkeypatch):
+    """2 is "I could not look", 1 is "I looked and it drifted". A human triages those
+    differently, and the exit code is what a launchd job or a script branches on."""
+    home, claude_home = paths
+    from canopy_runner import cdp_control
+    monkeypatch.setattr(cdp_control, "cdp_healthy", lambda **_: False)
+
+    _, code = upgrade_check.run(str(tmp_path / "missing.db"), port=9222,
+                                home=home, claude_home=claude_home)
+    assert code == 2
+
+
+def test_a_pre_1_2_emdash_skips_rather_than_reporting_a_drift(paths, tmp_path):
+    """`provider_session_id` is the referee and only exists from 1.2. Running against
+    an older emdash is a legitimate state, so the check loses its ground truth and
+    says so — it does not call the older emdash broken."""
+    home, claude_home = paths
+    old_schema = _SCHEMA_12.replace(",\n      provider_session_id TEXT", "")
+    db = _db(tmp_path, old_schema)
+
+    check = upgrade_check.check_transcripts(db, home=home, claude_home=claude_home)
+    assert check.ok and check.skipped
+    assert "predates provider_session_id" in check.summary

--- a/runner/canopy_runner/tests/test_verify_emdash.py
+++ b/runner/canopy_runner/tests/test_verify_emdash.py
@@ -5,14 +5,17 @@ from pathlib import Path
 from canopy_runner.main import verify_emdash
 
 _SCHEMA = """
-    CREATE TABLE projects (id TEXT PRIMARY KEY, name TEXT NOT NULL);
+    CREATE TABLE projects (id TEXT PRIMARY KEY, name TEXT NOT NULL, deleted_at TEXT);
     CREATE TABLE tasks (
       id TEXT PRIMARY KEY, project_id TEXT NOT NULL, name TEXT NOT NULL, status TEXT NOT NULL,
       archived_at TEXT, last_interacted_at TEXT,
-      created_at TEXT DEFAULT CURRENT_TIMESTAMP NOT NULL, type TEXT DEFAULT 'task' NOT NULL
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP NOT NULL, type TEXT DEFAULT 'task' NOT NULL,
+      deleted_at TEXT
     );
     CREATE TABLE conversations (
-      id TEXT PRIMARY KEY, task_id TEXT NOT NULL, agent_status TEXT, last_interacted_at TEXT
+      id TEXT PRIMARY KEY, task_id TEXT NOT NULL, agent_status TEXT,
+      last_session_activity_at TEXT,
+      updated_at TEXT DEFAULT CURRENT_TIMESTAMP NOT NULL
     );
 """
 
@@ -21,6 +24,10 @@ def _cfg(tmp_path, db_path) -> Path:
     p = tmp_path / "runner.json"
     p.write_text(json.dumps({
         "base_url": "http://x", "token": "t", "runner_id": "r-1", "emdash_db": str(db_path),
+        # A port nothing listens on, so the DOM probe SKIPS. Without it these tests
+        # reach out to whatever emdash happens to be running on the developer's box
+        # and stop being about the schema at all.
+        "cdp_port": 1,
     }))
     return p
 
@@ -37,7 +44,9 @@ def _mkdb(tmp_path, schema=_SCHEMA):
 def test_verify_exits_0_when_schema_intact(tmp_path, capsys):
     cfg = _cfg(tmp_path, _mkdb(tmp_path))
     assert verify_emdash(cfg) == 0
-    assert "intact" in capsys.readouterr().out
+    out = capsys.readouterr().out
+    assert "OK" in out
+    assert "db schema" in out
 
 
 def test_verify_exits_1_and_names_the_drift(tmp_path, capsys):

--- a/uv.lock
+++ b/uv.lock
@@ -400,7 +400,7 @@ wheels = [
 
 [[package]]
 name = "canopy-agent-runs"
-version = "0.1.1"
+version = "0.1.3"
 source = { editable = "packages/canopy_agent_runs" }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Closes #633. Closes #634.

Kept as **one** PR because it is one upgrade response and the halves genuinely depend on each other — the new transcript check asserts the layout fix, so splitting them would stack two PRs through a merge queue that serializes them anyway. The remaining emdash-1.2 work is separate issues with separate PRs, where the split buys something.

## What broke

emdash auto-updated to 1.2.0 (bundle landed 2026-08-28 06:01) and moved three things. `verify-emdash` caught one.

| | before | after |
|---|---|---|
| sessions reporting a real `agent_status` | **0/12** | 11/12 |
| open sessions whose transcript resolves | 9/12 | **11/12** (12th has written nothing — that is the ceiling) |
| soft-deleted tasks reported as open | would be all of them | none |

**1. `conversations.last_interacted_at` dropped.** emdash's own migration train copied the values into `last_session_activity_at` first, so the successor is its choice, not our guess. The successor is nullable and sparsely written (10 of 26 rows), so this is not a straight column swap — ordering by a mostly-NULL column is not an ordering. `COALESCE` onto `updated_at`, which emdash declares NOT NULL.

**2. The worktree layout changed** — both halves: `worktrees/<repo>/emdash/<task>` → `worktrees/<repo>-<8 hex>/emdash-<task>`. Confirmed by creation time, not inferred: every new-shape dir was created minutes after 1.2 first ran, every older one is the old shape, and the two coexist.

This is the one nothing would have caught. An unknown layout returns `None`, every caller reads `None` as "no transcript yet", and the session streams nothing and backfills nothing forever with no error anywhere. The hook path was worse — it returned the hashed dir as the repo, matching no session canopy knows about.

**3. Soft delete.** 1.2 added `deleted_at` and asks for live tasks as `and(isNull(archivedAt), isNull(deletedAt))`. Canopy filtered only the first. Nothing carries `deleted_at` yet, which is why now is the cheap time.

## The check

`verify-emdash` now covers all four surfaces instead of one:

```
emdash upgrade check — OK
  + version: emdash 1.2.0 (unchanged since the last clean check)
  + db schema: all 15 columns across tasks, projects, conversations present
  + transcripts: 10/10 resolvable transcripts found across 11 open sessions
  + cdp dom: all required contracts resolve (open_task_labels=9, new_task_labels=19, …)
```

Read-only throughout — clicks nothing, opens nothing, selects no tab — so it is safe mid-turn on a working box. Skips rather than fails when it cannot conclude (emdash not running ⇒ no DOM probe; pre-1.2 emdash ⇒ no transcript check), because a check that reddens on a healthy box gets muted and is then missing on the day it is right.

## Review notes

- The 1.2 repo hash cannot be derived from `(repo, task)`, so that candidate is **globbed off disk** rather than constructed, and the repo half of the split is then matched **exactly**. Without that, `canopy-*` also lands on `canopy-web-05b9fcc4` and serves another repo's transcript — a wrong transcript being worse than none. My own test caught this; it is `test_the_1_2_layout_does_not_borrow_a_sibling_repo`.
- New tests each reconstruct a drift emdash actually shipped rather than asserting green, since a check that only ever passes is indistinguishable from one that cannot fail.
- Test fixtures moved to 1.2's schema and their positional `INSERT`s are now column-named — a positional INSERT breaks every time emdash adds a column.

## Verification

517 runner tests + 84 transcript tests pass. The check reports clean against the live 1.2 box, and each number in the table above was measured on it rather than reasoned about.

## Deploy note

This ships in the runner package, not the web app — it needs `install-runner` on **both** macOS accounts. `jjackson`'s emdash is still on the pre-1.2 binary (process started Aug 26; bundle landed Aug 28), so that account will hit all three of these the moment it restarts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHEEiXYVT6VoLoq9y91q7D