### PR TITLE
Fix the CLI authorize flow behind the /canopy mount

### DIFF
--- a/apps/common/middleware.py
+++ b/apps/common/middleware.py
@@ -11,6 +11,8 @@ from django.conf import settings
 from django.http import JsonResponse
 from django.shortcuts import redirect
 
+from apps.common.script_prefix import self_full_path
+
 PUBLIC_PATH_PREFIXES = (
     "/accounts/",            # allauth login/logout/callback
     "/admin/",               # Django admin has its own auth
@@ -21,7 +23,13 @@ PUBLIC_PATH_PREFIXES = (
     "/api/docs/",             # Scalar HTML
     "/api/redoc/",            # Redoc HTML
     "/api/mcp/",              # FastMCP server — auth via Bearer in the request
-    "/auth/cli/authorize/",   # @login_required handles its own OAuth bounce + preserves ?cb/?state/?label
+    # NOTE: /auth/cli/authorize/ is deliberately NOT listed. It used to be, so
+    # that the view's own @login_required would bounce and preserve
+    # ?cb/?state/?label — but Django's decorator builds ?next= from
+    # request.get_full_path(), which drops the /canopy script prefix (see
+    # apps.common.script_prefix), so a first-time operator landed on Connect
+    # Labs after signing in. This middleware's own bounce below preserves the
+    # query string too AND keeps the prefix, so it is the correct handler.
     "/api/auth/token-exchange",  # auth=None — self-enforces via the AppCredential Bearer header
     "/api/inbound/",          # auth=None — self-enforces via the Google-signed OIDC push token
 )
@@ -168,9 +176,8 @@ class LoginRequiredMiddleware:
         if request.path.startswith("/api/"):
             return JsonResponse({"detail": "Authentication required"}, status=401)
 
-        # Build the post-login target from SCRIPT_NAME + path_info so it works
-        # both locally (no prefix) and on the labs sub-path deployment, where
-        # request.path is prefix-stripped by the StripScriptName ASGI wrapper —
-        # a bare request.path would bounce the user to a sibling tenant's path.
-        next_target = request.META.get("SCRIPT_NAME", "") + request.get_full_path_info()
+        # Build the post-login target so it works both locally (no prefix) and
+        # on the labs sub-path deployment — a bare request.path would bounce the
+        # user to a sibling tenant's path. See apps.common.script_prefix.
+        next_target = self_full_path(request)
         return redirect(f"{settings.LOGIN_URL}?{urlencode({'next': next_target})}")

--- a/apps/common/script_prefix.py
+++ b/apps/common/script_prefix.py
@@ -1,0 +1,43 @@
+"""Building a URL that points back at THIS request, under a script prefix.
+
+canopy-web runs as a path-prefixed tenant on labs.connect.dimagi.com/canopy.
+``config.asgi_prefix.StripScriptName`` removes ``/canopy`` from the incoming
+ASGI scope so the Starlette mounts (MCP at ``/api/mcp``, Django at ``/``) match,
+and ``FORCE_SCRIPT_NAME`` independently re-adds it to URLs Django *generates*
+via ``reverse()``.
+
+The gap between those two halves is ``request.path``. Django's ``ASGIRequest``
+sets ``self.path = scope["path"]`` verbatim — unlike ``WSGIRequest``, which
+rebuilds it as ``script_name + path_info`` — so under the stripping wrapper
+``request.path`` and ``request.get_full_path()`` come back WITHOUT the prefix.
+
+That is deliberate and load-bearing: every allowlist and route check in
+``apps.common.middleware`` (``_is_public``, ``path.startswith("/api/")``, …)
+is written against the stripped path. Do NOT "fix" it by restoring the prefix
+in the ASGI layer — that silently reverses those checks.
+
+What it breaks instead is any URL built to point back at the current request.
+``request.get_full_path()`` yields ``/auth/cli/authorize/?…``, which on labs is
+a *Connect Labs* path, not a canopy-web one: it 404s with Resolver404, or —
+worse, as a ``?next=`` target — bounces the operator into a sibling tenant
+after a successful login.
+
+Use this helper for that case. It is the idiom already relied on by
+``LoginRequiredMiddleware``; it is correct both locally (empty ``SCRIPT_NAME``)
+and on the prefixed deployment, and it preserves the query string, which
+matters for flows like the CLI authorize handshake that carry ``?cb``,
+``?state`` and ``?label`` through an OAuth round trip.
+"""
+from __future__ import annotations
+
+from django.http import HttpRequest
+
+
+def self_full_path(request: HttpRequest) -> str:
+    """Return the path+query of THIS request, including any script prefix.
+
+    Prefer this over ``request.get_full_path()`` anywhere the result is handed
+    back to a browser — a form ``action``, a ``?next=`` target, a redirect to
+    self. See the module docstring for why the two differ.
+    """
+    return request.META.get("SCRIPT_NAME", "") + request.get_full_path_info()

--- a/apps/common/tests/test_script_prefix.py
+++ b/apps/common/tests/test_script_prefix.py
@@ -1,0 +1,77 @@
+"""A URL pointing back at the current request must keep the /canopy prefix.
+
+On labs.connect.dimagi.com/canopy the ASGI wrapper strips the prefix before
+Django sees the path, and Django's ASGIRequest — unlike WSGIRequest — sets
+`request.path` straight from the stripped scope. So `get_full_path()` returns
+a path that belongs to the SIBLING tenant (Connect Labs), not to canopy-web.
+
+Two places hand such a URL back to a browser, and both 404'd a first-time
+operator minting a CLI token on the deployed instance:
+  - the CLI authorize page's form `action` (the Authorize button POSTed to
+    Connect Labs),
+  - the `?next=` target of the pre-login bounce (a successful sign-in landed
+    on Connect Labs).
+
+`self_full_path` is the one home for that idiom; these tests pin both the
+helper and the two call sites.
+"""
+from __future__ import annotations
+
+from django.test import RequestFactory
+
+from apps.common.middleware import _is_public
+from apps.common.script_prefix import self_full_path
+
+
+def _req(path, script_name="", **params):
+    request = RequestFactory().get(path, params)
+    request.META["SCRIPT_NAME"] = script_name
+    # RequestFactory builds a WSGIRequest, which derives path from
+    # SCRIPT_NAME + PATH_INFO at construction time. Under ASGI the prefix is
+    # absent from request.path entirely, which is the case being reproduced —
+    # so pin path/path_info to the stripped shape the wrapper actually yields.
+    request.path = path
+    request.path_info = path
+    return request
+
+
+def test_self_full_path_is_a_noop_without_a_prefix():
+    # local dev and GCP: FORCE_SCRIPT_NAME unset, nothing to re-add
+    assert self_full_path(_req("/auth/cli/authorize/")) == "/auth/cli/authorize/"
+
+
+def test_self_full_path_restores_the_script_prefix():
+    got = self_full_path(_req("/auth/cli/authorize/", script_name="/canopy"))
+    assert got == "/canopy/auth/cli/authorize/"
+
+
+def test_self_full_path_preserves_the_query_string():
+    # the CLI handshake carries ?cb/?state/?label through an OAuth round trip;
+    # losing them produces a "missing state" page that looks like a server bug
+    got = self_full_path(
+        _req(
+            "/auth/cli/authorize/",
+            script_name="/canopy",
+            cb="http://127.0.0.1:53123/cb",
+            state="nonce123",
+            label="canopy-cli",
+        )
+    )
+    assert got.startswith("/canopy/auth/cli/authorize/?")
+    assert "state=nonce123" in got
+    assert "cb=http" in got
+    assert "label=canopy-cli" in got
+
+
+def test_authorize_page_is_not_in_the_public_allowlist():
+    # It used to be, so that the view's own @login_required would bounce and
+    # keep ?cb/?state/?label. That decorator builds ?next= from
+    # get_full_path(), which drops the prefix — so the bounce must come from
+    # LoginRequiredMiddleware, which preserves the query AND the prefix.
+    assert _is_public("/auth/cli/authorize/") is False
+
+
+def test_the_rest_of_the_public_allowlist_is_untouched():
+    assert _is_public("/accounts/google/login/") is True
+    assert _is_public("/health/") is True
+    assert _is_public("/api/mcp/") is True

--- a/apps/tokens/cli_authorize_views.py
+++ b/apps/tokens/cli_authorize_views.py
@@ -25,6 +25,8 @@ from django.http import HttpRequest, HttpResponse, HttpResponseBadRequest, HttpR
 from django.shortcuts import render
 from django.views.decorators.http import require_http_methods
 
+from apps.common.script_prefix import self_full_path
+
 from .models import PersonalToken
 
 logger = logging.getLogger(__name__)
@@ -80,7 +82,10 @@ def cli_authorize(request: HttpRequest) -> HttpResponse:
             {
                 "label": label,
                 "cb_host": urlparse(cb).netloc,
-                "form_action": request.get_full_path(),
+                # NOT request.get_full_path() — under the /canopy script prefix
+                # that omits the prefix, so the Authorize button POSTs to a
+                # Connect Labs path and 404s. See apps.common.script_prefix.
+                "form_action": self_full_path(request),
             },
         )
 

