### PR TITLE
fix(runner): the 1.2 reads must not break every emdash older than 1.2

### DIFF
--- a/runner/canopy_runner/canopy_runner/emdash.py
+++ b/runner/canopy_runner/canopy_runner/emdash.py
@@ -35,38 +35,87 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Iterator
 
-# The exact columns the two reads below depend on. verify-emdash asserts these
-# still exist after an emdash update. Update this the moment you change the SQL.
-READ_SCHEMA: dict[str, list[str]] = {
-    "tasks": [
-        "name",
-        "archived_at",
-        "created_at",
-        "status",
-        "last_interacted_at",
-        "type",
-        "project_id",
-        "deleted_at",
-    ],
-    "projects": ["id", "name", "deleted_at"],
-    # Emdash's OWN liveness flag, per conversation. Read fail-soft (see
-    # `_agent_statuses`) but listed here anyway: verify-emdash is where you find
-    # out a read drifted, and a degradation that nothing reports is exactly the
-    # class this file exists to prevent.
-    #
-    # `last_interacted_at` lived here until emdash 1.2. Its migration train copied
-    # the values into `last_session_activity_at` (0036) and then dropped the legacy
-    # column (0037) — so the successor is emdash's own choice, not our guess. It is
-    # NULLABLE and sparsely populated (10 of 26 rows on the fleet laptop, 2026-08-28),
-    # hence the COALESCE onto `updated_at` in the ORDER BY below rather than a
-    # straight swap: ordering by a mostly-NULL column is not an ordering.
-    "conversations": [
-        "task_id",
-        "agent_status",
-        "last_session_activity_at",
-        "updated_at",
-    ],
+# The columns the reads below depend on, split by WHEN emdash grew them.
+#
+# The split exists because the fleet's boxes update independently: two macOS accounts,
+# each with its own auto-updating emdash, were provably at different versions on
+# 2026-08-28. A read that names a 1.2 column unconditionally does not degrade on an
+# older box — `list_open_sessions` RAISES, and its caller must then skip the session
+# report entirely (reporting an empty list would clear every RunnerBinding). So the
+# SQL is built from what the connected DB actually has; see `_cols`.
+#
+# REQUIRED: present in every emdash we support. Missing one IS a drift.
+REQUIRED_SCHEMA: dict[str, list[str]] = {
+    "tasks": ["name", "archived_at", "created_at", "status", "last_interacted_at",
+              "type", "project_id"],
+    "projects": ["id", "name"],
+    # Emdash's OWN liveness flag, per conversation — the one signal a transcript
+    # cannot give (a session inside a long tool call is silent, not finished).
+    "conversations": ["task_id", "agent_status"],
 }
+
+# VERSION-GATED: introduced by emdash 1.2. Absence means "older emdash", NOT drift —
+# reporting it as drift is a false red on a healthy box, and a check that cries wolf
+# is muted before the day it is right.
+#
+#   * `deleted_at` — 1.2 soft-deletes PROJECTS (emdash calls them "tombstoned") and
+#     filters live tasks as and(isNull(archivedAt), isNull(deletedAt)). The projects
+#     one is load-bearing: without it a removed repo keeps being advertised in
+#     `capabilities.projects` and the runner claims turns it cannot possibly run.
+#   * `last_session_activity_at` — 1.2's migration train copied
+#     `conversations.last_interacted_at` into it (0036) and dropped the legacy name
+#     (0037), so the successor is emdash's own choice rather than our guess.
+OPTIONAL_SCHEMA: dict[str, list[str]] = {
+    "tasks": ["deleted_at"],
+    "projects": ["deleted_at"],
+    "conversations": ["last_session_activity_at", "updated_at"],
+}
+
+# Kept as the union so existing callers/tests that ask "every column we touch" still
+# get one answer. `check_read_schema` is what distinguishes the two halves.
+READ_SCHEMA: dict[str, list[str]] = {
+    t: REQUIRED_SCHEMA.get(t, []) + OPTIONAL_SCHEMA.get(t, [])
+    for t in {**REQUIRED_SCHEMA, **OPTIONAL_SCHEMA}
+}
+
+
+def _cols(conn: sqlite3.Connection, table: str) -> set[str]:
+    """The column names `table` actually has, or an empty set if it has none.
+
+    Every version-gated predicate below asks this rather than assuming, because the
+    cost of assuming is not a degraded read — it is a raised one, and a raised one
+    costs the whole session report.
+    """
+    try:
+        # PRAGMA cannot be parameter-bound; the table name is our own constant.
+        return {r["name"] for r in conn.execute(f"PRAGMA table_info({table})")}
+    except sqlite3.Error:
+        return set()
+
+
+def _not_deleted(conn: sqlite3.Connection, table: str, alias: str) -> str:
+    """`AND <alias>.deleted_at IS NULL`, or "" on an emdash that has no such column.
+
+    Empty is the correct degradation: an emdash without the column cannot have
+    soft-deleted anything, so there is nothing the predicate would have excluded.
+    """
+    return f" AND {alias}.deleted_at IS NULL" if "deleted_at" in _cols(conn, table) else ""
+
+
+# Conversation ordering, newest last, most-preferred first. 1.2 renamed the first to
+# the second; `updated_at` is the NOT NULL backstop, needed because
+# `last_session_activity_at` is nullable and sparsely written (10 of 26 rows on the
+# fleet laptop) — ordering by a mostly-NULL column is not an ordering.
+_CONV_ORDER_CANDIDATES = ("last_session_activity_at", "last_interacted_at", "updated_at")
+
+
+def _conv_order(conn: sqlite3.Connection) -> str:
+    """The ORDER BY expression for `conversations`, from what this emdash actually has."""
+    have = [c for c in _CONV_ORDER_CANDIDATES if c in _cols(conn, "conversations")]
+    if not have:
+        return "rowid"          # no timestamp at all: insertion order still beats nothing
+    return f"COALESCE({', '.join(have)})" if len(have) > 1 else have[0]
+
 
 # `conversations.agent_status` when emdash is actively driving the agent. The
 # other value seen in practice is 'awaiting-input' (the agent stopped and is
@@ -107,30 +156,45 @@ def _db(db_path: str) -> Iterator[sqlite3.Connection]:
         conn.close()
 
 
-def check_read_schema(db_path: str) -> list[str]:
-    """Verify every column the CDP-path reads depend on still exists.
+def check_read_schema(db_path: str) -> tuple[list[str], list[str]]:
+    """Verify the columns the reads depend on. Returns ``(problems, older)``.
 
-    Returns a list of human-readable problems (``"tasks.foo missing"``,
-    ``"table 'projects' missing"``); an EMPTY list means the read surface is intact.
+    ``problems`` are real drifts — a REQUIRED column or whole table that has gone.
+    ``older`` are version-gated columns emdash 1.2 introduced and this DB lacks, which
+    means "an emdash older than 1.2", NOT a drift.
+
+    Keeping those apart is the whole point. Reporting a pre-1.2 box as drifted is a
+    false red on a perfectly healthy install, and a check that reddens on healthy boxes
+    gets muted — after which it is absent on the day it is right. The reads themselves
+    already tolerate the older shape (see `_cols`), so "older" is genuinely informational.
+
     Raises ``SchemaCheckError`` if the DB itself can't be opened, so "can't find the
     DB" stays distinct from "the schema drifted".
     """
     if not Path(db_path).exists():  # don't let sqlite3.connect() create an empty file
         raise SchemaCheckError(f"emdash DB not found at {db_path}")
     problems: list[str] = []
+    older: list[str] = []
     try:
         with _db(db_path) as conn:
-            for table, cols in READ_SCHEMA.items():
-                # PRAGMA can't be parameter-bound; the table name is our own constant,
-                # never user input, so the f-string is safe here.
-                present = {r["name"] for r in conn.execute(f"PRAGMA table_info({table})")}
+            for table in READ_SCHEMA:
+                present = _cols(conn, table)
                 if not present:
                     problems.append(f"table {table!r} missing (or has no columns)")
                     continue
-                problems.extend(f"{table}.{col} missing" for col in cols if col not in present)
+                problems.extend(
+                    f"{table}.{col} missing"
+                    for col in REQUIRED_SCHEMA.get(table, [])
+                    if col not in present
+                )
+                older.extend(
+                    f"{table}.{col} absent (emdash 1.2+ only)"
+                    for col in OPTIONAL_SCHEMA.get(table, [])
+                    if col not in present
+                )
     except sqlite3.Error as exc:
         raise SchemaCheckError(f"cannot read emdash DB {db_path}: {exc}") from exc
-    return problems
+    return problems, older
 
 
 def task_state(db_path: str, name: str) -> str:
@@ -156,7 +220,8 @@ def task_state(db_path: str, name: str) -> str:
     try:
         with _db(db_path) as conn:
             row = conn.execute(
-                "SELECT archived_at FROM tasks WHERE name=? AND deleted_at IS NULL "
+                "SELECT archived_at FROM tasks WHERE name=?"
+                f"{_not_deleted(conn, 'tasks', 'tasks')} "
                 "ORDER BY created_at DESC LIMIT 1",
                 (name,),
             ).fetchone()
@@ -192,8 +257,7 @@ def _agent_statuses(conn: sqlite3.Connection) -> dict[str, str]:
             """
             SELECT task_id, COALESCE(agent_status, '') AS agent_status
             FROM conversations
-            ORDER BY COALESCE(last_session_activity_at, updated_at)
-            """
+            ORDER BY """ + _conv_order(conn)
         ).fetchall()
     except sqlite3.Error:
         return {}
