### PR TITLE
Stop said "cancelled" whether or not the agent stopped

### DIFF
--- a/runner/canopy_runner/canopy_runner/cdp/emdash_control.mjs
+++ b/runner/canopy_runner/canopy_runner/cdp/emdash_control.mjs
@@ -413,10 +413,57 @@ try {
     // Cancel: open the task exactly as open-send does (find + focus its terminal),
     // but instead of inserting text just press Escape — Claude Code's TUI treats Esc
     // as "stop the current turn" mid-flight.
+    //
+    // AND THEN CHECK. This used to be `press('Escape'); out({ok:true})` — a keypress
+    // fired at a pane and reported as a stop, with no readback of any kind. Every
+    // send site in this file verifies what it did; the one command whose entire job
+    // is "make the agent stop" did not, so a stop that missed was indistinguishable
+    // from one that landed, all the way up to a web UI that said "cancelled".
+    //
+    // The running-state signal is Claude Code's own status line, `esc to interrupt`
+    // — the same marker `activeTerm`, `composerText` and the send-keys pane check
+    // already key off, so this adds no new contract to drift (verify-emdash covers
+    // it). Two presses, because Esc is context-sensitive: with a dialog up the first
+    // one dismisses the dialog and the turn keeps running.
+    //
+    // Reports FACTS, never a verdict, and never fails the command — the runner
+    // decides what a non-stop means (chat_pump.finish_chat_bridge):
+    //   interrupted  = was running, is not now
+    //   idle         = nothing was running to interrupt (a stop that raced the reply)
+    //   still-running = pressed twice, the status line is still there
+    //   unreadable   = could not see the frame; we make NO claim either way
     const { task } = args;
     await openTask(task);
-    await page.keyboard.press('Escape');   // Claude Code: Esc interrupts the running turn
-    out({ ok: true, task });
+    const running = () => page.evaluate(String.raw`(() => { ${ACTIVE_TERM_FN}; return (() => {
+      const term = activeTerm();
+      const rows = term && term.querySelector('.xterm-rows');
+      if (!rows) return null;                       // no frame to read — not "stopped"
+      const text = rows.textContent || '';
+      if (/esc to interrupt/i.test(text)) return true;
+      // A frame we can positively identify as Claude's, without the running marker,
+      // is a real "not running". Anything else is unreadable, not idle — the
+      // distinction this whole branch exists to preserve.
+      if (/[⏺✻⎿]/.test(text) || /shift\\+tab to cycle|bypass permissions/i.test(text)) return false;
+      return null;
+    })(); })()`);
+
+    const before = await running();
+    if (before === false) { out({ ok: true, task, action: 'idle' }); }
+    else {
+      let state = before;
+      for (let attempt = 0; attempt < 2; attempt++) {
+        await page.keyboard.press('Escape');   // Claude Code: Esc interrupts the running turn
+        // Give the TUI time to repaint its status line before believing the frame.
+        for (let i = 0; i < 5; i++) {
+          await page.waitForTimeout(400);
+          state = await running();
+          if (state === false) break;
+        }
+        if (state === false) break;
+      }
+      out({ ok: true, task,
+            action: state === false ? 'interrupted' : state === true ? 'still-running' : 'unreadable' });
+    }
 
   } else if (command === 'close-task') {
     // Delete `task` from the sidebar (the designed close behaviour). emdash's context

--- a/runner/canopy_runner/canopy_runner/cdp_control.py
+++ b/runner/canopy_runner/canopy_runner/cdp_control.py
@@ -230,11 +230,27 @@ def send_keys(task: str, keys: list[str], *, port: int = 9222) -> dict:
 
 
 def interrupt(task: str, *, port: int = 9222) -> dict:
-    """Press Escape in the task's emdash session — interrupts the running turn.
+    """Press Escape in the task's emdash session and VERIFY it stopped.
 
     Opens `task` the same way `open_and_send` does (no text is inserted), then sends
     Escape, which Claude Code's TUI treats as "stop the current turn". Raises CDPError
-    if the task isn't present (mirrors open_and_send's TASK_NOT_FOUND)."""
+    if the task isn't present (mirrors open_and_send's TASK_NOT_FOUND).
+
+    Returns ``{"action": ...}`` — the sidecar reports what it SAW, and the caller
+    decides what it means:
+
+    * ``interrupted``   — the running marker was there and is gone. The stop landed.
+    * ``idle``          — nothing was running. A stop that raced the reply; cancelling
+                          the turn is still correct.
+    * ``still-running`` — two Escapes and Claude Code is STILL running. The stop did
+                          not land, and reporting the turn cancelled would be a lie.
+    * ``unreadable``    — the frame could not be identified. We make no claim; the
+                          caller treats this as unverified rather than as failure,
+                          because a false red is still a wrong answer.
+
+    An older sidecar returns no ``action`` at all; callers must treat a missing key
+    as ``unreadable`` (unverified), never as success — a runner and its sidecar are
+    updated separately, so the un-verifying version WILL be live under this code."""
     return _run("interrupt", {"task": task, "port": port})
 
 