--- a/apps/tokens/tests/test_cli_authorize.py
+++ b/apps/tokens/tests/test_cli_authorize.py
@@ -5,10 +5,10 @@ from urllib.parse import parse_qs, urlencode, urlparse
 
 import pytest
 from django.contrib.auth import get_user_model
-from django.test import override_settings
+from django.test import AsyncRequestFactory, override_settings
 from django.urls import reverse
 
-from apps.tokens.cli_authorize_views import _validate_callback
+from apps.tokens.cli_authorize_views import _validate_callback, cli_authorize
 from apps.tokens.models import PersonalToken
 
 User = get_user_model()
@@ -167,3 +167,47 @@ def test_method_not_allowed(authed_client):
     client, _ = authed_client
     resp = client.delete(reverse("cli_authorize") + "?" + urlencode(_qs()))
     assert resp.status_code == 405
+
+
+# ---------------------------------------------------------------------------
+# Script-prefix regression — the deployed instance runs at /canopy
+# ---------------------------------------------------------------------------
+#
+# These use AsyncRequestFactory, NOT the default test client, and that choice is
+# the whole point. The bug is ASGI-only: WSGIRequest rebuilds `path` as
+# SCRIPT_NAME + PATH_INFO, so under the ordinary (WSGI) test client
+# get_full_path() ALREADY carries /canopy and the broken code passes. ASGIRequest
+# instead sets `self.path = scope["path"]` verbatim, and canopy-web's ASGI
+# wrapper has already stripped the prefix from that scope — which is exactly
+# what production does. Written against the WSGI client, every assertion below
+# passes on the unfixed view (measured, 2026-09-01).
+
+
+def _asgi_get(path="/auth/cli/authorize/", **overrides):
+    """A request shaped like the one uvicorn hands Django behind /canopy."""
+    request = AsyncRequestFactory().get(path, _qs(**overrides))
+    request.user = User(username="alice", email="alice@dimagi.com")
+    return request
+
+
+@override_settings(FORCE_SCRIPT_NAME="/canopy")
+def test_form_action_carries_the_script_prefix():
+    """The Authorize button must POST back to canopy-web, not its host tenant.
+
+    request.get_full_path() names a Connect Labs URL here; posting there 404s
+    with Resolver404, which reads like a canopy-web outage rather than a
+    canopy-web bug. See apps.common.script_prefix.
+    """
+    resp = cli_authorize(_asgi_get())
+    assert resp.status_code == 200
+    body = resp.content.decode()
+    assert 'action="/canopy/auth/cli/authorize/?' in body
+    # the handshake params must survive into the POST target
+    assert "state=nonce-abc" in body
+
+
+def test_form_action_has_no_prefix_when_unprefixed():
+    # local dev and GCP: FORCE_SCRIPT_NAME unset, nothing to re-add
+    resp = cli_authorize(_asgi_get())
+    assert resp.status_code == 200
+    assert 'action="/auth/cli/authorize/?' in resp.content.decode()


