### PR TITLE
feat(runner): ask emdash where a transcript is, instead of guessing at its layout

### DIFF
--- a/runner/canopy_runner/canopy_runner/emdash.py
+++ b/runner/canopy_runner/canopy_runner/emdash.py
@@ -326,3 +326,48 @@ def list_recently_archived_tasks(db_path: str, limit: int = 100) -> list[str]:
         return [r["emdash_task"] for r in rows]
     except sqlite3.Error as exc:
         raise EmdashReadError(f"emdash archived-task read failed: {exc}") from exc
+
+
+def session_transcript_ref(db_path: str, project: str, task: str) -> tuple[str, str] | None:
+    """READ-ONLY: `(cwd, provider_session_id)` for an emdash (project, task), or None.
+
+    The two halves of "where is this session's transcript", answered by emdash rather
+    than reconstructed from a path convention emdash owns and has now changed twice.
+    `cwd` is the real worktree; `provider_session_id` is Claude Code's OWN session id,
+    which NAMES the .jsonl — so together they address the file exactly, with nothing
+    left to guess (see `canopy_transcript.resolve_cli_transcript`, which already does
+    this lookup for the cloud runner).
+
+    Returns None — never raises, and never a partial answer — when emdash cannot
+    answer: no DB, a pre-1.2 emdash without the columns, no such task, or a session
+    Claude Code has not reported an id for yet (`provider_session_id` is NULL until it
+    does). Every one of those is a legitimate "ask the convention instead", and the
+    caller falls back. Raising here would turn "emdash is older than I expected" into
+    a broken runner.
+
+    A task can own several conversations; the newest that HAS an id wins, for the same
+    reason `_agent_statuses` prefers the newest — an earlier conversation under a
+    reused task name must not answer for the live one.
+    """
+    if not project or not task or not Path(db_path).exists():
+        return None
+    try:
+        with _db(db_path) as conn:
+            row = conn.execute(
+                """
+                SELECT cv.cwd AS cwd, cv.provider_session_id AS sid
+                FROM tasks t
+                JOIN projects p ON p.id = t.project_id
+                JOIN conversations cv ON cv.task_id = t.id
+                WHERE t.name = ? AND p.name = ? AND t.deleted_at IS NULL
+                  AND cv.cwd IS NOT NULL AND cv.provider_session_id IS NOT NULL
+                ORDER BY COALESCE(cv.last_session_activity_at, cv.updated_at) DESC
+                LIMIT 1
+                """,
+                (task, project),
+            ).fetchone()
+    except sqlite3.Error:
+        return None            # older emdash, locked db, drifted column — all "ask the convention"
+    if row is None or not row["cwd"] or not row["sid"]:
+        return None
+    return row["cwd"], row["sid"]

--- a/runner/canopy_runner/canopy_runner/execute.py
+++ b/runner/canopy_runner/canopy_runner/execute.py
@@ -176,21 +176,28 @@ def _deliver_to_existing(cfg, client, runner_id, turn, task, state, work_prompt)
     return f"reused:{turn_id}"
 
 
-def _resolve_transcript_path(target: str, task: str):
+def _resolve_transcript_path(target: str, task: str, *, emdash_db: str | None = None):
     home = Path.home()
     return transcript.resolve_transcript(
-        target, task, home=home, claude_home=home / ".claude" / "projects"
+        target, task, home=home, claude_home=home / ".claude" / "projects",
+        emdash_db=emdash_db,
     )
 
 
