### PR TITLE
feat(runner): check emdash's coupling surfaces at startup, not only on request

### DIFF
--- a/runner/canopy_runner/canopy_runner/main.py
+++ b/runner/canopy_runner/canopy_runner/main.py
@@ -922,6 +922,13 @@ def main() -> None:
     logger.info("  COST note: idle cycles + inbox polls are ~free (HTTP only); a 'CREATE' "
                 "line = one NEW claude session (tokens), 'REUSE' = none. grep the log for CREATE.")
 
+    # emdash auto-updates, so the only reliable moment to notice it moved under us is a
+    # restart — which an update causes anyway. Cheap checks only, never blocking. See
+    # upgrade_check.log_startup_drift.
+    from . import upgrade_check as _uc
+    _uc.log_startup_drift(cfg.emdash_db, home=Path.home(),
+                          claude_home=Path.home() / ".claude" / "projects", log=logger)
+
     # Pause sentinel: the menu-bar app (or `touch ~/.canopy/PAUSED`) drops this file
     # to halt ALL token-spending work instantly without killing the process or fighting
     # launchd's KeepAlive. Paused = we still heartbeat (so the control plane sees the

--- a/runner/canopy_runner/canopy_runner/upgrade_check.py
+++ b/runner/canopy_runner/canopy_runner/upgrade_check.py
@@ -279,3 +279,45 @@ def render(checks: list[Check]) -> str:
         lines.append(f"  {mark} {c.name}: {c.summary}")
         lines.extend(f"      {n}" for n in c.notes)
     return "\n".join(lines)
+
+
+def log_startup_drift(db_path: str, *, home: Path, claude_home: Path, log) -> None:
+    """Run the CHEAP checks at runner startup and log what they find.
+
+    emdash auto-updates: nobody is prompted, nobody picks a moment. `verify-emdash` is
+    only as good as somebody remembering to type it after an event they were never told
+    about — which is the weakest possible trigger for a check whose whole purpose is
+    catching a silent change. The runner restarts on update and on reboot, so this is
+    the one moment that reliably follows an emdash change without anyone deciding
+    anything.
+
+    Deliberately NOT the DOM probe: it shells out to node and costs seconds, and the
+    contract it checks fails loudly on the next real turn anyway. The two silent
+    surfaces are the ones worth paying for here.
+
+    Never blocks and never raises. A drifted schema still leaves most of the runner
+    working, so refusing to start would turn a partial degradation into a total outage —
+    and a diagnostic that can kill the process is a liability, not a safeguard.
+
+    WARNING is reserved for a real drift. "This emdash predates 1.2" is a healthy state
+    (the reads adapt to it), and logging it at warning level would fill the fleet's logs
+    with a condition nobody should act on.
+    """
+    try:
+        checks = [check_schema(db_path),
+                  check_transcripts(db_path, home=home, claude_home=claude_home)]
+    except Exception:  # noqa: BLE001 — a diagnostic must never cost the runner its start
+        log.debug("emdash startup check failed to run (non-fatal)", exc_info=True)
+        return
+
+    drifted = [c for c in checks if not c.ok]
+    if not drifted:
+        detail = "; ".join(c.summary for c in checks if not c.skipped)
+        log.info("  emdash: %s", detail or "checks skipped")
+        return
+
+    for c in drifted:
+        log.warning("emdash DRIFT (%s): %s", c.name, c.summary)
+        for n in c.notes:
+            log.warning("    %s", n)
+    log.warning("    run `canopy-runner verify-emdash --config <cfg>` for the full report")

--- a/runner/canopy_runner/tests/test_upgrade_check.py
+++ b/runner/canopy_runner/tests/test_upgrade_check.py
@@ -240,3 +240,69 @@ def test_a_pre_1_2_emdash_skips_rather_than_reporting_a_drift(paths, tmp_path):
     check = upgrade_check.check_transcripts(db, home=home, claude_home=claude_home)
     assert check.ok and check.skipped
     assert "predates provider_session_id" in check.summary