@@ -237,7 +301,8 @@ def list_open_sessions(db_path: str, limit: int = 30) -> list[dict]:
                        t.last_interacted_at AS last_interacted_at
                 FROM tasks t
                 LEFT JOIN projects p ON p.id = t.project_id
-                WHERE t.archived_at IS NULL AND t.deleted_at IS NULL AND t.type = 'task'
+                WHERE t.archived_at IS NULL AND t.type = 'task'
+                """ + _not_deleted(conn, "tasks", "t") + """
                 ORDER BY t.last_interacted_at DESC
                 LIMIT ?
                 """,
@@ -289,7 +354,8 @@ def list_projects(db_path: str) -> list[str]:
     try:
         with _db(db_path) as conn:
             rows = conn.execute(
-                "SELECT name FROM projects WHERE deleted_at IS NULL ORDER BY name"
+                "SELECT name FROM projects WHERE 1=1"
+                f"{_not_deleted(conn, 'projects', 'projects')} ORDER BY name"
             ).fetchall()
     except sqlite3.Error as exc:
         raise EmdashReadError(f"emdash project read failed: {exc}") from exc
@@ -317,7 +383,8 @@ def list_recently_archived_tasks(db_path: str, limit: int = 100) -> list[str]:
                 """
                 SELECT t.name AS emdash_task
                 FROM tasks t