-def _wait_for_transcript(target: str, task: str, *, timeout: float = 45.0, poll: float = 0.5):
+def _wait_for_transcript(target: str, task: str, *, timeout: float = 45.0, poll: float = 0.5,
+                         emdash_db: str | None = None):
     """A freshly-created emdash session's transcript .jsonl doesn't exist until Claude
-    Code starts writing. Wait (bounded) for it to appear; reused sessions resolve at once."""
+    Code starts writing. Wait (bounded) for it to appear; reused sessions resolve at once.
+
+    This is the one caller where asking emdash pays twice: it re-resolves on every poll,
+    and emdash names the session's `provider_session_id` as soon as Claude Code reports
+    it — which is earlier than the directory-scan can find a file, and exact when it
+    does."""
     deadline = time.monotonic() + timeout
-    path = _resolve_transcript_path(target, task)
+    path = _resolve_transcript_path(target, task, emdash_db=emdash_db)
     while path is None and time.monotonic() < deadline:
         time.sleep(poll)
-        path = _resolve_transcript_path(target, task)
+        path = _resolve_transcript_path(target, task, emdash_db=emdash_db)
     return path
 
 
@@ -379,7 +386,7 @@ def execute_chat_turn(cfg, client, runner_id: str, turn: dict, cancel_check=None
         )
         logger.info("chat turn=%s created emdash task=%s (agent=%s)", turn_id, task, target)
 
-    path = _wait_for_transcript(target, task)
+    path = _wait_for_transcript(target, task, emdash_db=cfg.emdash_db)
     if path is None:
         logger.warning("chat turn=%s: no transcript for task=%s (agent=%s) — reply not bridged",
                        turn_id, task, target)

--- a/runner/canopy_runner/canopy_runner/sessions.py
+++ b/runner/canopy_runner/canopy_runner/sessions.py
@@ -75,7 +75,8 @@ def session_changed(cfg: Config, sessions: list[dict]) -> bool:
         tr = _tail_readers.get(task)
         if tr is None:  # unresolved (new session, or transcript not found yet) — (re)try
             path = transcript.resolve_transcript(
-                s.get("project") or "", task, home=home, claude_home=claude_home
+                s.get("project") or "", task, home=home, claude_home=claude_home,
+                emdash_db=cfg.emdash_db,
             )
             tr = TailReader(str(path)) if path else None
             if tr is not None:
@@ -157,7 +158,8 @@ def annotate_engine_staleness(
             continue
         try:
             path = transcript.resolve_transcript(
-                s.get("project") or "", task, home=home, claude_home=claude_home
+                s.get("project") or "", task, home=home, claude_home=claude_home,
+                emdash_db=cfg.emdash_db,
             )
         except Exception:  # noqa: BLE001 — a fragile half must not cost us the report
             path = None

--- a/runner/canopy_runner/canopy_runner/streams.py
+++ b/runner/canopy_runner/canopy_runner/streams.py
@@ -117,7 +117,8 @@ def sync_session_streams(cfg: Config, client: Client) -> None:
         # after which the reader tails a file nobody is writing to, forever. Costs
         # a scandir per session per tick against a warm dentry cache.
         path = transcript.resolve_transcript(
-            st["project"], st["session_key"], home=home, claude_home=claude_home
+            st["project"], st["session_key"], home=home, claude_home=claude_home,
+            emdash_db=cfg.emdash_db,
         )
         if not path:
             continue  # transcript wasn't there yet — retry resolving next tick
@@ -255,7 +256,8 @@ def drain_backfills(cfg: Config, client: Client) -> None:
     for b in backfills:
         sid = b.get("session_id")
         path = transcript.resolve_transcript(
-            b.get("project") or "", b.get("session_key") or "", home=home, claude_home=claude_home
+            b.get("project") or "", b.get("session_key") or "", home=home,
+            claude_home=claude_home, emdash_db=cfg.emdash_db,
         )
         if not (sid and path):
             continue  # transcript not resolvable -> leave it; server keeps showing the tail

--- a/runner/canopy_runner/canopy_runner/transcript.py
+++ b/runner/canopy_runner/canopy_runner/transcript.py
@@ -97,7 +97,10 @@ _SUFFIX_RE = re.compile(r"-[0-9a-z]+$")
 # written the same encoding). Re-exported so existing callers and tests keep
 # importing it from here.
 from canopy_transcript import encode_project_dir  # noqa: E402,F401
+from canopy_transcript import resolve_cli_transcript as _resolve_cli
 from canopy_transcript import resolve_emdash_transcript as _resolve_emdash
+
+from . import emdash as _emdash
 
 
 def _worktree_bases(repo: str, task: str, home: Path) -> list[Path]:
@@ -109,12 +112,44 @@ def _worktree_bases(repo: str, task: str, home: Path) -> list[Path]:
     return [root / "emdash" / task, root / task]
 
 
-def resolve_transcript(repo: str, task: str, *, home: Path, claude_home: Path) -> Path | None:
+def resolve_transcript(
+    repo: str,
+    task: str,
+    *,
+    home: Path,
+    claude_home: Path,
+    emdash_db: str | None = None,
+) -> Path | None:
     """Newest transcript .jsonl for (repo, task), or None.
 