--- a/runner/canopy_runner/canopy_runner/chat_bridge.py
+++ b/runner/canopy_runner/canopy_runner/chat_bridge.py
@@ -136,6 +136,10 @@ class LiveBridge:
     raw_pending: list[str] = field(default_factory=list)
     raw_batches_sent: int = 0
     transcript_truncated: bool = False
+    # Stops attempted on this turn whose interrupt did NOT confirm. Between-tick
+    # state for the same reason everything else here is: `cancel_chat_bridge` retries
+    # the Escape across ticks rather than finishing on the first unconfirmed press.
+    cancel_attempts: int = 0
 
     def step(self, new_records: list[dict], raw_lines: list[str] | None = None,
              blocked: bool = False) -> None:

--- a/runner/canopy_runner/canopy_runner/chat_pump.py
+++ b/runner/canopy_runner/canopy_runner/chat_pump.py
@@ -39,22 +39,92 @@ def _is_blocked(task: str) -> bool:
 
 def finish_chat_bridge(cfg: Config, client: Client, bridge, *, status: str, note: str) -> None:
     """Retire one in-flight bridge: drop it from the registry FIRST (so a failing
-    finish can't leave it pumping forever), interrupt the live session on a cancel,
-    then tell the server. Best-effort — a client hiccup must not wedge the loop."""
-    from . import cdp_control
+    finish can't leave it pumping forever), then tell the server. Best-effort — a
+    client hiccup must not wedge the loop.
 