-                WHERE t.archived_at IS NOT NULL AND t.deleted_at IS NULL AND t.type = 'task'
+                WHERE t.archived_at IS NOT NULL AND t.type = 'task'
+                """ + _not_deleted(conn, "tasks", "t") + """
                 ORDER BY t.archived_at DESC
                 LIMIT ?
                 """,

--- a/runner/canopy_runner/canopy_runner/upgrade_check.py
+++ b/runner/canopy_runner/canopy_runner/upgrade_check.py
@@ -118,10 +118,15 @@ def check_version() -> Check:
 
 
 def check_schema(db_path: str) -> Check:
-    """The sqlite columns the CDP-path reads name. The pre-existing check, unchanged
-    in behaviour — it is the one surface that was already covered."""
+    """The sqlite columns the reads name.
+
+    Distinguishes a REQUIRED column going missing (a real drift, and the failure this
+    check was built for) from a version-gated 1.2 column simply not being there yet —
+    which is an older emdash, reported as a note. The reads tolerate both shapes, so
+    calling the older one a failure would redden a healthy box for no action.
+    """
     try:
-        problems = emdash.check_read_schema(db_path)
+        problems, older = emdash.check_read_schema(db_path)
     except emdash.SchemaCheckError as exc:
         return Check("db schema", False, str(exc))
     if problems:
@@ -130,12 +135,19 @@ def check_schema(db_path: str) -> Check:
             "read schema drifted — the reads would SILENTLY degrade",
             notes=problems + [
                 "fix: reconcile emdash.py's SQL against emdash's new schema, then "
-                "update READ_SCHEMA to match",
+                "update REQUIRED_SCHEMA/OPTIONAL_SCHEMA to match",
             ],
         )
-    n = sum(len(c) for c in emdash.READ_SCHEMA.values())
+    n = sum(len(c) for c in emdash.REQUIRED_SCHEMA.values())
+    if older:
+        return Check(
+            "db schema", True,
+            f"all {n} required columns present; this emdash predates 1.2",
+            notes=older + ["the reads adapt to it — nothing to do unless you want 1.2's features"],
+        )
+    total = sum(len(c) for c in emdash.READ_SCHEMA.values())
     return Check("db schema", True,
-                 f"all {n} columns across {', '.join(emdash.READ_SCHEMA)} present")
+                 f"all {total} columns across {', '.join(emdash.READ_SCHEMA)} present")
 
 
 def check_transcripts(db_path: str, *, home: Path, claude_home: Path) -> Check:

--- a/runner/canopy_runner/tests/test_emdash.py
+++ b/runner/canopy_runner/tests/test_emdash.py
@@ -49,7 +49,7 @@ def db(tmp_path: Path) -> str:
 # --------------------------------------------------------------------------------------
 
 def test_check_read_schema_intact(db):
-    assert check_read_schema(db) == []
+    assert check_read_schema(db) == ([], [])
 
 
 def test_check_read_schema_names_a_dropped_column(db):
@@ -59,8 +59,9 @@ def test_check_read_schema_names_a_dropped_column(db):
     conn.execute("ALTER TABLE tasks RENAME COLUMN last_interacted_at TO touched_at")
     conn.commit()
     conn.close()
-    problems = check_read_schema(db)
+    problems, older = check_read_schema(db)
     assert problems == ["tasks.last_interacted_at missing"]
+    assert older == []
 
 
 def test_check_read_schema_reports_a_missing_table(tmp_path):
@@ -72,7 +73,8 @@ def test_check_read_schema_reports_a_missing_table(tmp_path):
     )  # no `projects` table at all
     conn.commit()
     conn.close()
-    assert "table 'projects' missing (or has no columns)" in check_read_schema(str(path))
+    problems, _ = check_read_schema(str(path))
+    assert "table 'projects' missing (or has no columns)" in problems
 
 
 def test_check_read_schema_raises_when_db_absent(tmp_path):
@@ -276,7 +278,7 @@ def test_a_drifted_conversations_table_costs_the_status_not_the_report(db):
     assert row["emdash_task"] == "still-listed"
     assert row["agent_status"] == ""
     # ...and verify-emdash is where that degradation becomes visible.
-    assert check_read_schema(db) == ["conversations.agent_status missing"]
+    assert check_read_schema(db)[0] == ["conversations.agent_status missing"]
 
 
 # --------------------------------------------------------------------------------------
@@ -319,3 +321,77 @@ def test_a_soft_deleted_task_is_not_reported_as_archived(db):
     _add_task(db, "binned", archived_at="2026-08-27T00:00:00Z")
     _soft_delete(db, "binned")
     assert list_recently_archived_tasks(db) == ["really-archived"]
+
+
+# --------------------------------------------------------------------------------------
+# An emdash OLDER than 1.2. The fleet's two macOS accounts each auto-update their own
+# emdash, so it is routinely mixed-version — and a read that names a 1.2 column
+# unconditionally does not degrade on the older box, it RAISES. `list_open_sessions`
+# raising means the caller skips the whole session report (reporting empty would clear
+# every RunnerBinding), so the phone's list silently goes stale and stays stale (#641).
+#
+# Every fixture above was moved to 1.2's shape when those columns were added, which is
+# exactly why nothing caught it. These pin the older shape.
+# --------------------------------------------------------------------------------------
+
+_PRE_1_2_SCHEMA = """
+    CREATE TABLE projects (id TEXT PRIMARY KEY, name TEXT NOT NULL);
+    CREATE TABLE tasks (
+      id TEXT PRIMARY KEY, project_id TEXT, name TEXT NOT NULL, status TEXT,
+      archived_at TEXT, created_at TEXT, last_interacted_at TEXT,
+      type TEXT DEFAULT 'task' NOT NULL
+    );
+    CREATE TABLE conversations (
+      id TEXT PRIMARY KEY, task_id TEXT, agent_status TEXT, last_interacted_at TEXT
+    );
+"""
+
+
+@pytest.fixture()
+def old_db(tmp_path: Path) -> str:
+    path = tmp_path / "emdash4.db"
+    conn = sqlite3.connect(path)
+    conn.executescript(_PRE_1_2_SCHEMA)
+    conn.execute("INSERT INTO projects (id, name) VALUES ('p', 'canopy-web')")
+    conn.execute(
+        "INSERT INTO tasks (id, project_id, name, status, type) "
+        "VALUES ('t', 'p', 'some-task', 'in_progress', 'task')"
+    )
+    conn.execute(
+        "INSERT INTO conversations (id, task_id, agent_status, last_interacted_at) "
+        "VALUES ('c', 't', 'working', '2026-08-20T00:00:00Z')"
+    )
+    conn.commit()
+    conn.close()
+    return str(path)
+
+
+def test_open_sessions_still_work_on_a_pre_1_2_emdash(old_db):
+    rows = list_open_sessions(old_db)
+    assert [r["emdash_task"] for r in rows] == ["some-task"]
+
+
+def test_agent_status_survives_on_a_pre_1_2_emdash(old_db):
+    """The ordering column was RENAMED, not merely added, so this is the one that has
+    to fall back rather than simply omit a predicate — `last_interacted_at` is what the
+    older emdash calls it."""
+    (row,) = list_open_sessions(old_db)
+    assert row["agent_status"] == "working"
+
+
+def test_task_state_still_answers_on_a_pre_1_2_emdash(old_db):
+    """"unknown" here would push every reuse decision onto the CDP verdict, which is
+    the false-negative that duplicates live sessions."""
+    assert task_state(old_db, "some-task") == "live"
+
+
+def test_projects_still_list_on_a_pre_1_2_emdash(old_db):
+    from canopy_runner.emdash import list_projects
+
+    assert list_projects(old_db) == ["canopy-web"]
+
+
+def test_a_pre_1_2_emdash_is_not_reported_as_drifted(old_db):
+    problems, older = check_read_schema(old_db)
+    assert problems == []
+    assert any("deleted_at" in o for o in older)

--- a/runner/canopy_runner/tests/test_upgrade_check.py
+++ b/runner/canopy_runner/tests/test_upgrade_check.py
@@ -74,9 +74,25 @@ def paths(tmp_path):
 
 # --- the schema surface (the drift emdash 1.2 actually shipped) -------------------------
 
-def test_a_dropped_column_is_named(tmp_path):
-    """emdash 1.2 dropped `conversations.last_interacted_at`. The check has to say
-    WHICH column: "something drifted" sends a human to read a diff of the whole app."""
+def test_a_dropped_required_column_is_named(tmp_path):
+    """The check has to say WHICH column: "something drifted" sends a human to read a
+    diff of the whole app."""
+    db = _db(tmp_path)
+    conn = sqlite3.connect(db)
+    conn.execute("ALTER TABLE conversations DROP COLUMN agent_status")
+    conn.commit()
+    conn.close()
+
+    check = upgrade_check.check_schema(db)
+    assert not check.ok
+    assert any("conversations.agent_status missing" in n for n in check.notes)
+
+
+def test_an_absent_1_2_column_reads_as_an_older_emdash_not_a_drift(tmp_path):
+    """The distinction #641 exists for. The fleet's boxes auto-update independently, so
+    it is routinely mixed-version. Calling the older shape "drifted" reddens a healthy
+    install — and a check that reddens on healthy boxes is muted before the day it is
+    right. The reads adapt, so this is informational."""
     db = _db(tmp_path)
     conn = sqlite3.connect(db)
     conn.execute("ALTER TABLE conversations DROP COLUMN last_session_activity_at")
@@ -84,8 +100,9 @@ def test_a_dropped_column_is_named(tmp_path):
     conn.close()
 
     check = upgrade_check.check_schema(db)
-    assert not check.ok
-    assert any("conversations.last_session_activity_at missing" in n for n in check.notes)
+    assert check.ok
+    assert "predates 1.2" in check.summary
+    assert any("last_session_activity_at absent" in n for n in check.notes)
 
 
 def test_a_missing_db_is_not_reported_as_a_drift(tmp_path):


### PR DESCRIPTION
Closes #641. Self-reported regression from #635 (already merged). Found by testing the new reads against a reconstructed pre-1.2 schema instead of only the 1.2 box they were written on.

## The bug

#635 taught the reads emdash 1.2's schema and named its new columns unconditionally:

```
>>> list_open_sessions('<pre-1.2 db>')
EmdashReadError: emdash open-session read failed: no such column: t.deleted_at
```

`list_open_sessions` **raising is not a soft failure**. By its own contract the caller then skips the session report entirely — because the alternative, reporting `[]`, clears every `RunnerBinding` server-side. So on an older emdash:

- no session report, ever; the phone's list goes stale and stays stale
- nothing in the log, because skipping is the *designed* response to a read failure
- `task_state` degrades to `"unknown"`, pushing every reuse decision onto the CDP verdict

Same silent-degradation class as #633, pointing the other way.

## Why this is not a theoretical concern

The fleet runs **two macOS accounts, each with its own independently auto-updating emdash**, and on 2026-08-28 they were provably at different versions (`acedimagi` on the 1.2 bundle since 06:02; `jjackson` running since Aug 26 on its predecessor). I can't read the other account's DB to check its migration state, so "they're probably both fine" isn't assertable — and a fleet whose boxes update independently is *never* uniformly versioned at a given moment.

## Fix

Build the SQL from what the connected DB actually has:

- `_cols(conn, table)` — what's really there
- `_not_deleted(...)` — omits the `deleted_at` predicate where the column is absent. Omission is the correct degradation: an emdash without the column cannot have soft-deleted anything, so nothing is being let through.
- `_conv_order(conn)` — `last_session_activity_at` → `last_interacted_at` → `updated_at`. This one needs a *fallback chain* rather than an omitted clause, because 1.2 **renamed** it rather than adding it.

`READ_SCHEMA` splits into `REQUIRED_SCHEMA` (every emdash we support — missing one is a real drift) and `OPTIONAL_SCHEMA` (1.2+ — absence means "older emdash"). Without that split, `verify-emdash` would report a healthy pre-1.2 box as **drifted**, which is a false red, and a check that reddens on healthy boxes gets muted long before the day it's right. It now says:

```
+ db schema: all 11 required columns present; this emdash predates 1.2
    conversations.last_session_activity_at absent (emdash 1.2+ only)
    the reads adapt to it — nothing to do unless you want 1.2's features
```

## Verification

Both generations, not just the one in front of me:

| | pre-1.2 fixture | live 1.2 box |
|---|---|---|
| open sessions | ✅ resolved | 12/12 |
| `agent_status` | ✅ `working` | 12/12 have one |
| `task_state` | ✅ `live` | ✅ |
| `list_projects` | ✅ | 21 |
| `check_read_schema` | no problems, 4 "older" notes | clean |

523 tests pass; `verify-emdash` exits 0 against the live box.

## The test gap that allowed it

Every fixture was migrated to 1.2's shape in #635 *as part of adding the columns*, so nothing exercised the older schema — the change and the thing that would have caught it moved together. Five tests now pin the pre-1.2 reads, and the required/optional split is itself covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHEEiXYVT6VoLoq9y91q7D