-    Thin wrapper over `canopy_transcript.resolve_emdash_transcript`; the
-    convention and its two real-world wrinkles are documented there.
+    Two strategies, in order of how much they assume:
+
+    **Ask emdash** (`emdash_db` given). emdash 1.2 records `conversations.cwd` and
+    `conversations.provider_session_id` — the worktree, and Claude Code's own session
+    id, which NAMES the file. Together they address it exactly, via the same
+    `resolve_cli_transcript` the cloud runner has always used. Nothing is guessed.
+
+    **Ask the convention** (otherwise, or when emdash cannot answer). Reconstruct the
+    worktree path from (repo, task) and take the newest .jsonl in the matching project
+    dir — see `canopy_transcript.resolve_emdash_transcript` for the three layouts and
+    why each exists.
+
+    The fallback is load-bearing, not politeness: emdash knows a task before Claude
+    Code has written anything, `provider_session_id` is NULL until the provider
+    reports one, and a pre-1.2 emdash has neither column. So this is strictly
+    additive — it can make resolution SUCCEED where the convention failed, never the
+    reverse. Which matters, because the convention is the part that breaks silently
+    when emdash renames a directory, and every caller reads None as "not yet".
     """
+    if emdash_db:
+        ref = _emdash.session_transcript_ref(emdash_db, repo, task)
+        if ref is not None:
+            exact = _resolve_cli(ref[0], ref[1], claude_home=claude_home)
+            # A ref that does not resolve is NOT a dead end: emdash can name a session
+            # whose file Claude Code has not created yet. Fall through rather than
+            # returning None, so the convention still gets its say.
+            if exact is not None:
+                return exact
     return _resolve_emdash(repo, task, home=home, claude_home=claude_home)
 
 

--- a/runner/canopy_runner/tests/test_engine_flag_staleness.py
+++ b/runner/canopy_runner/tests/test_engine_flag_staleness.py
@@ -15,6 +15,7 @@ from canopy_runner import transcript
 
 class _Cfg:
     session_tail_count = 30
+    emdash_db = ""      # no emdash DB here: resolution falls back to the convention
 
 
 def _touch(path, when):

--- a/runner/canopy_runner/tests/test_session_backfill_runner.py
+++ b/runner/canopy_runner/tests/test_session_backfill_runner.py
@@ -9,6 +9,7 @@ from canopy_runner.chat_bridge import compose_index as _ix
 
 class _Cfg:
     runner_id = "r"
+    emdash_db = ""      # no emdash DB here: resolution falls back to the convention
 
 
 class _Client:

--- a/runner/canopy_runner/tests/test_session_streaming.py
+++ b/runner/canopy_runner/tests/test_session_streaming.py
@@ -14,6 +14,7 @@ from canopy_runner.chat_bridge import compose_index as _ix
 
 class _Cfg:
     runner_id = "r"
+    emdash_db = ""      # no emdash DB in these tests: resolution falls back to the convention
 
 
 class _Client:

--- a/runner/canopy_runner/tests/test_transcript_from_emdash_record.py
+++ b/runner/canopy_runner/tests/test_transcript_from_emdash_record.py
@@ -1,0 +1,199 @@
+"""Resolving a transcript from emdash's OWN record instead of a path convention.
+
+The convention is a guess at a layout emdash owns and has changed twice. emdash 1.2
+records `conversations.cwd` and `conversations.provider_session_id` — the worktree and
+the id that NAMES the .jsonl — so the answer can be read rather than reconstructed.
+
+What these tests defend is the FALLBACK as much as the new path: this must be strictly
+additive. It may make resolution succeed where the convention failed; it must never
+make it fail where the convention would have worked.
+"""
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from canopy_runner import transcript
+from canopy_runner.emdash import session_transcript_ref
+from canopy_transcript import encode_project_dir
+
+_SCHEMA = """
+    CREATE TABLE projects (id TEXT PRIMARY KEY, name TEXT NOT NULL, deleted_at TEXT);
+    CREATE TABLE tasks (
+      id TEXT PRIMARY KEY, project_id TEXT, name TEXT NOT NULL, type TEXT DEFAULT 'task',
+      archived_at TEXT, deleted_at TEXT
+    );
+    CREATE TABLE conversations (
+      id TEXT PRIMARY KEY, task_id TEXT, cwd TEXT, provider_session_id TEXT,
+      last_session_activity_at TEXT,
+      updated_at TEXT DEFAULT CURRENT_TIMESTAMP NOT NULL
+    );
+"""
+
+_PRE_1_2 = """
+    CREATE TABLE projects (id TEXT PRIMARY KEY, name TEXT NOT NULL);
+    CREATE TABLE tasks (id TEXT PRIMARY KEY, project_id TEXT, name TEXT, type TEXT, archived_at TEXT);
+    CREATE TABLE conversations (id TEXT PRIMARY KEY, task_id TEXT);
+"""
+
+
+def _db(tmp_path, schema=_SCHEMA):
+    p = tmp_path / "emdash4.db"
+    conn = sqlite3.connect(p)
+    conn.executescript(schema)
+    conn.commit()
+    conn.close()
+    return str(p)
+
+
+def _row(db, *, project, task, cwd=None, sid=None, at="2026-08-28T12:00:00Z", deleted=None):
+    conn = sqlite3.connect(db)
+    conn.execute("INSERT OR IGNORE INTO projects (id, name) VALUES (?, ?)", (project, project))
+    conn.execute(
+        "INSERT OR IGNORE INTO tasks (id, project_id, name, type, deleted_at) "
+        "VALUES (?, ?, ?, 'task', ?)",
+        (f"{project}/{task}", project, task, deleted),
+    )
+    conn.execute(
+        "INSERT INTO conversations (id, task_id, cwd, provider_session_id, last_session_activity_at) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (f"c-{project}-{sid or at}", f"{project}/{task}", cwd, sid, at),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _plant(claude_home, cwd, sid):
+    d = claude_home / encode_project_dir(cwd)
+    d.mkdir(parents=True, exist_ok=True)
+    f = d / f"{sid}.jsonl"
+    f.write_text("{}\n")
+    return f
+
+
+@pytest.fixture()
+def paths(tmp_path):
+    home = tmp_path / "home"
+    ch = home / ".claude" / "projects"
+    ch.mkdir(parents=True)
+    return home, ch
+
+
+# --- the read ---------------------------------------------------------------------------
+
+def test_ref_returns_both_halves(tmp_path):
+    db = _db(tmp_path)
+    _row(db, project="canopy-web", task="emdash-check", cwd="/w/x", sid="sid-1")
+    assert session_transcript_ref(db, "canopy-web", "emdash-check") == ("/w/x", "sid-1")
+
+
+def test_ref_is_none_when_the_provider_has_not_reported_an_id(tmp_path):
+    """emdash knows the task the instant it is created; Claude Code reports its session
+    id later. A half-answer must read as no answer, or the caller skips the fallback and
+    the session resolves to nothing during exactly the window it is being set up."""
+    db = _db(tmp_path)
+    _row(db, project="ace", task="fresh", cwd="/w/fresh", sid=None)
+    assert session_transcript_ref(db, "ace", "fresh") is None
+
+
+def test_ref_is_none_on_a_pre_1_2_emdash(tmp_path):
+    """An older emdash has neither column. That is a legitimate state, so the read
+    degrades to "ask the convention" rather than raising and taking the runner with it."""
+    db = _db(tmp_path, _PRE_1_2)
+    assert session_transcript_ref(db, "ace", "anything") is None
+
+
+def test_ref_ignores_a_soft_deleted_task(tmp_path):
+    db = _db(tmp_path)
+    _row(db, project="ace", task="binned", cwd="/w/binned", sid="sid-x", deleted="2026-08-28T00:00:00Z")
+    assert session_transcript_ref(db, "ace", "binned") is None
+
+
+def test_ref_prefers_the_newest_conversation(tmp_path):
+    """Task names are reused and a task owns several conversations. An earlier one must
+    not answer for the live session — that is how you tail a file nobody is writing."""
+    db = _db(tmp_path)
+    _row(db, project="ace", task="dup", cwd="/w/old", sid="old", at="2026-08-27T00:00:00Z")
+    _row(db, project="ace", task="dup", cwd="/w/new", sid="new", at="2026-08-28T00:00:00Z")
+    assert session_transcript_ref(db, "ace", "dup") == ("/w/new", "new")
+
+
+def test_ref_does_not_cross_projects(tmp_path):
+    db = _db(tmp_path)
+    _row(db, project="ace", task="shared-name", cwd="/w/ace", sid="a")
+    _row(db, project="eva", task="shared-name", cwd="/w/eva", sid="e")
+    assert session_transcript_ref(db, "eva", "shared-name") == ("/w/eva", "e")
+
+
+# --- resolution, and the fallback ---------------------------------------------------------
+
+def test_emdash_record_resolves_a_layout_no_convention_knows(paths, tmp_path):
+    """The whole point. This worktree matches none of the three conventions, and it
+    resolves anyway — so the NEXT layout change costs a fallback, not an outage."""
+    home, ch = paths
+    db = _db(tmp_path)
+    cwd = "/somewhere/emdash/has/not/told/us/about"
+    _row(db, project="canopy-web", task="emdash-check", cwd=cwd, sid="sid-1")
+    want = _plant(ch, cwd, "sid-1")
+
+    got = transcript.resolve_transcript(
+        "canopy-web", "emdash-check", home=home, claude_home=ch, emdash_db=db
+    )
+    assert got == want
+    # ...and without the DB, the same lookup finds nothing at all.
+    assert transcript.resolve_transcript(
+        "canopy-web", "emdash-check", home=home, claude_home=ch
+    ) is None
+
+
+def test_falls_back_when_emdash_names_a_file_that_does_not_exist_yet(paths, tmp_path):
+    """emdash reports a session id before Claude Code has created the file. Returning
+    None there would be a REGRESSION against the convention, which can still find an
+    older transcript for the same task."""
+    home, ch = paths
+    db = _db(tmp_path)
+    _row(db, project="ace", task="spark", cwd="/w/not-written-yet", sid="sid-missing")
+    worktree = home / "emdash" / "worktrees" / "ace" / "emdash" / "spark-ry12q"
+    worktree.mkdir(parents=True)
+    want = _plant(ch, str(worktree), "conventional")
+
+    got = transcript.resolve_transcript(
+        "ace", "spark", home=home, claude_home=ch, emdash_db=db
+    )
+    assert got == want
+
+
+def test_falls_back_when_there_is_no_emdash_db_at_all(paths, tmp_path):
+    home, ch = paths
+    worktree = home / "emdash" / "worktrees" / "ace" / "emdash" / "spark-ry12q"
+    worktree.mkdir(parents=True)
+    want = _plant(ch, str(worktree), "conventional")
+
+    got = transcript.resolve_transcript(
+        "ace", "spark", home=home, claude_home=ch, emdash_db=str(tmp_path / "nope.db")
+    )
+    assert got == want
+
+
+def test_the_exact_answer_beats_the_conventional_one(paths, tmp_path):
+    """Both resolve; emdash's wins. The convention takes the NEWEST .jsonl in the dir,
+    which is the wrong session whenever a worktree has hosted more than one — emdash
+    names the actual conversation."""
+    home, ch = paths
+    db = _db(tmp_path)
+    worktree = home / "emdash" / "worktrees" / "ace" / "emdash" / "spark-ry12q"
+    worktree.mkdir(parents=True)
+    _row(db, project="ace", task="spark", cwd=str(worktree), sid="the-real-one")
+    exact = _plant(ch, str(worktree), "the-real-one")
+    newer = _plant(ch, str(worktree), "a-later-unrelated-session")
+    import os, time
+    os.utime(newer, (time.time() + 3600, time.time() + 3600))  # convention prefers newest
+
+    got = transcript.resolve_transcript(
+        "ace", "spark", home=home, claude_home=ch, emdash_db=db
+    )
+    assert got == exact
+    assert transcript.resolve_transcript(
+        "ace", "spark", home=home, claude_home=ch
+    ) == newer


### PR DESCRIPTION
Closes #636. **Stacked on #635** (base is `runner/emdash-1-2-upgrade`) — it needs that PR's layout fix to compare against. Retarget to `main` once #635 lands.

## Why

Canopy reconstructs a path emdash owns. emdash has changed it twice, and both times the failure was silent: an unresolvable path is indistinguishable from "this session hasn't written yet", so every caller `continue`s with nothing in any log.

emdash 1.2 records the answer directly — `conversations.cwd` (the real worktree) and `conversations.provider_session_id` (Claude Code's own session id, which *names* the `.jsonl`), both populated 26/26. The exact resolver already exists: `resolve_cli_transcript`, which the cloud runner has always used. This just supplies its two arguments from emdash's DB.

## The fallback is the important half

A partial answer reads as **no** answer, and a ref that doesn't resolve falls *through* rather than returning None — because emdash knows a task before Claude Code writes anything, `provider_session_id` is NULL until the provider reports one, and a pre-1.2 emdash has neither column. All three are legitimate "ask the convention instead".

That keeps this **strictly additive**: it can make resolution succeed where the convention failed, never the reverse. Four tests exist only to pin that.

## What it actually buys — measured, not claimed

Both paths resolve **12/12** open sessions on the live box today, with **zero disagreements**, because #635 already taught the convention 1.2's layout. So this is not a numbers win right now, and I'd rather say so than dress it up. It buys two other things:

1. **Immunity to the next rename.** A future layout change becomes a fallback nobody notices instead of an outage nobody sees.
2. **Correctness where the convention is merely lucky.** 8 worktrees on this box hold more than one transcript — one holds 12. There the convention takes the newest by mtime, which is a guess at which conversation you meant. emdash knows. `test_the_exact_answer_beats_the_conventional_one` pins it.

## Threading

`emdash_db` is optional and passed where `Config` is already in scope — `sync_session_streams`, `drain_backfills`, `session_changed`, `annotate_engine_staleness`, and the chat path's `_wait_for_transcript` (which pays twice over: it re-resolves every poll, and emdash names the id *earlier* than a directory scan can find a file).

Test stubs for `Config` gained `emdash_db` rather than production learning to `getattr` it — a default would have silently disabled the exact path in production too, which is the same class of bug as the one being fixed.

## Verification

527 runner tests + 84 transcript tests pass. Live numbers above measured against the running 1.2 box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHEEiXYVT6VoLoq9y91q7D