### PR TITLE
perf(walkthroughs): a seek cost two Drive round-trips, and nothing was cacheable

### DIFF
--- a/apps/walkthroughs/streaming.py
+++ b/apps/walkthroughs/streaming.py
@@ -37,6 +37,17 @@ def _parse_range(header: str, total: int) -> tuple[int, int] | None:
     return start, min(end, total - 1)
 
 
+# Token-gated, so `private` (never a shared cache) — but the bytes behind one
+# walkthrough id are immutable, so the BROWSER should keep them. Without this
+# every scrub back to a spot already watched re-fetched it from Drive at ~1.3s.
+_CACHE_CONTROL = "private, max-age=86400, immutable"
+
+
+def _etag(w) -> str:
+    """Stable per-file validator, so a revalidation is a 304 not a re-download."""
+    return f'"{w.drive_file_id}-{w.size_bytes}"'
+
+
 def _get_or_404(wid):
     # ValidationError: the route now accepts <str:wid>, so a non-UUID id reaches
     # the UUIDField pk lookup and raises ValidationError (not ValueError) — treat
@@ -77,10 +88,24 @@ def walkthrough_content(request, wid):
     range_hdr = request.META.get("HTTP_RANGE", "")
     try:
         if range_hdr:
-            # We need the total to clamp the range — do a tiny head download.
-            _, _, _, total = storage.download(
-                file_id=w.drive_file_id, start=0, end=0,
-            )
+            # The total is only needed to clamp the range, and we already know
+            # it: `size_bytes` is recorded at upload and the bytes never change
+            # (there is no in-place replace — a new cut is a new walkthrough).
+            #
+            # This used to be a `download(start=0, end=0)` head request, which
+            # meant EVERY range the <video> element asked for cost two
+            # sequential Drive round-trips instead of one. Measured against
+            # prod: ~1.93s TTFB with the probe, ~1.37s without — ~0.55s of pure
+            # latency added to the initial load and to every single seek. A
+            # scrub is several ranges, so it compounded.
+            #
+            # Falls back to the probe when size_bytes is missing (rows that
+            # predate the field), so nothing that worked stops working.
+            total = w.size_bytes
+            if not total:
+                _, _, _, total = storage.download(
+                    file_id=w.drive_file_id, start=0, end=0,
+                )
             parsed = _parse_range(range_hdr, total)
             if parsed is None:
                 resp = HttpResponse(status=416)
@@ -95,10 +120,13 @@ def walkthrough_content(request, wid):
                 status=206,
                 content_type=w.content_type,
             )
+            # `t` comes back from the byte fetch itself, so the denominator we
+            # publish is Drive's own count even if size_bytes ever drifted.
             resp["Content-Range"] = f"bytes {s}-{e}/{t}"
             resp["Content-Length"] = str(len(data))
             resp["Accept-Ranges"] = "bytes"
-            resp["Cache-Control"] = "private"
+            resp["Cache-Control"] = _CACHE_CONTROL
+            resp["ETag"] = _etag(w)
             return resp
 
         data, s, e, t = storage.download(file_id=w.drive_file_id)
@@ -109,7 +137,8 @@ def walkthrough_content(request, wid):
         )
         resp["Content-Length"] = str(len(data))
         resp["Accept-Ranges"] = "bytes"
-        resp["Cache-Control"] = "private"
+        resp["Cache-Control"] = _CACHE_CONTROL
+        resp["ETag"] = _etag(w)
         return resp
     except DriveNotConfigured:
         return HttpResponse(status=500)