### PR DESCRIPTION
Closes #654. Reported by @smazumdar, who hit it minting her first PAT and could only get through with a devtools one-liner rewriting the form action.

Not a Windows bug — every operator, every platform, at the first step that needs a token.

## The bug

`StripScriptName` removes `/canopy` from the ASGI scope so the Starlette mounts match. Django's `ASGIRequest` then sets `self.path = scope["path"]` **verbatim** — unlike `WSGIRequest`, which rebuilds it as `script_name + path_info`. So `request.get_full_path()` loses the prefix while `reverse()` keeps it, and any URL built to point back at the current request names *Connect Labs* instead of canopy-web.

Both halves of the handshake broke on that:

| | built from | result |
|---|---|---|
| Authorize button's form `action` | `request.get_full_path()` | POSTs to `/auth/cli/authorize/` → `Resolver404` |
| pre-login `?next=` (hit first — a new operator has no session) | Django's `@login_required`, also `get_full_path()` | signing in lands on Connect Labs |

## The fix

**The stripped path stays.** Every allowlist and route check in `apps/common/middleware.py` (`_is_public`, `path.startswith("/api/")`, …) is written against it; restoring the prefix in the ASGI layer would silently reverse all of them. That is the tempting fix and it is the wrong one.

`LoginRequiredMiddleware` already had the correct idiom (`SCRIPT_NAME + get_full_path_info()`) with a comment explaining why. So:

- `apps/common/script_prefix.self_full_path()` — one home for the idiom, with the trap written down so the next person doesn't "fix" the ASGI layer.
- The view's form action uses it.
- `/auth/cli/authorize/` comes **out** of `PUBLIC_PATH_PREFIXES`, so the middleware's already-correct bounce owns the pre-login case. It preserves `?cb/?state/?label` too — the only reason the carve-out existed.

## The tests use AsyncRequestFactory on purpose

This is the part worth reviewing. Written against the ordinary test client, **every assertion here passes on the unfixed code** — `WSGIRequest` rebuilds `path` with the prefix already on it, so the bug is invisible. Measured, not assumed.

Verified both directions on this branch:

```
# against origin/main's view + middleware
FAILED apps/tokens/tests/test_cli_authorize.py::test_form_action_carries_the_script_prefix
FAILED apps/common/tests/test_script_prefix.py::test_authorize_page_is_not_in_the_public_allowlist
2 failed, 19 passed

# with the fix
21 passed
```

## ace-web is not affected

Same `request.get_full_path()` line at `apps/auth/cli_authorize_views.py:86`, different topology: `frontend/nginx.prod.conf` proxies `location /ace/auth/` with **no trailing slash** on `proxy_pass`, so nginx forwards the URI verbatim and Django receives `/ace/auth/cli/authorize/` intact. (`/ace/ws/` does carry the trailing slash, and does strip — the conf comments that difference.) No change needed.

## Gates

`bin/hal-ci-gates` says only `ci.yml` fires (`regen-openapi.yml`'s paths filter excludes every changed file). Backend gates, each with its own output:

- `ruff check . --select F` → `All checks passed!`
- `makemigrations --check --dry-run` → `No changes detected`
- `manage.py check` → `System check identified no issues (0 silenced).`
- `pytest` → **2216 passed, 1 skipped**

No frontend or `packages/` files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VTSU1EQ8HX1249Xcsqhb7K