+
+
+# --- the startup hook ---------------------------------------------------------------------
+# emdash auto-updates, so a check nobody runs is a check that does not exist (#643).
+
+class _Log:
+    def __init__(self):
+        self.warns, self.infos = [], []
+    def warning(self, msg, *a): self.warns.append(msg % a if a else msg)
+    def info(self, msg, *a): self.infos.append(msg % a if a else msg)
+    def debug(self, *a, **k): pass
+
+
+def test_startup_warns_and_says_what_to_run_when_a_surface_drifts(paths, tmp_path):
+    home, claude_home = paths
+    db = _db(tmp_path)
+    _session(db, repo="canopy-web", task="emdash-check", sid="sid-1")
+    _plant_transcript(home, claude_home, worktree_rel="totally-new-shape/emdash-check", sid="sid-1")
+    log = _Log()
+
+    upgrade_check.log_startup_drift(db, home=home, claude_home=claude_home, log=log)
+
+    assert any("DRIFT" in w for w in log.warns)
+    assert any("verify-emdash" in w for w in log.warns)
+
+
+def test_startup_is_quiet_when_everything_is_intact(paths, tmp_path):
+    """A startup line per boot is fine; a WARNING per boot trains people to ignore
+    warnings from this runner."""
+    home, claude_home = paths
+    db = _db(tmp_path)
+    _session(db, repo="ace", task="fresh", sid=None)
+    log = _Log()
+
+    upgrade_check.log_startup_drift(db, home=home, claude_home=claude_home, log=log)
+
+    assert log.warns == []
+    assert log.infos
+
+
+def test_an_older_emdash_does_not_warn(paths, tmp_path):
+    """"predates 1.2" is a healthy state — the reads adapt to it (#641). Warning here
+    would put a permanent, un-actionable warning in the log of every older box."""
+    home, claude_home = paths
+    old = _SCHEMA_12.replace(",\n      provider_session_id TEXT", "")
+    old = old.replace(", deleted_at TEXT\n    );", "\n    );")
+    old = old.replace(",\n      last_session_activity_at TEXT", "")
+    db = _db(tmp_path, old)
+    log = _Log()
+
+    upgrade_check.log_startup_drift(db, home=home, claude_home=claude_home, log=log)
+
+    assert log.warns == []
+
+
+def test_startup_never_raises_even_when_the_check_itself_breaks(paths, tmp_path, monkeypatch):
+    """A diagnostic that can kill the runner is a liability, not a safeguard — launchd
+    KeepAlive would turn it into a restart loop."""
+    home, claude_home = paths
+    monkeypatch.setattr(upgrade_check, "check_schema",
+                        lambda *_a, **_k: (_ for _ in ()).throw(RuntimeError("boom")))
+    log = _Log()
+
+    upgrade_check.log_startup_drift("whatever", home=home, claude_home=claude_home, log=log)
+
+    assert log.warns == []


### PR DESCRIPTION
Closes #643. **Stacked on #642** — retarget to `main` once that lands.

## Why

emdash auto-updates. Nobody is prompted, nobody picks a moment. 1.2 landed at 06:01 on 2026-08-28, and the first anyone knew was a human asking whether anything had broken — hours after `agent_status` had gone blank on every session and new sessions had stopped resolving to a transcript.

`verify-emdash` is a manual command. It is only as good as somebody remembering to type it *after* an event they were never told about — the weakest possible trigger for a check whose whole purpose is catching a silent change.

The runner restarts on update and on reboot. That is the one moment that reliably **follows** an emdash change without anyone deciding anything.

## What it does

Runs the two **silent-failure** checks — schema and transcript resolution — and logs the result. On a healthy box that is one line:

```
INFO   emdash: all 15 columns across tasks, projects, conversations present;
       13/13 resolvable transcripts found across 13 open sessions
```

On a drifted one, a WARNING naming the surface and the command for the full report.

The DOM probe is deliberately **not** included: it shells out to node and costs seconds, and the contract it covers fails loudly on the next real turn anyway.

## Three rules that keep a diagnostic from becoming a liability

- **Never blocks, never raises.** A drifted schema still leaves most of the runner working, so refusing to start would convert a partial degradation into a total outage — and under launchd's `KeepAlive`, into a restart loop. A test asserts it stays silent even when the check itself throws.
- **WARNING only for a real drift.** "This emdash predates 1.2" is a healthy state the reads adapt to (#642); warning on it would put a permanent, un-actionable line in the log of every older box. A test pins that.
- **Names the command.** The warning says `verify-emdash` so the reader doesn't hunt for it.

## Verification

527 tests pass, including 4 new ones for the startup hook specifically (drift warns and names the command; healthy is quiet; older emdash doesn't warn; a broken check can't kill the runner). Output above is from the real function against the live 1.2 box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHEEiXYVT6VoLoq9y91q7D