### PR TITLE
docs(runner): correct two emdash.py docstrings that no longer match reality

### DIFF
--- a/runner/canopy_runner/canopy_runner/emdash.py
+++ b/runner/canopy_runner/canopy_runner/emdash.py
@@ -15,18 +15,28 @@ mistake "could not read" for "zero open sessions" — reporting an empty list cl
 every RunnerBinding server-side. The risk both reads share is a *silent* schema drift —
 emdash renaming a column these queries name — which is why `check_read_schema`
 (surfaced as `canopy_runner verify-emdash`) exists: run it after an emdash update to
-confirm the columns these two functions depend on still exist. Keep `READ_SCHEMA` in
-lockstep with the SQL below — it IS the list of columns the SQL names.
+confirm the columns these two functions depend on still exist. Keep
+`REQUIRED_SCHEMA`/`OPTIONAL_SCHEMA` in lockstep with the SQL below — between them they
+ARE the list of columns the SQL names, and `READ_SCHEMA` is just their union.
 
-**A row is live only if it is neither archived NOR soft-deleted.** emdash 1.2 added
-`deleted_at` to `tasks` and `projects` and its own queries pair the two —
-`and(isNull(tasks.archivedAt), isNull(tasks.deletedAt))` is how emdash itself asks for
-live tasks. Matching that is not defensive tidiness: filtering on `archived_at` alone
-means canopy reports as OPEN a task emdash no longer shows anywhere, so the supervisor
-grows sessions nobody can click into and `task_state` calls a deleted task "live" and
-hands it to the reuse path. The columns were empty on the fleet laptop when this was
-written (2026-08-28), so the divergence is latent rather than observed — which is the
-point of fixing it now: it starts costing the moment anyone deletes a task.
+**A row is live only if it is neither archived NOR soft-deleted** — but the three
+tables emdash 1.2 gave `deleted_at` do not use it alike, and the difference decides
+which of these filters is load-bearing (read out of the shipped bundle, 2026-08-28):
+
+  * `projects` ARE soft-deleted: `update(projects).set({deletedAt: ...})`, which emdash
+    itself calls "tombstoned". This filter is the one that matters. `list_projects`
+    feeds `capabilities.projects`, which is what makes a repo's turns claimable — so
+    without it a project someone removed keeps being advertised as drivable and the
+    runner claims turns for a repo it can no longer open.
+  * `tasks` are still HARD deleted: both paths run
+    `tx.delete(tasks).where(eq(tasks.id, task.id))`. emdash FILTERS on
+    `tasks.deleted_at` (`and(isNull(archivedAt), isNull(deletedAt))`) but nothing
+    writes it, so our matching filter is alignment with emdash's own query rather than
+    a live fix — correct to keep, and currently inert.
+
+The consequence worth remembering: 1.2 does NOT give canopy the closing signal it
+lacks. Absence from the wholesale open-task report is still the only signal emdash
+gives that a session is over.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
Docs-only. No behaviour change; 533 tests pass unchanged.

Both docstrings were written by me earlier today and both are now wrong. That matters more than usual here: these comments are the reason the next person trusts the reads without re-deriving emdash's behaviour from its bundle.

**1. `READ_SCHEMA` is no longer the hand-maintained list.** #642 split it into `REQUIRED_SCHEMA` / `OPTIONAL_SCHEMA`; `READ_SCHEMA` is now their union. The instruction to "keep `READ_SCHEMA` in lockstep with the SQL" now points at a derived value.

**2. The soft-delete paragraph asserted something I later disproved.** It claimed filtering `tasks.deleted_at` protects against a task emdash no longer shows. Reading emdash's shipped delete paths says otherwise:

| table | deletion | writes `deleted_at`? |
|---|---|---|
| `tasks` | `tx.delete(tasks).where(eq(tasks.id, task.id))` — hard delete, both paths | **no** |
| `projects` | `update(projects).set({deletedAt: ...})` — "tombstoned" in emdash's own words | **yes** |

So the filter carrying weight is the **projects** one — `list_projects` feeds `capabilities.projects`, which is what makes a repo's turns claimable, and without it a removed project keeps being advertised as drivable. The tasks filter is alignment with emdash's own query (which does filter the column it never writes) — correct to keep, currently inert.

The code was right for both; only the explanation of *which* filter is doing work was wrong.

Also records the thing I had hoped otherwise about, so nobody re-derives it: **1.2 does not give canopy the closing signal it lacks.** Absence from the wholesale open-task report is still the only signal emdash offers that a session is over.

Correction previously posted to #633; this puts it where the code is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHEEiXYVT6VoLoq9y91q7D