### PR TITLE
Stop works on any session, not just the ones a Turn happens to own

### DIFF
--- a/apps/canopy_sessions/consumers.py
+++ b/apps/canopy_sessions/consumers.py
@@ -153,8 +153,8 @@ class SessionConsumer(AsyncJsonWebsocketConsumer):
         # but only when something was actually cancelled/cancel-requested, so a
         # stray Stop with nothing to cancel doesn't flip everyone's UI to
         # "cancelled" for no reason.
-        cancelled = await database_sync_to_async(self._cancel_session_turn)()
-        if not cancelled:
+        stopped = await database_sync_to_async(self._stop_session)()
+        if not stopped:
             return
         await self._broadcast({
             "type": "chat.stream_cancelled",
@@ -178,7 +178,24 @@ class SessionConsumer(AsyncJsonWebsocketConsumer):
             draft.save(update_fields=["body", "version", "updated_at"])
         return draft
 
-    def _cancel_session_turn(self) -> bool:
+    def _stop_session(self) -> bool:
+        """Stop this session, by whichever route actually owns the running work.
+
+        TURNS FIRST. A chat reply is owned by a live Turn: cancelling it is what
+        records the intent, reaches a queued turn behind the running one, and lets
+        the runner's bridge interrupt and finish it. That path is unchanged.
+
+        THEN THE SESSION. If no turn moved, the work is not turn-shaped — which is
+        the normal state of an agent, board or scheduled turn, because those are
+        fire-and-continue and go terminal seconds after the prompt is delivered
+        (runner execute.py). Stop used to end here, find nothing, and return False:
+        no interrupt, no broadcast, not even a flicker, while the agent worked on
+        for another ten minutes. They are all sessions, so stop them as sessions.
+
+        Deliberately not both: a chat turn's cancel already interrupts the same
+        terminal through the bridge, and firing a second Escape at it could land
+        after the agent has moved on to something else.
+        """
         # ALL non-terminal turns, not just the newest: a mid-reply send queues a
         # second turn behind the one still running, so Stop must reach both.
         # NOTE: not a bare `any(... for turn in turns)` — any() short-circuits
@@ -189,7 +206,9 @@ class SessionConsumer(AsyncJsonWebsocketConsumer):
         for turn in turns:
             if harness_services.cancel_turn(turn) is not None:
                 cancelled = True
-        return cancelled
+        if cancelled:
+            return True
+        return chat_services.interrupt_session(self.session) == "sent"
 
     def _resolve_message_id_sync(self, turn_id, seq):
         if turn_id:

--- a/apps/canopy_sessions/services.py
+++ b/apps/canopy_sessions/services.py
@@ -1122,6 +1122,44 @@ def answer_menu(*, session: Session, option: int | None,
     return "sent"
 
 
+def interrupt_session(session: Session) -> str:
+    """Stop whatever this session's agent is doing, by interrupting its TERMINAL.
+
+    The turn-shaped stop (`cancel_session_turns` below) can only reach work a
+    non-terminal Turn still owns, which in practice means chat. An agent, board or
+    scheduled turn is fire-and-continue: `execute_turn` finishes it the moment the
+    prompt is delivered (runner execute.py), so seconds later the agent is working
+    hard on a turn that is already DONE, and a stop keyed on turns finds nothing to
+    cancel and silently does nothing.
+
+    But the work is not turn-shaped, it is SESSION-shaped, and canopy already knows
+    the session: `harness.services.record_session` gives every agent/project/phone
+    thread a durable Session plus a RunnerBinding carrying `session_key` — the very
+    same binding `answer_menu` above uses to press a key into that terminal. So
+    stopping is addressed exactly like answering: name the session, let the runner
+    own the keystroke.
+
+    Returns "sent" | "unavailable" | "unbound", mirroring `answer_menu`'s refusal
+    shape rather than raising — a session can go idle between a thumb reaching the
+    button and the frame landing, and that is ordinary, not an error.
+    """
+    binding = getattr(session, "runner_binding", None)
+    if binding is None or binding.runner_id is None or not binding.session_key:
+        return "unbound"
+    # Same reasoning as answer_menu: pause stops STARTING work, never finishing it,
+    # and an agent mid-turn is work already running. Reachable, not available.
+    if not binding.runner.is_reachable:
+        return "unavailable"
+
+    from apps.realtime import groups
+    groups.publish(groups.runner_group(binding.runner_id), {
+        "type": "runner.session_interrupt",
+        "session_id": str(session.id),
+        "session_key": binding.session_key,
+    })
+    return "sent"
+
+
 def cancel_session_turns(session: Session) -> bool:
     """Cancel every non-terminal turn on a session. Returns whether anything moved.
 

--- a/apps/realtime/consumers.py
+++ b/apps/realtime/consumers.py
@@ -244,6 +244,19 @@ class RunnerConsumer(AsyncJsonWebsocketConsumer):
         # cancel set every bridge poll (~0.5s), interrupts emdash, finishes CANCELLED.
         await self.send_json({"type": "cancel", "turn_id": message.get("turn_id")})
 
+    async def runner_session_interrupt(self, message):
+        # runner.{id} group_send type="runner.session_interrupt" — the user asked to
+        # stop a SESSION rather than a turn. The turn-shaped cancel above can only
+        # reach work a live Turn still owns; an agent/board/scheduled turn is
+        # fire-and-continue and terminal seconds after delivery, so this is the only
+        # route that reaches it. The runner presses Escape in that session's
+        # terminal, keyed on session_key exactly as menu_answer is.
+        await self.send_json({
+            "type": "session_interrupt",
+            "session_id": message.get("session_id"),
+            "session_key": message.get("session_key"),
+        })
+
     async def runner_stream(self, message):
         # runner.{id} group_send type="runner.stream" — start/stop live streaming a
         # session this runner backs. Forwarded to the runner socket; the runner also

--- a/runner/canopy_runner/canopy_runner/main.py
+++ b/runner/canopy_runner/canopy_runner/main.py
@@ -36,7 +36,7 @@ import logging
 import time
 from pathlib import Path
 
-from . import chat_bridge, chat_pump, close, hooks, inbox_due, sessions, streams
+from . import chat_bridge, chat_pump, close, hooks, inbox_due, sessions, session_interrupt, streams
 from . import __version__, provenance
 from .cancel import CANCELLED_TURNS
 from .client import Client, ClientError
@@ -584,6 +584,10 @@ def run_once(cfg: Config, client: Client) -> str:
     # ARRIVING, which is the very thing a drifted config stops.
     hooks.ensure_hook_config()
     chat_pump.pump_chat_bridges(cfg, client)
+    # Before the session report, so a session stopped this tick is reported idle
+    # rather than working — otherwise the very next report re-asserts `working`
+    # over the interrupt and the web shows the stop undoing itself.
+    session_interrupt.drain(cfg, client, cfg.runner_id)
     sessions.maybe_report_sessions(cfg, client)
     streams.sync_session_streams(cfg, client)
     streams.drain_menu_answers(cfg, client)
@@ -811,6 +815,14 @@ def make_control_handler(cfg: Config, waker, client=None):
     def _on_control(msg: dict) -> None:
         if msg.get("type") == "cancel" and msg.get("turn_id"):
             CANCELLED_TURNS.add(str(msg["turn_id"]))
+        elif msg.get("type") == "session_interrupt" and msg.get("session_key"):
+            # A stop aimed at a SESSION, not a turn — the only route that reaches an
+            # agent/board/scheduled turn, which is terminal seconds after its prompt
+            # is delivered and so owns nothing for a turn-cancel to find.
+            # Only marks it due: pressing Escape is a CDP round trip, and this thread
+            # also carries cancel, wake and menu_answer.
+            session_interrupt.ring(str(msg["session_key"]), str(msg.get("session_id") or ""))
+            waker.event.set()
         elif msg.get("type") == "check_inbox" and msg.get("mailbox"):
             # THE DOORBELL. Gmail told canopy-web this mailbox changed; check it
             # on the next tick instead of waiting out inbox_poll_seconds. Only

--- a/runner/canopy_runner/canopy_runner/session_interrupt.py
+++ b/runner/canopy_runner/canopy_runner/session_interrupt.py
@@ -1,0 +1,128 @@
+"""Stops asked of a SESSION rather than of a turn.
+
+The turn-shaped cancel (`cancel.CANCELLED_TURNS` -> `chat_pump.cancel_chat_bridge`)
+can only reach work a live Turn still owns, which in practice means chat. An agent,
+board or scheduled turn is fire-and-continue: `execute_turn` finishes it the moment
+the prompt is delivered, so seconds later the agent is working hard on a turn that
+is already DONE and nothing turn-shaped can reach it. Those sessions were simply
+unstoppable from the web.
+
+They are sessions, though, and canopy knows the session: every agent/project/phone
+thread gets a durable Session plus a RunnerBinding carrying `session_key` — the emdash
+task. So a stop is addressed exactly the way a menu answer already is.
+
+THE THREAD SPLIT IS THE POINT, and it is why this is a doorbell rather than a
+function the socket calls. `ring()` runs on the WAKE-LISTENER thread, which also
+carries `cancel`, `wake` and `menu_answer`; a CDP round trip there would block the
+socket that keeps this runner alive for however long emdash takes to answer. So the
+frame only marks work due and the POLL thread does it, the same rule `inbox_due`
+follows for the same reason.
+
+Retries live here too. A single Escape is not proof (see cdp_control.interrupt): the
+sidecar reports what it saw, and an unconfirmed stop is worth trying again on the
+next tick rather than being declared done or declared failed on one look.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+
+logger = logging.getLogger("canopy_runner")
+
+#: How many ticks an unconfirmed stop keeps trying before we give up on it. Mirrors
+#: chat_pump.CANCEL_MAX_ATTEMPTS — the same question, asked about a session.
+MAX_ATTEMPTS = 3
+
+#: {session_key: {"session_id": str, "attempts": int}} — stops rung and not yet
+#: confirmed. Guarded because ring() and take() run on different threads.
+_pending: dict[str, dict] = {}
+_lock = threading.Lock()
+
+
+def ring(session_key: str, session_id: str = "") -> None:
+    """A stop arrived for this session. Called from the wake-listener thread.
+
+    Re-ringing a session already pending does NOT reset its attempt count: a human
+    jabbing the button three times is asking for the same stop, not for nine
+    Escapes at a terminal that may since have moved on to other work.
+    """
+    if not session_key:
+        return
+    with _lock:
+        entry = _pending.setdefault(session_key, {"session_id": session_id, "attempts": 0})
+        if session_id:
+            entry["session_id"] = session_id
+
+
+def take() -> list[tuple[str, str]]:
+    """Drain the rung stops as (session_key, session_id), for this tick's attempt.
+
+    Draining rather than peeking: `settle()` puts back the ones still unconfirmed,
+    so a stop that lands cleanly leaves no state behind and one that does not is
+    retried a bounded number of times.
+    """
+    with _lock:
+        return [(key, entry["session_id"]) for key, entry in _pending.items()]
+
+
+def settle(session_key: str, *, confirmed: bool) -> bool:
+    """Record this tick's outcome. Returns whether the stop is now finished with —
+    either because it landed, or because it has used up its attempts."""
+    with _lock:
+        entry = _pending.get(session_key)
+        if entry is None:
+            return True
+        if confirmed:
+            _pending.pop(session_key, None)
+            return True
+        entry["attempts"] += 1
+        if entry["attempts"] >= MAX_ATTEMPTS:
+            _pending.pop(session_key, None)
+            return True
+        return False
+
+
+def drain(cfg, client, runner_id: str) -> int:
+    """Press Escape for every session with a stop pending. Runs on the POLL thread.
+
+    Returns the number confirmed stopped this tick. Never raises: this sits in the
+    main loop next to the heartbeat, and a wedged emdash must not cost the runner
+    its liveness.
+    """
+    from . import cdp_control
+
+    confirmed_count = 0
+    for session_key, session_id in take():
+        try:
+            res = cdp_control.interrupt(session_key, port=cfg.cdp_port) or {}
+            # A sidecar older than the verifying `interrupt` returns no `action`.
+            # Unverified, NOT success — runner and sidecar update separately.
+            action = res.get("action") or "unreadable"
+        except Exception as exc:  # noqa: BLE001 — one bad session must not stop the loop
+            logger.warning("session stop: interrupt failed for %s: %s", session_key, exc)
+            action = "unreadable"
+
+        confirmed = action in ("interrupted", "idle")
+        if confirmed:
+            confirmed_count += 1
+            # Tell the web the agent is idle now. `activity` is the only state the
+            # session surface has, and after a confirmed interrupt "idle" is simply
+            # true. Nothing is posted when it is NOT confirmed, deliberately: the
+            # session stays `working`, which is also true, and is what tells the
+            # person who pressed the button that the stop has not taken.
+            if session_id:
+                try:
+                    client.post_session_stream(runner_id, session_id, [{
+                        "kind": "activity:idle", "seq": -1, "index": -1, "payload": {},
+                    }])
+                except Exception:  # noqa: BLE001 — reporting is best-effort
+                    logger.debug("session stop: could not report idle for %s",
+                                 session_id, exc_info=True)
+        done = settle(session_key, confirmed=confirmed)
+        if confirmed:
+            logger.info("session stop: %s interrupted (%s)", session_key, action)
+        elif done:
+            logger.warning("session stop: giving up on %s after %d attempts (%s) — "
+                           "the agent may still be working",
+                           session_key, MAX_ATTEMPTS, action)
+    return confirmed_count

--- a/runner/canopy_runner/tests/test_session_interrupt.py
+++ b/runner/canopy_runner/tests/test_session_interrupt.py
@@ -1,0 +1,120 @@
+"""Stopping a session that no Turn owns.
+
+The turn-shaped cancel can only reach chat: an agent/board/scheduled turn is
+fire-and-continue and terminal seconds after its prompt is delivered, so those
+sessions were unstoppable from the web no matter how hard anyone pressed the button.
+"""
+import types
+
+import pytest
+
+from canopy_runner import session_interrupt
+
+
+class _FakeClient:
+    def __init__(self):
+        self.streamed = []
+
+    def post_session_stream(self, runner_id, session_id, events, transcript_id=""):
+        self.streamed.append((session_id, events))
+
+
+def _cfg():
+    return types.SimpleNamespace(cdp_port=9222, runner_id="r1")
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    session_interrupt._pending.clear()
+    yield
+    session_interrupt._pending.clear()
+
+
+def _interrupts(monkeypatch, *actions):
+    from canopy_runner import cdp_control
+
+    calls = []
+    seq = list(actions)
+
+    def _fake(task, port=None):
+        calls.append(task)
+        action = seq.pop(0) if len(seq) > 1 else seq[0]
+        if isinstance(action, Exception):
+            raise action
+        return {"ok": True, "action": action}
+
+    monkeypatch.setattr(cdp_control, "interrupt", _fake)
+    return calls
+
+
+def test_a_rung_session_is_interrupted_and_reported_idle(monkeypatch):
+    calls = _interrupts(monkeypatch, "interrupted")
+    client = _FakeClient()
+    session_interrupt.ring("hal-canopy-sweep", "sess-1")
+
+    assert session_interrupt.drain(_cfg(), client, "r1") == 1
+
+    assert calls == ["hal-canopy-sweep"]
+    assert session_interrupt._pending == {}, "a landed stop leaves no state behind"
+    # The web has only `activity` to go on, and after a confirmed interrupt idle is
+    # simply true — without it the next session report re-asserts `working` and the
+    # stop appears to undo itself.
+    [(session_id, events)] = client.streamed
+    assert session_id == "sess-1"
+    assert events[0]["kind"] == "activity:idle"
+
+
+def test_an_unconfirmed_stop_retries_then_gives_up_quietly(monkeypatch):
+    """Never reported idle on a stop we could not confirm: the session stays
+    `working`, which is also true, and is what tells the human it did not take."""
+    calls = _interrupts(monkeypatch, "still-running")
+    client = _FakeClient()
+    session_interrupt.ring("hal-canopy-sweep", "sess-1")
+
+    for _ in range(session_interrupt.MAX_ATTEMPTS - 1):
+        assert session_interrupt.drain(_cfg(), client, "r1") == 0
+        assert "hal-canopy-sweep" in session_interrupt._pending, "keep trying"
+
+    assert session_interrupt.drain(_cfg(), client, "r1") == 0
+    assert len(calls) == session_interrupt.MAX_ATTEMPTS
+    assert session_interrupt._pending == {}, "bounded — never retried forever"
+    assert client.streamed == [], "an unconfirmed stop must not claim the agent is idle"
+
+
+def test_an_old_sidecar_counts_as_unconfirmed_not_success(monkeypatch):
+    """Runner and sidecar update separately, so a sidecar with no `action` WILL run
+    under this code. Reading a missing key as success is the false green again."""
+    from canopy_runner import cdp_control
+
+    monkeypatch.setattr(cdp_control, "interrupt", lambda task, port=None: {"ok": True})
+    client = _FakeClient()
+    session_interrupt.ring("hal-canopy-sweep", "sess-1")
+
+    assert session_interrupt.drain(_cfg(), client, "r1") == 0
+    assert client.streamed == []
+
+
+def test_a_dead_emdash_never_kills_the_loop(monkeypatch):
+    _interrupts(monkeypatch, RuntimeError("emdash gone"))
+    client = _FakeClient()
+    session_interrupt.ring("hal-canopy-sweep", "sess-1")
+
+    assert session_interrupt.drain(_cfg(), client, "r1") == 0  # no raise
+
+
+def test_jabbing_the_button_does_not_multiply_the_escapes(monkeypatch):
+    """Three impatient presses are one stop, not nine Escapes at a terminal that
+    may since have moved on to other work."""
+    calls = _interrupts(monkeypatch, "still-running")
+    client = _FakeClient()
+    for _ in range(3):
+        session_interrupt.ring("hal-canopy-sweep", "sess-1")
+
+    session_interrupt.drain(_cfg(), client, "r1")
+
+    assert len(calls) == 1, "one tick, one Escape, however many times it was rung"
+
+
+def test_a_ring_with_no_session_key_is_ignored():
+    session_interrupt.ring("", "sess-1")
+    assert session_interrupt._pending == {}

--- a/runner/canopy_runner/tests/test_wake.py
+++ b/runner/canopy_runner/tests/test_wake.py
@@ -171,3 +171,41 @@ def test_a_failed_retire_does_not_cost_the_socket(monkeypatch):
     on_control({"type": "menu_answer", "session_key": "k", "option": 1,
                 "session_id": "s", "answer_id": "a"})
     assert len(pressed) == 1
+
+
+def test_session_interrupt_frame_rings_without_touching_cdp():
+    """A stop aimed at a SESSION — the only route that reaches an agent/board/
+    scheduled turn, which is terminal seconds after its prompt is delivered.
+
+    It must only MARK the work due. This runs on the wake-listener thread, which
+    also carries cancel, wake and menu_answer; a CDP round trip here would block
+    the socket that keeps the runner alive for as long as emdash takes to answer.
+    """
+    from canopy_runner import cdp_control, session_interrupt
+
+    session_interrupt._pending.clear()
+    on_control, waker = _handler()
+
+    def _must_not_run(*a, **k):  # pragma: no cover - the assertion is that it isn't
+        raise AssertionError("interrupt must not be pressed on the wake thread")
+
+    real = cdp_control.interrupt
+    cdp_control.interrupt = _must_not_run
+    try:
+        on_control({"type": "session_interrupt", "session_id": "s1", "session_key": "hal-1"})
+    finally:
+        cdp_control.interrupt = real
+
+    assert "hal-1" in session_interrupt._pending
+    assert session_interrupt._pending["hal-1"]["session_id"] == "s1"
+    assert waker.event.is_set(), "the poll thread has work — don't wait out the tick"
+    session_interrupt._pending.clear()
+
+
+def test_session_interrupt_frame_without_a_key_is_ignored():
+    from canopy_runner import session_interrupt
+
+    session_interrupt._pending.clear()
+    on_control, _w = _handler()
+    on_control({"type": "session_interrupt", "session_id": "s1"})
+    assert session_interrupt._pending == {}

--- a/tests/test_session_interrupt_service.py
+++ b/tests/test_session_interrupt_service.py
@@ -1,0 +1,160 @@
+"""Stopping a session that no Turn owns.
+
+The turn-shaped stop reaches chat and nothing else: an agent, board or scheduled
+turn is fire-and-continue — `execute_turn` finishes it the moment the prompt is
+delivered — so seconds later the agent is working hard on a turn that is already
+DONE. Stop keyed on turns found nothing, did nothing, and did not even flicker.
+
+They are all sessions, and canopy already knows the session: `record_session` gives
+every agent/project/phone thread a durable Session plus a RunnerBinding carrying the
+emdash task. So stop them as sessions.
+"""
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth.models import User
+from django.utils import timezone
+
+from apps.agents.models import Agent
+from apps.canopy_sessions import services as chat
+from apps.canopy_sessions.models import RunnerBinding, Session
+from apps.harness.models import Runner, Turn
+from apps.workspaces.models import Workspace, WorkspaceMembership
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def seeded():
+    owner = User.objects.create_user("jj", "jj@dimagi.com", "pw")
+    ws = Workspace.objects.create(slug="canopy", display_name="Canopy", created_by=owner)
+    WorkspaceMembership.objects.create(user=owner, workspace=ws,
+                                       role=WorkspaceMembership.OWNER)
+    agent = Agent.objects.create(slug="hal", name="Hal", workspace=ws, owner=owner)
+    # An agent session, exactly as harness.services._thread_session builds one for a
+    # board/scheduled turn: origin=runner, no chat messages, no live Turn.
+    session = Session.objects.create(agent=agent, workspace=ws,
+                                     origin=Session.ORIGIN_RUNNER, title="hal:turn")
+    runner = Runner.objects.create(name="jj-mbp", kind=Runner.EMDASH, paired_by=owner,
+                                   status=Runner.ONLINE, last_heartbeat_at=timezone.now())
+    return owner, ws, agent, session, runner
+
+
+def _bind(session, runner, key="hal-canopy-sweep-1"):
+    return RunnerBinding.objects.create(session=session, runner=runner, session_key=key)
+
+
+def test_an_agent_session_with_no_turn_is_interrupted(seeded, monkeypatch):
+    """The whole point. No Turn owns this work — the only way to stop it is the
+    terminal, addressed by session_key exactly as a menu answer is."""
+    _owner, _ws, _agent, session, runner = seeded
+    _bind(session, runner)
+
+    published = []
+    from apps.realtime import groups
+    monkeypatch.setattr(groups, "publish", lambda group, msg: published.append((group, msg)))
+
+    assert chat.interrupt_session(session) == "sent"
+
+    [(group, msg)] = published
+    assert group == groups.runner_group(runner.id)
+    assert msg["type"] == "runner.session_interrupt"
+    assert msg["session_key"] == "hal-canopy-sweep-1"
+    assert msg["session_id"] == str(session.id)
+
+
+def test_an_unbound_session_refuses_rather_than_raising(seeded):
+    """A session canopy cannot reach a terminal for. Ordinary, not an error —
+    mirrors answer_menu's refusal shape."""
+    _owner, _ws, _agent, session, _runner = seeded
+    assert chat.interrupt_session(session) == "unbound"
+
+
+def test_a_binding_with_no_session_key_is_unbound(seeded):
+    _owner, _ws, _agent, session, runner = seeded
+    RunnerBinding.objects.create(session=session, runner=runner, session_key="")
+    assert chat.interrupt_session(session) == "unbound"
+
+
+def test_a_runner_that_is_gone_refuses(seeded):
+    """Reachable, not available — but a runner whose heartbeat has gone stale can
+    press nothing at all.
+
+    Note `status` is left ONLINE on purpose: that field holds what the runner last
+    self-REPORTED, and a box that died never gets to update it. `live_status`
+    derives STALE from the heartbeat, which is the honest signal."""
+    import datetime as dt
+
+    _owner, _ws, _agent, session, runner = seeded
+    Runner.objects.filter(pk=runner.pk).update(
+        last_heartbeat_at=timezone.now() - dt.timedelta(hours=2)
+    )
+    session.refresh_from_db()
+    _bind(session, Runner.objects.get(pk=runner.pk))
+    assert chat.interrupt_session(session) == "unavailable"
+
+
+def test_a_paused_runner_still_presses_escape(seeded, monkeypatch):
+    """Pause stops STARTING work, never finishing it, and an agent mid-turn is work
+    already running — the same reasoning answer_menu documents."""
+    _owner, _ws, _agent, session, runner = seeded
+    Runner.objects.filter(pk=runner.pk).update(status=Runner.PAUSED,
+                                               last_heartbeat_at=timezone.now())
+    session.refresh_from_db()
+    _bind(session, Runner.objects.get(pk=runner.pk))
+
+    from apps.realtime import groups
+    monkeypatch.setattr(groups, "publish", lambda group, msg: None)
+
+    assert chat.interrupt_session(session) == "sent"
+
+
+def test_a_chat_session_with_a_live_turn_is_not_double_interrupted(seeded, monkeypatch):
+    """The turn's own cancel already interrupts this same terminal through the
+    bridge. A second Escape could land after the agent has moved on to something
+    else, so the session route is the FALLBACK, not an addition."""
+    from apps.canopy_sessions.consumers import SessionConsumer
+
+    _owner, _ws, _agent, session, runner = seeded
+    _bind(session, runner)
+    Turn.objects.create(chat_session=session, origin=Turn.ORIGIN_API,
+                        idempotency_key="live-1", status=Turn.RUNNING, claimed_by=runner)
+
+    interrupted = []
+    monkeypatch.setattr(chat, "interrupt_session",
+                        lambda s: interrupted.append(s) or "sent")
+
+    consumer = SessionConsumer()
+    consumer.session = session
+    assert consumer._stop_session() is True
+    assert interrupted == [], "the turn owned it — don't also fire at the terminal"
+
+
+def test_stop_falls_through_to_the_session_when_no_turn_owns_it(seeded, monkeypatch):
+    """The regression this whole change exists for: with no non-terminal turn,
+    `_stop_session` used to return False — no interrupt, no broadcast, nothing."""
+    from apps.canopy_sessions.consumers import SessionConsumer
+
+    _owner, _ws, _agent, session, runner = seeded
+    _bind(session, runner)
+
+    interrupted = []
+    monkeypatch.setattr(chat, "interrupt_session",
+                        lambda s: interrupted.append(s) or "sent")
+
+    consumer = SessionConsumer()
+    consumer.session = session
+    assert consumer._stop_session() is True
+    assert interrupted == [session]
+
+
+def test_stop_still_reports_nothing_happened_when_it_could_not_reach_anything(seeded, monkeypatch):
+    """An unbound session must NOT flip every participant's Stop UI to
+    "cancelled" — the M4 rule, preserved through the new fallback."""
+    from apps.canopy_sessions.consumers import SessionConsumer
+
+    _owner, _ws, _agent, session, _runner = seeded  # no binding at all
+
+    consumer = SessionConsumer()
+    consumer.session = session
+    assert consumer._stop_session() is False


### PR DESCRIPTION
> *"all those things are still just session right, why would they not have the ability to be stopped as a session?"*

Correct, and that turned out to be the whole fix. They **are** just sessions. Nothing about a session prevented stopping it — only the turn-shaped plumbing did.

## The bug

Stop did **nothing at all** for an agent, board or scheduled turn. Not "sometimes failed" — no interrupt, no broadcast, not even a UI flicker, while the agent worked on for another ten minutes.

Stop was built on the **Turn**. A chat turn stays `EXECUTING` while its bridge pumps the reply, so there is something to cancel. Every other kind is fire-and-continue — `execute_turn` calls `client.finish` the moment the prompt is delivered (runner `execute.py:188`, `:531`), so seconds later the agent is working hard on a turn that is already `DONE`. `_cancel_session_turn` filtered on non-terminal turns, found none, returned `False`, and `_chat_stop` returned early **without broadcasting**.

## Why the session was always the right handle

`harness.services.record_session` — called for chat **and** agent turns alike — upserts *"the thread's durable Session + RunnerBinding"*, and `_thread_session` creates a real `Session` (origin=runner) for every agent/project/phone thread. That binding carries `session_key`, the emdash task.

It is the **same binding `answer_menu` already uses to press a key into that terminal.** The machinery to act on a session rather than a turn was fully built and proven; Stop just wasn't using it.

```
chat.stop -> cancel non-terminal turns          (unchanged; chat)
          -> if none moved, interrupt the session's terminal   (everything else)
```

A fallback rather than both, deliberately: a chat turn's cancel already interrupts that same terminal through the bridge, and a second Escape could land after the agent has moved on to other work.

## Runner side: a doorbell, and the thread split is the point

`ring()` runs on the **wake-listener thread**, which also carries `cancel`, `wake` and `menu_answer`. A CDP round trip there would block the socket that keeps the runner alive for as long as emdash takes to answer. So the frame only marks work due and the **poll thread** presses the key — the rule `inbox_due` already follows, and which `make_control_handler`'s own docstring spells out ("anything that touches CDP or a subprocess only marks work due").

It reuses **#649's verified interrupt** rather than assuming a keypress worked:

- confirmed → posts `activity:idle`, so the session surface reflects it (and the next session report doesn't re-assert `working` over it — that's why the drain runs *before* `maybe_report_sessions`)
- unconfirmed → retried across ticks, bounded, then given up on with a warning
- unconfirmed → posts **nothing**. The session stays `working`, which is *also true*, and is what tells you the stop hasn't taken
- a sidecar too old to report an `action` counts as unconfirmed, never as success

Re-ringing does not reset the attempt count: three impatient presses are one stop, not nine Escapes at a terminal that may have moved on.

## Scoped out

There is no dedicated *"we tried and could not stop it"* signal for a non-chat session. It has no Turn to hang an `error` event on (that's how #649 reports it for chat), and inventing a frame type for it is a bigger change than this one. Today the honest `working` state carries that meaning. Worth revisiting if it proves too quiet.

## Verification

- `2207 passed, 1 skipped` backend; `557 passed` runner.
- `ruff --select F`, `makemigrations --check`, `manage.py check` — all clean (CI gates, run locally).
- New tests cover the fallback, the no-double-interrupt rule, the M4 "don't broadcast when nothing happened" rule surviving the new path, both refusal shapes, the paused-runner-still-presses rule, and — importantly — that the control frame does **not** touch CDP on the wake thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JBEHhavkTEkwSHqru5yhSd