### PR TITLE
A suggestion claude offers is not text the human typed

### DIFF
--- a/runner/canopy_runner/canopy_runner/cdp/emdash_control.mjs
+++ b/runner/canopy_runner/canopy_runner/cdp/emdash_control.mjs
@@ -351,7 +351,12 @@ try {
       }));
       const full = composerText(descriptors.map(d => d.text));
       const typed = composerText(brightRows(descriptors));
-      return { found: full.found, text: full.text, typed: typed.found ? typed.text : '' };
+      // If the blanked frame LOSES the composer the structure itself was dim, which
+      // this rule does not model — so fall back to the full text (a collision, the
+      // human is asked) rather than to '' (send, and clobber whatever is there).
+      // Every send site in this file fails closed; this one does too.
+      return { found: full.found, text: full.text,
+               typed: typed.found ? typed.text : full.text };
     })(); })()`);
     // A frame with no composer is UNREADABLE, not empty: mid-redraw right after the
     // task click, a menu/dialog covering the input, or a clipped stale frame (all

--- a/runner/canopy_runner/canopy_runner/cdp/emdash_control.mjs
+++ b/runner/canopy_runner/canopy_runner/cdp/emdash_control.mjs
@@ -112,6 +112,33 @@ function composerText(rows) {
 }
 `;
 
+// TYPED vs OFFERED — the other half of the collision guard. claude renders an
+// inline suggestion (its offered next prompt, and its ghost hints) as DIM cells:
+// xterm gives them `.xterm-dim` / rgba(...,0.5) and parks the block cursor on the
+// suggestion's FIRST character. Real keystrokes are never dim. Reading the rows as
+// bare textContent threw that distinction away, so an offered suggestion read
+// exactly like a half-typed thought and every send into that session came back
+// `collision` — a dialog nobody was there to answer, defaulting to "don't deliver".
+// Measured on a live emdash 2026-08-28: three chat turns deferred inside 40 minutes
+// with the composer empty in all three, the whole line dim, cursor on its first char.
+//
+// Input is one descriptor per row, `{ text, spans: [{ text, dim }] }`. Dim runs are
+// blanked to spaces of the SAME WIDTH rather than dropped, so column positions — and
+// the box rules composerText() keys on — come through unchanged, which is what lets
+// the same scan run over both the full frame and the typed-only one.
+const BRIGHT_FN = String.raw`
+function brightRows(rows) {
+  return rows.map(r => {
+    const spans = r.spans || [];
+    if (!spans.length) return r.text || '';
+    return spans.map(s => {
+      const t = s.text || '';
+      return s.dim ? ' '.repeat(t.length) : t;
+    }).join('');
+  });
+}
+`;
+
 const command = process.argv[2];
 const args = JSON.parse(process.argv[3] || '{}');
 const port = args.port || 9222;