--- a/tests/test_walkthrough_streaming_perf.py
+++ b/tests/test_walkthrough_streaming_perf.py
@@ -1,0 +1,93 @@
+"""Range requests must cost ONE Drive round-trip, and be cacheable.
+
+Every range the <video> element asked for used to make two sequential Drive
+calls: a `download(start=0, end=0)` head probe purely to learn the total, then
+the real fetch. Measured against prod that was ~1.93s TTFB vs ~1.37s without
+the probe — ~0.55s added to the initial load and to every seek, and a scrub is
+several ranges. The total is already on the row (`size_bytes`) and the bytes
+behind one walkthrough id never change.
+"""
+from unittest.mock import patch
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import Client, override_settings
+
+from apps.walkthroughs.models import Walkthrough
+
+
+@pytest.fixture
+def owner(db):
+    return get_user_model().objects.create_user(
+        username="perf@dimagi.com", email="perf@dimagi.com",
+    )
+
+
+def _make(owner, **kw):
+    defaults = dict(
+        title="Demo", kind="video", owner=owner, visibility="link",
+        drive_file_id="file-1", drive_folder_id="folder-1",
+        content_type="video/mp4", size_bytes=10,
+    )
+    defaults.update(kw)
+    return Walkthrough.objects.create(**defaults)
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_a_range_request_makes_exactly_one_drive_call(owner):
+    w = _make(owner)
+    token = w.ensure_share_token()
+    with patch("apps.walkthroughs.streaming.storage.download",
+               return_value=(b"2345", 2, 5, 10)) as dl:
+        resp = Client().get(f"/walkthrough/{w.id}/content?t={token}", HTTP_RANGE="bytes=2-5")
+    assert resp.status_code == 206
+    assert dl.call_count == 1, "the size probe is back — every seek costs a second Drive round-trip"
+    assert dl.call_args.kwargs["start"] == 2
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_the_probe_still_happens_when_size_is_unknown(owner):
+    """Rows predating size_bytes must keep working."""
+    w = _make(owner, size_bytes=0)
+    token = w.ensure_share_token()
+    with patch("apps.walkthroughs.streaming.storage.download",
+               return_value=(b"2345", 2, 5, 10)) as dl:
+        resp = Client().get(f"/walkthrough/{w.id}/content?t={token}", HTTP_RANGE="bytes=2-5")
+    assert resp.status_code == 206
+    assert dl.call_count == 2
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_the_denominator_comes_from_the_fetch_not_the_row(owner):
+    """If size_bytes ever drifted, the published total is still Drive's."""
+    w = _make(owner, size_bytes=10)
+    token = w.ensure_share_token()
+    with patch("apps.walkthroughs.streaming.storage.download",
+               return_value=(b"2345", 2, 5, 999)):
+        resp = Client().get(f"/walkthrough/{w.id}/content?t={token}", HTTP_RANGE="bytes=2-5")
+    assert resp["Content-Range"] == "bytes 2-5/999"
+
+
+@override_settings(REQUIRE_AUTH=True)
+@pytest.mark.parametrize("headers", [{}, {"HTTP_RANGE": "bytes=2-5"}])
+def test_the_browser_may_cache_the_bytes_but_no_shared_cache_may(owner, headers):
+    w = _make(owner)
+    token = w.ensure_share_token()
+    with patch("apps.walkthroughs.streaming.storage.download",
+               return_value=(b"2345", 2, 5, 10)):
+        resp = Client().get(f"/walkthrough/{w.id}/content?t={token}", **headers)
+    cc = resp["Cache-Control"]
+    assert "private" in cc, "token-gated bytes must never enter a shared cache"
+    assert "immutable" in cc and "max-age=" in cc
+    assert resp["ETag"] == '"file-1-10"'
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_an_unsatisfiable_range_still_416s_without_fetching_bytes(owner):
+    w = _make(owner, size_bytes=10)
+    token = w.ensure_share_token()
+    with patch("apps.walkthroughs.streaming.storage.download") as dl:
+        resp = Client().get(f"/walkthrough/{w.id}/content?t={token}", HTTP_RANGE="bytes=99-")
+    assert resp.status_code == 416
+    assert resp["Content-Range"] == "bytes */10"
+    assert dl.call_count == 0


### PR DESCRIPTION
## The problem

Every range the `<video>` element asks for made **two sequential Drive calls**:

```python
_, _, _, total = storage.download(file_id=..., start=0, end=0)   # head probe, just to learn the size
data, s, e, t  = storage.download(file_id=..., start=start, end=end)
```

The total is already on the row — `size_bytes`, recorded at upload — and the bytes behind one walkthrough id never change (a new cut is a new walkthrough; there is no in-place replace).

Measured against prod, same file, same host, 3 runs each:

| request | TTFB |
|---|---|
| no Range → one Drive call | **~1.37s** |
| with Range → two Drive calls | **~1.93s** |
| an ordinary page on the same host | 0.22s |

The probe added **~0.55s to the initial load and to every seek** — and a scrub is several ranges, so it compounded. It also meant an unsatisfiable range hit Drive before returning 416; now that path touches Drive not at all.

Responses were `Cache-Control: private` with no freshness, so the browser re-fetched ranges it already held — scrubbing back to a spot you just watched paid full Drive latency again. Now `private, max-age=86400, immutable` plus a per-file `ETag`. Still `private`: these are token-gated and must never enter a shared cache.

## What this does NOT fix

The remaining **~1.3s is Drive itself**. Every byte still proxies through the app via the Drive API. Getting that to tens of milliseconds means object storage + a CDN (canopy-web already has an S3 bucket for chat attachments, so the dependency exists) — a migration, not a patch. Flagging it rather than pretending this closes it.

## Verification

- 6 new tests. **4 of them fail on `main`** (verified in a clean worktree) and pass here; the other 2 assert behaviour that must NOT change — the probe still runs when `size_bytes` is missing, and the published denominator still comes from the fetch, not the row, so drift can't produce a wrong `Content-Range`.
- Full suite: **2197 passed, 1 skipped**.
- `ruff` clean.