### PR TITLE
A turn that completed is not a cancelled one

### DIFF
--- a/apps/harness/services.py
+++ b/apps/harness/services.py
@@ -975,14 +975,40 @@ def finish_turn(
     """
     if status not in (Turn.DONE, Turn.FAILED, Turn.MISSED, Turn.CANCELLED):
         raise ValueError(f"finish status must be done|failed|missed|cancelled, got {status!r}")
-    if status == Turn.DONE and turn.events.filter(kind="cancel_requested").exists():
-        # Server-side backstop (a deaf/poll-only runner can miss the
-        # runner.cancel control frame entirely and finish DONE anyway,
-        # stranding a cancel_requested event with no CANCELLED turn to match
-        # it). Mirrors sweep_expired_leases's same reasoning: the user asked to
-        # stop, so a full reply that raced through the interrupt is still a
-        # cancelled turn, not a done one.
-        status = Turn.CANCELLED
+    # A turn that RAN TO COMPLETION after a stop was requested. This used to be
+    # rewritten DONE -> CANCELLED, on the reasoning that the user asked to stop so a
+    # reply that raced the interrupt "is still a cancelled turn". That records the
+    # user's INTENT in the field that is supposed to record the OUTCOME, and it costs
+    # more than it buys:
+    #
+    #   * The turn carries a complete reply. Labelling it `cancelled` puts a full
+    #     answer under a status that says it was stopped — self-contradictory on its
+    #     face, and unreadable to anyone auditing a session later.
+    #   * A stop that worked and a stop that was completely ignored both stored
+    #     `cancelled`, so the ledger could not tell them apart. That is exactly what
+    #     made "stop doesn't seem reliable" so hard to pin down (#649): the record
+    #     said the same thing either way.
+    #   * A scheduled occurrence that completed did NOT discharge its nag, because
+    #     the discharge below keys on DONE and the coercion had moved it. The work
+    #     was done and the board still asked for attention.
+    #
+    # And the "stranded cancel_requested" it was written to prevent is not stranded:
+    # the event is on the ledger, which is the durable record, and `cancel_requested`
+    # on a DONE turn is precisely the fact worth keeping — we asked, it finished
+    # anyway. So keep the outcome truthful and make the failed stop legible instead.
+    #
+    # Scoped deliberately to this case. `sweep_expired_leases` keeps its own
+    # cancel_requested -> CANCELLED rule: there the turn did NOT complete and the
+    # runner vanished mid-flight, so nothing knows what the agent did, and neither
+    # label is a claim about a finished reply.
+    stop_ignored = (
+        status == Turn.DONE and turn.events.filter(kind="cancel_requested").exists()
+    )
+    if stop_ignored:
+        result_note = (
+            f"{result_note} — NOTE: you asked to stop this turn and it ran to "
+            f"completion anyway; the cancel never reached the runner"
+        ).lstrip(" —")
     now = timezone.now()
     from_states = [Turn.CLAIMED, Turn.RUNNING, Turn.NEEDS_HUMAN]
     if allow_queued:
@@ -994,6 +1020,14 @@ def finish_turn(
     if not updated:
         return turn
     append_events(turn, [{"kind": "status", "payload": {"status": status, "result_note": result_note}}])
+    if stop_ignored:
+        # SAY IT WHERE THE PERSON WHO PRESSED STOP IS LOOKING. A `status` event
+        # carries no client-visible frame (stream_map.turn_event_to_frames), so the
+        # truthful DONE above would otherwise be indistinguishable, on screen, from a
+        # turn nobody tried to stop. `error` renders as chat.stream_error.
+        append_events(turn, [{"kind": "error", "payload": {
+            "detail": "your stop never reached the runner — this turn ran to completion",
+        }}])
     # A finished scheduled occurrence discharges any open nag for its schedule —
     # you no longer owe attention to a slot that has since completed.
     if status == Turn.DONE:
@@ -1011,8 +1045,18 @@ def finish_turn(
     # mode this hook exists to prevent for FAILED.
     # Keyed on the RunnerDrill FK, not the origin: a drill is an ordinary `api`
     # turn that names its runner, and the filter no-ops for a non-drill turn.
-    if status in (Turn.FAILED, Turn.CANCELLED):
-        if status == Turn.CANCELLED:
+    #
+    # `stop_ignored` is here for the same anti-stranding reason, and it is the one
+    # thing that had to move when the DONE -> CANCELLED coercion went away: such a
+    # turn USED to arrive here as CANCELLED and resolve its drill. Keying the hook on
+    # the status alone would have let it fall through as DONE and strand
+    # OUTCOME_PENDING forever — reintroducing, through the side door, the exact
+    # failure this hook exists to prevent. The drill's resolution depends on "a stop
+    # was requested", not on which label the turn ended up with.
+    if status in (Turn.FAILED, Turn.CANCELLED) or stop_ignored:
+        if stop_ignored:
+            summary = "drill turn completed after a cancel that never landed"
+        elif status == Turn.CANCELLED:
             summary = "drill turn cancelled"
         else:
             summary = result_note or "drill turn failed"

--- a/tests/test_harness_cancel_turn.py
+++ b/tests/test_harness_cancel_turn.py
@@ -179,12 +179,14 @@ def test_sweep_finishes_cancel_requested_as_cancelled(canopy):
     assert turn.status == Turn.CANCELLED
 
 
-def test_finish_turn_done_is_coerced_to_cancelled_when_cancel_was_requested(canopy, jj):
-    """I2 server-side backstop: a deaf/poll-only runner can miss the
-    runner.cancel control frame and finish the turn DONE anyway. finish_turn
-    must coerce that to CANCELLED when a cancel_requested event is already on
-    the ledger — the user asked to stop, so a full reply that raced through
-    the interrupt is still a cancelled turn, not a done one."""
+def test_a_turn_that_completed_despite_a_cancel_stays_done_and_says_so(canopy, jj):
+    """A deaf/poll-only runner can miss the runner.cancel frame and finish DONE.
+
+    This USED to be rewritten DONE -> CANCELLED. It is not any more: the turn carries
+    a complete reply, so `cancelled` would file a full answer under a status saying it
+    was stopped — and, worse, would store the same thing as a stop that actually
+    worked, which is what made a broken stop button so hard to pin down (#649).
+    The outcome stays truthful; the failed stop is recorded alongside it."""
     from django.utils import timezone
 
     from apps.harness import services
@@ -202,7 +204,74 @@ def test_finish_turn_done_is_coerced_to_cancelled_when_cancel_was_requested(cano
 
     out = services.finish_turn(turn, status=Turn.DONE, result_note="all done")
 
-    assert out.status == Turn.CANCELLED
+    assert out.status == Turn.DONE, "it completed; that is the outcome"
+    assert "never reached the runner" in out.result_note
+    assert "all done" in out.result_note, "the runner's own note is kept, not replaced"
+    # And it must be VISIBLE: a `status` event carries no client-visible frame, so
+    # without this the honest DONE looks on screen like a turn nobody tried to stop.
+    detail = turn.events.filter(kind="error").values_list("payload", flat=True).first()
+    assert detail and "your stop never reached the runner" in detail["detail"]
+
+
+def test_a_completed_scheduled_turn_discharges_its_nag_even_after_a_cancel(canopy, jj, monkeypatch):
+    """A consequence of dropping the coercion, and an argument for having dropped it.
+
+    The nag discharge keys on DONE. While a completed-after-cancel turn was rewritten
+    CANCELLED, the discharge was skipped — so a scheduled slot whose work had in fact
+    finished went on asking for attention."""
+    from django.utils import timezone
+
+    from apps.harness import services
+
+    agent = Agent.objects.create(slug="echo-nag", name="Echo", workspace=canopy)
+    runner = Runner.objects.create(
+        name="jj-mbp2", kind=Runner.EMDASH, paired_by=jj, status=Runner.ONLINE,
+        last_heartbeat_at=timezone.now(),
+    )
+    turn = Turn.objects.create(
+        agent=agent, origin=Turn.ORIGIN_API, idempotency_key="k-i2-nag",
+        status=Turn.RUNNING, claimed_by=runner, origin_ref={"schedule_id": "sched-1"},
+    )
+    services.append_events(turn, [{"kind": "cancel_requested", "payload": {}}])
+
+    discharged = []
+    monkeypatch.setattr(services, "resolve_schedule_nags", discharged.append)
+
+    out = services.finish_turn(turn, status=Turn.DONE, result_note="done")
+
+    assert out.status == Turn.DONE
+    assert discharged == ["sched-1"], "the slot's work completed — stop nagging for it"
+
+
+def test_a_drill_whose_stop_was_ignored_still_resolves(canopy, jj):
+    """The one thing that HAD to move when the coercion went away.
+
+    Such a turn used to arrive at the drill hook as CANCELLED and resolve its
+    RunnerDrill. Keying that hook on status alone would now let it through as DONE
+    and strand OUTCOME_PENDING forever — reintroducing, by the side door, the exact
+    failure the hook exists to prevent."""
+    from django.utils import timezone
+
+    from apps.harness import services
+    from apps.harness.models import RunnerDrill
+
+    agent = Agent.objects.create(slug="echo-drill-ignored", name="Echo", workspace=canopy)
+    runner = Runner.objects.create(
+        name="jj-mbp3", kind=Runner.EMDASH, paired_by=jj, status=Runner.ONLINE,
+        last_heartbeat_at=timezone.now(),
+    )
+    [drill] = services.start_drill(runner, [agent])
+    turn = drill.turn
+    Turn.objects.filter(pk=turn.pk).update(status=Turn.RUNNING, claimed_by=runner)
+    turn.refresh_from_db()
+    services.append_events(turn, [{"kind": "cancel_requested", "payload": {}}])
+
+    out = services.finish_turn(turn, status=Turn.DONE, result_note="done")
+
+    assert out.status == Turn.DONE
+    drill.refresh_from_db()
+    assert drill.outcome == RunnerDrill.OUTCOME_FAIL
+    assert drill.outcome != RunnerDrill.OUTCOME_PENDING, "must not strand"
 
 
 def test_finish_turn_done_without_cancel_request_stays_done(canopy, jj):


### PR DESCRIPTION
Follow-up to #649. You asked me to do this only **if it is strictly a better and clearer representation in the data model**, so here is the check I ran before touching it, including the one place it is *not* strictly better and which I therefore left alone.

## What it did

`finish_turn` rewrote `DONE → CANCELLED` whenever a `cancel_requested` event was on the ledger. Its comment: *"the user asked to stop, so a full reply that raced through the interrupt is still a cancelled turn, not a done one."*

That records the user's **intent** in the field that records the **outcome**.

## Why that is strictly worse, in three concrete ways

1. **It files a complete reply under a status saying it was stopped.** The turn's events are already posted; the answer is right there. `cancelled` contradicts the row's own contents.

2. **It made a working stop and an ignored stop indistinguishable.** Both stored `cancelled`. This is not theoretical — it is exactly why "stop doesn't appear reliable" was so hard to pin down in #649. The ledger said the same thing whether the Escape landed, was dropped in the claim→bridge race, or never reached the runner at all.

3. **It silently broke nag discharge.** `resolve_schedule_nags` keys on `status == Turn.DONE`. With the coercion, a scheduled occurrence that *completed* skipped its discharge and went on asking for attention — against that hook's own stated purpose ("you no longer owe attention to a slot that has since completed"). There is now a test pinning this.

And the failure it was written to prevent — a `cancel_requested` "stranded with no CANCELLED turn to match it" — was never stranded. The event is on the ledger, which is the durable record, and `cancel_requested` on a `DONE` turn is precisely the fact worth keeping: *we asked, it finished anyway.*

## What it does now

Status stays `DONE`. The runner's own `result_note` is **kept** and the failed stop appended to it. And because a `status` event carries no client-visible frame (`stream_map.turn_event_to_frames`), an `error` event is posted alongside so it renders as `chat.stream_error` — otherwise the honest `DONE` would look on screen exactly like a turn nobody tried to stop, which is the #649 failure mode wearing a different coat.

## The one thing that had to move

The `RunnerDrill` resolution hook. Such a turn used to arrive there **as `CANCELLED`** and resolve its drill. Keying that hook on status alone would now let it through as `DONE` and strand `OUTCOME_PENDING` forever — reintroducing by the side door the exact failure the hook exists to prevent. It now fires on *"a stop was requested"* rather than on whichever label the turn ended up with. Test: `test_a_drill_whose_stop_was_ignored_still_resolves`.

## Where it is NOT strictly better — so I left it

`sweep_expired_leases` keeps its own `cancel_requested → CANCELLED` rule. There the turn **did not complete** and the runner vanished mid-flight, so nothing knows what the agent did. Neither `LOST` nor `CANCELLED` is a claim about a finished reply, and every argument above turns on the reply existing. Changing it would be taste, not correctness, so it is untouched.

## Verification

- `2199 passed, 1 skipped` — full backend suite.
- `ruff check . --select F` clean; `makemigrations --check` reports no changes (both CI gates, run locally).
- The old assertion `test_finish_turn_done_is_coerced_to_cancelled_when_cancel_was_requested` is replaced by its inverse, plus two tests for the consequences above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JBEHhavkTEkwSHqru5yhSd