@@ -308,11 +335,23 @@ try {
     // draws its composer near the TOP of the pane (measured: row 13 of 38, the
     // whole scanned window blank) — which is exactly the state every new chat
     // session is in (#521).
-    const readComposer = () => page.evaluate(String.raw`(() => { ${ACTIVE_TERM_FN}; ${COMPOSER_FN}; return (() => {
+    // Returns {found, text, typed}: `text` is everything rendered in the composer,
+    // `typed` only the part the HUMAN put there (see BRIGHT_FN — dim cells are the
+    // suggestion claude is offering, not keystrokes). `found` comes from the full
+    // frame, since the box rules and ❯ that make a composer findable are never dim.
+    const readComposer = () => page.evaluate(String.raw`(() => { ${ACTIVE_TERM_FN}; ${COMPOSER_FN}; ${BRIGHT_FN}; return (() => {
       const term = activeTerm();
-      if (!term) return { found: false, text: '' };
-      const rows = [...term.querySelectorAll('.xterm-rows > div')].map(r => r.textContent || '');
-      return composerText(rows);
+      if (!term) return { found: false, text: '', typed: '' };
+      const descriptors = [...term.querySelectorAll('.xterm-rows > div')].map(r => ({
+        text: r.textContent || '',
+        spans: [...r.children].map(s => ({
+          text: s.textContent || '',
+          dim: (s.className || '').includes('xterm-dim'),
+        })),
+      }));
+      const full = composerText(descriptors.map(d => d.text));
+      const typed = composerText(brightRows(descriptors));
+      return { found: full.found, text: full.text, typed: typed.found ? typed.text : '' };
     })(); })()`);
     // A frame with no composer is UNREADABLE, not empty: mid-redraw right after the
     // task click, a menu/dialog covering the input, or a clipped stale frame (all
@@ -320,7 +359,7 @@ try {
     // a blind send would append into a composer we cannot see. The runner treats a
     // CDPError as "task exists but undrivable" and retries the turn; it never
     // duplicates the session.
-    let composer = { found: false, text: '' };
+    let composer = { found: false, text: '', typed: '' };
     for (let attempt = 0; attempt < 4; attempt++) {
       composer = await readComposer();
       if (composer.found) break;
@@ -331,7 +370,9 @@ try {
            `(mid-redraw, a menu is up, or a stale frame) — refusing a blind send`);
     }
     // Ghost/placeholder hints claude shows in an EMPTY input — treat as empty so the
-    // fast path still fires instead of popping a spurious collision dialog.
+    // fast path still fires instead of popping a spurious collision dialog. `typed`
+    // (above) already blanks every dim cell, which is the general form of this rule;
+    // the prefix list stays as a second net for any hint claude renders undimmed.
     const PLACEHOLDER = /^(Try |Ask |\/ for |\? for )/i;
     const isEmpty = (s) => !s || PLACEHOLDER.test(s);
 
@@ -343,7 +384,10 @@ try {
       await page.keyboard.press('Control+U');
       for (let i = 0; i < 6; i++) {
         const cur = await readComposer();
-        const n = Math.min(cur.found ? cur.text.length : 0, 300);
+        // `typed`, not `text`: once Ctrl+U empties the line claude re-offers a
+        // suggestion into it, and measuring THAT would backspace forever against
+        // text no keystroke can delete.
+        const n = Math.min(cur.found ? cur.typed.length : 0, 300);
         if (n === 0) break;
         await page.keyboard.press('End');
         for (let k = 0; k < n; k++) await page.keyboard.press('Backspace');
@@ -351,9 +395,9 @@ try {
       await page.keyboard.insertText(text);
       await page.keyboard.press('Enter');
       out({ ok: true, action: 'sent-cleared', task });
-    } else if (!isEmpty(composer.text)) {
+    } else if (!isEmpty(composer.typed)) {
       // Don't touch it — hand the collision back to the runner to ask the human.
-      out({ ok: true, action: 'collision', task, line: composer.text });
+      out({ ok: true, action: 'collision', task, line: composer.typed });
     } else {
       await page.keyboard.insertText(text);   // atomic commit, not char-by-char
       await page.keyboard.press('Enter');

--- a/runner/canopy_runner/canopy_runner/execute.py
+++ b/runner/canopy_runner/canopy_runner/execute.py
@@ -78,6 +78,14 @@ def _slug(text: str, n: int = 28) -> str:
     return re.sub(r"[^a-z0-9]+", "-", (text or "").lower()).strip("-")[:n].strip("-")
 
 
+def _preview(line: str, n: int = 120) -> str:
+    """Truncate a composer line for the log/event trail. It is the human's own
+    half-typed words, so it is bounded rather than dropped — enough to recognise
+    what blocked a send, not the whole thought."""
+    s = (line or "").strip()
+    return s if len(s) <= n else s[: n - 1] + "…"
+
+
 def _task_name(agent: str, turn: dict, now=None) -> str:
     """A HUMAN-READABLE, per-thread-UNIQUE emdash task name: agent + subject slug +
     a short thread discriminator + MMDD-HHMM, e.g. 'hal-security-alert-6355-0714-1514'.
@@ -139,11 +147,17 @@ def _deliver_to_existing(cfg, client, runner_id, turn, task, state, work_prompt)
         return f"failed:{turn_id}"
 
     if res.get("action") == "collision":
-        choice = dialog.collision_choice(task, res.get("line", ""))
-        logger.info("collision on '%s' (turn=%s): unsent text in prompt — human chose %r",
-                    task, turn_id, choice)
+        line = res.get("line", "")
+        choice = dialog.collision_choice(task, line)
+        # Log the LINE, not just the choice. Without it a collision is unfalsifiable
+        # after the fact — a real half-typed thought and a misread ghost suggestion
+        # produce identical log entries, which is how the dim-suggestion misread ran
+        # unnoticed (see cdp/emdash_control.mjs, readComposer `typed`).
+        logger.info("collision on '%s' (turn=%s): unsent text in prompt %r — human chose %r",
+                    task, turn_id, _preview(line), choice)
         client.post_events(turn_id, [{"kind": "status",
-            "payload": {"status": "collision", "task": task, "choice": choice}}])
+            "payload": {"status": "collision", "task": task, "choice": choice,
+                        "line": _preview(line)}}])
         if choice == dialog.NEW:
             return None                         # leave the prompt untouched; create fresh
         if choice == dialog.CANCEL:
@@ -353,9 +367,10 @@ def execute_chat_turn(cfg, client, runner_id: str, turn: dict, cancel_check=None
         # asks the same way, because it is the SAME hazard and the human is right
         # there.
         if res.get("action") == "collision":
-            choice = dialog.collision_choice(task, res.get("line", ""))
-            logger.info("chat collision on '%s' (turn=%s): unsent text in prompt — "
-                        "human chose %r", task, turn_id, choice)
+            line = res.get("line", "")
+            choice = dialog.collision_choice(task, line)
+            logger.info("chat collision on '%s' (turn=%s): unsent text in prompt %r — "
+                        "human chose %r", task, turn_id, _preview(line), choice)
             if choice == dialog.CLEAR:
                 cdp_control.open_and_send(task, prompt, clear_first=True, port=cfg.cdp_port)
             elif choice == dialog.CANCEL:

--- a/runner/canopy_runner/tests/test_cdp_control.py
+++ b/runner/canopy_runner/tests/test_cdp_control.py
@@ -272,8 +272,11 @@ def _evaluate_bodies():
     from pathlib import Path
     src = (Path(__file__).resolve().parents[1] / "canopy_runner" / "cdp"
            / "emdash_control.mjs").read_text()
-    helpers = {name: (re.search(rf"const {name} = String\.raw`([\s\S]*?)`;", src) or [None, ""])[1]
-               for name in ("ACTIVE_TERM_FN", "COMPOSER_FN")}
+    # DISCOVERED, not listed. A hardcoded roster silently exempts the next helper
+    # someone adds: its `${NEW_FN}` survives into the body, `new Function` chokes on
+    # the literal `${`, and the failure reads as "your JS is broken" rather than
+    # "the test doesn't know about this one".
+    helpers = dict(re.findall(r"const (\w+_FN) = String\.raw`([\s\S]*?)`;", src))
     bodies = []
     for m in re.findall(r"page\.evaluate\(String\.raw`([\s\S]*?)`\)", src):
         for name, helper_src in helpers.items():
@@ -439,3 +442,122 @@ def test_close_task_reports_an_already_gone_task_as_absent(monkeypatch):
         cdp_control, "_run", lambda c, a, **k: {"ok": True, "action": "absent"}
     )
     assert cdp_control.close_task("gone")["action"] == "absent"
+
+
+# -- typed vs offered: the dim-suggestion misread ------------------------------
+#
+# claude offers an inline next-prompt suggestion INSIDE an empty composer, drawn
+# with xterm's dim attribute and the block cursor on its FIRST character. Read as
+# bare text it is indistinguishable from a half-typed human thought, so every send
+# into such a session came back `collision` and the message was never delivered
+# (measured live 2026-08-28: three chat turns deferred inside 40 minutes, composer
+# empty in all three). BRIGHT_FN blanks dim runs so `typed` sees only keystrokes.
+
+def _bright_fn_source():
+    import re
+    from pathlib import Path
+    src = (Path(__file__).resolve().parents[1] / "canopy_runner" / "cdp"
+           / "emdash_control.mjs").read_text()
+    m = re.search(r"const BRIGHT_FN = String\.raw`([\s\S]*?)`;", src)
+    assert m, "BRIGHT_FN not found in emdash_control.mjs"
+    return m.group(1)
+
+
+def _typed(descriptors):
+    """Run the real readComposer pair (composerText over the full frame, and over
+    the dim-blanked one) against row descriptors, exactly as the sidecar does."""
+    import shutil
+    import subprocess
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("node not installed")
+    script = (_composer_fn_source() + _bright_fn_source()
+              + "\nconst d = JSON.parse(require('fs').readFileSync(0, 'utf8'));"
+              + "\nconst full = composerText(d.map(x => x.text));"
+              + "\nconst t = composerText(brightRows(d));"
+              + "\nprocess.stdout.write(JSON.stringify("
+              + "{found: full.found, text: full.text, typed: t.found ? t.text : ''}));")
+    out = subprocess.run([node, "-e", script], input=json.dumps(descriptors),
+                         capture_output=True, text=True, timeout=30)
+    assert out.returncode == 0, f"brightRows/composerText crashed: {out.stderr[:300]}"
+    return json.loads(out.stdout)
+
+
+def _plain(text):
+    return {"text": text, "spans": [{"text": text, "dim": False}]}
+
+
+def _frame(*composer_rows):
+    """A fresh-session frame (see _fresh_session) in descriptor form."""
+    body = [_plain("  word: ready."), _plain(""), _plain("⏺ ready"), _plain("")]
+    return (body + [_plain(_RULE), *composer_rows, _plain(_RULE), _plain(_STATUS)]
+            + [_plain("")] * 24)
+
+
+def test_offered_suggestion_reads_as_empty_typed():
+    # THE repro, span-for-span as measured on a live emdash 2026-08-28: cursor block
+    # parked on the suggestion's first character, every cell after ❯ dim.
+    suggestion = {
+        "text": "❯ run the concept and visual judges on all three",
+        "spans": [
+            {"text": "❯ ", "dim": False},
+            {"text": "r", "dim": True},
+            {"text": "un the concept and visual judges on all three", "dim": True},
+        ],
+    }
+    r = _typed(_frame(suggestion))
+    assert r["found"] is True
+    assert r["text"] == "run the concept and visual judges on all three"
+    assert r["typed"] == ""          # nothing to collide with — the send must go through
+
+
+def test_real_typed_text_still_collides():
+    # The guard's whole reason to exist: undimmed keystrokes are never blanked.
+    typed = {
+        "text": "❯ okay so any changes we should do here?",
+        "spans": [
+            {"text": "❯ ", "dim": False},
+            {"text": "okay so any changes we should do here?", "dim": False},
+        ],
+    }
+    r = _typed(_frame(typed))
+    assert r["typed"] == "okay so any changes we should do here?"
+
+
+def test_typed_prefix_with_dim_completion_keeps_the_prefix():
+    # Half-typed, with claude completing the rest inline: the human's words are a
+    # real collision, the offered tail is not part of it.
+    mixed = {
+        "text": "❯ run the concept and visual judges",
+        "spans": [
+            {"text": "❯ ", "dim": False},
+            {"text": "run the ", "dim": False},
+            {"text": "concept and visual judges", "dim": True},
+        ],
+    }
+    r = _typed(_frame(mixed))
+    assert r["typed"] == "run the"
+
+
+def test_blanking_preserves_columns_so_the_frame_stays_findable():
+    # Dim runs are padded, not dropped. If they were dropped the ❯ row would shift
+    # and the structural scan would lose the composer entirely — reading UNREADABLE
+    # (refuse every send) instead of empty.
+    wrapped = [
+        {"text": "❯ a long offered line that", "spans": [
+            {"text": "❯ ", "dim": False},
+            {"text": "a long offered line that", "dim": True}]},
+        {"text": "  wraps onto more rows", "spans": [
+            {"text": "  wraps onto more rows", "dim": True}]},
+    ]
+    r = _typed(_frame(*wrapped))
+    assert r["found"] is True
+    assert r["text"] == "a long offered line that wraps onto more rows"
+    assert r["typed"] == ""
+
+
+def test_rows_without_spans_fall_back_to_text():
+    # xterm rows are spans, but a row can render as a bare text node; the fallback
+    # must not silently blank a real composer.
+    r = _typed(_frame({"text": "❯ typed with no spans", "spans": []}))
+    assert r["typed"] == "typed with no spans"

--- a/runner/canopy_runner/tests/test_cdp_control.py
+++ b/runner/canopy_runner/tests/test_cdp_control.py
@@ -476,7 +476,7 @@ def _typed(descriptors):
               + "\nconst full = composerText(d.map(x => x.text));"
               + "\nconst t = composerText(brightRows(d));"
               + "\nprocess.stdout.write(JSON.stringify("
-              + "{found: full.found, text: full.text, typed: t.found ? t.text : ''}));")
+              + "{found: full.found, text: full.text, typed: t.found ? t.text : full.text}));")
     out = subprocess.run([node, "-e", script], input=json.dumps(descriptors),
                          capture_output=True, text=True, timeout=30)
     assert out.returncode == 0, f"brightRows/composerText crashed: {out.stderr[:300]}"
@@ -561,3 +561,19 @@ def test_rows_without_spans_fall_back_to_text():
     # must not silently blank a real composer.
     r = _typed(_frame({"text": "❯ typed with no spans", "spans": []}))
     assert r["typed"] == "typed with no spans"
+
+
+def test_all_dim_structure_falls_back_to_a_collision_not_a_send():
+    # If the box rules or ❯ were themselves dim the blanked frame would lose the
+    # composer, and this rule would not model that terminal. Fail CLOSED — report
+    # the full text (the human gets asked) rather than '' (send, and clobber it).
+    dim_everything = [
+        {"text": _RULE, "spans": [{"text": _RULE, "dim": True}]},
+        {"text": "❯ something already here", "spans": [
+            {"text": "❯ something already here", "dim": True}]},
+        {"text": _RULE, "spans": [{"text": _RULE, "dim": True}]},
+        {"text": _STATUS, "spans": [{"text": _STATUS, "dim": True}]},
+    ]
+    r = _typed([_plain("⏺ transcript"), *dim_everything])
+    assert r["found"] is True
+    assert r["typed"] == "something already here"


### PR DESCRIPTION
## The symptom

Chat messages sent from canopy-web into a live session came back `chat send deferred: unsent text in '<task>'` and never arrived. The composer was empty every time.

Three today before anyone looked, all defaulted to "don't deliver":

```
22:21:08  chat collision on 'targeting'                                — 'New session'
22:48:52  chat collision on 'connect-labs-resume-impact-eval-…'        — 'New session'
23:01:32  chat collision on 'targeting'                                — 'New session'
```

## The cause

Before typing, the sidecar reads the composer and refuses to send if it holds anything — the guard that stops it clobbering a half-typed thought. It read the rows as bare `textContent`:

```js
const rows = [...term.querySelectorAll('.xterm-rows > div')].map(r => r.textContent || '');
```

That throws away the one attribute separating the two cases. claude draws its offered next prompt as **dim** cells; real keystrokes are never dim. Measured span-for-span on a live emdash:

```
❯ run the concept and visual judges on all three
  "❯ "  → rgb(238,238,238)                                    opacity 1
  "r"   → xterm-cursor xterm-cursor-block xterm-dim        ← cursor on the FIRST char
  "un…" → xterm-dim, rgba(238,238,238,0.5)
```

So an offered suggestion read exactly like the human mid-sentence. Every send into that session returned `collision`, and the dialog it raises — which nobody was sitting in front of — timed out into its non-destructive default of *don't deliver*.

## The fix

`BRIGHT_FN` blanks dim runs, padded to the same width so column positions and the box rules `composerText()` keys on survive — which is what lets the same scan run over both the full frame and the typed-only one. `typed` carries only keystrokes; `text` still carries everything; `found` still comes from the full frame, since `❯` and the rules are never dim. The `PLACEHOLDER` prefix list stays as a second net for any hint claude renders undimmed.

Re-running the read against the live pane that was failing:

```
{ "found": true, "text": "the settlement, lets do the named places spike first", "typed": "" }
OLD verdict (text):   COLLISION
NEW verdict (typed):  SEND
```

Two things fall out:

- `clearFirst` measured `text` to size its backspace loop. Once Ctrl+U empties the line claude re-offers a suggestion into it, so the loop was measuring text no keystroke can delete. It measures `typed` now.
- A collision logged its **choice** but never its **line**, so a real half-typed thought and a misread suggestion produced identical log entries — which is how this ran unnoticed. Both call sites log a bounded preview now, and the agent path puts it on the status event too.

## Tests

Five new cases in `test_cdp_control.py` built from the measured span layout: the suggestion reads as empty-typed, real typed text still collides, a typed prefix with a dim completion keeps the prefix, blanking preserves columns so the frame stays *findable* (dropping instead of padding would read UNREADABLE and refuse every send), and a span-less row falls back to its text.

The evaluate-string validity guard listed its helpers by name, so `BRIGHT_FN` escaped it and the failure surfaced as "your JS is broken". It discovers every `*_FN` helper now, so the next one can't slip past.

`542 passed` in the runner suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018acCWfusjUSaghzbkyVD8y