+    Pressing Escape is NOT done here any more; see `cancel_chat_bridge`. It used to
+    be, and a cancel arrived at this function already committed to finishing the turn
+    `cancelled` — so an interrupt that raised was caught, logged at WARNING, and the
+    turn was reported cancelled anyway. The website said "stopped" while the agent
+    kept working, and a test asserted that behaviour."""
     chat_bridge.IN_FLIGHT.pop(bridge.turn_id, None)
     CANCELLED_TURNS.discard(bridge.turn_id)
-    if status == "cancelled":
-        try:
-            cdp_control.interrupt(bridge.task, port=cfg.cdp_port)
-        except Exception as exc:  # noqa: BLE001 — cancel must still finish the turn
-            logger.warning("chat turn=%s: interrupt failed: %s", bridge.turn_id, exc)
     try:
         client.finish(bridge.turn_id, note=note, status=status, emdash_task_id=bridge.task)
     except Exception:  # noqa: BLE001
         logger.warning("chat turn=%s: finish failed", bridge.turn_id, exc_info=True)
     logger.info("chat turn=%s %s (task=%s): %s", bridge.turn_id, status, bridge.task, note)
+
+
+# How many ticks a stop may spend trying before we report what actually happened.
+# Each attempt is itself two Escapes with a repaint wait inside the sidecar, so this
+# is seconds, not minutes — the human is watching a button they just pressed.
+CANCEL_MAX_ATTEMPTS = 3
+
+
+def cancel_chat_bridge(cfg: Config, client: Client, bridge) -> None:
+    """Act on a stop for one in-flight bridge: interrupt the live session, and finish
+    the turn ONLY once we know what the interrupt did.
+
+    The outcomes are the sidecar's, and they are not all "cancelled":
+
+    * `interrupted` / `idle` — the agent is not running. Finish CANCELLED; true.
+    * `still-running`        — Escape did not take. Retried across ticks, then the
+                               turn finishes FAILED, because a turn reported
+                               cancelled while its agent runs on is the one outcome
+                               a stop button must never produce. The note names it.
+    * `unreadable` / raised  — we could not see. Retried, then CANCELLED with the
+                               uncertainty IN the note: a false red is a wrong answer
+                               too, and "emdash is gone" genuinely does end the turn.
+
+    Retrying leaves the bridge in flight for a tick, which pauses streaming for that
+    tick. That is the right trade: the human asked for it to stop.
+    """
+    from . import cdp_control
+
+    try:
+        res = cdp_control.interrupt(bridge.task, port=cfg.cdp_port) or {}
+        # A sidecar older than this code returns no `action`. Unverified, NOT success:
+        # runner and sidecar update separately, so that version will be live here.
+        action = res.get("action") or "unreadable"
+        err = ""
+    except Exception as exc:  # noqa: BLE001 — a stop must still reach a verdict
+        action, err = "unreadable", str(exc)[:200]
+
+    if action in ("interrupted", "idle"):
+        note = "cancelled by user" if action == "interrupted" else (
+            "cancelled by user (the agent had already stopped)")
+        finish_chat_bridge(cfg, client, bridge, status="cancelled", note=note)
+        return
+
+    bridge.cancel_attempts += 1
+    if bridge.cancel_attempts < CANCEL_MAX_ATTEMPTS:
+        logger.warning("chat turn=%s: stop attempt %d/%d on task=%s did not confirm (%s%s)",
+                       bridge.turn_id, bridge.cancel_attempts, CANCEL_MAX_ATTEMPTS,
+                       bridge.task, action, f": {err}" if err else "")
+        return  # stays in flight; CANCELLED_TURNS still holds the id, so we retry next tick
+
+    if action == "still-running":
+        note = (f"stop did not take: Escape was pressed {CANCEL_MAX_ATTEMPTS} times and "
+                f"'{bridge.task}' is still running — the agent may still be working")
+        # SAY IT ON THE CHANNEL THE HUMAN IS WATCHING. A turn's terminal `status` and
+        # its result_note carry no client-visible frame (stream_map.turn_event_to_frames:
+        # "status / heartbeat / question / approval carry no client-visible stream
+        # frame"), so finishing `failed` alone would just make the reply stop — which
+        # is what a successful stop looks like too. An `error` event renders as
+        # chat.stream_error, which is the only way this fix reaches the person who
+        # pressed the button.
+        try:
+            client.post_events(bridge.turn_id, [{"kind": "error", "payload": {"detail": note}}])
+        except Exception:  # noqa: BLE001 — telling them is best-effort; finishing is not
+            logger.warning("chat turn=%s: could not report the failed stop to the client",
+                           bridge.turn_id, exc_info=True)
+        finish_chat_bridge(cfg, client, bridge, status="failed", note=note)
+    else:
+        finish_chat_bridge(
+            cfg, client, bridge, status="cancelled",
+            note=("cancelled by user (interrupt could not be verified"
+                  + (f": {err}" if err else "") + ")"))
 
 
 def pump_chat_bridges(cfg: Config, client: Client) -> None:
@@ -71,7 +141,7 @@ def pump_chat_bridges(cfg: Config, client: Client) -> None:
     """
     for turn_id, bridge in list(chat_bridge.IN_FLIGHT.items()):
         if turn_id in CANCELLED_TURNS:
-            finish_chat_bridge(cfg, client, bridge, status="cancelled", note="cancelled by user")
+            cancel_chat_bridge(cfg, client, bridge)
             continue
         try:
             new_records = bridge.reader.read_new()

--- a/runner/canopy_runner/canopy_runner/execute.py
+++ b/runner/canopy_runner/canopy_runner/execute.py
@@ -332,7 +332,13 @@ def execute_chat_turn(cfg, client, runner_id: str, turn: dict, cancel_check=None
     tick (`chat_pump.pump_chat_bridges`) and the turn is finished there, when the transcript
     says the agent handed the floor back. Cancellation moved with it: the pump watches
     CANCELLED_TURNS, presses Escape in the live emdash session, and finishes CANCELLED.
-    `cancel_check` is accepted for signature compatibility and is no longer read here.
+
+    `cancel_check` is read ONCE here, immediately before delivery. It used to be
+    ignored outright ("accepted for signature compatibility"), which made the cheapest
+    stop of all impossible: a human who hits stop between the claim and the send still
+    had the message typed into their agent, because the only consumer of the signal
+    was a pump that does not exist yet at this point. Nothing after delivery is checked
+    here — from then on the bridge owns it, and the pump does the interrupting.
     """
     turn_id = turn["id"]
     agent_slug = turn.get("agent_slug") or ""
@@ -351,6 +357,17 @@ def execute_chat_turn(cfg, client, runner_id: str, turn: dict, cancel_check=None
     task = plan.get("emdash_task_id") if plan.get("reuse") else None
     if task and emdash.task_state(cfg.emdash_db, task) in ("absent", "archived"):
         task = None  # the linked emdash session is gone — create a fresh one
+
+    # The stop arrived before we typed anything. Deliver NOTHING — the cheapest and
+    # most complete cancel there is, and the only one that leaves no trace in the
+    # agent's session. `client.start` has already run, so the turn is RUNNING and
+    # finishing it CANCELLED is a legal transition.
+    if cancel_check is not None and cancel_check(turn_id):
+        logger.info("chat turn=%s cancelled before delivery (agent=%s)", turn_id, target)
+        client.finish(turn_id, note="cancelled by user before the message was delivered",
+                      status="cancelled", emdash_task_id=task or "")
+        return f"cancelled:{turn_id}"
+
     if task:
         try:
             res = cdp_control.open_and_send(task, prompt, port=cfg.cdp_port)

--- a/runner/canopy_runner/canopy_runner/main.py
+++ b/runner/canopy_runner/canopy_runner/main.py
@@ -506,7 +506,17 @@ def _claim_and_execute(cfg: Config, client: Client, paused: set) -> str:
         # ids aren't reused today, but leaking membership is a latent footgun either
         # way — and it just keeps a module-level set growing unbounded for the life
         # of the process).
-        CANCELLED_TURNS.discard(turn["id"])
+        #
+        # UNLESS a chat bridge now owns the turn. `cancel` arrives on the wake-listener
+        # THREAD while this one is still inside execute_turn, and that window is long:
+        # the CDP send, plus `_wait_for_transcript` — up to 45 SECONDS for a freshly
+        # created session. An id added during it was read by nobody (execute_chat_turn
+        # hands off without consulting it) and then wiped right here, so the pump never
+        # saw the stop, the agent ran the whole turn, and the server's DONE ->
+        # CANCELLED backstop labelled the finished turn "cancelled" anyway. Press stop
+        # in that window and it looked like it worked; nothing had been interrupted.
+        if turn["id"] not in chat_bridge.IN_FLIGHT:
+            CANCELLED_TURNS.discard(turn["id"])
         _mark_in_flight(cfg)
 
 

--- a/runner/canopy_runner/tests/test_chat_pump.py
+++ b/runner/canopy_runner/tests/test_chat_pump.py
@@ -99,37 +99,111 @@ def test_pump_retries_undelivered_text_instead_of_losing_it():
     assert client.finished[0][1] == "done"
 
 
-def test_pump_cancels_via_interrupt_and_finishes_cancelled(monkeypatch):
+def _interrupts(monkeypatch, *actions):
+    """Stub cdp_control.interrupt to return `actions` in order (last one repeats).
+    An element that is an Exception is raised instead. Records the calls."""
     from canopy_runner import cdp_control
 
-    interrupted = {}
-    monkeypatch.setattr(cdp_control, "interrupt",
-                        lambda task, port=None: interrupted.update(task=task, port=port))
+    calls = []
+    seq = list(actions)
+
+    def _fake(task, port=None):
+        calls.append((task, port))
+        action = seq.pop(0) if len(seq) > 1 else seq[0]
+        if isinstance(action, Exception):
+            raise action
+        return {"ok": True, "task": task, "action": action}
+
+    monkeypatch.setattr(cdp_control, "interrupt", _fake)
+    return calls
+
+
+def test_pump_cancels_via_interrupt_and_finishes_cancelled(monkeypatch):
+    calls = _interrupts(monkeypatch, "interrupted")
 
     client = _FakeClient()
     _register([[]])
     cancel.CANCELLED_TURNS.add("t1")
     chat_pump.pump_chat_bridges(_cfg(), client)
 
-    assert interrupted == {"task": "echo-1", "port": 9222}
+    assert calls == [("echo-1", 9222)]
     assert client.finished == [("t1", "cancelled", "cancelled by user")]
     assert chat_bridge.IN_FLIGHT == {}
     assert "t1" not in cancel.CANCELLED_TURNS
 
 
-def test_pump_cancel_survives_a_failed_interrupt(monkeypatch):
-    """Cancel must not get stuck because the Escape press failed (emdash closed)."""
-    from canopy_runner import cdp_control
-
-    def _boom(task, port=None):
-        raise RuntimeError("emdash gone")
-
-    monkeypatch.setattr(cdp_control, "interrupt", _boom)
+def test_pump_cancel_of_an_already_idle_session_is_still_a_cancel(monkeypatch):
+    """The stop raced the reply: nothing was running. The user still asked to stop."""
+    _interrupts(monkeypatch, "idle")
     client = _FakeClient()
     _register([[]])
     cancel.CANCELLED_TURNS.add("t1")
     chat_pump.pump_chat_bridges(_cfg(), client)
-    assert client.finished == [("t1", "cancelled", "cancelled by user")]
+    assert client.finished[0][1] == "cancelled"
+    assert "already stopped" in client.finished[0][2]
+
+
+def test_pump_retries_a_stop_that_did_not_take_then_reports_it_failed(monkeypatch):
+    """THE REGRESSION THIS FILE USED TO ASSERT THE WRONG WAY ROUND.
+
+    An Escape that does not stop the agent must never finish the turn `cancelled` —
+    that is the website saying "stopped" over an agent that is still working. Retry,
+    then say what actually happened."""
+    calls = _interrupts(monkeypatch, "still-running")
+    client = _FakeClient()
+    _register([[], [], []])
+    cancel.CANCELLED_TURNS.add("t1")
+
+    for _ in range(chat_pump.CANCEL_MAX_ATTEMPTS - 1):
+        chat_pump.pump_chat_bridges(_cfg(), client)
+        assert client.finished == [], "an unconfirmed stop must keep trying, not finish"
+        assert "t1" in chat_bridge.IN_FLIGHT
+
+    chat_pump.pump_chat_bridges(_cfg(), client)
+    assert len(calls) == chat_pump.CANCEL_MAX_ATTEMPTS
+    assert client.finished[0][:2] == ("t1", "failed")
+    assert "still running" in client.finished[0][2]
+    assert chat_bridge.IN_FLIGHT == {}
+    # And the person who pressed stop has to SEE it. A terminal status carries no
+    # client-visible frame, so without this the failed stop looks exactly like a
+    # successful one: the reply simply stops arriving.
+    assert [e["kind"] for e in client.events] == ["error"]
+    assert "still running" in client.events[0]["payload"]["detail"]
+
+
+def test_pump_cancel_survives_a_failed_interrupt(monkeypatch):
+    """Cancel must not get stuck because the Escape press failed (emdash closed).
+
+    Still CANCELLED — an unreadable frame is not evidence the agent kept running, and
+    "emdash is gone" really does end the turn — but the note carries the uncertainty
+    instead of claiming a clean stop."""
+    _interrupts(monkeypatch, RuntimeError("emdash gone"))
+    client = _FakeClient()
+    _register([[], [], []])
+    cancel.CANCELLED_TURNS.add("t1")
+    for _ in range(chat_pump.CANCEL_MAX_ATTEMPTS):
+        chat_pump.pump_chat_bridges(_cfg(), client)
+    assert client.finished[0][:2] == ("t1", "cancelled")
+    assert "could not be verified" in client.finished[0][2]
+    assert "emdash gone" in client.finished[0][2]
+
+
+def test_pump_treats_an_old_sidecar_as_unverified_not_success(monkeypatch):
+    """A sidecar predating the verifying `interrupt` returns no `action`. The runner
+    and the sidecar update separately, so that version WILL run under this code — and
+    reading a missing key as success is exactly the false green being removed."""
+    from canopy_runner import cdp_control
+
+    monkeypatch.setattr(cdp_control, "interrupt", lambda task, port=None: {"ok": True})
+    client = _FakeClient()
+    _register([[], [], []])
+    cancel.CANCELLED_TURNS.add("t1")
+    chat_pump.pump_chat_bridges(_cfg(), client)
+    assert client.finished == [], "no `action` is unverified — retry, don't declare victory"
+    for _ in range(chat_pump.CANCEL_MAX_ATTEMPTS - 1):
+        chat_pump.pump_chat_bridges(_cfg(), client)
+    assert client.finished[0][:2] == ("t1", "cancelled")
+    assert "could not be verified" in client.finished[0][2]
 
 
 def test_pump_survives_an_unreadable_transcript():

--- a/runner/canopy_runner/tests/test_claim_crash_readiness.py
+++ b/runner/canopy_runner/tests/test_claim_crash_readiness.py
@@ -47,3 +47,60 @@ def test_execute_crash_marks_runner_not_ready(tmp_path, monkeypatch):
     marker = readiness._marker(cfg)
     assert marker.exists(), "execute_turn crash must call readiness.mark_failed"
     assert "runner execute crashed" in marker.read_text()
+
+
+def test_a_cancel_arriving_mid_execute_survives_for_the_pump(tmp_path, monkeypatch):
+    """The stop that vanished.
+
+    `cancel` lands on the WAKE-LISTENER thread while this one is still inside
+    execute_turn — a window that includes the CDP send and `_wait_for_transcript`
+    (up to 45s for a fresh session). execute_chat_turn hands off without consulting
+    the set, so the only consumer is the pump, on a LATER tick — and the `finally`
+    here used to wipe the id before that tick ever ran. The stop was dropped in
+    silence, the agent ran the whole turn, and the server's DONE -> CANCELLED
+    backstop then labelled the completed turn "cancelled".
+    """
+    from canopy_runner import chat_bridge
+    from canopy_runner.cancel import CANCELLED_TURNS
+
+    CANCELLED_TURNS.clear()
+    chat_bridge.IN_FLIGHT.clear()
+
+    def _register_bridge_then_cancel(cfg, client, runner_id, turn, cancel_check=None):
+        # What execute_chat_turn does on the happy path...
+        chat_bridge.IN_FLIGHT[turn["id"]] = object()
+        # ...and the human pressing stop on the other thread, before we return.
+        CANCELLED_TURNS.add(turn["id"])
+        return f"chat:{turn['id']}:echo-1"
+
+    monkeypatch.setattr(execute, "execute_turn", _register_bridge_then_cancel)
+    try:
+        main_mod._claim_and_execute(_cfg(tmp_path), FakeClient({"id": "t-1", "agent_slug": "echo"}),
+                                    paused=set())
+        assert "t-1" in CANCELLED_TURNS, "the pump owns this turn now — don't drop its stop"
+    finally:
+        CANCELLED_TURNS.clear()
+        chat_bridge.IN_FLIGHT.clear()
+
+
+def test_a_cancel_with_no_bridge_is_still_evicted(tmp_path, monkeypatch):
+    """The eviction the guard must not break: a non-chat turn registers no bridge, so
+    its id has no future consumer and leaving it in would grow the set forever (and
+    latently mark any turn that reused the id)."""
+    from canopy_runner import chat_bridge
+    from canopy_runner.cancel import CANCELLED_TURNS
+
+    CANCELLED_TURNS.clear()
+    chat_bridge.IN_FLIGHT.clear()
+
+    def _no_bridge(cfg, client, runner_id, turn, cancel_check=None):
+        CANCELLED_TURNS.add(turn["id"])
+        return f"reused:{turn['id']}"
+
+    monkeypatch.setattr(execute, "execute_turn", _no_bridge)
+    try:
+        main_mod._claim_and_execute(_cfg(tmp_path), FakeClient({"id": "t-1", "agent_slug": "echo"}),
+                                    paused=set())
+        assert "t-1" not in CANCELLED_TURNS
+    finally:
+        CANCELLED_TURNS.clear()

--- a/runner/canopy_runner/tests/test_execute_chat.py
+++ b/runner/canopy_runner/tests/test_execute_chat.py
@@ -212,3 +212,29 @@ def test_a_bounce_with_no_dialog_on_screen_stays_a_plain_failure(monkeypatch):
     assert res.startswith("failed:")
     assert not [e for s in client.streamed for e in s["events"]
                 if e["kind"] == "activity:blocked"]
+
+
+def test_a_stop_before_delivery_sends_nothing_at_all(monkeypatch, tmp_path):
+    """The cheapest cancel there is: the human pressed stop between the claim and the
+    send, so the message must never reach the agent's session.
+
+    `cancel_check` used to be "accepted for signature compatibility and is no longer
+    read here", which made this cancel impossible — the only consumer of the signal
+    was the pump, and at this point there is no bridge for it to pump. The message was
+    typed into the agent regardless, and the turn then ran to completion."""
+    sent = []
+    monkeypatch.setattr(execute.cdp_control, "create_task",
+                        lambda *a, **k: sent.append(a) or {"task": "echo-1234"})
+    monkeypatch.setattr(execute.cdp_control, "open_and_send",
+                        lambda *a, **k: sent.append(a) or {"action": "sent"})
+
+    cfg = types.SimpleNamespace(cdp_port=9222, emdash_db="/nonexistent")
+    client = _FakeClient()
+
+    res = execute.execute_chat_turn(cfg, client, "runner1", _turn(),
+                                    cancel_check=lambda tid: tid == "t1")
+
+    assert res == "cancelled:t1"
+    assert sent == [], "nothing may be delivered into the agent's session"
+    assert client.finished_status == "cancelled"
+    assert chat_bridge.IN_FLIGHT == {}, "no bridge to pump — the turn is already over"


### PR DESCRIPTION
Reported live: *"the ability to stop AI from canopy web did not appear reliable when the AI is running."* It isn't. Four defects on one path, each sufficient on its own.

## 1. The interrupt was never verified

The sidecar's `interrupt` was, in full:

```js
await openTask(task);
await page.keyboard.press('Escape');
out({ ok: true, task });
```

A keypress fired at a pane and reported as a stop, with no readback of any kind. Every *send* site in that file verifies what it did — composer readback, collision detection, and (as of #647/#648) failing closed when the blanked frame loses the composer. The one command whose entire job is "make the agent stop" had none of it.

It now checks Claude Code's own `esc to interrupt` status line before and after, and presses **twice** — Esc is context-sensitive, so with a dialog up the first press dismisses the dialog and the turn keeps running. It reports what it saw (`interrupted` / `idle` / `still-running` / `unreadable`) and leaves the verdict to the runner. The markers are the ones `activeTerm`, `composerText` and the send-keys pane check already key off, so no new TUI contract.

## 2. A failed interrupt still reported success

`finish_chat_bridge` caught any interrupt failure into a `logger.warning` and finished the turn `cancelled` regardless — and `test_pump_cancel_survives_a_failed_interrupt` asserted exactly that. The website said "stopped" over an agent that was still working.

An unconfirmed stop is now retried across ticks, then finishes `failed` naming what happened. `unreadable` still finishes `cancelled` — a frame we cannot see is not evidence the agent kept running, and "emdash is gone" genuinely does end the turn — but the note carries the uncertainty. A **missing** `action` counts as unverified, never success: runner and sidecar update separately, so the un-verifying sidecar will be live under this code.

## 3. A cancel arriving mid-execute was silently discarded

`cancel` lands on the wake-listener thread while the poll thread is still inside `execute_turn` — a window that includes the CDP send **and `_wait_for_transcript`, up to 45 s for a fresh session**. `execute_chat_turn` ignored `cancel_check` outright ("accepted for signature compatibility and is no longer read here"), so the only consumer was a pump that has no bridge yet — and `_claim_and_execute`'s `finally` then wiped the id before that tick ever ran.

Net effect: press stop in that window and the stop vanished, the agent ran the whole turn, and `finish_turn`'s DONE → CANCELLED backstop labelled the completed turn "cancelled". It looked like it worked.

The eviction now skips a turn a bridge owns, and `execute_chat_turn` reads `cancel_check` once before delivery — so a stop that beats the send delivers nothing into the agent's session at all.

## 4. The user was never told

A turn's terminal status and `result_note` carry no client-visible frame (`stream_map`: *"status / heartbeat / question / approval carry no client-visible stream frame"*), so a failed stop looked exactly like a successful one — the reply just stops arriving. A failed stop now also posts an `error` event, which renders as `chat.stream_error` where the person who pressed the button is looking.

## Evidence

`~/.canopy/runner.log`, 36 MB, contains exactly one cancel: turn `d8ce1a44` on eva/`kindora`, logged `cancelled (task=kindora): cancelled by user`. That session's transcript has no `[Request interrupted by user]` anywhere near it — the only real one in the file is a manual Esc in the terminal a day later. One sample, not proof, but the shape the code predicts.

## Scoped out, deliberately

- **The DONE → CANCELLED coercion** for a reply that races through an interrupt (`services.finish_turn`, `sweep_expired_leases`) keeps its current semantics. That is a genuine question about what "stopped" should mean, not a defect, and it belongs to whoever owns that call.
- **Non-chat turns** (agent / board / scheduled / repo) remain uncancellable — they fire-and-continue and are terminal before the agent starts working, so Stop finds nothing to cancel. Worth fixing; a different change.

## Tests

549 pass. The three that matter are regressions with teeth — `test_a_cancel_arriving_mid_execute_survives_for_the_pump` fails on `main` with `assert 't-1' in set()`, and `test_pump_retries_a_stop_that_did_not_take_then_reports_it_failed` is the inverse of the assertion that was there before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JBEHhavkTEkwSHqru5yhSd