### PR TITLE
Say whether the stop actually took

### DIFF
--- a/apps/canopy_sessions/consumers.py
+++ b/apps/canopy_sessions/consumers.py
@@ -153,8 +153,17 @@ class SessionConsumer(AsyncJsonWebsocketConsumer):
         # but only when something was actually cancelled/cancel-requested, so a
         # stray Stop with nothing to cancel doesn't flip everyone's UI to
         # "cancelled" for no reason.
-        stopped = await database_sync_to_async(self._stop_session)()
-        if not stopped:
+        route = await database_sync_to_async(self._stop_session)()
+        if not route:
+            return
+        if route == "session":
+            # NOT `chat.stream_cancelled`. All that has happened is that a frame was
+            # published to the runner; nothing has pressed Escape yet, and it may
+            # well fail (#649 exists because it often did). Claiming "cancelled"
+            # here would be the same false green that bug was about, moved onto the
+            # new path. Say what is actually true — we asked — and let the runner
+            # report whether it landed (`stop:stopped` / `stop:failed`).
+            await self._broadcast({"type": "session.stop", "state": "requested"})
             return
         await self._broadcast({
             "type": "chat.stream_cancelled",
@@ -178,8 +187,13 @@ class SessionConsumer(AsyncJsonWebsocketConsumer):
             draft.save(update_fields=["body", "version", "updated_at"])
         return draft
 
-    def _stop_session(self) -> bool:
+    def _stop_session(self) -> str:
         """Stop this session, by whichever route actually owns the running work.
+
+        Returns WHICH route fired — "turns" | "session" | "" — because the two mean
+        different things to the client and must not be reported identically. A
+        cancelled turn is a cancellation that has happened; a published session
+        interrupt is a request that has not been attempted yet.
 
         TURNS FIRST. A chat reply is owned by a live Turn: cancelling it is what
         records the intent, reaches a queued turn behind the running one, and lets
@@ -207,8 +221,8 @@ class SessionConsumer(AsyncJsonWebsocketConsumer):
             if harness_services.cancel_turn(turn) is not None:
                 cancelled = True
         if cancelled:
-            return True
-        return chat_services.interrupt_session(self.session) == "sent"
+            return "turns"
+        return "session" if chat_services.interrupt_session(self.session) == "sent" else ""
 
     def _resolve_message_id_sync(self, turn_id, seq):
         if turn_id:
@@ -270,6 +284,14 @@ class SessionConsumer(AsyncJsonWebsocketConsumer):
         await self.send_json({
             "event": "chat.stream_cancelled",
             "data": {"message_id": message.get("message_id"), "partial_len": message.get("partial_len", 0)},
+        })
+
+    async def session_stop(self, message):
+        # "requested" comes from here, the moment we publish to the runner.
+        # "stopped"/"failed" come from the runner itself, up the session stream
+        # as `stop:` events (stream_map) — this handler serves the first only.
+        await self.send_json({
+            "event": "session.stop", "data": {"state": message.get("state", "requested")},
         })
 
     async def presence_joined(self, message):

--- a/apps/canopy_sessions/stream_map.py
+++ b/apps/canopy_sessions/stream_map.py
@@ -34,6 +34,15 @@ def turn_event_to_frames(evt: dict, resolve_message_id: Callable[[int], str]) ->
         if isinstance(menu, dict) and menu:
             data["menu"] = menu
         return [{"event": "session.activity", "data": data}]
+
+    if isinstance(kind, str) and kind.startswith("stop:"):
+        # Did the stop the human asked for actually land. Its own frame rather than
+        # a value of `activity`, because the two are independent: a stop that FAILED
+        # leaves the agent `working`, which is true and has to stay true, and a
+        # `stop:failed` folded into activity would either overwrite that with a lie
+        # or be dropped as "still working, nothing to say" — which is precisely the
+        # silence this frame exists to break.
+        return [{"event": "session.stop", "data": {"state": kind.split(":", 1)[1]}}]
     if kind == "user":
         # Text a human typed straight into emdash. It reaches no web client any
         # other way — there was no optimistic echo, because no web client sent

--- a/apps/harness/api.py
+++ b/apps/harness/api.py
@@ -68,6 +68,18 @@ router = Router(auth=session_auth, tags=["harness"])
 # Allowed values for TurnEvent.kind. Kept in sync with the event kinds the
 # runner/agent side actually emits; anything else 422s at the API boundary
 # rather than being silently persisted.
+# Session-stream kinds that are STATE, not transcript: they fan out to watching
+# clients and are never persisted (index -1 already excludes them from the durable
+# write, and they have no transcript row to be).
+#
+#   activity:  is the agent producing right now — working | idle | blocked
+#   stop:      did a stop the human asked for actually land — requested | stopped
+#              | failed. A SEPARATE axis from activity on purpose: after a stop
+#              that did not take, the agent is still `working`, and that is true
+#              and must stay true. Folding "the stop failed" into activity would
+#              either lie about what the agent is doing or lose the stop entirely.
+LIVE_ONLY_PREFIXES = ("activity:", "stop:")
+
 ALLOWED_EVENT_KINDS = {
     "status",
     "assistant",
@@ -785,7 +797,7 @@ def post_session_stream(request: HttpRequest, runner_id: uuid.UUID, payload: Ses
         # applied only on the durable path would drop a harness marker from
         # history while still pushing it to every watching client — so it would
         # appear live, then vanish on reload. Same rule, both paths.
-        if e.kind.startswith("activity:"):
+        if e.kind.startswith(LIVE_ONLY_PREFIXES):
             # Fans out, never persists — index -1 already excludes it from the
             # durable write, and it has no transcript row to be.
             groups.publish(sgroup, {

--- a/frontend/packages/canopy-ui/src/chat/ChatPanel.tsx
+++ b/frontend/packages/canopy-ui/src/chat/ChatPanel.tsx
@@ -176,6 +176,7 @@ export function ChatPanel({
         onUpdate={onUpdateDraft}
         onSend={onSend}
         onStop={onStop}
+        stopState={state.stopState}
         onTakeOver={onTakeOver}
         banner={banner}
         disabledReason={disabledReason}

--- a/frontend/packages/canopy-ui/src/chat/SendBox.tsx
+++ b/frontend/packages/canopy-ui/src/chat/SendBox.tsx
@@ -44,6 +44,10 @@ interface Props {
    *  The server cancels every non-terminal turn regardless, so a null id is
    *  a valid cancel, not a no-op. */
   onStop: (messageId: string | null) => void;
+  /** Whether the stop the human asked for actually landed. Rendered next to the
+   *  button that asked for it, because that is where the person who pressed it
+   *  is looking. Undefined = no stop has been asked for on this turn. */
+  stopState?: "requested" | "stopped" | "failed";
   onTakeOver: () => void;
   /** Optional app-supplied banner rendered above the composer (e.g. an
    *  imported-session note). The kit itself has no CLI-auth banners. */
@@ -76,6 +80,7 @@ export function SendBox({
   onUpdate,
   onSend,
   onStop,
+  stopState,
   onTakeOver,
   banner,
   disabledReason,
@@ -335,6 +340,26 @@ export function SendBox({
               {disabledReason}
             </span>
           )}
+          {stopState === "failed" ? (
+            // The one state that MUST be loud. Everything else here is either
+            // self-evident (the reply stopped) or transient. A stop that did not
+            // take looks exactly like a stop that worked — the agent keeps
+            // running either way — so without this it is invisible, which is the
+            // whole reason Stop could not be trusted.
+            <span
+              role="status"
+              className="mr-auto text-xs font-medium text-destructive"
+              title="Escape was pressed and the agent is still running. Try again, or stop it in the terminal."
+            >
+              stop didn&rsquo;t take — still running
+            </span>
+          ) : null}
+          {/* Never DISABLED while a stop is in flight, only relabelled. If the
+              runner dies between the request and the verdict, `stopState` never
+              advances — and a button that latched off would leave the human with
+              no way to ask again, the exact trap #519 documents for the composer
+              lock. Pressing again is harmless: the runner dedupes by session_key,
+              so three impatient presses are still one Escape. */}
           {isStreaming ? (
             <Button
               type="button"
@@ -342,7 +367,7 @@ export function SendBox({
               size="sm"
               onClick={handleStopClick}
             >
-              stop
+              {stopState === "requested" ? "stopping…" : "stop"}
             </Button>
           ) : null}
           {!canEdit && holderIsPresent && !holderIsIdle ? (

--- a/frontend/packages/canopy-ui/src/chat/protocol.ts
+++ b/frontend/packages/canopy-ui/src/chat/protocol.ts
@@ -131,6 +131,16 @@ export interface SessionState {
    *  those apart — but it is the difference between "still thinking, wait" and
    *  "it is waiting on YOU", which previously rendered identically. */
   activity?: "working" | "idle" | "blocked";
+  /** Whether a stop the human asked for actually landed. A SEPARATE axis from
+   *  `activity`, deliberately: a stop that failed leaves the agent `working`,
+   *  which is true and must stay true, so the outcome of the stop cannot be a
+   *  value of activity without either lying or being lost.
+   *
+   *  "requested" is set the moment the server publishes to the runner — nothing
+   *  has pressed Escape yet. Only the runner can say "stopped" or "failed", and
+   *  it only says so after verifying the terminal (see #649: an unverified
+   *  Escape reported as success is what made Stop untrustworthy). */
+  stopState?: "requested" | "stopped" | "failed";
   /** The dialog the agent is waiting on. Carried in the CONNECT SNAPSHOT, not
    *  only in live frames: `session.activity` is view-only and reaches a client
    *  only if it was already connected when the agent blocked — which is exactly
@@ -162,6 +172,7 @@ export type WsEvent =
   // The agent started or finished a turn. Distinct from tool events: it fires
   // while Claude is THINKING, before any content exists to show.
   | { event: "session.activity"; data: { state: "working" | "idle" | "blocked"; menu?: SessionMenu } }
+  | { event: "session.stop"; data: { state: "requested" | "stopped" | "failed" } }
   // The agent started, or stopped, waiting on a dialog. Its own frame rather
   // than an overloaded `session.activity`: activity answers "is it producing",
   // which the hook path owns on a much faster clock, and inventing a state here

--- a/frontend/packages/canopy-ui/src/chat/sessionReducer.test.ts
+++ b/frontend/packages/canopy-ui/src/chat/sessionReducer.test.ts
@@ -686,3 +686,44 @@ describe("the dialog an agent is blocked on", () => {
     expect(state.menu?.options[0].description).toContain("real LLO");
   });
 });
+
+describe("session.stop — whether the stop actually landed", () => {
+  const base = (over: Partial<SessionState> = {}): SessionState => ({
+    messages: [],
+    active_draft: null,
+    participants: [],
+    presence_user_ids: [],
+    current_user_id: 1,
+    ...over,
+  });
+
+  it("records a requested stop without claiming it worked", () => {
+    const out = sessionReducer(base(), {
+      event: "session.stop",
+      data: { state: "requested" },
+    } as WsEvent);
+    expect(out.stopState).toBe("requested");
+  });
+
+  it("keeps the agent WORKING when the stop failed", () => {
+    // The whole point of a separate axis. A failed stop leaves the agent running,
+    // and both facts have to survive together — collapsing them into `activity`
+    // loses whichever one loses the race, and it was always the stop.
+    const out = sessionReducer(base({ activity: "working" }), {
+      event: "session.stop",
+      data: { state: "failed" },
+    } as WsEvent);
+    expect(out.stopState).toBe("failed");
+    expect(out.activity).toBe("working");
+  });
+
+  it("a new turn clears a stale stop outcome", () => {
+    // "your stop did not take" pinned over fresh work is a warning about
+    // something the human has already moved on from.
+    const out = sessionReducer(base({ stopState: "failed" }), {
+      event: "chat.stream_start",
+      data: { message_id: "m1" },
+    } as WsEvent);
+    expect(out.stopState).toBeUndefined();
+  });
+});

--- a/frontend/packages/canopy-ui/src/chat/sessionReducer.ts
+++ b/frontend/packages/canopy-ui/src/chat/sessionReducer.ts
@@ -28,6 +28,12 @@ const UNBLOCKING_FRAMES = new Set([
 ]);
 
 export function sessionReducer(prev: SessionState, frame: WsEvent): SessionState {
+  if (frame.event === "chat.stream_start" || frame.event === "draft.committed") {
+    // A new turn is starting, so the previous turn's stop outcome is history —
+    // leaving "your stop did not take" pinned over fresh work would be a stale
+    // warning about something the human has already moved on from.
+    prev = { ...prev, stopState: undefined };
+  }
   if (prev.activity === "blocked" && UNBLOCKING_FRAMES.has(frame.event)) {
     // Dropping the menu with the state matters as much as the state itself —
     // the dialog is gone, and buttons that answer a gone dialog send a stray
@@ -84,6 +90,14 @@ export function sessionReducer(prev: SessionState, frame: WsEvent): SessionState
         return { ...prev, activity: frame.data.state, menu: undefined };
       }
       return { ...prev, activity: "blocked", menu: frame.data.menu ?? prev.menu };
+
+    case "session.stop":
+      // Independent of `activity` on purpose. A stop that FAILED leaves the agent
+      // working, and both facts have to be sayable at once: "it is still going"
+      // AND "your stop did not take". Collapsing them loses whichever one loses
+      // the race, and it was always the second — which is how a dead Stop button
+      // stayed invisible.
+      return { ...prev, stopState: frame.data.state };
 
     case "session.menu":
       // The authoritative producer: the session report re-derives the dialog

--- a/runner/canopy_runner/canopy_runner/session_interrupt.py
+++ b/runner/canopy_runner/canopy_runner/session_interrupt.py
@@ -103,22 +103,31 @@ def drain(cfg, client, runner_id: str) -> int:
             action = "unreadable"
 
         confirmed = action in ("interrupted", "idle")
+        done = settle(session_key, confirmed=confirmed)
+
+        # Say what happened, on both outcomes. Only the SUCCESS was reported before,
+        # which left a failed stop indistinguishable from a stop nobody asked for —
+        # the person who pressed the button watched a session that just went on
+        # working with no explanation. Two independent facts go up:
+        #
+        #   activity:  what the AGENT is doing. `idle` only when confirmed. Never
+        #              touched on failure, because it is genuinely still working.
+        #   stop:      whether the STOP took. This is the one that was missing.
+        events = []
         if confirmed:
             confirmed_count += 1
-            # Tell the web the agent is idle now. `activity` is the only state the
-            # session surface has, and after a confirmed interrupt "idle" is simply
-            # true. Nothing is posted when it is NOT confirmed, deliberately: the
-            # session stays `working`, which is also true, and is what tells the
-            # person who pressed the button that the stop has not taken.
-            if session_id:
-                try:
-                    client.post_session_stream(runner_id, session_id, [{
-                        "kind": "activity:idle", "seq": -1, "index": -1, "payload": {},
-                    }])
-                except Exception:  # noqa: BLE001 — reporting is best-effort
-                    logger.debug("session stop: could not report idle for %s",
-                                 session_id, exc_info=True)
-        done = settle(session_key, confirmed=confirmed)
+            events.append({"kind": "activity:idle", "seq": -1, "index": -1, "payload": {}})
+            events.append({"kind": "stop:stopped", "seq": -1, "index": -1, "payload": {}})
+        elif done:
+            events.append({"kind": "stop:failed", "seq": -1, "index": -1,
+                           "payload": {"attempts": MAX_ATTEMPTS, "reason": action}})
+        if events and session_id:
+            try:
+                client.post_session_stream(runner_id, session_id, events)
+            except Exception:  # noqa: BLE001 — reporting is best-effort, stopping is not
+                logger.debug("session stop: could not report the outcome for %s",
+                             session_id, exc_info=True)
+
         if confirmed:
             logger.info("session stop: %s interrupted (%s)", session_key, action)
         elif done:

--- a/runner/canopy_runner/tests/test_session_interrupt.py
+++ b/runner/canopy_runner/tests/test_session_interrupt.py
@@ -61,7 +61,10 @@ def test_a_rung_session_is_interrupted_and_reported_idle(monkeypatch):
     # stop appears to undo itself.
     [(session_id, events)] = client.streamed
     assert session_id == "sess-1"
-    assert events[0]["kind"] == "activity:idle"
+    kinds = [e["kind"] for e in events]
+    # TWO independent facts: what the agent is doing, and whether the stop took.
+    assert "activity:idle" in kinds
+    assert "stop:stopped" in kinds
 
 
 def test_an_unconfirmed_stop_retries_then_gives_up_quietly(monkeypatch):
@@ -78,7 +81,16 @@ def test_an_unconfirmed_stop_retries_then_gives_up_quietly(monkeypatch):
     assert session_interrupt.drain(_cfg(), client, "r1") == 0
     assert len(calls) == session_interrupt.MAX_ATTEMPTS
     assert session_interrupt._pending == {}, "bounded — never retried forever"
-    assert client.streamed == [], "an unconfirmed stop must not claim the agent is idle"
+
+    # It must SAY SO. Reporting only the success left a failed stop
+    # indistinguishable from a stop nobody asked for: the agent just went on
+    # working with no explanation, which is how a dead Stop button stayed
+    # invisible in the first place.
+    [(session_id, events)] = client.streamed
+    kinds = [e["kind"] for e in events]
+    assert kinds == ["stop:failed"]
+    assert "activity:idle" not in kinds, "it is still working — do not claim idle"
+    assert events[0]["payload"]["attempts"] == session_interrupt.MAX_ATTEMPTS
 
 
 def test_an_old_sidecar_counts_as_unconfirmed_not_success(monkeypatch):
@@ -91,7 +103,7 @@ def test_an_old_sidecar_counts_as_unconfirmed_not_success(monkeypatch):
     session_interrupt.ring("hal-canopy-sweep", "sess-1")
 
     assert session_interrupt.drain(_cfg(), client, "r1") == 0
-    assert client.streamed == []
+    assert client.streamed == [], "one unconfirmed attempt is not yet a verdict"
 
 
 def test_a_dead_emdash_never_kills_the_loop(monkeypatch):

--- a/tests/test_session_interrupt_service.py
+++ b/tests/test_session_interrupt_service.py
@@ -126,7 +126,7 @@ def test_a_chat_session_with_a_live_turn_is_not_double_interrupted(seeded, monke
 
     consumer = SessionConsumer()
     consumer.session = session
-    assert consumer._stop_session() is True
+    assert consumer._stop_session() == "turns"
     assert interrupted == [], "the turn owned it — don't also fire at the terminal"
 
 
@@ -144,7 +144,7 @@ def test_stop_falls_through_to_the_session_when_no_turn_owns_it(seeded, monkeypa
 
     consumer = SessionConsumer()
     consumer.session = session
-    assert consumer._stop_session() is True
+    assert consumer._stop_session() == "session"
     assert interrupted == [session]
 
 
@@ -157,4 +157,36 @@ def test_stop_still_reports_nothing_happened_when_it_could_not_reach_anything(se
 
     consumer = SessionConsumer()
     consumer.session = session
-    assert consumer._stop_session() is False
+    assert consumer._stop_session() == ""
+
+
+def test_a_published_frame_is_reported_as_requested_not_as_cancelled():
+    """`interrupt_session` returning "sent" means A FRAME WAS PUBLISHED — nothing
+    has pressed Escape yet, and it may well fail.
+
+    Reporting that as `chat.stream_cancelled` (which the client renders as
+    "cancelled") would be the #649 false green rebuilt on the session path: the UI
+    declaring victory before anything was attempted. The session route says
+    `session.stop / requested`, and only the RUNNER — after verifying the terminal
+    — may say stopped or failed.
+    """
+    from apps.canopy_sessions import stream_map
+
+    assert stream_map.turn_event_to_frames({"kind": "stop:stopped", "seq": -1,
+                                            "payload": {}}, lambda _s: "m") == [
+        {"event": "session.stop", "data": {"state": "stopped"}}]
+    assert stream_map.turn_event_to_frames({"kind": "stop:failed", "seq": -1,
+                                            "payload": {}}, lambda _s: "m") == [
+        {"event": "session.stop", "data": {"state": "failed"}}]
+
+
+def test_a_stop_event_fans_out_live_and_is_never_persisted():
+    """Same contract as `activity:` — it is state, not transcript. Persisting it
+    would put "stop failed" into the durable history as if it were something the
+    agent said."""
+    from apps.harness.api import LIVE_ONLY_PREFIXES
+
+    assert "stop:".startswith(LIVE_ONLY_PREFIXES) or "stop:" in LIVE_ONLY_PREFIXES
+    assert "stop:failed".startswith(LIVE_ONLY_PREFIXES)
+    assert "activity:working".startswith(LIVE_ONLY_PREFIXES)
+    assert not "assistant".startswith(LIVE_ONLY_PREFIXES)


### PR DESCRIPTION
You asked whether being explicit about the state is *strictly* better. Checking that turned up a regression I introduced in #652, so: yes, and here is the evidence rather than the argument.

## 1. A false green I built in #652

`interrupt_session` returning `"sent"` means **a frame was published to the runner**. Nothing has pressed Escape. It may well fail — #649 exists because it often did.

`_chat_stop` broadcast `chat.stream_cancelled` on that. The client renders it as:

```ts
status: "error", error_detail: `cancelled (partial: ${partial_len} chars)`
```

So the session path declared victory *before anything was attempted* — the exact false green #649 removed, rebuilt on the path I added. That is not "less clear", it is wrong, and it is mine.

## 2. The failure was silent

The runner verifies the interrupt and then reported only the **success**. On failure it logged a warning nobody reads and posted nothing, leaving the session at `activity: working`. True — but indistinguishable from a stop nobody ever asked for. The agent just goes on working with no explanation, which is precisely how a dead Stop button stays invisible.

## The fix: `stop:` alongside `activity:`

```
activity:   what the AGENT is doing    — working | idle | blocked
stop:       whether the STOP took      — requested | stopped | failed
```

**They have to be separate axes**, and this is the load-bearing design point. A stop that failed leaves the agent working, and both facts must be sayable at once. Folding the outcome into `activity` either overwrites a true `working` with a lie, or gets dropped as "still working, nothing to say" — and it was always the stop that lost that race. That silence *is* the bug.

`stop:` reuses the proven live-only session-stream convention: fans out to watching clients, never persisted (a "stop failed" in durable history would read as something the agent said).

Who may say what is deliberate too:

- **`requested`** — the server, on publish. All it knows.
- **`stopped` / `failed`** — only the **runner**, and only after verifying the terminal. An unverified Escape reported as success is what made Stop untrustworthy to begin with.

## In the UI

`stop` → `stopping…` on request, and a failed stop says so in words next to the button that asked for it.

The button is relabelled but **never disabled**. If the runner dies between request and verdict, `stopState` never advances — and a button latched off would leave the human with no way to ask again, the same trap the composer lock already taught us ("a loud bounce beats a silent lock"). Re-pressing is harmless: the runner dedupes by `session_key`, so three impatient presses are still one Escape. A new turn clears a stale outcome, so "your stop didn't take" is never left pinned over fresh work.

## Verification

- `2209 passed, 1 skipped` backend · `564 passed` runner · `648 passed (64 files)` vitest · `npm run build` clean.
- `ruff --select F`, `makemigrations --check`, `manage.py check` — clean. All five CI gates run locally.
- Tests pin the two facts staying independent (`stop:failed` must not disturb `activity: working`), that one unconfirmed attempt is not yet a verdict, that the failed verdict carries its attempt count, and that a new turn clears a stale outcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JBEHhavkTEkwSHqru5yhSd