### PR TITLE
Route a turn by WHO it came from, so the cloud runner can finally be switched on

### DIFF
--- a/apps/agents/api.py
+++ b/apps/agents/api.py
@@ -310,24 +310,36 @@ def list_agent_runner_rules(request: HttpRequest, slug: str) -> list[AgentRunner
     """The per-source overrides on top of the default ordered list (spec
     2026-07-27). One rule per source, max — the priority runner, and whether it is
     the only one allowed to take that source's work."""
-    from django.db.models import Count
+    from collections import Counter
 
+    from apps.harness.actors import actor_of
     from apps.harness.models import Runner, RunnerAssignment, Turn
 
     agent = _get_agent_or_404(request, slug)
-    # Per-source queued depth in one query — what the UI's "N turns are parked"
-    # warning renders next to a strict rule whose runner is offline.
-    queued = dict(
+    # Queued depth per (source, actor) — what the UI's "N turns are parked" warning
+    # renders next to a strict rule whose runner is offline. This cannot stay a
+    # `values_list("origin").annotate(Count)` now that the key includes the actor:
+    # the actor is DERIVED per turn (from `origin_ref["from"]` for mail, from
+    # `enqueued_by` otherwise), so it is grouped in Python. Queued sets are single
+    # digits in practice, and a count keyed only on origin would attribute other
+    # people's parked work to your rule.
+    queued: Counter = Counter()
+    for t in (
         Turn.objects.filter(agent=agent, status=Turn.QUEUED)
-        .values_list("origin").annotate(n=Count("id"))
-    )
+        .select_related("enqueued_by")
+        .only("origin", "origin_ref", "enqueued_by")
+    ):
+        queued[(t.origin, actor_of(t))] += 1
+
     rows = (
         RunnerAssignment.objects.filter(agent=agent).exclude(source="")
-        .select_related("runner").order_by("source")
+        .select_related("runner").order_by("source", "actor", "rank")
     )
     return [
         AgentRunnerRuleOut(
             source=row.source,
+            actor=row.actor,
+            rank=row.rank,
             runner_id=row.runner.id,
             runner_name=row.runner.name,
             kind=row.runner.kind,
@@ -337,7 +349,9 @@ def list_agent_runner_rules(request: HttpRequest, slug: str) -> list[AgentRunner
             online=row.runner.live_status == Runner.ONLINE,
             ready=row.runner.ready,
             enabled=row.enabled,
-            queued_count=queued.get(row.source, 0),
+            # Every row of a rule repeats its RULE's count: the parked queue belongs
+            # to the rule, not to one runner in it.
+            queued_count=queued.get((row.source, row.actor), 0),
         )
         for row in rows
     ]
@@ -355,20 +369,44 @@ def replace_agent_runner_rules(
     the other's rows (they share one table), and so the existing GET response
     shape stays what the frontend already consumes.
     """
+    from apps.harness.actors import normalize_actor
     from apps.harness.api import _runner_visibility_q
     from apps.harness.models import Runner, RunnerAssignment
 
     agent = _get_agent_or_404(request, slug)
 
-    # One rule per source. Caught here rather than left to the DB constraint so
-    # the caller gets a named reason instead of an IntegrityError 500.
-    sources = [r.source for r in payload.rules]
-    if len(sources) != len(set(sources)):
-        raise HttpError(422, "one rule per source: duplicate source in list")
+    # Normalize BEFORE validating or storing, so a rule pasted straight out of a
+    # mail client ("Sarvesh Tewari <STewari@Dimagi.com>") matches a turn whose
+    # sender resolves to the bare lowercase address. Rejecting an unparseable
+    # actor is the point: stored as-is it would be a rule that silently never
+    # matches, which is indistinguishable from a routing bug.
+    actors: list[str] = []
+    for r in payload.rules:
+        actor = normalize_actor(r.actor) if r.actor else ""
+        if r.actor and not actor:
+            raise HttpError(422, f"not an email address: {r.actor!r}")
+        actors.append(actor)
+
+    # One rule per (source, actor) — several actors MAY share a source, which is
+    # the whole feature. Caught here rather than left to the DB constraint so the
+    # caller gets a named reason instead of an IntegrityError 500.
+    keys = list(zip([r.source for r in payload.rules], actors))
+    if len(keys) != len(set(keys)):
+        raise HttpError(422, "one rule per (source, actor): duplicate in list")
+
+    for r, actor in zip(payload.rules, actors):
+        if not r.runners:
+            # A zero-length strict rule composes to an empty list and parks the
+            # queue naming no runner as the reason. Deleting the rule is how you
+            # turn it off.
+            raise HttpError(422, f"a rule needs at least one runner: {r.source}/{actor}")
+        seen = [row.runner_id for row in r.runners]
+        if len(seen) != len(set(seen)):
+            raise HttpError(422, f"a runner may appear once per rule: {r.source}/{actor}")
 
     # Same visibility predicate the default-list PUT gates on — a runner the
     # caller can't see must 422 as unknown, never be attachable by guessed UUID.
-    ids = [r.runner_id for r in payload.rules]
+    ids = [row.runner_id for r in payload.rules for row in r.runners]
     runners = list(
         Runner.objects.filter(id__in=ids)
         .exclude(status=Runner.RETIRED)
@@ -382,13 +420,15 @@ def replace_agent_runner_rules(
     with transaction.atomic():
         RunnerAssignment.objects.filter(agent=agent).exclude(source="").delete()
         RunnerAssignment.objects.bulk_create([
-            # rank=0: meaningless on a source row (the constraint allows exactly
-            # one per source), and the composition helper renumbers anyway.
+            # `rank` is the runner's position WITHIN its rule — the list order the
+            # caller sent. `strict` is rule-level and written to every row of the
+            # rule, so the composer can read it off the first.
             RunnerAssignment(
-                agent=agent, runner=by_id[r.runner_id], rank=0,
-                source=r.source, strict=r.strict, enabled=r.enabled,
+                agent=agent, runner=by_id[row.runner_id], rank=rank,
+                source=r.source, actor=actor, strict=r.strict, enabled=row.enabled,
             )
-            for r in payload.rules
+            for r, actor in zip(payload.rules, actors)
+            for rank, row in enumerate(r.runners)
         ])
     return list_agent_runner_rules(request, slug)
 

--- a/apps/agents/schemas.py
+++ b/apps/agents/schemas.py
@@ -99,6 +99,14 @@ class AgentRunnerRuleOut(StrictModel):
     queued turns from this source, which is what the UI's parked warning reads."""
 
     source: str
+    # "" = the rule applies to any actor (what a source rule meant before actors).
+    # Otherwise a normalized bare address. Plain `str` for the same reason `source`
+    # is: an output schema serializes what the DB holds.
+    actor: str = ""
+    # Position WITHIN this rule. Rows sharing (source, actor) are one rule; the UI
+    # groups on that pair and renders them as the same rank chip row the default
+    # order uses.
+    rank: int = 0
     runner_id: uuid.UUID
     runner_name: str
     kind: str
@@ -110,14 +118,28 @@ class AgentRunnerRuleOut(StrictModel):
 
 
 class AgentRunnerRuleIn(StrictModel):
-    """One rule of the wholesale-replace body. `source` is typed as the routable
-    literal so an unknown source is a 422 here rather than a rule that silently
-    never matches anything — and so the generated TypeScript carries the union."""
+    """One rule of the wholesale-replace body — a source, an optional actor, and
+    the ORDERED runners that may take that work.
+
+    `source` is typed as the routable literal so an unknown source is a 422 here
+    rather than a rule that silently never matches anything — and so the generated
+    TypeScript carries the union.
+
+    `runners` reuses the default list's row schema, and its ORDER is the rule's
+    rank order. A rule names several runners because the operator's own boxes are
+    two macOS accounts alternated as each runs out of tokens: "either of mine,
+    never cloud" cannot be said with one runner (spec 2026-09-05). Per-runner
+    `enabled` lives on the row, which is why this schema has no rule-level
+    `enabled` — a change from the pre-actor shape, safe because canopy-web's own
+    frontend is the only caller and no rules exist in production yet.
+
+    `strict` is rule-level and written to every row.
+    """
 
     source: RoutableSource
-    runner_id: uuid.UUID
+    actor: str = ""
+    runners: list[AgentRunnerRowIn] = Field(default_factory=list)
     strict: bool = False
-    enabled: bool = True
 
 
 class AgentRunnerRulesIn(StrictModel):

--- a/apps/canopy_sessions/services.py
+++ b/apps/canopy_sessions/services.py
@@ -852,8 +852,8 @@ def send_message(
     origin = origin or default_origin(session)
     if transcript_sourced(session):
         return _send_transcript_sourced_message(
-            session=session, text=text, client_id=client_id, placement=placement,
-            origin=origin,
+            session=session, text=text, user=user, client_id=client_id,
+            placement=placement, origin=origin,
         )
     with transaction.atomic():
         Session.objects.select_for_update().get(pk=session.pk)
@@ -897,6 +897,13 @@ def send_message(
             idempotency_key=f"chat:{session.id.hex}:{client_id or index}",
             prompt=text,
             origin_ref=origin_ref,
+            # WHO sent it. Not decoration: this is the actor half of the routing key
+            # (spec 2026-09-05), and it is the ONLY place an `ace_web` or
+            # `canopy_web_chat` turn can get one — neither carries the
+            # `origin_ref["from"]` an email turn is routed by. Left unset, every actor
+            # rule on those sources silently matches nothing. `enqueue_turn` ignores an
+            # unauthenticated user, so this is safe to pass unconditionally.
+            enqueued_by=user,
             pinned_runner=pinned,
         )
     # RC4 — multiplayer interjection: if a turn is ALREADY running for this session,
@@ -940,8 +947,8 @@ def place_queued_turn(*, session: Session, placement: str) -> Turn:
 
 
 def _send_transcript_sourced_message(
-    *, session: Session, text: str, client_id: str = "", placement: str | None = None,
-    origin: str = Turn.ORIGIN_CANOPY_WEB_CHAT,
+    *, session: Session, text: str, user=None, client_id: str = "",
+    placement: str | None = None, origin: str = Turn.ORIGIN_CANOPY_WEB_CHAT,
 ) -> tuple[Message, Turn]:
     """The transcript-sourced send path: enqueue the Turn, author NO durable user row.
 
@@ -982,6 +989,13 @@ def _send_transcript_sourced_message(
         idempotency_key=f"chat:{session.id.hex}:{client_id or uuid.uuid4().hex}",
         prompt=text,
         origin_ref=origin_ref,
+        # WHO sent it. Not decoration: this is the actor half of the routing key
+        # (spec 2026-09-05), and it is the ONLY place an `ace_web` or
+        # `canopy_web_chat` turn can get one — neither carries the
+        # `origin_ref["from"]` an email turn is routed by. Left unset, every actor
+        # rule on those sources silently matches nothing. `enqueue_turn` ignores an
+        # unauthenticated user, so this is safe to pass unconditionally.
+        enqueued_by=user,
         pinned_runner=pinned,
     )
     _maybe_interject(session, message)

--- a/apps/harness/actors.py
+++ b/apps/harness/actors.py
@@ -1,0 +1,90 @@
+"""Who a turn is FROM — the actor half of the routing key.
+
+Source rules (spec 2026-07-27) answer "which box runs this KIND of work".
+Actor rules (spec 2026-09-05) answer "which box runs THIS PERSON'S work", which
+is what lets a cloud runner take other people's work while the operator's own
+work stays on the operator's boxes. This module is the resolution half: one pure
+function mapping a turn to a normalized actor.
+
+The actor is DERIVED, never stored. A second column beside `origin_ref` and
+`enqueued_by` would be a third writer of the same fact, which is exactly the
+mistake the source spec avoided when it declined to add `source` beside `origin`.
+
+Two things that are NOT true, and which the obvious implementation gets wrong:
+
+  1. `Turn.enqueued_by` on an EMAIL turn is not the sender. It is set once, in
+     `harness/api.py` as `request.user` — the account the runner's inbox watcher
+     authenticates as. Every email turn in production reads the runner owner's
+     address regardless of who wrote in, so keying on it collapses every
+     correspondent onto one rule. The sender is in `origin_ref["from"]`, written
+     by `runner/canopy_runner/canopy_runner/inbox.py`.
+  2. Chat and ace-web turns carry no `origin_ref["from"]` at all. Their actor is
+     `enqueued_by` — which the session-send path only began setting alongside
+     this spec.
+
+So there is no single field. There is a per-origin rule, and it is this table.
+"""
+from __future__ import annotations
+
+from email.utils import parseaddr
+
+from apps.harness.models import Turn
+
+#: Origins whose actor is the SENDER, read out of `origin_ref["from"]`.
+_SENDER_ORIGINS = frozenset({Turn.ORIGIN_EMAIL})
+
+#: Origins with no human actor at all. A schedule fires on a clock; matching it
+#: against a person's rule would route it by accident, so it resolves to "" and
+#: falls through to the source rule. (Extension point, if this is ever wanted:
+#: `AgentSchedule.created_by`.)
+_ACTORLESS_ORIGINS = frozenset({Turn.ORIGIN_CANOPY_SCHEDULER})
+
+
+def normalize_actor(value: str | None) -> str:
+    """A bare, lowercased address — or "" when there isn't one.
+
+    Accepts both shapes a rule or a header can carry: `addr@host` and
+    `Display Name <addr@host>`. Uses `parseaddr` rather than slicing on `<`,
+    because a quoted display name may contain the delimiters a hand-rolled parse
+    would trip on — `'"Anthropic, PBC" <invoice+statements@mail.anthropic.com>'`
+    is a real value in the fleet.
+
+    Returns "" for anything that does not resolve to something address-shaped.
+    Empty is the safe answer: it matches no actor rule, so the turn falls through
+    to the source rule and then the default order. A partial or guessed value
+    would silently route instead.
+    """
+    _, addr = parseaddr((value or "").strip())
+    addr = addr.strip().lower()
+    # parseaddr is lenient — it returns the input unchanged for plenty of
+    # non-addresses. Require the one structural thing an address must have.
+    if "@" not in addr:
+        return ""
+    local, _, domain = addr.partition("@")
+    return addr if local and domain else ""
+
+
+def resolve_actor(origin: str, origin_ref, enqueued_by_email: str | None) -> str:
+    """The normalized actor for one turn, or "" when it has none.
+
+    Pure: no queries, no clock. Callable from `claim_next_turn`,
+    `unclaimable_queued_turns` and the rules API alike, which is what keeps the
+    three from disagreeing about who a turn is from.
+    """
+    if origin in _ACTORLESS_ORIGINS:
+        return ""
+    if origin in _SENDER_ORIGINS:
+        # `origin_ref` is a JSONField and a malformed row must not break claiming
+        # for the whole fleet, so this tolerates a non-dict rather than trusting
+        # the shape.
+        ref = origin_ref if isinstance(origin_ref, dict) else {}
+        return normalize_actor(ref.get("from"))
+    return normalize_actor(enqueued_by_email)
+
+
+def actor_of(turn: Turn) -> str:
+    """`resolve_actor` for a loaded Turn. The one place that knows an email is
+    reached through the `enqueued_by` FK, so callers can select_related it once
+    rather than each re-deriving the traversal."""
+    email = turn.enqueued_by.email if turn.enqueued_by_id else ""
+    return resolve_actor(turn.origin, turn.origin_ref, email)

--- a/apps/harness/migrations/0040_actor_runner_routing.py
+++ b/apps/harness/migrations/0040_actor_runner_routing.py
@@ -1,0 +1,45 @@
+"""Actor-aware runner routing (spec 2026-09-05-actor-aware-runner-routing-design).
+
+Schema-only and backwards compatible in both directions for one deploy:
+
+  - `actor` is added blank-defaulted, so every existing row keeps meaning exactly
+    what it means today (a rule that applies to any actor), and code running the
+    OLD composition simply never reads the column.
+  - The constraint swap RELAXES: `one_priority_runner_per_agent_source` capped a
+    rule at one runner; the replacement caps a RUNNER at one row per rule. A
+    relaxation cannot fail on existing data, and no row has a non-empty `actor`
+    yet, so the new constraint is trivially satisfied on apply.
+
+No data migration. `rank` — previously written 0 and ignored on a source row —
+becomes meaningful WITHIN a rule, and 0 stays correct for a rule of length one.
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('agents', '0017_delete_agentturn'),
+        ('harness', '0039_turn_attempts'),
+    ]
+
+    operations = [
+        migrations.RemoveConstraint(
+            model_name='runnerassignment',
+            name='one_priority_runner_per_agent_source',
+        ),
+        migrations.AddField(
+            model_name='runnerassignment',
+            name='actor',
+            field=models.CharField(blank=True, default='', max_length=254),
+        ),
+        migrations.AddConstraint(
+            model_name='runnerassignment',
+            constraint=models.UniqueConstraint(
+                condition=models.Q(('source', ''), _negated=True),
+                fields=('agent', 'source', 'actor', 'runner'),
+                name='one_row_per_runner_per_agent_source_actor',
+            ),
+        ),
+    ]

--- a/apps/harness/models.py
+++ b/apps/harness/models.py
@@ -883,6 +883,14 @@ class RunnerAssignment(models.Model):
     # it, because the rule is its own row with its own toggle. Pinned by
     # tests/test_source_rules.py and stated in the Runners-tab UI.
     source = models.CharField(max_length=32, blank=True, default="")
+    # THE ACTOR RULE (spec 2026-09-05). "" = this rule applies to any actor
+    # (exactly what a source rule meant before actors existed). Non-empty = a
+    # normalized, lowercased bare address, matched against `actors.actor_of(turn)`.
+    #
+    # Only meaningful alongside a non-empty `source`: a default-list row routes
+    # every actor by definition, and the constraints below keep `actor` out of
+    # its key. 254 is the RFC 5321 maximum address length.
+    actor = models.CharField(max_length=254, blank=True, default="")
     # Only meaningful on a source row. False: the priority runner goes first and
     # the default list follows beneath it. True: that runner or nothing — the turn
     # waits rather than degrading, which is the point for a source whose work can
@@ -899,11 +907,15 @@ class RunnerAssignment(models.Model):
                 condition=models.Q(source=""),
                 name="one_default_assignment_per_agent_runner",
             ),
-            # … and exactly one priority runner per (agent, source).
+            # … and, within one RULE — the rows sharing (agent, source, actor),
+            # rank-ordered — each runner at most once. This REPLACED a constraint
+            # that capped a rule at a single runner, which could not express
+            # "either of my two boxes, never cloud" for an operator whose live
+            # account rotates (spec 2026-09-05).
             models.UniqueConstraint(
-                fields=["agent", "source"],
+                fields=["agent", "source", "actor", "runner"],
                 condition=~models.Q(source=""),
-                name="one_priority_runner_per_agent_source",
+                name="one_row_per_runner_per_agent_source_actor",
             ),
         ]
 

--- a/apps/harness/services.py
+++ b/apps/harness/services.py
@@ -20,6 +20,7 @@ from django.db.models import F, Max, Q
 from django.utils import timezone
 
 from apps.canopy_sessions.staleness import stale_cutoff
+from apps.harness import actors
 from apps.workspaces import services as wsvc
 
 # HEARTBEAT_ONLINE_WINDOW lives on models.py (Runner.live_status uses it too;
@@ -226,11 +227,14 @@ def sweep_expired_leases() -> int:
 def load_assignment_rows(agent_ids) -> tuple[dict, dict]:
     """Load every ENABLED assignment row for these agents in one query, split into
     the two shapes routing needs: the per-agent default list (rank-ordered) and the
-    per-(agent, source) priority row.
+    per-(agent, source, actor) RULE — a rank-ordered LIST of rows, not one row
+    (spec 2026-09-05).
 
     enabled=False is filtered here, once, so a disabled row can neither claim nor
-    count as a better-ranked availability blocker — and a disabled SOURCE row means
-    the rule is simply off, falling back to the default list.
+    count as a better-ranked availability blocker. A rule whose rows are ALL
+    disabled therefore disappears entirely and its turns fall through — meaning
+    switching a rule off also switches its strictness off, which is what keeps
+    "off" from parking a queue.
     """
     defaults: dict = {}
     priorities: dict = {}
@@ -242,31 +246,51 @@ def load_assignment_rows(agent_ids) -> tuple[dict, dict]:
     )
     for row in rows:
         if row.source:
-            priorities[(row.agent_id, row.source)] = row
+            priorities.setdefault((row.agent_id, row.source, row.actor), []).append(row)
         else:
             defaults.setdefault(row.agent_id, []).append((row.rank, row.runner))
     return defaults, priorities
 
 
-def assignment_rows_for(agent_id, origin: str, defaults: dict, priorities: dict) -> list:
-    """THE ordered runner list for one (agent, source) pair — what the availability
-    cascade then walks. Pure: no queries, no clock.
+def assignment_rows_for(
+    agent_id, origin: str, actor: str, defaults: dict, priorities: dict
+) -> list:
+    """THE ordered runner list for one (agent, source, actor) triple — what the
+    availability cascade then walks. Pure: no queries, no clock.
+
+    The ladder is actor rule, then source rule (`actor=""`), then the default
+    order; `claim_next_turn` layers pins and session stickiness above it.
 
     Ranks are renumbered from 0 because the cascade compares them to decide who
-    blocks whom; a source row's stored rank is meaningless (one row per source) and
-    leaving it would put two runners at rank 0, each apparently blocking the other.
+    blocks whom; stored ranks are per-rule and would otherwise put two runners at
+    rank 0, each apparently blocking the other.
     """
     base = defaults.get(agent_id) or []
-    row = priorities.get((agent_id, origin))
-    if row is None:
+    exact = priorities.get((agent_id, origin, actor)) if actor else None
+    anyone = priorities.get((agent_id, origin, ""))
+    ladder = [rule for rule in (exact, anyone) if rule]
+    if not ladder:
         return [(i, r) for i, (_rank, r) in enumerate(base)]
-    if row.strict:
-        # That runner or nothing: the turn waits rather than degrading. Everyone
-        # else is absent from the list, so the wedged-runner grace cannot promote
-        # them either — which is what makes "and nowhere else" actually hold.
-        return [(0, row.runner)]
-    rest = [r for _rank, r in base if r.id != row.runner_id]
-    return [(0, row.runner)] + [(i + 1, r) for i, r in enumerate(rest)]
+
+    seen: set = set()
+    out: list = []
+    truncated = False
+    for rule in ladder:
+        for row in rule:  # already rank-ordered by load_assignment_rows
+            if row.runner_id not in seen:
+                seen.add(row.runner_id)
+                out.append(row.runner)
+        # "These runners or nothing": the turn waits rather than degrading.
+        # Everything below this rung is absent from the list, so the wedged-runner
+        # grace has nobody to promote — which is what makes "and nowhere else"
+        # actually hold. Appending the default order regardless would hand the work
+        # straight back to the runners the rule exists to exclude.
+        if rule[0].strict:
+            truncated = True
+            break
+    if not truncated:
+        out += [r for _rank, r in base if r.id not in seen]
+    return list(enumerate(out))
 
 
 def _kind_allows(runner: Runner, routing: str) -> bool:
@@ -293,7 +317,9 @@ def _assignment_allows_for_agent(runner: Runner, agent_id, turn: Turn,
     single-entry list, so every other runner reads as "not in the list" and the
     grace has nobody to promote.
     """
-    rows = assignment_rows_for(agent_id, turn.origin, defaults, priorities)
+    rows = assignment_rows_for(
+        agent_id, turn.origin, actors.actor_of(turn), defaults, priorities
+    )
     mine = next((rank for rank, r in rows if r.id == runner.id), None)
     if mine is None:
         return False
@@ -493,7 +519,13 @@ def unclaimable_queued_turns(user) -> list[dict]:
             routed_agent = t.agent_id
         if not routed_agent:
             return True  # project turn / agentless session: runner_target_q had the last word
-        rows = assignment_rows_for(routed_agent, t.origin, defaults, priorities)
+        # The SAME actor resolution the claim path uses. These two disagreeing is
+        # the drift class tests/test_claim_schedule_parity.py exists for: a strict
+        # actor rule pointing at an offline box must report `offline`
+        # (recoverable), never `config` (never runs).
+        rows = assignment_rows_for(
+            routed_agent, t.origin, actors.actor_of(t), defaults, priorities
+        )
         return any(rr.id == r.id for _rank, rr in rows)
 
     def _covered_by(rs) -> set:

--- a/apps/inbound/services.py
+++ b/apps/inbound/services.py
@@ -69,8 +69,17 @@ def online_runners_for(mailbox: InboundMailbox) -> list[Runner]:
     already filtered by `load_assignment_rows`.
     """
     defaults, priorities = harness.load_assignment_rows([mailbox.agent_id])
+    # actor="" DELIBERATELY: a Gmail push carries a mailbox, not a sender — the
+    # sender is only known after the `gog gmail thread get` the runner does AFTER
+    # this ring. So the doorbell composes at the SOURCE rung and rings that
+    # superset. Safe by this function's own design (it already rings every
+    # eligible runner rather than the best rank, and the enqueue is idempotent per
+    # (thread, messageCount)): under a strict actor rule the box that DISCOVERS a
+    # thread may not be the box that ANSWERS it — the enqueue lands, the discoverer
+    # is refused at claim time, and the rule's runner takes it on its own 5s claim
+    # poll. A ring we get wrong costs latency, never correctness (spec 2026-09-05).
     rows = harness.assignment_rows_for(
-        mailbox.agent_id, Turn.ORIGIN_EMAIL, defaults, priorities
+        mailbox.agent_id, Turn.ORIGIN_EMAIL, "", defaults, priorities
     )
     # `is_available`, not `live_status == ONLINE`: it is the cascade's own
     # availability probe (online AND self-reported ready), so "who might claim

--- a/docs/superpowers/specs/2026-09-05-actor-aware-runner-routing-design.md
+++ b/docs/superpowers/specs/2026-09-05-actor-aware-runner-routing-design.md
@@ -1,0 +1,380 @@
+# Actor-aware runner routing
+
+**Date:** 2026-09-05
+**Status:** Design — approved in outline, not yet built
+**Builds on:** `2026-07-27-source-aware-runner-routing-design.md` (source rules on
+`RunnerAssignment`, the `explicit → sticky → source → default` ladder,
+`assignment_rows_for`, the claim/unclaimable parity discipline)
+**Related:** `2026-07-24-directed-runner-routing-design.md`,
+`2026-07-25-cloud-agent-bootstrap-design.md`,
+ace-web `docs/plans/2026-07-26-run-convergence-ace-side.md`
+
+## Problem
+
+Multiplayer is built and switched off, and it is switched off for a routing reason.
+
+Everything the feature needs has shipped: multiplayer chat (SP3), ace-web's chat
+cutover, cross-app presence, run-execution convergence
+(`CANOPY_RUN_EXECUTION=true` is live in ace-web's deployed CloudFormation), and
+source-aware routing itself. `cloud-ec2-1` is online, ready, session-capable, and
+passed readiness drills for ace/echo/eva/hal on 2026-08-12/13 — the ACE drill ran
+`bin/ace-doctor` on the box end to end and returned *47 PASS / 13 WARN / 0 FAIL,
+HEALTHY*.
+
+It has nonetheless claimed **zero turns**. Measured over the 200 most recent turns,
+2026-08-17 → 2026-09-04:
+
+```
+39  canopy_scheduler -> jj-mbp-cdp        22  canopy_web_chat -> acedimagi-mbp-cdp
+34  email            -> jj-mbp-cdp        17  api             -> jj-mbp-cdp
+29  email            -> acedimagi-mbp-cdp 15  api             -> acedimagi-mbp-cdp
+24  canopy_scheduler -> acedimagi-mbp-cdp  9  canopy_web_chat -> jj-mbp-cdp
+                                           0  * -> cloud-ec2-1
+```
+
+`cloud-ec2-1` is `enabled: false` on **every** agent's assignment list, and no agent
+has a single source rule (`GET /api/agents/{slug}/runner-rules` → `[]` for all five).
+The CloudFormation comment justifying `CANOPY_RUN_EXECUTION=true` asserts *"the
+ace_web source rule is non-strict, so a dead cloud runner degrades to the laptop"* —
+that rule does not exist.
+
+The history says the switch-off was deliberate, not a regression. Sixteen canopy
+sessions carry `metadata.source=ace-web`, **all sixteen on 2026-07-28**: a bring-up
+arc (`ace toolchain probe`, `ace mcp tool probe`, `ace:status on the cloud runner`,
+`routing check: derived origin`) ending in `ace@ round-trip: ace-web -> cloud runner`
+and `/ace:run bednet-spot-check`, both bound to `cloud-ec2-1`. It worked. Then it was
+turned off and nothing has used it in five weeks.
+
+**Why it was turned off is the actual problem.** Source rules answer "which box runs
+this *kind* of work". They cannot answer "which box runs *this person's* work". So
+enabling the cloud runner is all-or-nothing per source: the moment `ace_web` or
+`email` routes to cloud, the operator's own debugging work goes there too — and the
+operator needs it local. The safe configuration is therefore "cloud off", which is
+the configuration that has held for five weeks and blocks every other person from
+using any of the shipped machinery.
+
+Granularity is not a follow-on to multiplayer. It is its precondition.
+
+## Two things that are not true, and would have mis-routed everything
+
+The obvious implementation — key rules on `Turn.enqueued_by_email` — is wrong twice,
+and both failures are silent.
+
+**`enqueued_by_email` on an email turn is not the sender.** It is set once, at
+`apps/harness/api.py:1030`, as `request.user` — the account the *runner* authenticates
+as when its inbox watcher POSTs the turn. All 63 email turns in the sample read
+`jjackson@dimagi.com` regardless of who wrote in:
+
+```
+enq= jjackson@dimagi.com  | from= Jonathan Jackson <jjackson@dimagi.com>
+enq= jjackson@dimagi.com  | from= Beth Geoffroy <egeoffroy@dimagi.com>
+enq= jjackson@dimagi.com  | from= Labs Alerts <no-reply@sns.amazonaws.com>
+```
+
+Keying on it would collapse every sender onto one rule. The true actor is
+`origin_ref["from"]`, which the runner already writes
+(`runner/canopy_runner/canopy_runner/inbox.py:145`).
+
+**Chat turns carry no actor at all.** 30/30 `canopy_web_chat` turns in the sample have
+`enqueued_by_email` empty, because `canopy_sessions/services.py` calls
+`harness_services.enqueue_turn(...)` without it. ace-web dispatches through that same
+session-send path (`apps/canopy/run_dispatch.py` → `client.send_message` →
+`POST /api/canopy-sessions/{id}/send`), so **`ace_web` turns would have no actor
+either** — the single most important source for this feature.
+
+So the actor must first be made *observable*, and it is not one field.
+
+## Decisions
+
+- **The actor is a resolved value, not a column.** One pure function maps a turn to
+  a normalized actor; each origin names where its actor lives. A second stored
+  column beside `origin_ref`/`enqueued_by` is exactly the two-overlapping-writers
+  mistake the source spec rejected when it declined to add `source` beside `origin`.
+- **`enqueued_by` gets set on the chat/ace-web send path.** Not a new field — a
+  field that already exists, already has the user in hand (`send_message(*, session,
+  text, user, ...)`), and simply isn't threaded through. This is the whole ace-web leg.
+- **Actor rules are the same rows as source rules**, with one more column.
+  `actor=""` means *any actor* — bit-for-bit today's behaviour, so no existing row
+  changes meaning and the migration cannot alter routing.
+- **One actor per row.** Two addresses for one person (Beth appears as both
+  `bgeoffroy@` and `egeoffroy@`) is two rows. No comma-lists, no cohort objects —
+  each rule stays independently toggleable and auditable, which is what "while we
+  work out the kinks" needs. `RunnerAssignment.rank` remains the escape hatch if an
+  ordered per-actor list is ever wanted.
+- **`strict` is per-rule, and stays per-rule.** It already is a boolean on the row;
+  actor rules inherit it unchanged. There is no global strict mode, and the direction
+  is not fixed: a strict rule pointing *at* cloud keeps other people's work off the
+  operator's laptop, and a strict rule pointing *at* the laptop keeps the operator's
+  work off cloud. Both are wanted, on the same agent, at the same time.
+- **Precedence extends rather than branches:**
+  `explicit pin → sticky session binding → (source, actor) → (source, "") → default order`.
+
+## Actor resolution
+
+```python
+def resolve_actor(origin: str, origin_ref: dict, enqueued_by_email: str) -> str
+```
+
+Pure, no queries, no clock. Returns a lowercased bare address, or `""` when the turn
+has no human actor.
+
+| origin | actor source | note |
+|---|---|---|
+| `email` | address parsed from `origin_ref["from"]` | `Beth Geoffroy <egeoffroy@dimagi.com>` → `egeoffroy@dimagi.com` |
+| `ace_web` | `enqueued_by.email` | the signed-in ace-web user, via the delegated token |
+| `canopy_web_chat` | `enqueued_by.email` | |
+| `slack` | `enqueued_by.email` | reserved; no producer yet, and needs none beyond setting `enqueued_by` |
+| `api` | `enqueued_by.email` | |
+| `canopy_scheduler` | `""` | a schedule has no live human. Extension point: `AgentSchedule.created_by` |
+
+Parsing is `email.utils.parseaddr` — it is stdlib, it is what wrote the header, and
+hand-rolled `<...>` slicing fails on quoted display names like
+`"Anthropic, PBC" <invoice+statements@mail.anthropic.com>`, which is a real value in
+the sample.
+
+A turn whose actor resolves to `""` matches no actor rule and falls through to the
+source rule, then the default list. That is the correct behaviour for every
+scheduler turn and for any turn enqueued by an unauthenticated caller.
+
+## The rule model
+
+`RunnerAssignment` gains one column:
+
+```python
+actor = models.CharField(max_length=254, blank=True, default="")   # 254 = RFC 5321
+```
+
+The `one_priority_runner_per_agent_source` constraint is replaced by:
+
+```python
+models.UniqueConstraint(
+    fields=["agent", "source", "actor"],
+    condition=~models.Q(source=""),
+    name="one_priority_runner_per_agent_source_actor",
+)
+```
+
+`one_default_assignment_per_agent_runner` (`condition=Q(source="")`) is untouched —
+a default row never carries an actor, and `actor` is not in its key.
+
+No existing row has a non-empty `actor`, so the swap cannot fail and every current
+rule keeps meaning exactly what it means today.
+
+### Claim-time composition
+
+`assignment_rows_for` gains one parameter and one rung. It stays pure.
+
+```python
+def assignment_rows_for(agent_id, origin, actor, defaults, priorities) -> list:
+    base = defaults.get(agent_id) or []
+    exact = priorities.get((agent_id, origin, actor)) if actor else None
+    anyone = priorities.get((agent_id, origin, ""))
+    ladder = [row for row in (exact, anyone) if row is not None]
+    if not ladder:
+        return [(i, r) for i, (_rank, r) in enumerate(base)]
+
+    seen, out, truncated = set(), [], False
+    for row in ladder:                            # actor rule, then source rule …
+        if row.runner_id not in seen:
+            seen.add(row.runner_id)
+            out.append(row.runner)
+        if row.strict:                            # "that runner or nothing":
+            truncated = True                      # nothing below this rung may claim
+            break
+    if not truncated:
+        out += [r for _rank, r in base if r.id not in seen]   # … then the default order
+    return list(enumerate(out))
+```
+
+**Any strict rung truncates the list at itself** — that is what makes "and nowhere
+else" actually hold, and it is why the default order must be appended only when no
+rung truncated. Appending it unconditionally would let a strict rule leak work back
+to the very runners it exists to exclude, and the wedged-runner grace would then
+promote them after 60s. (Writing that bug and catching it in review is the reason
+this block is spelled out rather than described.)
+
+A non-strict actor rule composes down through the source rule and then the default
+order — honouring both layers rather than skipping the middle one, which would make
+a source rule silently inert for anyone who also had an actor rule.
+
+`load_assignment_rows` keys `priorities` on `(agent_id, source, actor)` instead of
+`(agent_id, source)`. It stays one query.
+
+`_assignment_allows_for_agent` resolves the actor from the turn it already holds and
+passes it through. Rank renumbering, `is_available`, `enabled`, the 60s
+`CASCADE_GRACE_SECONDS` and drills are all untouched — the cascade walks whatever
+list it is handed.
+
+### The two other callers
+
+**`unclaimable_queued_turns` must resolve the actor the same way.** These two
+disagreeing is the drift class this codebase already has a parity test for
+(`tests/test_claim_schedule_parity.py`); coverage becomes per-`(agent, origin, actor)`.
+A strict actor rule pointing at an offline box must report `offline` (recoverable),
+never `config` (never runs).
+
+**`inbound.online_runners_for` rings with `actor=""`, and that asymmetry is
+deliberate.** A Gmail push carries a mailbox, not a sender — the sender is only known
+after `gog gmail thread get`, which happens on the runner *after* the ring. So the
+doorbell composes at the source rung and rings that set. This is safe and is already
+the module's stated design: it rings *all* eligible runners rather than the best rank,
+the enqueue is idempotent per `(thread, messageCount)`, and a ring we get wrong costs
+latency, never correctness. Concretely: a strict `(ace, email, stewari@) → cloud` rule
+means the laptop may be the box that *discovers* Sarvesh's thread while cloud is the
+box that *answers* it — the enqueue lands, the laptop is refused at claim time, and
+cloud takes it on its own 5s claim poll. Stated here because it will otherwise be
+re-derived as a bug.
+
+## API
+
+`AgentRunnerRuleOut` and `AgentRunnerRuleIn` gain `actor: str = ""`.
+
+- **Dedupe key in `replace_agent_runner_rules` becomes `(source, actor)`**, and the
+  422 message becomes `"one rule per (source, actor): duplicate in list"`. The
+  existing wholesale-replace discipline is unchanged, as is its scoping to
+  `.exclude(source="")` — the default-list PUT must still not clobber rules, and
+  vice versa.
+- **`actor` is normalized at the boundary** (lowercase, `parseaddr`'d) so a rule
+  written as `Sarvesh Tewari <STewari@dimagi.com>` matches a turn from
+  `stewari@dimagi.com`. A rule that cannot be normalized to something containing `@`
+  is a 422, not a row that silently never matches.
+- **`queued_count` becomes per-`(source, actor)`.** Today it is one `values_list("origin")
+  .annotate(Count)`. With actors it must resolve the actor of each queued turn, so it
+  becomes a small Python group-by over `Turn.objects.filter(agent, status=QUEUED)
+  .only("origin", "origin_ref", "enqueued_by")`. Queued sets are single digits in
+  practice; this is not a hot path, and getting it wrong makes the parked warning lie.
+- `GET`/`PUT` paths, auth, and `_runner_visibility_q` gating are unchanged.
+
+Regenerate `frontend/src/api/generated.ts` (`npm run gen:api`) — `regen-openapi.yml`
+fails the PR otherwise.
+
+## UI — Runners tab
+
+`RunnerSourceRules.tsx` keeps its shape; each rule line gains an optional actor field.
+
+```
+▾ Ace
+    DEFAULT ORDER
+    [1 ● jj-mbp-cdp emdash ↑ ↓ ⏻]  [2 ● acedimagi-mbp emdash ↑ ↓ ⏻]  [+ add]
+
+    EXCEPT WHEN THE WORK COMES FROM
+    email    from [stewari@dimagi.com]  →  [● cloud-ec2-1 ▾]  ( only | fall through )  ✕
+    ace_web  from [stewari@dimagi.com]  →  [● cloud-ec2-1 ▾]  ( only | fall through )  ✕
+    email    from [anyone            ]  →  [● jj-mbp-cdp  ▾]  ( only | fall through )  ✕
+    [+ rule]
+```
+
+- The actor field is free text with placeholder `anyone`; empty renders as `anyone`
+  and stores `""`, which is today's source rule. **The existing rules keep rendering
+  and editing identically** — this is the property that makes the UI change additive.
+- The source picker no longer excludes a source that already has a rule (several
+  actors may share one source); it excludes only exact `(source, actor)` duplicates,
+  which is what the API validates.
+- Rules sort by `(source, actor)` with `actor=""` last, so the specific rules read
+  above the catch-all — matching the order the cascade evaluates them in.
+- The parked warning keeps its count and gains the actor:
+  *"⚠ cloud-ec2-1 is offline — 3 ace_web turns from stewari@dimagi.com are parked,
+  and will stay parked."*
+- The precedence ladder is stated once where rules are edited, updated to five rungs.
+
+## Migration
+
+1. Add `RunnerAssignment.actor`; swap `one_priority_runner_per_agent_source` for the
+   three-field constraint. No data migration — every existing row gets `actor=""`,
+   which is its current meaning.
+2. `canopy_sessions/services.py`: thread `user` into `enqueue_turn(..., enqueued_by=user)`
+   on **both** send paths — `send_message` and `_send_transcript_sourced_message`
+   (the latter needs `user` added to its signature; it does not take one today).
+3. `harness/services.py`: `load_assignment_rows` re-keys; `assignment_rows_for` gains
+   `actor`; `_assignment_allows_for_agent` resolves and passes it.
+4. `harness/actors.py` (new): `resolve_actor`. Pure, unit-tested against the real
+   header shapes observed in production.
+5. `unclaimable_queued_turns` and `inbound.online_runners_for` updated per above.
+6. API schemas, endpoint, generated types, `RunnerSourceRules.tsx`.
+
+Migrations run before cutover, so old code briefly meets the new schema — an added
+nullable-defaulted varchar and a swapped conditional constraint are both compatible
+with it, and old code composing without an actor gets precisely today's behaviour.
+
+## Day-one configuration (the flip)
+
+The point of the work. Applied **after** the code lands and a real round-trip is
+verified, not before.
+
+| agent | default order | rules |
+|---|---|---|
+| **ace** | unchanged: `[1 jj-mbp-cdp] [2 acedimagi-mbp-cdp]` | `(email, stewari@dimagi.com) → cloud-ec2-1` **only**<br>`(ace_web, stewari@dimagi.com) → cloud-ec2-1` **only**<br>`(email, <matt>) → cloud-ec2-1` **only**<br>`(ace_web, <matt>) → cloud-ec2-1` **only** |
+| **echo** | `[1 cloud-ec2-1] [2 jj-mbp-cdp] [3 acedimagi-mbp-cdp]` | `(email, jjackson@dimagi.com) → jj-mbp-cdp` **only**<br>`(canopy_web_chat, jjackson@dimagi.com) → jj-mbp-cdp` **only**<br>`(api, jjackson@dimagi.com) → jj-mbp-cdp` **only** |
+| **eva, hal, ada** | unchanged (laptop-default) | none |
+
+ACE is an **allowlist to cloud**: named people go to the cloud box, everything else —
+including all of the operator's own work — stays local while the kinks get worked out.
+Echo is the inverse, cloud-default with the operator carved back out, because Echo
+already declares `runner_preference: ['cloud','emdash']`.
+
+Strict in both directions is deliberate: strict cloud rules keep other people's work
+off the operator's laptop (the isolation the whole feature exists for), and strict
+laptop rules keep the operator's work off cloud.
+
+**Two prerequisites this config depends on, both currently unmet:**
+
+- **`cloud-ec2-1` must be `enabled: true`** on ace and echo. It is `enabled: false`
+  on all five agents today. An actor rule is its own row with its own toggle, so the
+  rule rows can be enabled without touching ace's default list — but echo's
+  cloud-default *does* require flipping the existing row.
+- **`jj-mbp-cdp` is paused** (`~/.canopy/PAUSED`, since 2026-08-27) and reads
+  `online: false`. Every strict rule pointing at it will park immediately. That is
+  the toggle working as specified, and the UI will say so with a count — but it must
+  be an expected outcome, not a surprise. Unpause before applying echo's rules.
+
+`<matt>`'s address is the one input not yet resolved; it is not in `config/allowlist.txt`
+(which is domain-wide `@dimagi.com`) and no fleet turn carries it.
+
+## Testing
+
+Extends `tests/test_source_rules.py` and the parity discipline rather than starting a
+new suite.
+
+- **Resolution** — every row of the actor table, against the real header shapes:
+  bare address, `Display Name <addr>`, `"Quoted, Name" <addr>`, empty, malformed.
+  Case-folding. `canopy_scheduler` → `""`.
+- **Composition** — no rule → default; actor rule non-strict → actor, source, defaults
+  deduped in that order; actor rule strict → that runner only; actor rule absent but
+  source rule present → today's behaviour exactly; disabled actor rule → falls to
+  source rule; actor `""` rule behaves identically to a pre-migration source rule.
+- **Strictness holds past the grace** — a queued strict actor turn older than
+  `CASCADE_GRACE_SECONDS` still refuses every non-priority runner.
+- **Precedence** — a pinned turn ignores a contradicting actor rule; a bound session
+  ignores one; an actor rule beats a source rule beats the default order.
+- **Parity** — `unclaimable_queued_turns` and `claim_next_turn` agree per
+  `(agent, origin, actor)`.
+- **The wipe** — `PUT /runners` leaves actor rules intact; `PUT /runner-rules`
+  leaves the default order intact; two rules differing only in `actor` both survive.
+- **Frontend** — `RunnerSourceRules.test.tsx` changes shape: `availableSources()`
+  must stop excluding a source that already has a rule (several actors share one
+  source) and `nextRulesForRemove()` must key on `(source, actor)`. Both existing
+  assertions are wrong under this design and must be updated, not deleted — a rule
+  with `actor=""` is still one-per-source.
+- **Producer** — a chat send and an ace-web dispatch both land a turn whose
+  `enqueued_by` is the sending user; an email turn's actor is the sender, **not**
+  `enqueued_by`. This is the regression test for the two false assumptions above.
+- **Doorbell** — `online_runners_for` composes at the source rung and is unaffected
+  by a strict actor rule (it rings the superset).
+- **End to end, the three real cases:** `(ace, email, stewari@) → cloud strict` while
+  `(ace, email, jjackson@) → default laptops`; `(echo, email, jjackson@) → jj-mbp
+  strict` while echo's default is cloud; a scheduler turn matches no actor rule.
+
+## Out of scope
+
+- **A Slack producer.** `slack` is already a reserved origin and needs nothing here
+  beyond setting `enqueued_by` when it lands; actor rules will work on it for free.
+- **Actor cohorts / groups.** One actor per row, deliberately. Revisit if the rule
+  list outgrows a screen.
+- **Scheduler actors** (`AgentSchedule.created_by`). Named as the extension point;
+  no current need routes on it.
+- **Retiring `turn_driver`** (ace-web Task 12). Unblocked by this work in principle —
+  its precondition was a session-capable cloud runner actually taking ace-web's
+  turns — but it is ace-web's change and its own decision.
+- **Hard workspace isolation** between ace workspaces on canopy (the residual
+  documented in ace-web's `CLAUDE.md`: session LIST is scoped by `origin_key`, but a
+  canopy workspace member can still open a session by id). Unrelated to routing.

--- a/docs/superpowers/specs/2026-09-05-actor-aware-runner-routing-design.md
+++ b/docs/superpowers/specs/2026-09-05-actor-aware-runner-routing-design.md
@@ -21,16 +21,21 @@ passed readiness drills for ace/echo/eva/hal on 2026-08-12/13 — the ACE drill 
 `bin/ace-doctor` on the box end to end and returned *47 PASS / 13 WARN / 0 FAIL,
 HEALTHY*.
 
-It has nonetheless claimed **zero turns**. Measured over the 200 most recent turns,
-2026-08-17 → 2026-09-04:
+It has nonetheless claimed **zero turns**. Of the 100 turns created since the
+operator paused the `jj-mbp-cdp` account on 2026-08-27:
 
 ```
-39  canopy_scheduler -> jj-mbp-cdp        22  canopy_web_chat -> acedimagi-mbp-cdp
-34  email            -> jj-mbp-cdp        17  api             -> jj-mbp-cdp
-29  email            -> acedimagi-mbp-cdp 15  api             -> acedimagi-mbp-cdp
-24  canopy_scheduler -> acedimagi-mbp-cdp  9  canopy_web_chat -> jj-mbp-cdp
-                                           0  * -> cloud-ec2-1
+ 89  -> acedimagi-mbp-cdp
+ 11  -> (unclaimed)
+  0  -> jj-mbp-cdp        (the pause working correctly)
+  0  -> cloud-ec2-1
 ```
+
+Every claimed turn in the fleet — five agents, every source — lands on a single
+macOS account on the operator's own machine. Widening to the last 200 turns
+(2026-08-17 →) splits those claims across `jj-mbp-cdp` and `acedimagi-mbp-cdp`, but
+that is the *same operator on two accounts* before and after a pause, not two
+people; `cloud-ec2-1` is still at zero across the whole window.
 
 `cloud-ec2-1` is `enabled: false` on **every** agent's assignment list, and no agent
 has a single source rule (`GET /api/agents/{slug}/runner-rules` → `[]` for all five).
@@ -96,11 +101,22 @@ So the actor must first be made *observable*, and it is not one field.
 - **Actor rules are the same rows as source rules**, with one more column.
   `actor=""` means *any actor* — bit-for-bit today's behaviour, so no existing row
   changes meaning and the migration cannot alter routing.
-- **One actor per row.** Two addresses for one person (Beth appears as both
-  `bgeoffroy@` and `egeoffroy@`) is two rows. No comma-lists, no cohort objects —
+- **One actor per rule.** Two addresses for one person (Beth appears as both
+  `bgeoffroy@` and `egeoffroy@`) is two rules. No comma-lists, no cohort objects —
   each rule stays independently toggleable and auditable, which is what "while we
-  work out the kinks" needs. `RunnerAssignment.rank` remains the escape hatch if an
-  ordered per-actor list is ever wanted.
+  work out the kinks" needs.
+- **A rule is an ordered LIST of runners, not one runner.** This is a change from
+  the source-rule model, and it is forced by the operator's actual topology:
+  `jj-mbp-cdp` and `acedimagi-mbp-cdp` are two macOS accounts on the operator's
+  own machine, alternated as each runs out of tokens. So "my work stays on my
+  boxes, never cloud" names *two* runners whose live one **rotates**. A
+  single-runner rule cannot say it: strict names one box and parks whenever the
+  other account is the active one, and non-strict falls through to the default
+  order — which, on a cloud-default agent, puts cloud *above* the operator's other
+  laptop and lands the work in exactly the place the rule existed to avoid.
+  The source spec left the door open for this, keeping `rank` on the row because
+  *"the column stays free for a future ordered source list without another
+  migration."* This is that future; `rank` becomes meaningful within a rule.
 - **`strict` is per-rule, and stays per-rule.** It already is a boolean on the row;
   actor rules inherit it unchanged. There is no global strict mode, and the direction
   is not fixed: a strict rule pointing *at* cloud keeps other people's work off the
@@ -144,41 +160,60 @@ scheduler turn and for any turn enqueued by an unauthenticated caller.
 actor = models.CharField(max_length=254, blank=True, default="")   # 254 = RFC 5321
 ```
 
-The `one_priority_runner_per_agent_source` constraint is replaced by:
+A **rule** is now the set of rows sharing `(agent, source, actor)`, ordered by `rank`.
+The `one_priority_runner_per_agent_source` constraint — which capped a rule at one
+runner — is replaced by one that caps a *runner* at one appearance per rule:
 
 ```python
 models.UniqueConstraint(
-    fields=["agent", "source", "actor"],
+    fields=["agent", "source", "actor", "runner"],
     condition=~models.Q(source=""),
-    name="one_priority_runner_per_agent_source_actor",
+    name="one_row_per_runner_per_agent_source_actor",
 )
 ```
 
 `one_default_assignment_per_agent_runner` (`condition=Q(source="")`) is untouched —
 a default row never carries an actor, and `actor` is not in its key.
 
-No existing row has a non-empty `actor`, so the swap cannot fail and every current
-rule keeps meaning exactly what it means today.
+Two properties are rule-level but stored per row:
+
+- **`strict`** must agree across every row of a rule; the API writes one value to
+  all of them and the composer reads the first. Enforced on write (422), not left
+  to disagree silently.
+- **`enabled`** stays genuinely per row, so one runner can be dropped from a rule
+  without deleting it. A rule whose rows are *all* disabled vanishes from
+  `load_assignment_rows` and the turn falls through — which is the existing
+  documented semantics ("a disabled source row is simply the rule switched off"),
+  and it means **disabling a strict rule also disables its strictness**. That is
+  intended and worth stating: switching a rule off must not park a queue.
+
+Relaxing a uniqueness constraint can never fail on existing data, and no existing
+row has a non-empty `actor`, so every current rule keeps meaning exactly what it
+means today — a one-runner rule is just a rule of length one.
 
 ### Claim-time composition
 
 `assignment_rows_for` gains one parameter and one rung. It stays pure.
+
+`priorities` maps `(agent_id, source, actor)` to a **rank-ordered list of rows** —
+the rule — rather than to a single row.
 
 ```python
 def assignment_rows_for(agent_id, origin, actor, defaults, priorities) -> list:
     base = defaults.get(agent_id) or []
     exact = priorities.get((agent_id, origin, actor)) if actor else None
     anyone = priorities.get((agent_id, origin, ""))
-    ladder = [row for row in (exact, anyone) if row is not None]
+    ladder = [rule for rule in (exact, anyone) if rule]
     if not ladder:
         return [(i, r) for i, (_rank, r) in enumerate(base)]
 
     seen, out, truncated = set(), [], False
-    for row in ladder:                            # actor rule, then source rule …
-        if row.runner_id not in seen:
-            seen.add(row.runner_id)
-            out.append(row.runner)
-        if row.strict:                            # "that runner or nothing":
+    for rule in ladder:                           # actor rule, then source rule …
+        for row in rule:                          # … each already rank-ordered
+            if row.runner_id not in seen:
+                seen.add(row.runner_id)
+                out.append(row.runner)
+        if rule[0].strict:                        # "these runners or nothing":
             truncated = True                      # nothing below this rung may claim
             break
     if not truncated:
@@ -227,11 +262,38 @@ re-derived as a bug.
 
 ## API
 
-`AgentRunnerRuleOut` and `AgentRunnerRuleIn` gain `actor: str = ""`.
+**`AgentRunnerRuleOut` stays flat — one entry per row**, gaining `actor` and `rank`.
+A rule of two runners is two entries sharing `(source, actor)`; the UI groups them.
+Keeping it flat preserves the shape the frontend already consumes (`runner_name`,
+`kind`, `online`, `ready`, `enabled` per runner) instead of nesting it, and the
+derived-liveness fields are per runner anyway.
 
-- **Dedupe key in `replace_agent_runner_rules` becomes `(source, actor)`**, and the
-  422 message becomes `"one rule per (source, actor): duplicate in list"`. The
-  existing wholesale-replace discipline is unchanged, as is its scoping to
+**`AgentRunnerRuleIn` becomes rule-shaped**, reusing the row schema the default-list
+PUT already has:
+
+```python
+class AgentRunnerRuleIn(StrictModel):
+    source: RoutableSource
+    actor: str = ""                      # "" = any actor (today's source rule)
+    runners: list[AgentRunnerRowIn]      # ORDERED; rank = list index
+    strict: bool = False                 # rule-level; written to every row
+```
+
+This drops the rule-level `enabled` in favour of the per-row `enabled` inside
+`AgentRunnerRowIn`. That is a breaking change to the request body — acceptable
+because the endpoint's only consumer is canopy-web's own frontend and **there are
+zero rules in production today** (all five agents return `[]`), so there is no
+migration to perform and no third-party caller to break. Worth doing now rather
+than after rules exist.
+
+- **Dedupe key in `replace_agent_runner_rules` becomes `(source, actor)`** across
+  rules, and `runner_id` within a rule; the 422s are
+  `"one rule per (source, actor): duplicate in list"` and
+  `"a runner may appear once per rule: duplicate runner in <source>/<actor>"`.
+- **An empty `runners` list is a 422**, not a rule that matches and yields nothing.
+  A zero-length strict rule would compose to an empty list and park the queue with
+  no runner named as the reason — deleting the rule is how you turn it off.
+- The existing wholesale-replace discipline is unchanged, as is its scoping to
   `.exclude(source="")` — the default-list PUT must still not clobber rules, and
   vice versa.
 - **`actor` is normalized at the boundary** (lowercase, `parseaddr`'d) so a rule
@@ -243,6 +305,8 @@ re-derived as a bug.
   becomes a small Python group-by over `Turn.objects.filter(agent, status=QUEUED)
   .only("origin", "origin_ref", "enqueued_by")`. Queued sets are single digits in
   practice; this is not a hot path, and getting it wrong makes the parked warning lie.
+  Every row of a rule repeats its rule's count — the parked queue belongs to the
+  rule, not to one runner in it.
 - `GET`/`PUT` paths, auth, and `_runner_visibility_q` gating are unchanged.
 
 Regenerate `frontend/src/api/generated.ts` (`npm run gen:api`) — `regen-openapi.yml`
@@ -253,20 +317,26 @@ fails the PR otherwise.
 `RunnerSourceRules.tsx` keeps its shape; each rule line gains an optional actor field.
 
 ```
-▾ Ace
+▾ Echo
     DEFAULT ORDER
-    [1 ● jj-mbp-cdp emdash ↑ ↓ ⏻]  [2 ● acedimagi-mbp emdash ↑ ↓ ⏻]  [+ add]
+    [1 ● cloud-ec2-1 cloud ↑ ↓ ⏻]  [2 ● acedimagi-mbp emdash ↑ ↓ ⏻]  [3 ● jj-mbp-cdp emdash ↑ ↓ ⏻]  [+ add]
 
     EXCEPT WHEN THE WORK COMES FROM
-    email    from [stewari@dimagi.com]  →  [● cloud-ec2-1 ▾]  ( only | fall through )  ✕
-    ace_web  from [stewari@dimagi.com]  →  [● cloud-ec2-1 ▾]  ( only | fall through )  ✕
-    email    from [anyone            ]  →  [● jj-mbp-cdp  ▾]  ( only | fall through )  ✕
+    email   from [jjackson@dimagi.com]  →  [1 ● acedimagi-mbp ↑ ↓ ⏻] [2 ● jj-mbp-cdp ↑ ↓ ⏻] [+]   ( only | fall through )  ✕
+    api     from [jjackson@dimagi.com]  →  [1 ● acedimagi-mbp ↑ ↓ ⏻] [2 ● jj-mbp-cdp ↑ ↓ ⏻] [+]   ( only | fall through )  ✕
+    email   from [anyone             ]  →  [1 ● cloud-ec2-1  ↑ ↓ ⏻]                          [+]   ( only | fall through )  ✕
     [+ rule]
 ```
 
+- **A rule's runners render as the same rank chip row the default order uses**,
+  with the same `↑ ↓ ⏻` affordances and the same optimistic-commit machinery
+  (`rowsRef`, `commitSeqRef`). One interaction model for both, rather than a
+  dropdown for rules and chips for the default list.
 - The actor field is free text with placeholder `anyone`; empty renders as `anyone`
-  and stores `""`, which is today's source rule. **The existing rules keep rendering
-  and editing identically** — this is the property that makes the UI change additive.
+  and stores `""`, which is today's source rule. **A pre-existing one-runner source
+  rule keeps rendering and editing identically** — it is simply a rule of length
+  one — which is the property that makes this change additive rather than a
+  migration of the UI's mental model.
 - The source picker no longer excludes a source that already has a rule (several
   actors may share one source); it excludes only exact `(source, actor)` duplicates,
   which is what the API validates.
@@ -280,8 +350,10 @@ fails the PR otherwise.
 ## Migration
 
 1. Add `RunnerAssignment.actor`; swap `one_priority_runner_per_agent_source` for the
-   three-field constraint. No data migration — every existing row gets `actor=""`,
-   which is its current meaning.
+   four-field `one_row_per_runner_per_agent_source_actor`. No data migration —
+   every existing row gets `actor=""`, which is its current meaning, and `rank`
+   (previously written `0` and ignored on a source row) becomes meaningful within a
+   rule while `0` stays correct for a rule of length one.
 2. `canopy_sessions/services.py`: thread `user` into `enqueue_turn(..., enqueued_by=user)`
    on **both** send paths — `send_message` and `_send_transcript_sourced_message`
    (the latter needs `user` added to its signature; it does not take one today).
@@ -301,34 +373,58 @@ with it, and old code composing without an actor gets precisely today's behaviou
 The point of the work. Applied **after** the code lands and a real round-trip is
 verified, not before.
 
+**`OPERATOR_BOXES` = `[acedimagi-mbp-cdp, jj-mbp-cdp]`** — one machine, two macOS
+accounts, alternated as each runs out of tokens. `acedimagi` is listed first because
+it is the live one (100% of the 100 turns since the 2026-08-27 pause). Any rule that
+means "the operator's own work" names **both, in that order** — never one.
+
 | agent | default order | rules |
 |---|---|---|
-| **ace** | unchanged: `[1 jj-mbp-cdp] [2 acedimagi-mbp-cdp]` | `(email, stewari@dimagi.com) → cloud-ec2-1` **only**<br>`(ace_web, stewari@dimagi.com) → cloud-ec2-1` **only**<br>`(email, <matt>) → cloud-ec2-1` **only**<br>`(ace_web, <matt>) → cloud-ec2-1` **only** |
-| **echo** | `[1 cloud-ec2-1] [2 jj-mbp-cdp] [3 acedimagi-mbp-cdp]` | `(email, jjackson@dimagi.com) → jj-mbp-cdp` **only**<br>`(canopy_web_chat, jjackson@dimagi.com) → jj-mbp-cdp` **only**<br>`(api, jjackson@dimagi.com) → jj-mbp-cdp` **only** |
-| **eva, hal, ada** | unchanged (laptop-default) | none |
+| **ace** | unchanged: `OPERATOR_BOXES` | `(email, stewari@dimagi.com) → [cloud-ec2-1]` **only**<br>`(ace_web, stewari@dimagi.com) → [cloud-ec2-1]` **only**<br>`(email, <matt>) → [cloud-ec2-1]` **only**<br>`(ace_web, <matt>) → [cloud-ec2-1]` **only** |
+| **echo** | `[1 cloud-ec2-1] + OPERATOR_BOXES` | `(email, jjackson@dimagi.com) → OPERATOR_BOXES` **only**<br>`(canopy_web_chat, jjackson@dimagi.com) → OPERATOR_BOXES` **only**<br>`(api, jjackson@dimagi.com) → OPERATOR_BOXES` **only** |
+| **eva, hal, ada** | unchanged (operator-default) | none |
 
 ACE is an **allowlist to cloud**: named people go to the cloud box, everything else —
-including all of the operator's own work — stays local while the kinks get worked out.
-Echo is the inverse, cloud-default with the operator carved back out, because Echo
-already declares `runner_preference: ['cloud','emdash']`.
+including all of the operator's own work — stays on the operator's boxes while the
+kinks get worked out. Note ACE therefore needs **no rule for the operator at all**:
+its default order is already exactly `OPERATOR_BOXES`.
+
+Echo is the inverse — cloud-default, with the operator carved back out by rule. That
+carve-out is the case that *requires* multi-runner rules, and it is why the model
+changed.
 
 Strict in both directions is deliberate: strict cloud rules keep other people's work
-off the operator's laptop (the isolation the whole feature exists for), and strict
-laptop rules keep the operator's work off cloud.
+off the operator's boxes (the isolation the whole feature exists for), and the strict
+operator rules keep the operator's work off cloud without pinning it to whichever
+account happens to be logged out.
 
-**Two prerequisites this config depends on, both currently unmet:**
+**One prerequisite this config depends on, currently unmet:**
 
-- **`cloud-ec2-1` must be `enabled: true`** on ace and echo. It is `enabled: false`
-  on all five agents today. An actor rule is its own row with its own toggle, so the
-  rule rows can be enabled without touching ace's default list — but echo's
-  cloud-default *does* require flipping the existing row.
-- **`jj-mbp-cdp` is paused** (`~/.canopy/PAUSED`, since 2026-08-27) and reads
-  `online: false`. Every strict rule pointing at it will park immediately. That is
-  the toggle working as specified, and the UI will say so with a count — but it must
-  be an expected outcome, not a surprise. Unpause before applying echo's rules.
+- **`cloud-ec2-1` must be `enabled: true`.** It is `enabled: false` on all five
+  agents today, which is the single reason it has claimed nothing. An actor rule is
+  its own row with its own toggle, so ace's rule rows can be enabled without touching
+  ace's default list — but echo's cloud-default *does* require flipping the existing
+  rank-2 row and re-ranking it to 0.
+
+**Not a prerequisite, contrary to an earlier draft of this spec:** `jj-mbp-cdp` being
+paused does not need fixing before applying these rules. Under the multi-runner model
+its rules also name `acedimagi-mbp-cdp`, which is online — so a paused account
+degrades within the rule instead of parking the queue. Removing that prerequisite is
+the concrete payoff of the model change.
+
+**Correction worth recording:** an earlier draft singled Echo out because it was the
+only agent with a non-empty `Agent.runner_preference` (`['cloud','emdash']`). That
+field does not route. It is read in exactly one place —
+`harness/services.seed_assignments_from_capabilities`, the one-time bridge behind
+data migration `0024_seed_runner_assignments` — and the frontend calls it "the
+deprecated kind-based `runner_preference` … supersed[ed] by RunnerAssignment". All
+five agents have identical live routing config. Echo's selection here is a product
+choice, not a reflection of existing state, and `runner_preference` should be treated
+as vestigial by anything reasoning about routing.
 
 `<matt>`'s address is the one input not yet resolved; it is not in `config/allowlist.txt`
-(which is domain-wide `@dimagi.com`) and no fleet turn carries it.
+(which is domain-wide `@dimagi.com`) and no fleet turn carries it. ACE's other three
+rules do not depend on it and can ship first.
 
 ## Testing
 
@@ -338,10 +434,18 @@ new suite.
 - **Resolution** — every row of the actor table, against the real header shapes:
   bare address, `Display Name <addr>`, `"Quoted, Name" <addr>`, empty, malformed.
   Case-folding. `canopy_scheduler` → `""`.
-- **Composition** — no rule → default; actor rule non-strict → actor, source, defaults
-  deduped in that order; actor rule strict → that runner only; actor rule absent but
-  source rule present → today's behaviour exactly; disabled actor rule → falls to
-  source rule; actor `""` rule behaves identically to a pre-migration source rule.
+- **Composition** — no rule → default; actor rule non-strict → actor rule's runners
+  in rank order, then the source rule's, then defaults, deduped; actor rule strict →
+  that rule's runners **and no others**; actor rule absent but source rule present →
+  today's behaviour exactly; a rule whose rows are all disabled → falls through
+  (and its strictness falls through with it); actor `""` rule of length one behaves
+  identically to a pre-migration source rule.
+- **Multi-runner rules — the case the model exists for.** A strict two-runner rule
+  `(echo, email, jjackson@) → [acedimagi, jj-mbp]` composes to exactly those two in
+  that order, never cloud; with `acedimagi` unavailable it yields `jj-mbp` rather
+  than parking; with **both** unavailable it parks rather than falling to cloud.
+  All three are asserted, because the middle one is the whole point and the third is
+  what makes it strict.
 - **Strictness holds past the grace** — a queued strict actor turn older than
   `CASCADE_GRACE_SECONDS` still refuses every non-priority runner.
 - **Precedence** — a pinned turn ignores a contradicting actor rule; a bound session
@@ -368,8 +472,12 @@ new suite.
 
 - **A Slack producer.** `slack` is already a reserved origin and needs nothing here
   beyond setting `enqueued_by` when it lands; actor rules will work on it for free.
-- **Actor cohorts / groups.** One actor per row, deliberately. Revisit if the rule
-  list outgrows a screen.
+- **Actor cohorts / groups.** One actor per rule, deliberately — two people wanting
+  the same routing is two rules. Revisit if the rule list outgrows a screen. (The
+  *runner* side is now a list; the *actor* side is deliberately not.)
+- **Retiring `Agent.runner_preference`.** Confirmed vestigial by this work — read
+  only by the `0024` seed bridge, described as deprecated by the frontend. Deleting
+  it is a separate, unrelated cleanup and touches the agents API surface.
 - **Scheduler actors** (`AgentSchedule.created_by`). Named as the extension point;
   no current need routes on it.
 - **Retiring `turn_driver`** (ace-web Task 12). Unblocked by this work in principle —

--- a/frontend/src/api/agents.ts
+++ b/frontend/src/api/agents.ts
@@ -254,7 +254,7 @@ export async function getAgentRunnerRules(slug: string): Promise<AgentRunnerRule
 
 export async function putAgentRunnerRules(
   slug: string,
-  rules: readonly { source: string; runnerId: string; strict: boolean }[],
+  rules: readonly { source: string; actor: string; runnerIds: readonly string[]; strict: boolean }[],
 ): Promise<AgentRunnerRuleOut[]> {
   const res = await apiV2.PUT('/api/agents/{slug}/runner-rules', {
     params: { path: { slug } },
@@ -264,12 +264,21 @@ export async function putAgentRunnerRules(
         // .source is a plain string (output schemas serialize what the DB holds),
         // so casting to it would type-check nothing.
         source: r.source as RoutableSource,
-        runner_id: r.runnerId,
+        // '' = any actor, which is what a rule meant before actors existed. The
+        // server normalizes (a pasted "Name <addr>" header resolves to the bare
+        // lowercase address) and 422s anything that isn't address-shaped.
+        actor: r.actor,
+        // ORDER IS THE PREFERENCE: rank is the index. A rule names several
+        // runners because the operator's two macOS accounts alternate, so the
+        // live one rotates (spec 2026-09-05).
+        runners: r.runnerIds.map((id) => ({
+          runner_id: id,
+          // Always enabled: this editor has no per-runner disable affordance —
+          // a runner you don't want in a rule is removed from it (cheap to
+          // re-add). The server keeps `enabled` per row for the API's sake.
+          enabled: true,
+        })),
         strict: r.strict,
-        // Always sent: the generated body type requires it, and this editor has
-        // no disable affordance — a rule you don't want is deleted (cheap to
-        // re-add), so every rule it writes is an enabled one.
-        enabled: true,
       })),
     },
   })

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -6491,6 +6491,16 @@ export interface components {
             /** Source */
             readonly source: string;
             /**
+             * Actor
+             * @default
+             */
+            readonly actor: string;
+            /**
+             * Rank
+             * @default 0
+             */
+            readonly rank: number;
+            /**
              * Runner Id
              * Format: uuid
              */
@@ -6518,9 +6528,22 @@ export interface components {
         };
         /**
          * AgentRunnerRuleIn
-         * @description One rule of the wholesale-replace body. `source` is typed as the routable
-         *     literal so an unknown source is a 422 here rather than a rule that silently
-         *     never matches anything — and so the generated TypeScript carries the union.
+         * @description One rule of the wholesale-replace body — a source, an optional actor, and
+         *     the ORDERED runners that may take that work.
+         *
+         *     `source` is typed as the routable literal so an unknown source is a 422 here
+         *     rather than a rule that silently never matches anything — and so the generated
+         *     TypeScript carries the union.
+         *
+         *     `runners` reuses the default list's row schema, and its ORDER is the rule's
+         *     rank order. A rule names several runners because the operator's own boxes are
+         *     two macOS accounts alternated as each runs out of tokens: "either of mine,
+         *     never cloud" cannot be said with one runner (spec 2026-09-05). Per-runner
+         *     `enabled` lives on the row, which is why this schema has no rule-level
+         *     `enabled` — a change from the pre-actor shape, safe because canopy-web's own
+         *     frontend is the only caller and no rules exist in production yet.
+         *
+         *     `strict` is rule-level and written to every row.
          */
         readonly AgentRunnerRuleIn: {
             /**
@@ -6529,20 +6552,17 @@ export interface components {
              */
             readonly source: "ace_web" | "email" | "canopy_scheduler" | "canopy_web_chat" | "slack" | "api";
             /**
-             * Runner Id
-             * Format: uuid
+             * Actor
+             * @default
              */
-            readonly runner_id: string;
+            readonly actor: string;
+            /** Runners */
+            readonly runners?: readonly components["schemas"]["AgentRunnerRowIn"][];
             /**
              * Strict
              * @default false
              */
             readonly strict: boolean;
-            /**
-             * Enabled
-             * @default true
-             */
-            readonly enabled: boolean;
         };
         /**
          * AgentRunnerRulesIn

--- a/frontend/src/components/agents/RunnerSourceRules.test.tsx
+++ b/frontend/src/components/agents/RunnerSourceRules.test.tsx
@@ -1,40 +1,52 @@
 import { describe, expect, it } from 'vitest'
 import {
   availableSources,
+  groupRules,
+  nextRulesForActor,
   nextRulesForAdd,
   nextRulesForRemove,
-  nextRulesForRunner,
+  nextRulesForRunnerAdd,
+  nextRulesForRunnerMove,
+  nextRulesForRunnerRemove,
   nextRulesForStrict,
+  ruleKey,
+  type AgentRunnerRuleOut,
   type RuleRow,
 } from './RunnerSourceRules'
 
+// A rule is now (source, actor) -> an ORDERED list of runners. `actor: ''` means
+// "any actor", which is exactly what a source rule meant before actors existed —
+// so every pre-actor rule is just a rule of length one with an empty actor.
 const rules: RuleRow[] = [
-  { source: 'ace_web', runnerId: 'r-cloud', strict: true },
-  { source: 'email', runnerId: 'r-laptop', strict: false },
+  { source: 'ace_web', actor: '', runnerIds: ['r-cloud'], strict: true },
+  { source: 'email', actor: '', runnerIds: ['r-laptop'], strict: false },
 ]
 
+const K = (source: string, actor = '') => ruleKey({ source, actor })
+
 describe('rule list transforms', () => {
-  it('adds a rule defaulting to fall-through', () => {
+  it('adds a rule defaulting to fall-through and no actor', () => {
     // Fall-through is the safe default: a new rule prefers a box without
     // parking the queue when that box is down.
     const next = nextRulesForAdd(rules, 'canopy_scheduler', 'r-cloud')
     expect(next).toHaveLength(3)
-    expect(next[2]).toEqual({ source: 'canopy_scheduler', runnerId: 'r-cloud', strict: false })
-  })
-
-  it('repoints one rule without touching the others', () => {
-    const next = nextRulesForRunner(rules, 'email', 'r-cloud')
-    expect(next[1].runnerId).toBe('r-cloud')
-    expect(next[0]).toEqual(rules[0])
+    expect(next[2]).toEqual({
+      source: 'canopy_scheduler', actor: '', runnerIds: ['r-cloud'], strict: false,
+    })
   })
 
   it('flips strict in place', () => {
-    expect(nextRulesForStrict(rules, 'email')[1].strict).toBe(true)
-    expect(nextRulesForStrict(rules, 'email')[0]).toEqual(rules[0])
+    expect(nextRulesForStrict(rules, K('email'))[1].strict).toBe(true)
+    expect(nextRulesForStrict(rules, K('email'))[0]).toEqual(rules[0])
   })
 
-  it('removes by source', () => {
-    expect(nextRulesForRemove(rules, 'ace_web').map((r) => r.source)).toEqual(['email'])
+  it('removes by (source, actor), not by source alone', () => {
+    const two: RuleRow[] = [
+      { source: 'email', actor: 'jj@dimagi.com', runnerIds: ['r-laptop'], strict: true },
+      { source: 'email', actor: 'stewari@dimagi.com', runnerIds: ['r-cloud'], strict: true },
+    ]
+    const next = nextRulesForRemove(two, K('email', 'jj@dimagi.com'))
+    expect(next.map((r) => r.actor)).toEqual(['stewari@dimagi.com'])
   })
 
   it('never mutates the input list', () => {
@@ -42,19 +54,137 @@ describe('rule list transforms', () => {
     // transform would corrupt it.
     const before = JSON.stringify(rules)
     nextRulesForAdd(rules, 'slack', 'r-cloud')
-    nextRulesForStrict(rules, 'email')
-    nextRulesForRemove(rules, 'email')
+    nextRulesForStrict(rules, K('email'))
+    nextRulesForRemove(rules, K('email'))
+    nextRulesForRunnerAdd(rules, K('email'), 'r-cloud')
+    nextRulesForRunnerMove(rules, K('email'), 0, 1)
     expect(JSON.stringify(rules)).toBe(before)
   })
+})
 
-  it('offers only sources not already ruled on', () => {
+describe('actors', () => {
+  it('sets the actor on one rule only', () => {
+    const next = nextRulesForActor(rules, K('email'), 'stewari@dimagi.com')
+    expect(next[1].actor).toBe('stewari@dimagi.com')
+    expect(next[0]).toEqual(rules[0])
+  })
+
+  it('lets two actors share one source', () => {
+    // The whole feature: Sarvesh's mail to cloud, mine to my own box.
+    let next = nextRulesForAdd(rules, 'email', 'r-cloud')
+    next = nextRulesForActor(next, K('email'), 'stewari@dimagi.com')
+    expect(next.filter((r) => r.source === 'email')).toHaveLength(2)
+  })
+
+  it('offers a source again once its rules all name an actor', () => {
+    // Only the catch-all (actor: '') consumes a source; a source with only
+    // actor-specific rules still needs to be addable for everyone else.
+    const specific: RuleRow[] = [
+      { source: 'email', actor: 'jj@dimagi.com', runnerIds: ['r-laptop'], strict: true },
+    ]
+    expect(availableSources(specific)).toContain('email')
+  })
+
+  it('stops offering a source that already has a catch-all rule', () => {
     expect(availableSources(rules)).not.toContain('ace_web')
     expect(availableSources(rules)).not.toContain('email')
     expect(availableSources(rules)).toContain('canopy_scheduler')
   })
 
-  it('offers nothing once every source has a rule', () => {
-    const all = availableSources([]).map((s) => ({ source: s, runnerId: 'r', strict: false }))
+  it('offers nothing once every source has a catch-all rule', () => {
+    const all = availableSources([]).map((s) => ({
+      source: s, actor: '', runnerIds: ['r'], strict: false,
+    }))
     expect(availableSources(all)).toEqual([])
+  })
+})
+
+describe('a rule names several runners', () => {
+  // Why this exists: jj-mbp-cdp and acedimagi-mbp-cdp are two macOS accounts on
+  // ONE machine, alternated as each runs out of tokens. "My work, never cloud"
+  // therefore names two runners whose live one rotates — unsayable with one.
+  const boxes: RuleRow[] = [
+    { source: 'email', actor: 'jj@dimagi.com', runnerIds: ['r-acedimagi'], strict: true },
+  ]
+
+  it('appends a runner to a rule', () => {
+    const next = nextRulesForRunnerAdd(boxes, K('email', 'jj@dimagi.com'), 'r-jj')
+    expect(next[0].runnerIds).toEqual(['r-acedimagi', 'r-jj'])
+  })
+
+  it('refuses to add the same runner twice — the server 422s on it', () => {
+    const next = nextRulesForRunnerAdd(boxes, K('email', 'jj@dimagi.com'), 'r-acedimagi')
+    expect(next[0].runnerIds).toEqual(['r-acedimagi'])
+  })
+
+  it('reorders runners, because order is the preference', () => {
+    const two = nextRulesForRunnerAdd(boxes, K('email', 'jj@dimagi.com'), 'r-jj')
+    const next = nextRulesForRunnerMove(two, K('email', 'jj@dimagi.com'), 1, -1)
+    expect(next[0].runnerIds).toEqual(['r-jj', 'r-acedimagi'])
+  })
+
+  it('ignores a move off either end', () => {
+    const next = nextRulesForRunnerMove(boxes, K('email', 'jj@dimagi.com'), 0, -1)
+    expect(next[0].runnerIds).toEqual(['r-acedimagi'])
+  })
+
+  it('removes a runner from a rule', () => {
+    const two = nextRulesForRunnerAdd(boxes, K('email', 'jj@dimagi.com'), 'r-jj')
+    const next = nextRulesForRunnerRemove(two, K('email', 'jj@dimagi.com'), 'r-acedimagi')
+    expect(next[0].runnerIds).toEqual(['r-jj'])
+  })
+
+  it('drops the whole rule when its last runner goes', () => {
+    // A zero-runner rule is a 422 server-side: a strict one would compose to an
+    // empty list and park the queue naming no runner as the reason.
+    const next = nextRulesForRunnerRemove(boxes, K('email', 'jj@dimagi.com'), 'r-acedimagi')
+    expect(next).toEqual([])
+  })
+})
+
+describe('groupRules', () => {
+  // The API returns rows FLAT — one per runner — so the component groups them.
+  const flat = [
+    { source: 'email', actor: 'jj@dimagi.com', rank: 1, runner_id: 'r-jj', runner_name: 'jj-mbp',
+      kind: 'emdash', strict: true, online: false, ready: true, enabled: true, queued_count: 3 },
+    { source: 'email', actor: 'jj@dimagi.com', rank: 0, runner_id: 'r-ace', runner_name: 'acedimagi',
+      kind: 'emdash', strict: true, online: true, ready: true, enabled: true, queued_count: 3 },
+    { source: 'ace_web', actor: '', rank: 0, runner_id: 'r-cloud', runner_name: 'cloud-1',
+      kind: 'cloud', strict: false, online: true, ready: true, enabled: true, queued_count: 0 },
+  ] as unknown as AgentRunnerRuleOut[]
+
+  it('groups rows into rules and orders runners by rank', () => {
+    const grouped = groupRules(flat)
+    expect(grouped).toHaveLength(2)
+    const mine = grouped.find((g) => g.actor === 'jj@dimagi.com')!
+    expect(mine.runners.map((r) => r.runner_name)).toEqual(['acedimagi', 'jj-mbp'])
+  })
+
+  it('sorts specific rules above the catch-all, matching evaluation order', () => {
+    const grouped = groupRules([
+      { source: 'email', actor: '', rank: 0, runner_id: 'r-cloud' },
+      { source: 'email', actor: 'jj@dimagi.com', rank: 0, runner_id: 'r-jj' },
+    ] as unknown as AgentRunnerRuleOut[])
+    expect(grouped.map((g) => g.actor)).toEqual(['jj@dimagi.com', ''])
+  })
+
+  it('is parked only when EVERY runner of the rule is offline', () => {
+    // The point of naming two boxes: one being asleep is not a parked queue.
+    const grouped = groupRules(flat)
+    expect(grouped.find((g) => g.actor === 'jj@dimagi.com')!.parked).toBe(false)
+  })
+
+  it('is parked when a strict rule has no online runner left', () => {
+    const allDown = flat
+      .filter((r) => r.actor === 'jj@dimagi.com')
+      .map((r) => ({ ...r, online: false })) as unknown as AgentRunnerRuleOut[]
+    expect(groupRules(allDown)[0].parked).toBe(true)
+  })
+
+  it('a fall-through rule never reads as parked — it degrades instead', () => {
+    const soft = flat
+      .filter((r) => r.actor === 'jj@dimagi.com')
+      .map((r) => ({ ...r, online: false, strict: false })) as unknown as AgentRunnerRuleOut[]
+    expect(groupRules(soft)[0].parked).toBe(false)
   })
 })

--- a/frontend/src/components/agents/RunnerSourceRules.tsx
+++ b/frontend/src/components/agents/RunnerSourceRules.tsx
@@ -7,11 +7,22 @@ import {
 } from '@/api/agents'
 import { type RunnerOut } from '@/api/harness'
 
-// The per-source exception list that sits under an agent's DEFAULT runner order
-// (see RunnerAssignments). A rule is one priority runner plus a strict toggle —
-// deliberately not a second ordered list: ordering already exists once, in the
-// default list, and a source only needs to say "prefer this box" and optionally
-// "and nowhere else".
+export type { AgentRunnerRuleOut }
+
+// The per-(source, actor) exception list that sits under an agent's DEFAULT
+// runner order (see RunnerAssignments).
+//
+// A rule is (source, actor) -> an ORDERED LIST of runners, plus a strict toggle.
+// It names a LIST rather than one runner because the operator's own boxes are two
+// macOS accounts on one machine, alternated as each runs out of tokens: "my work,
+// on either of mine, never cloud" cannot be said with a single runner — naming the
+// logged-out account parks the queue roughly half the time, and falling through
+// hands the work to whatever sits next in the default order (on a cloud-default
+// agent, cloud). Spec: 2026-09-05-actor-aware-runner-routing-design.md.
+//
+// `actor: ''` means "any actor" — bit-for-bit the pre-actor source rule — so an
+// existing rule is simply a rule of length one with an empty actor, and renders
+// and edits exactly as it did.
 //
 // Mirrors RunnerAssignments' commit machinery: optimistic local state, a ref that
 // keeps pace with it so a fast second click composes on top of the first, and a
@@ -41,39 +52,148 @@ const SOURCE_LABEL: Record<string, string> = {
   api: 'api (unclassified)',
 }
 
-export type RuleRow = { source: string; runnerId: string; strict: boolean }
+export type RuleRow = {
+  source: string
+  actor: string
+  runnerIds: string[]
+  strict: boolean
+}
 
-function toRows(rules: readonly AgentRunnerRuleOut[]): RuleRow[] {
-  return rules.map((r) => ({ source: r.source, runnerId: r.runner_id, strict: r.strict }))
+// A rule's identity is the PAIR. Keying on source alone is what the pre-actor
+// version did, and it is why several actors could not share a source.
+// NUL-joined so an actor containing the separator can't forge another rule's key.
+export function ruleKey(r: { source: string; actor: string }): string {
+  return `${r.source}\u0000${r.actor}`
+}
+
+export type GroupedRule = {
+  source: string
+  actor: string
+  strict: boolean
+  runners: AgentRunnerRuleOut[]
+  queuedCount: number
+  // A STRICT rule with no online runner left. Not "its first runner is offline":
+  // naming two boxes exists precisely so one being asleep is not a parked queue.
+  // A fall-through rule is never parked — it degrades to the default order.
+  parked: boolean
+}
+
+// The API returns rows FLAT, one per runner, so the response shape stays the one
+// the frontend already consumes (name/kind/online/ready are per runner anyway).
+// Grouping happens here.
+export function groupRules(rules: readonly AgentRunnerRuleOut[]): GroupedRule[] {
+  const byKey = new Map<string, AgentRunnerRuleOut[]>()
+  for (const row of rules) {
+    const k = ruleKey(row)
+    const bucket = byKey.get(k)
+    if (bucket) bucket.push(row)
+    else byKey.set(k, [row])
+  }
+  const out: GroupedRule[] = []
+  for (const rows of byKey.values()) {
+    const runners = [...rows].sort((a, b) => (a.rank ?? 0) - (b.rank ?? 0))
+    const first = runners[0]
+    out.push({
+      source: first.source,
+      actor: first.actor ?? '',
+      strict: first.strict,
+      runners,
+      queuedCount: first.queued_count ?? 0,
+      parked: first.strict && !runners.some((r) => r.online),
+    })
+  }
+  // Specific rules above the catch-all, matching the order the cascade evaluates
+  // them in, so reading the list top-down reads the precedence.
+  return out.sort(
+    (a, b) =>
+      a.source.localeCompare(b.source) ||
+      (a.actor === '' ? 1 : 0) - (b.actor === '' ? 1 : 0) ||
+      a.actor.localeCompare(b.actor),
+  )
+}
+
+export function toRows(rules: readonly AgentRunnerRuleOut[]): RuleRow[] {
+  return groupRules(rules).map((g) => ({
+    source: g.source,
+    actor: g.actor,
+    runnerIds: g.runners.map((r) => r.runner_id),
+    strict: g.strict,
+  }))
 }
 
 // Pure list transforms, extracted so they unit-test without a React renderer
 // (see RunnerSourceRules.test.tsx). None of them mutates its input — the commit
 // lane keeps a `prev` snapshot to revert to on failure.
+function mapRule(
+  rules: readonly RuleRow[], key: string, fn: (r: RuleRow) => RuleRow,
+): RuleRow[] {
+  return rules.map((r) => (ruleKey(r) === key ? fn(r) : r))
+}
+
 export function nextRulesForAdd(
   rules: readonly RuleRow[], source: string, runnerId: string,
 ): RuleRow[] {
   // strict=false by default: a new rule prefers a box without parking the queue
   // when that box is down. Opting into "only" should be a deliberate click.
-  return [...rules, { source, runnerId, strict: false }]
+  // actor='' by default: a rule is born as a plain source rule, and naming a
+  // person is the second, explicit step.
+  return [...rules, { source, actor: '', runnerIds: [runnerId], strict: false }]
 }
 
-export function nextRulesForRunner(
-  rules: readonly RuleRow[], source: string, runnerId: string,
+export function nextRulesForActor(
+  rules: readonly RuleRow[], key: string, actor: string,
 ): RuleRow[] {
-  return rules.map((r) => (r.source === source ? { ...r, runnerId } : r))
+  return mapRule(rules, key, (r) => ({ ...r, actor }))
 }
 
-export function nextRulesForStrict(rules: readonly RuleRow[], source: string): RuleRow[] {
-  return rules.map((r) => (r.source === source ? { ...r, strict: !r.strict } : r))
+export function nextRulesForStrict(rules: readonly RuleRow[], key: string): RuleRow[] {
+  return mapRule(rules, key, (r) => ({ ...r, strict: !r.strict }))
 }
 
-export function nextRulesForRemove(rules: readonly RuleRow[], source: string): RuleRow[] {
-  return rules.filter((r) => r.source !== source)
+export function nextRulesForRemove(rules: readonly RuleRow[], key: string): RuleRow[] {
+  return rules.filter((r) => ruleKey(r) !== key)
+}
+
+export function nextRulesForRunnerAdd(
+  rules: readonly RuleRow[], key: string, runnerId: string,
+): RuleRow[] {
+  // A runner twice in one rule is a 422 server-side; refusing here keeps the
+  // optimistic render honest rather than showing a row the save will reject.
+  return mapRule(rules, key, (r) =>
+    r.runnerIds.includes(runnerId) ? r : { ...r, runnerIds: [...r.runnerIds, runnerId] },
+  )
+}
+
+export function nextRulesForRunnerMove(
+  rules: readonly RuleRow[], key: string, index: number, delta: number,
+): RuleRow[] {
+  return mapRule(rules, key, (r) => {
+    const to = index + delta
+    if (to < 0 || to >= r.runnerIds.length) return r
+    const ids = [...r.runnerIds]
+    ;[ids[index], ids[to]] = [ids[to], ids[index]]
+    return { ...r, runnerIds: ids }
+  })
+}
+
+export function nextRulesForRunnerRemove(
+  rules: readonly RuleRow[], key: string, runnerId: string,
+): RuleRow[] {
+  // Dropping the last runner deletes the RULE. A zero-runner rule is a 422: a
+  // strict one would compose to an empty list and park the queue naming no
+  // runner as the reason.
+  return rules.flatMap((r) => {
+    if (ruleKey(r) !== key) return [r]
+    const ids = r.runnerIds.filter((id) => id !== runnerId)
+    return ids.length ? [{ ...r, runnerIds: ids }] : []
+  })
 }
 
 export function availableSources(rules: readonly RuleRow[]): RoutableSource[] {
-  const taken = new Set(rules.map((r) => r.source))
+  // Only a CATCH-ALL rule (actor: '') consumes a source — several actors may
+  // share one, which is the feature. A source whose only rules name people must
+  // still be addable for everyone else.
+  const taken = new Set(rules.filter((r) => r.actor === '').map((r) => r.source))
   return ROUTABLE_SOURCES.filter((s) => !taken.has(s))
 }
 
@@ -113,23 +233,28 @@ export function RunnerSourceRules(
   const commit = async (next: RuleRow[], prev: AgentRunnerRuleOut[]) => {
     const mySeq = ++seqRef.current
     // Optimistic: patch names/state from the fleet list so a fresh rule renders
-    // immediately rather than flashing empty until the PUT returns.
+    // immediately rather than flashing empty until the PUT returns. Flattened
+    // back to one row per runner, which is the shape the server returns.
     apply(
-      next.map((r) => {
-        const existing = prev.find((p) => p.source === r.source)
-        const f = fleet.find((x) => x.id === r.runnerId)
-        return {
-          source: r.source,
-          runner_id: r.runnerId,
-          runner_name: f?.name ?? existing?.runner_name ?? r.runnerId,
-          kind: f?.kind ?? existing?.kind ?? '',
-          strict: r.strict,
-          online: f ? f.status === 'online' : (existing?.online ?? false),
-          ready: f?.ready ?? existing?.ready ?? false,
-          enabled: true,
-          queued_count: existing?.queued_count ?? 0,
-        } as AgentRunnerRuleOut
-      }),
+      next.flatMap((r) =>
+        r.runnerIds.map((id, rank) => {
+          const existing = prev.find((p) => ruleKey(p) === ruleKey(r) && p.runner_id === id)
+          const f = fleet.find((x) => x.id === id)
+          return {
+            source: r.source,
+            actor: r.actor,
+            rank,
+            runner_id: id,
+            runner_name: f?.name ?? existing?.runner_name ?? id,
+            kind: f?.kind ?? existing?.kind ?? '',
+            strict: r.strict,
+            online: f ? f.status === 'online' : (existing?.online ?? false),
+            ready: f?.ready ?? existing?.ready ?? false,
+            enabled: true,
+            queued_count: existing?.queued_count ?? 0,
+          } as AgentRunnerRuleOut
+        }),
+      ),
     )
     setError(null)
     try {
@@ -157,7 +282,10 @@ export function RunnerSourceRules(
     )
   }
 
+  const grouped = groupRules(rules)
   const unruled = availableSources(toRows(rules))
+  const unused = (g: GroupedRule) =>
+    fleet.filter((f) => !g.runners.some((r) => r.runner_id === f.id))
 
   return (
     <div className="flex flex-col gap-1" data-testid={`runner-rules-${agentSlug}`}>
@@ -165,91 +293,164 @@ export function RunnerSourceRules(
         Except when the work comes from
       </span>
 
-      {rules.length === 0 && (
+      {grouped.length === 0 && (
         <span className="text-[11px] text-muted-foreground">
           No exceptions — every source follows the default order.
         </span>
       )}
 
-      {rules.map((r) => (
-        <div key={r.source} data-testid={`runner-rule-${r.source}`}>
-          <div className="flex flex-wrap items-center gap-2 rounded-md border border-border bg-card px-2 py-1">
-            <span className="rounded border border-primary/30 bg-primary/10 px-1.5 py-0.5 font-mono text-[11px] text-primary">
-              {SOURCE_LABEL[r.source] ?? r.source}
-            </span>
-            <span className="text-muted-foreground">→</span>
+      {grouped.map((g) => {
+        const key = ruleKey(g)
+        const testId = g.actor ? `${g.source}-${g.actor}` : g.source
+        return (
+          <div key={key} data-testid={`runner-rule-${testId}`}>
+            <div className="flex flex-wrap items-center gap-2 rounded-md border border-border bg-card px-2 py-1">
+              <span className="rounded border border-primary/30 bg-primary/10 px-1.5 py-0.5 font-mono text-[11px] text-primary">
+                {SOURCE_LABEL[g.source] ?? g.source}
+              </span>
 
-            <select
-              value={r.runner_id}
-              onChange={(e) => mutate((rows) => nextRulesForRunner(rows, r.source, e.target.value))}
-              aria-label={`Runner for ${r.source}`}
-              className="rounded border border-input bg-input px-1.5 py-0.5 text-[12px] text-foreground"
-            >
-              {fleet.map((f) => (
-                <option key={f.id} value={f.id}>
-                  {f.name}
-                </option>
-              ))}
-            </select>
+              {/* Free text, placeholder `anyone`: an operator pastes what their
+                  mail client shows, and the server normalizes a full
+                  "Name <addr>" header down to the bare address it routes on. */}
+              <span className="text-[11px] text-muted-foreground">from</span>
+              <input
+                type="text"
+                defaultValue={g.actor}
+                placeholder="anyone"
+                onBlur={(e) => {
+                  const v = e.target.value.trim()
+                  if (v !== g.actor) mutate((rows) => nextRulesForActor(rows, key, v))
+                }}
+                aria-label={`Actor for the ${g.source} rule`}
+                className="w-52 rounded border border-input bg-input px-1.5 py-0.5 font-mono text-[11px] text-foreground"
+              />
+              <span className="text-muted-foreground">→</span>
 
-            {/* The strict toggle, worded as its consequence rather than as the
-                flag name: "only" parks the queue when that box is down, which is
-                the point for a source that can only run in one place. */}
-            <div className="flex overflow-hidden rounded border border-input text-[10px]">
+              {/* The rule's runners as the SAME rank chip row the default order
+                  uses — order is the preference, and a rule may name several
+                  because the operator's two macOS accounts alternate. */}
+              <div className="flex flex-wrap items-center gap-1">
+                {g.runners.map((r, i) => (
+                  <span
+                    key={r.runner_id}
+                    className="flex items-center gap-1 rounded border border-input bg-input px-1.5 py-0.5 text-[11px]"
+                    data-testid={`rule-runner-${testId}-${r.runner_name}`}
+                  >
+                    <span className={r.online ? 'text-success' : 'text-muted-foreground'}>●</span>
+                    <span className="font-mono">{r.runner_name}</span>
+                    <button
+                      type="button"
+                      onClick={() => mutate((rows) => nextRulesForRunnerMove(rows, key, i, -1))}
+                      disabled={i === 0}
+                      aria-label={`Move ${r.runner_name} up in the ${g.source} rule`}
+                      className="text-muted-foreground hover:text-primary disabled:opacity-30"
+                    >
+                      ↑
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => mutate((rows) => nextRulesForRunnerMove(rows, key, i, 1))}
+                      disabled={i === g.runners.length - 1}
+                      aria-label={`Move ${r.runner_name} down in the ${g.source} rule`}
+                      className="text-muted-foreground hover:text-primary disabled:opacity-30"
+                    >
+                      ↓
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        mutate((rows) => nextRulesForRunnerRemove(rows, key, r.runner_id))
+                      }
+                      aria-label={`Remove ${r.runner_name} from the ${g.source} rule`}
+                      className="text-muted-foreground hover:text-destructive"
+                    >
+                      ✕
+                    </button>
+                  </span>
+                ))}
+                {unused(g).length > 0 && (
+                  <select
+                    value=""
+                    onChange={(e) => {
+                      if (e.target.value) {
+                        mutate((rows) => nextRulesForRunnerAdd(rows, key, e.target.value))
+                      }
+                    }}
+                    aria-label={`Add a runner to the ${g.source} rule`}
+                    className="rounded border border-input bg-input px-1 py-0.5 text-[11px] text-foreground-secondary"
+                  >
+                    <option value="">+</option>
+                    {unused(g).map((f) => (
+                      <option key={f.id} value={f.id}>
+                        {f.name}
+                      </option>
+                    ))}
+                  </select>
+                )}
+              </div>
+
+              {/* The strict toggle, worded as its consequence rather than as the
+                  flag name: "only" parks the queue when every runner it names is
+                  down, which is the point for work that can only run in one place. */}
+              <div className="flex overflow-hidden rounded border border-input text-[10px]">
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (!g.strict) mutate((rows) => nextRulesForStrict(rows, key))
+                  }}
+                  className={`px-2 py-0.5 ${
+                    g.strict ? 'bg-primary text-primary-foreground' : 'text-muted-foreground'
+                  }`}
+                  aria-pressed={g.strict}
+                >
+                  only
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (g.strict) mutate((rows) => nextRulesForStrict(rows, key))
+                  }}
+                  className={`px-2 py-0.5 ${
+                    g.strict ? 'text-muted-foreground' : 'bg-primary text-primary-foreground'
+                  }`}
+                  aria-pressed={!g.strict}
+                >
+                  fall through
+                </button>
+              </div>
+
+              {/* Rules ARE deletable, unlike default-order chips (which toggle):
+                  a rule is cheap to re-add, and a greyed rule sitting next to a
+                  greyed runner would read as two different kinds of "off". */}
               <button
                 type="button"
-                onClick={() => {
-                  if (!r.strict) mutate((rows) => nextRulesForStrict(rows, r.source))
-                }}
-                className={`px-2 py-0.5 ${
-                  r.strict ? 'bg-primary text-primary-foreground' : 'text-muted-foreground'
-                }`}
-                aria-pressed={r.strict}
+                onClick={() => mutate((rows) => nextRulesForRemove(rows, key))}
+                aria-label={`Remove the ${g.source} rule`}
+                className="ml-auto px-1 text-muted-foreground hover:text-destructive"
               >
-                only
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  if (r.strict) mutate((rows) => nextRulesForStrict(rows, r.source))
-                }}
-                className={`px-2 py-0.5 ${
-                  r.strict ? 'text-muted-foreground' : 'bg-primary text-primary-foreground'
-                }`}
-                aria-pressed={!r.strict}
-              >
-                fall through
+                ✕
               </button>
             </div>
 
-            {/* Rules ARE deletable, unlike default-order chips (which toggle):
-                a rule is cheap to re-add, and a greyed rule sitting next to a
-                greyed runner would read as two different kinds of "off". */}
-            <button
-              type="button"
-              onClick={() => mutate((rows) => nextRulesForRemove(rows, r.source))}
-              aria-label={`Remove the ${r.source} rule`}
-              className="ml-auto px-1 text-muted-foreground hover:text-destructive"
-            >
-              ✕
-            </button>
+            {/* Strictness parking a queue is the toggle working; parking it
+                SILENTLY is the failure. Say it, with the count — and only when
+                EVERY runner the rule names is down, since naming two boxes
+                exists precisely so one being asleep is not a parked queue. */}
+            {g.parked && (
+              <p
+                className="mt-0.5 pl-2 text-[11px] text-warning"
+                data-testid={`runner-rule-parked-${testId}`}
+              >
+                ⚠ {g.runners.map((r) => r.runner_name).join(' and ')}{' '}
+                {g.runners.length > 1 ? 'are' : 'is'} offline
+                {g.queuedCount > 0
+                  ? ` — ${g.queuedCount} ${g.source}${g.actor ? ` turn${g.queuedCount === 1 ? '' : 's'} from ${g.actor}` : ` turn${g.queuedCount === 1 ? '' : 's'}`} parked, and will stay parked.`
+                  : ' — this work will not run until one returns.'}
+              </p>
+            )}
           </div>
-
-          {/* Strictness parking a queue is the toggle working; parking it
-              SILENTLY is the failure. Say it, with the count. */}
-          {r.strict && !r.online && (
-            <p
-              className="mt-0.5 pl-2 text-[11px] text-warning"
-              data-testid={`runner-rule-parked-${r.source}`}
-            >
-              ⚠ {r.runner_name} is offline
-              {r.queued_count > 0
-                ? ` — ${r.queued_count} ${r.source} turn${r.queued_count === 1 ? '' : 's'} parked, and will stay parked.`
-                : ' — this source will not run until it returns.'}
-            </p>
-          )}
-        </div>
-      ))}
+        )
+      })}
 
       <div className="relative">
         <button
@@ -282,12 +483,13 @@ export function RunnerSourceRules(
 
       {/* The precedence ladder, stated once where rules are edited — and the one
           place `enabled` means two things: a runner switched OFF in Default order
-          still takes the work of any source that names it, because the rule is
-          its own row with its own toggle. Left unsaid, a greyed chip above reads
-          as "this box is off" while it is quietly answering email. */}
+          still takes the work of any rule that names it, because the rule is its
+          own row with its own toggle. Left unsaid, a greyed chip above reads as
+          "this box is off" while it is quietly answering email. */}
       <p className="text-[10px] text-foreground-subtle">
-        A named runner wins over a rule; a live chat stays on the box hosting it.
-        A rule still routes to its runner even when that runner is switched off above.
+        A named runner wins over a rule; a live chat stays on the box hosting it; a rule naming
+        a person beats one naming only a source, which beats the default order. A rule still
+        routes to its runners even when they are switched off above.
       </p>
 
       {error && <span className="text-[11px] text-destructive">{error}</span>}

--- a/tests/test_actor_resolution.py
+++ b/tests/test_actor_resolution.py
@@ -1,0 +1,97 @@
+"""Who a turn is FROM — the routing key that source rules cannot express.
+
+Pure, no DB. The two shapes this exists to get right, both observed in
+production and both of which the obvious implementation gets wrong:
+
+  - an `email` turn's `enqueued_by` is the RUNNER's account (the inbox watcher
+    POSTs as the box's paired user), so the sender lives in `origin_ref["from"]`;
+  - a `canopy_web_chat` / `ace_web` turn has no `origin_ref["from"]` at all, so
+    its actor is `enqueued_by`.
+
+Spec: docs/superpowers/specs/2026-09-05-actor-aware-runner-routing-design.md
+"""
+from __future__ import annotations
+
+import pytest
+
+from apps.harness.actors import resolve_actor
+from apps.harness.models import Turn
+
+
+def test_an_email_turns_actor_is_the_sender_not_the_enqueuer():
+    """The bug this module exists to prevent.
+
+    Every email turn in production carries `enqueued_by=jjackson@dimagi.com` —
+    the account the runner's inbox watcher authenticates as — regardless of who
+    wrote in. Keying on it collapses every correspondent onto one rule.
+    """
+    actor = resolve_actor(
+        Turn.ORIGIN_EMAIL,
+        {"from": "Beth Geoffroy <egeoffroy@dimagi.com>"},
+        "jjackson@dimagi.com",
+    )
+    assert actor == "egeoffroy@dimagi.com"
+
+
+@pytest.mark.parametrize(
+    "header,expected",
+    [
+        ("Jonathan Jackson <jjackson@dimagi.com>", "jjackson@dimagi.com"),
+        ("stewari@dimagi.com", "stewari@dimagi.com"),
+        # A quoted display name containing a comma — real, and the shape that
+        # breaks any hand-rolled split on '<' or ','.
+        ('"Anthropic, PBC" <invoice+statements@mail.anthropic.com>',
+         "invoice+statements@mail.anthropic.com"),
+        ("Labs Alerts <no-reply@sns.amazonaws.com>", "no-reply@sns.amazonaws.com"),
+        ("  Neal Lesh  <NLesh@Dimagi.com>  ", "nlesh@dimagi.com"),
+    ],
+)
+def test_email_headers_resolve_to_a_bare_lowercase_address(header, expected):
+    assert resolve_actor(Turn.ORIGIN_EMAIL, {"from": header}, "") == expected
+
+
+@pytest.mark.parametrize(
+    "origin",
+    [Turn.ORIGIN_ACE_WEB, Turn.ORIGIN_CANOPY_WEB_CHAT, Turn.ORIGIN_API, Turn.ORIGIN_SLACK],
+)
+def test_non_email_origins_use_the_enqueuer(origin):
+    assert resolve_actor(origin, {}, "Sarvesh@Dimagi.com") == "sarvesh@dimagi.com"
+
+
+def test_a_non_email_origin_ignores_a_from_in_origin_ref():
+    """`from` is the email producer's field. A chat turn that somehow carries one
+    must not be routed by it — the enqueuer is the authenticated caller."""
+    assert resolve_actor(
+        Turn.ORIGIN_ACE_WEB, {"from": "someone@else.com"}, "real@dimagi.com"
+    ) == "real@dimagi.com"
+
+
+def test_a_scheduled_turn_has_no_actor():
+    """A schedule has no live human. It must fall through to the source rule
+    rather than match some rule by accident."""
+    assert resolve_actor(
+        Turn.ORIGIN_CANOPY_SCHEDULER, {"schedule_id": 7, "slot": "..."}, ""
+    ) == ""
+
+
+@pytest.mark.parametrize(
+    "origin,ref,enq",
+    [
+        (Turn.ORIGIN_EMAIL, {}, ""),                       # no header at all
+        (Turn.ORIGIN_EMAIL, {"from": ""}, ""),             # empty header
+        (Turn.ORIGIN_EMAIL, {"from": "not an address"}, ""),  # unparseable
+        (Turn.ORIGIN_EMAIL, {"from": None}, ""),           # null header
+        (Turn.ORIGIN_API, {}, ""),                         # unauthenticated enqueue
+        (Turn.ORIGIN_API, {}, None),                       # no enqueued_by row
+    ],
+)
+def test_an_unresolvable_actor_is_empty_never_a_guess(origin, ref, enq):
+    """Empty means "matches no actor rule, falls through" — which is the safe
+    outcome. Returning a partial or made-up value would silently route."""
+    assert resolve_actor(origin, ref, enq) == ""
+
+
+def test_origin_ref_that_is_not_a_dict_does_not_raise():
+    """`origin_ref` is a JSONField; a malformed row must not take down claiming."""
+    assert resolve_actor(Turn.ORIGIN_EMAIL, None, "") == ""
+    assert resolve_actor(Turn.ORIGIN_EMAIL, "garbage", "") == ""

--- a/tests/test_actor_rules.py
+++ b/tests/test_actor_rules.py
@@ -1,0 +1,185 @@
+"""Actor rules: route by WHO the work came from, not just what kind it is.
+
+A rule is the set of rows sharing (agent, source, actor), rank-ordered — a LIST
+of runners, not one. That is forced by the operator's real topology: two macOS
+accounts on one machine, alternated as each runs out of tokens, so "my work
+stays on my boxes" names two runners whose live one rotates.
+
+Precedence: explicit pin -> sticky binding -> (source, actor) -> (source, "")
+-> default order. This file covers the two middle rungs; the outer two are
+claim_next_turn's and are covered in tests/test_source_rules.py and the
+directed-routing suite.
+
+Spec: docs/superpowers/specs/2026-09-05-actor-aware-runner-routing-design.md
+"""
+from __future__ import annotations
+
+import pytest
+from django.db import IntegrityError
+
+from apps.agents.models import Agent
+from apps.harness import services
+from apps.harness.models import Runner, RunnerAssignment, Turn
+from apps.workspaces.testing import a_workspace
+
+pytestmark = pytest.mark.django_db
+
+JON = "jjackson@dimagi.com"
+SARVESH = "stewari@dimagi.com"
+
+
+def _agent(slug="echo"):
+    return Agent.objects.create(slug=slug, name=slug.title(), workspace=a_workspace())
+
+
+def _runner(name, kind=Runner.EMDASH):
+    return Runner.objects.create(name=name, kind=kind, capabilities={})
+
+
+def _rows(agent, origin, actor=""):
+    defaults, priorities = services.load_assignment_rows([agent.id])
+    return [
+        r for _rank, r in services.assignment_rows_for(agent.id, origin, actor, defaults, priorities)
+    ]
+
+
+def _rule(agent, source, actor, runners, *, strict=False, enabled=True):
+    """One rule = its runners in rank order."""
+    for rank, runner in enumerate(runners):
+        RunnerAssignment.objects.create(
+            agent=agent, runner=runner, rank=rank,
+            source=source, actor=actor, strict=strict, enabled=enabled,
+        )
+
+
+# --- the constraint -----------------------------------------------------------
+
+def test_a_runner_may_appear_only_once_within_one_rule():
+    a, r1 = _agent(), _runner("r1")
+    RunnerAssignment.objects.create(
+        agent=a, runner=r1, rank=0, source=Turn.ORIGIN_EMAIL, actor=JON
+    )
+    with pytest.raises(IntegrityError):
+        RunnerAssignment.objects.create(
+            agent=a, runner=r1, rank=1, source=Turn.ORIGIN_EMAIL, actor=JON
+        )
+
+
+def test_two_actors_may_now_share_one_source():
+    """The constraint this replaces capped a source at ONE row, which is what
+    made per-person routing impossible."""
+    a, cloud, laptop = _agent(), _runner("cloud-1", Runner.CLOUD), _runner("jj-mbp")
+    _rule(a, Turn.ORIGIN_EMAIL, SARVESH, [cloud])
+    _rule(a, Turn.ORIGIN_EMAIL, JON, [laptop])
+    assert RunnerAssignment.objects.filter(agent=a, source=Turn.ORIGIN_EMAIL).count() == 2
+
+
+# --- composition --------------------------------------------------------------
+
+def test_an_actor_rule_beats_the_source_rule_which_beats_the_defaults():
+    a = _agent()
+    mine, cloud, other = _runner("acedimagi-mbp"), _runner("cloud-1", Runner.CLOUD), _runner("spare")
+    RunnerAssignment.objects.create(agent=a, runner=other, rank=0)          # default
+    _rule(a, Turn.ORIGIN_EMAIL, "", [cloud])                                # source rule
+    _rule(a, Turn.ORIGIN_EMAIL, JON, [mine])                                # actor rule
+    assert _rows(a, Turn.ORIGIN_EMAIL, JON) == [mine, cloud, other]
+
+
+def test_an_unmatched_actor_falls_through_to_the_source_rule():
+    a, mine, cloud = _agent(), _runner("acedimagi-mbp"), _runner("cloud-1", Runner.CLOUD)
+    _rule(a, Turn.ORIGIN_EMAIL, "", [cloud])
+    _rule(a, Turn.ORIGIN_EMAIL, JON, [mine])
+    assert _rows(a, Turn.ORIGIN_EMAIL, SARVESH) == [cloud]
+
+
+def test_an_actorless_turn_never_matches_an_actor_rule():
+    """A scheduler turn resolves to actor="" and must land on the source rule."""
+    a, mine, cloud = _agent(), _runner("acedimagi-mbp"), _runner("cloud-1", Runner.CLOUD)
+    _rule(a, Turn.ORIGIN_EMAIL, "", [cloud])
+    _rule(a, Turn.ORIGIN_EMAIL, JON, [mine])
+    assert _rows(a, Turn.ORIGIN_EMAIL, "") == [cloud]
+
+
+def test_an_actor_rule_is_scoped_to_its_own_source():
+    a, cloud, laptop = _agent(), _runner("cloud-1", Runner.CLOUD), _runner("jj-mbp")
+    RunnerAssignment.objects.create(agent=a, runner=laptop, rank=0)
+    _rule(a, Turn.ORIGIN_ACE_WEB, SARVESH, [cloud], strict=True)
+    assert _rows(a, Turn.ORIGIN_ACE_WEB, SARVESH) == [cloud]
+    assert _rows(a, Turn.ORIGIN_EMAIL, SARVESH) == [laptop]
+
+
+# --- multi-runner rules: the case the model exists for -------------------------
+
+def test_a_strict_rule_yields_its_runners_in_rank_order_and_no_others():
+    """OPERATOR_BOXES: either of my accounts, never cloud."""
+    a = _agent()
+    cloud, acedimagi, jj = _runner("cloud-1", Runner.CLOUD), _runner("acedimagi-mbp"), _runner("jj-mbp")
+    RunnerAssignment.objects.create(agent=a, runner=cloud, rank=0)      # cloud-DEFAULT agent
+    RunnerAssignment.objects.create(agent=a, runner=acedimagi, rank=1)
+    _rule(a, Turn.ORIGIN_EMAIL, JON, [acedimagi, jj], strict=True)
+    assert _rows(a, Turn.ORIGIN_EMAIL, JON) == [acedimagi, jj]
+
+
+def test_a_strict_rule_truncates_the_list_so_the_defaults_cannot_leak_back():
+    """The bug caught in spec review: appending the default order after a strict
+    rule hands work straight back to the runners the rule exists to exclude —
+    and the 60s wedged-runner grace would then promote them."""
+    a, cloud, mine = _agent(), _runner("cloud-1", Runner.CLOUD), _runner("acedimagi-mbp")
+    RunnerAssignment.objects.create(agent=a, runner=cloud, rank=0)
+    _rule(a, Turn.ORIGIN_EMAIL, JON, [mine], strict=True)
+    assert cloud not in _rows(a, Turn.ORIGIN_EMAIL, JON)
+
+
+def test_a_non_strict_multi_runner_rule_still_falls_through_to_the_defaults():
+    a, r1, r2, spare = _agent(), _runner("r1"), _runner("r2"), _runner("spare")
+    RunnerAssignment.objects.create(agent=a, runner=spare, rank=0)
+    _rule(a, Turn.ORIGIN_EMAIL, JON, [r1, r2], strict=False)
+    assert _rows(a, Turn.ORIGIN_EMAIL, JON) == [r1, r2, spare]
+
+
+def test_a_runner_in_both_a_rule_and_the_defaults_appears_once_keeping_its_rule_rank():
+    a, mine, spare = _agent(), _runner("acedimagi-mbp"), _runner("spare")
+    RunnerAssignment.objects.create(agent=a, runner=spare, rank=0)
+    RunnerAssignment.objects.create(agent=a, runner=mine, rank=1)
+    _rule(a, Turn.ORIGIN_EMAIL, JON, [mine])
+    assert _rows(a, Turn.ORIGIN_EMAIL, JON) == [mine, spare]
+
+
+def test_ranks_are_renumbered_from_zero_so_the_cascade_can_compare_them():
+    """Two runners both sitting at rank 0 would each read as blocking the other."""
+    a, mine, spare = _agent(), _runner("acedimagi-mbp"), _runner("spare")
+    RunnerAssignment.objects.create(agent=a, runner=spare, rank=0)
+    _rule(a, Turn.ORIGIN_EMAIL, JON, [mine])
+    defaults, priorities = services.load_assignment_rows([a.id])
+    assert [rank for rank, _r in
+            services.assignment_rows_for(a.id, Turn.ORIGIN_EMAIL, JON, defaults, priorities)] == [0, 1]
+
+
+# --- enabled ------------------------------------------------------------------
+
+def test_disabling_every_row_of_a_rule_switches_the_rule_off_strictness_included():
+    """Switching a rule off must not park its queue — the rule simply stops
+    existing and the turn falls through."""
+    a, cloud, mine = _agent(), _runner("cloud-1", Runner.CLOUD), _runner("acedimagi-mbp")
+    RunnerAssignment.objects.create(agent=a, runner=cloud, rank=0)
+    _rule(a, Turn.ORIGIN_EMAIL, JON, [mine], strict=True, enabled=False)
+    assert _rows(a, Turn.ORIGIN_EMAIL, JON) == [cloud]
+
+
+def test_disabling_one_runner_of_a_rule_drops_only_that_runner():
+    a, r1, r2 = _agent(), _runner("r1"), _runner("r2")
+    _rule(a, Turn.ORIGIN_EMAIL, JON, [r1], strict=True, enabled=False)
+    RunnerAssignment.objects.create(
+        agent=a, runner=r2, rank=1, source=Turn.ORIGIN_EMAIL, actor=JON, strict=True
+    )
+    assert _rows(a, Turn.ORIGIN_EMAIL, JON) == [r2]
+
+
+# --- backwards compatibility --------------------------------------------------
+
+def test_a_rule_with_no_actor_behaves_exactly_like_a_pre_migration_source_rule():
+    a, cloud, laptop = _agent(), _runner("cloud-1", Runner.CLOUD), _runner("jj-mbp")
+    RunnerAssignment.objects.create(agent=a, runner=laptop, rank=0)
+    _rule(a, Turn.ORIGIN_ACE_WEB, "", [cloud])
+    assert _rows(a, Turn.ORIGIN_ACE_WEB, JON) == [cloud, laptop]
+    assert _rows(a, Turn.ORIGIN_ACE_WEB, "") == [cloud, laptop]

--- a/tests/test_agent_runner_rules_api.py
+++ b/tests/test_agent_runner_rules_api.py
@@ -52,7 +52,7 @@ def _put_default(client, runner):
 
 def test_put_then_get_round_trips_a_rule(setup):
     res = _put_rules(setup["client"], [
-        {"source": "ace_web", "runner_id": str(setup["cloud"].id), "strict": True},
+        {"source": "ace_web", "runners": [{"runner_id": str(setup["cloud"].id), "enabled": True}], "strict": True},
     ])
     assert res.status_code == 200, res.content
 
@@ -67,7 +67,7 @@ def test_put_then_get_round_trips_a_rule(setup):
 def test_saving_the_default_list_does_not_wipe_the_rules(setup):
     """RunnerAssignment holds both; PUT /runners must scope its delete to source=''."""
     _put_rules(setup["client"], [
-        {"source": "email", "runner_id": str(setup["laptop"].id), "strict": True},
+        {"source": "email", "runners": [{"runner_id": str(setup["laptop"].id), "enabled": True}], "strict": True},
     ])
 
     assert _put_default(setup["client"], setup["cloud"]).status_code == 200
@@ -79,7 +79,7 @@ def test_saving_the_rules_does_not_wipe_the_default_list(setup):
     _put_default(setup["client"], setup["cloud"])
 
     _put_rules(setup["client"], [
-        {"source": "email", "runner_id": str(setup["laptop"].id), "strict": True},
+        {"source": "email", "runners": [{"runner_id": str(setup["laptop"].id), "enabled": True}], "strict": True},
     ])
 
     assert RunnerAssignment.objects.filter(agent=setup["agent"], source="").count() == 1
@@ -89,7 +89,7 @@ def test_the_default_list_read_excludes_rule_rows(setup):
     """Otherwise a rule would show up as a phantom chip in the Default order row."""
     _put_default(setup["client"], setup["cloud"])
     _put_rules(setup["client"], [
-        {"source": "email", "runner_id": str(setup["laptop"].id)},
+        {"source": "email", "runners": [{"runner_id": str(setup["laptop"].id), "enabled": True}]},
     ])
 
     got = setup["client"].get("/api/agents/echo/runners").json()
@@ -99,27 +99,29 @@ def test_the_default_list_read_excludes_rule_rows(setup):
 
 def test_put_replaces_wholesale(setup):
     _put_rules(setup["client"], [
-        {"source": "email", "runner_id": str(setup["laptop"].id), "strict": True},
+        {"source": "email", "runners": [{"runner_id": str(setup["laptop"].id), "enabled": True}], "strict": True},
     ])
     _put_rules(setup["client"], [
-        {"source": "ace_web", "runner_id": str(setup["cloud"].id), "strict": False},
+        {"source": "ace_web", "runners": [{"runner_id": str(setup["cloud"].id), "enabled": True}], "strict": False},
     ])
 
     rows = RunnerAssignment.objects.filter(agent=setup["agent"]).exclude(source="")
     assert [r.source for r in rows] == ["ace_web"]
 
 
-def test_a_duplicate_source_is_rejected(setup):
+def test_a_duplicate_source_and_actor_is_rejected(setup):
+    """Two rules on the same (source, actor). Two rules on the same source with
+    DIFFERENT actors is now legal — that is the feature."""
     res = _put_rules(setup["client"], [
-        {"source": "email", "runner_id": str(setup["laptop"].id)},
-        {"source": "email", "runner_id": str(setup["cloud"].id)},
+        {"source": "email", "runners": [{"runner_id": str(setup["laptop"].id), "enabled": True}]},
+        {"source": "email", "runners": [{"runner_id": str(setup["cloud"].id), "enabled": True}]},
     ])
     assert res.status_code == 422
 
 
 def test_a_non_routable_source_is_rejected(setup):
     res = _put_rules(setup["client"], [
-        {"source": "not_a_source", "runner_id": str(setup["laptop"].id)},
+        {"source": "not_a_source", "runners": [{"runner_id": str(setup["laptop"].id), "enabled": True}]},
     ])
     assert res.status_code == 422
 
@@ -132,7 +134,7 @@ def test_a_runner_the_caller_cannot_see_is_rejected(setup):
     )
 
     res = _put_rules(setup["client"], [
-        {"source": "email", "runner_id": str(theirs.id)},
+        {"source": "email", "runners": [{"runner_id": str(theirs.id), "enabled": True}]},
     ])
 
     assert res.status_code == 422
@@ -144,7 +146,7 @@ def test_a_runner_the_caller_cannot_see_is_rejected(setup):
 def test_queued_count_reports_the_parked_work(setup):
     """The UI's 'N turns are parked' warning reads this."""
     _put_rules(setup["client"], [
-        {"source": "email", "runner_id": str(setup["laptop"].id), "strict": True},
+        {"source": "email", "runners": [{"runner_id": str(setup["laptop"].id), "enabled": True}], "strict": True},
     ])
     Turn.objects.create(agent=setup["agent"], origin=Turn.ORIGIN_EMAIL, idempotency_key="q1")
     Turn.objects.create(agent=setup["agent"], origin=Turn.ORIGIN_EMAIL, idempotency_key="q2")
@@ -169,3 +171,98 @@ def test_a_non_member_cannot_read_or_write_the_rules(client):
         "/api/agents/secret/runner-rules",
         data={"rules": []}, content_type="application/json",
     ).status_code == 404
+
+
+# --- actors (spec 2026-09-05) -------------------------------------------------
+
+def test_a_rule_round_trips_its_actor(setup):
+    res = _put_rules(setup["client"], [
+        {"source": "email", "actor": "stewari@dimagi.com",
+         "runners": [{"runner_id": str(setup["cloud"].id), "enabled": True}], "strict": True},
+    ])
+    assert res.status_code == 200, res.content
+
+    got = setup["client"].get("/api/agents/echo/runner-rules").json()
+    assert [(r["source"], r["actor"], r["runner_name"]) for r in got] == [
+        ("email", "stewari@dimagi.com", "cloud-1"),
+    ]
+
+
+def test_two_actors_may_share_one_source(setup):
+    """The whole point: Sarvesh's mail to cloud, mine to my laptop."""
+    res = _put_rules(setup["client"], [
+        {"source": "email", "actor": "stewari@dimagi.com",
+         "runners": [{"runner_id": str(setup["cloud"].id), "enabled": True}]},
+        {"source": "email", "actor": "jj@dimagi.com",
+         "runners": [{"runner_id": str(setup["laptop"].id), "enabled": True}]},
+    ])
+    assert res.status_code == 200, res.content
+    assert len(setup["client"].get("/api/agents/echo/runner-rules").json()) == 2
+
+
+def test_a_rule_may_name_several_runners_in_order(setup):
+    """OPERATOR_BOXES: two macOS accounts on one machine, whichever is live."""
+    res = _put_rules(setup["client"], [
+        {"source": "email", "actor": "jj@dimagi.com", "strict": True, "runners": [
+            {"runner_id": str(setup["laptop"].id), "enabled": True},
+            {"runner_id": str(setup["cloud"].id), "enabled": True},
+        ]},
+    ])
+    assert res.status_code == 200, res.content
+
+    got = setup["client"].get("/api/agents/echo/runner-rules").json()
+    assert [(r["rank"], r["runner_name"]) for r in got] == [(0, "jj-mbp"), (1, "cloud-1")]
+
+
+def test_an_actor_is_normalized_so_a_pasted_header_still_matches(setup):
+    """Operators paste what they see in a mail client. A rule written as a full
+    From header must match a turn whose sender resolves to the bare address."""
+    _put_rules(setup["client"], [
+        {"source": "email", "actor": "Sarvesh Tewari <STewari@Dimagi.com>",
+         "runners": [{"runner_id": str(setup["cloud"].id), "enabled": True}]},
+    ])
+    got = setup["client"].get("/api/agents/echo/runner-rules").json()
+    assert got[0]["actor"] == "stewari@dimagi.com"
+
+
+def test_an_unparseable_actor_is_rejected_not_stored_as_a_dead_rule(setup):
+    res = _put_rules(setup["client"], [
+        {"source": "email", "actor": "not an address",
+         "runners": [{"runner_id": str(setup["cloud"].id), "enabled": True}]},
+    ])
+    assert res.status_code == 422
+
+
+def test_the_same_runner_twice_in_one_rule_is_rejected(setup):
+    res = _put_rules(setup["client"], [
+        {"source": "email", "actor": "jj@dimagi.com", "runners": [
+            {"runner_id": str(setup["cloud"].id), "enabled": True},
+            {"runner_id": str(setup["cloud"].id), "enabled": True},
+        ]},
+    ])
+    assert res.status_code == 422
+
+
+def test_a_rule_with_no_runners_is_rejected(setup):
+    """A zero-length strict rule would compose to an empty list and park the queue
+    with no runner named as the reason. Deleting the rule is how you turn it off."""
+    res = _put_rules(setup["client"], [
+        {"source": "email", "actor": "jj@dimagi.com", "runners": [], "strict": True},
+    ])
+    assert res.status_code == 422
+
+
+def test_queued_count_is_scoped_to_the_rules_actor(setup):
+    """Otherwise the parked warning counts other people's work as yours."""
+    jj = get_user_model().objects.get(username="jj")
+    _put_rules(setup["client"], [
+        {"source": "api", "actor": "jj@dimagi.com",
+         "runners": [{"runner_id": str(setup["laptop"].id), "enabled": True}], "strict": True},
+    ])
+    Turn.objects.create(
+        agent=setup["agent"], origin=Turn.ORIGIN_API, idempotency_key="mine", enqueued_by=jj,
+    )
+    Turn.objects.create(agent=setup["agent"], origin=Turn.ORIGIN_API, idempotency_key="theirs")
+
+    got = setup["client"].get("/api/agents/echo/runner-rules").json()
+    assert got[0]["queued_count"] == 1

--- a/tests/test_send_records_the_actor.py
+++ b/tests/test_send_records_the_actor.py
@@ -1,0 +1,70 @@
+"""A send must record WHO sent it, or actor routing has nothing to route on.
+
+`Turn.enqueued_by` is set in `harness/api.py` for turns POSTed to the API, and was
+never set on the chat/session-send path — so every `canopy_web_chat` turn in
+production carries no actor, and so does every `ace_web` turn, because ace-web's
+run dispatcher goes through this same path
+(`ace-web apps/canopy/run_dispatch.py` -> `POST /api/canopy-sessions/{id}/send`).
+
+That makes this the load-bearing half of the ace-web leg: without it, an
+`ace_web` actor rule can never match anything.
+
+Spec: docs/superpowers/specs/2026-09-05-actor-aware-runner-routing-design.md
+"""
+from __future__ import annotations
+
+import pytest
+
+from apps.agents.models import Agent
+from apps.canopy_sessions import services as chat
+from apps.canopy_sessions.models import Session
+from apps.harness import actors
+from apps.harness.models import Turn
+from apps.workspaces.testing import a_workspace
+
+pytestmark = pytest.mark.django_db
+
+
+def _setup(django_user_model, *, metadata=None, email="sarvesh@dimagi.com"):
+    ws = a_workspace()
+    user = django_user_model.objects.create(username=email, email=email)
+    agent = Agent.objects.create(slug="ace", name="Ace", workspace=ws)
+    session = Session.objects.create(
+        workspace=ws, agent=agent, created_by=user, title="t", metadata=metadata or {},
+    )
+    return user, session
+
+
+def test_a_chat_send_records_the_sender_as_the_turns_actor(django_user_model):
+    user, session = _setup(django_user_model)
+    _msg, turn = chat.send_message(session=session, text="hi", user=user)
+
+    assert turn.origin == Turn.ORIGIN_CANOPY_WEB_CHAT
+    assert turn.enqueued_by_id == user.id
+    assert actors.actor_of(turn) == "sarvesh@dimagi.com"
+
+
+def test_an_ace_web_send_records_the_ace_web_user_as_the_actor(django_user_model):
+    """The whole point. ace-web exchanges a delegated token for the signed-in
+    user's email, so canopy knows exactly which human triggered the run — and an
+    `(ace, ace_web, sarvesh@dimagi.com)` rule can finally match it."""
+    user, session = _setup(django_user_model, metadata={"source": "ace-web"})
+    _msg, turn = chat.send_message(session=session, text="/ace:run bednet", user=user)
+
+    assert turn.origin == Turn.ORIGIN_ACE_WEB
+    assert actors.actor_of(turn) == "sarvesh@dimagi.com"
+
+
+def test_the_actor_is_normalized_so_a_rule_matches_regardless_of_casing(django_user_model):
+    user, session = _setup(django_user_model, email="Sarvesh@Dimagi.com")
+    _msg, turn = chat.send_message(session=session, text="hi", user=user)
+    assert actors.actor_of(turn) == "sarvesh@dimagi.com"
+
+
+def test_a_send_with_no_authenticated_user_records_no_actor(django_user_model):
+    """`enqueue_turn` only stores an authenticated user. No actor means the turn
+    falls through to the source rule — never matches one by accident."""
+    _user, session = _setup(django_user_model)
+    _msg, turn = chat.send_message(session=session, text="hi", user=None)
+    assert turn.enqueued_by_id is None
+    assert actors.actor_of(turn) == ""

--- a/tests/test_source_routing_e2e.py
+++ b/tests/test_source_routing_e2e.py
@@ -43,10 +43,18 @@ def fleet(client):
     return {"client": client, "ace": ace, "echo": echo, "laptop": laptop, "cloud": cloud}
 
 
-def _rule(client, slug, source, runner, strict):
+def _rule(client, slug, source, runner, strict, actor=""):
+    """A rule now names an ORDERED LIST of runners (spec 2026-09-05); this helper
+    keeps posting one, so every assertion below is unchanged — which is the point:
+    a one-runner, no-actor rule must behave exactly as it did before actors."""
     res = client.put(
         f"/api/agents/{slug}/runner-rules",
-        data={"rules": [{"source": source, "runner_id": str(runner.id), "strict": strict}]},
+        data={"rules": [{
+            "source": source,
+            "actor": actor,
+            "runners": [{"runner_id": str(runner.id), "enabled": True}],
+            "strict": strict,
+        }]},
         content_type="application/json",
     )
     assert res.status_code == 200, res.content
@@ -133,3 +141,140 @@ def test_the_three_rules_coexist_on_one_fleet(fleet):
 
     assert first is not None and first.origin == Turn.ORIGIN_EMAIL
     assert second is not None and second.origin == Turn.ORIGIN_ACE_WEB
+
+
+# --- actor rules: route by WHO, not just what kind (spec 2026-09-05) ----------
+
+def _rules(client, slug, rules):
+    """Several rules at once — the wholesale-replace body the Runners tab sends."""
+    res = client.put(
+        f"/api/agents/{slug}/runner-rules",
+        data={"rules": rules}, content_type="application/json",
+    )
+    assert res.status_code == 200, res.content
+
+
+def _runners_of(rule):
+    return [{"runner_id": str(r.id), "enabled": True} for r in rule]
+
+
+def test_one_persons_mail_goes_to_cloud_while_everyone_elses_stays_local(fleet):
+    """THE case multiplayer was blocked on.
+
+    ACE keeps the operator's boxes as its default order and allowlists named
+    colleagues onto the cloud runner — so other people can use ace-web without
+    their work landing on the machine the operator is debugging on.
+    """
+    _rules(fleet["client"], "ace", [{
+        "source": "email", "actor": "stewari@dimagi.com",
+        "runners": _runners_of([fleet["cloud"]]), "strict": True,
+    }])
+
+    theirs = _queue(fleet["ace"], Turn.ORIGIN_EMAIL, "k-sarvesh",
+                    origin_ref={"from": "Sarvesh Tewari <STewari@Dimagi.com>"})
+    mine = _queue(fleet["ace"], Turn.ORIGIN_EMAIL, "k-jj",
+                  origin_ref={"from": "Jonathan Jackson <jjackson@dimagi.com>"})
+
+    # The laptop outranks cloud in the default order and Sarvesh's turn is the
+    # OLDER of the two — yet the laptop skips straight past it to the operator's
+    # own mail, because the strict rule removes the laptop from Sarvesh's list.
+    assert services.claim_next_turn(fleet["laptop"]).id == mine.id
+
+    # `one_executing_turn_per_agent` now holds ace's slot, so free it before
+    # asking who takes Sarvesh's — otherwise this asserts the index, not routing.
+    services.finish_turn(mine, status=Turn.DONE)
+
+    assert services.claim_next_turn(fleet["cloud"]).id == theirs.id
+
+
+def test_a_strict_operator_rule_survives_one_of_the_two_accounts_being_down(fleet):
+    """OPERATOR_BOXES. jj-mbp and acedimagi-mbp are two macOS accounts on ONE
+    machine, alternated as each runs out of tokens — so a rule naming only the
+    logged-out one would park roughly half the time. Naming both is the fix, and
+    this is the assertion that proves a one-runner rule could not have done it."""
+    acedimagi = Runner.objects.create(
+        name="acedimagi-mbp", kind=Runner.EMDASH, paired_by=fleet["laptop"].paired_by,
+        status=Runner.DISCONNECTED, last_heartbeat_at=timezone.now() - dt.timedelta(hours=2),
+        capabilities={},
+    )
+    # echo is cloud-DEFAULT: without the rule, the operator's own work goes to cloud.
+    RunnerAssignment.objects.filter(agent=fleet["echo"], runner=fleet["cloud"]).update(rank=0)
+    RunnerAssignment.objects.filter(agent=fleet["echo"], runner=fleet["laptop"]).update(rank=1)
+    _rules(fleet["client"], "echo", [{
+        "source": "email", "actor": "jjackson@dimagi.com",
+        # acedimagi first — it is normally the live account — then jj-mbp.
+        "runners": _runners_of([acedimagi, fleet["laptop"]]), "strict": True,
+    }])
+
+    _queue(fleet["echo"], Turn.ORIGIN_EMAIL, "k-mine",
+           origin_ref={"from": "Jonathan Jackson <jjackson@dimagi.com>"})
+
+    # The preferred account is offline, so the rule degrades WITHIN itself …
+    assert services.claim_next_turn(fleet["laptop"]) is not None
+    # … and never to cloud, which outranks both in the default order.
+    assert services.claim_next_turn(fleet["cloud"]) is None
+
+
+def test_a_strict_rule_parks_rather_than_leaking_to_cloud_past_the_grace(fleet):
+    """The wedged-runner grace opens a turn to lower ranks after 60s. A strict
+    rule's excluded runners are absent from the list entirely, so there is nobody
+    for the grace to promote — including past the grace."""
+    RunnerAssignment.objects.filter(agent=fleet["echo"], runner=fleet["cloud"]).update(rank=0)
+    _rules(fleet["client"], "echo", [{
+        "source": "email", "actor": "jjackson@dimagi.com",
+        "runners": _runners_of([fleet["laptop"]]), "strict": True,
+    }])
+    old = _queue(fleet["echo"], Turn.ORIGIN_EMAIL, "k-old",
+                 origin_ref={"from": "jjackson@dimagi.com"})
+    Turn.objects.filter(pk=old.pk).update(
+        created_at=timezone.now() - dt.timedelta(seconds=services.CASCADE_GRACE_SECONDS + 30)
+    )
+
+    assert services.claim_next_turn(fleet["cloud"]) is None
+    assert services.claim_next_turn(fleet["laptop"]).id == old.id
+
+
+def test_a_scheduled_turn_matches_no_actor_rule(fleet):
+    """A schedule has no human actor, so it must fall through to the source rule
+    rather than match somebody's rule by accident."""
+    _rules(fleet["client"], "echo", [
+        {"source": "canopy_scheduler", "actor": "jjackson@dimagi.com",
+         "runners": _runners_of([fleet["laptop"]]), "strict": True},
+        {"source": "canopy_scheduler", "actor": "",
+         "runners": _runners_of([fleet["cloud"]]), "strict": True},
+    ])
+    fired = _queue(fleet["echo"], Turn.ORIGIN_CANOPY_SCHEDULER, "k-sched",
+                   origin_ref={"schedule_id": 1, "slot": "2026-09-05T00:00:00Z"})
+
+    assert services.claim_next_turn(fleet["laptop"]) is None
+    assert services.claim_next_turn(fleet["cloud"]).id == fired.id
+
+
+def test_claim_and_unclaimable_agree_per_actor(fleet):
+    """The parity discipline, extended to the actor key. A strict actor rule
+    pointing at a box that is merely OFFLINE must read as recoverable — if these
+    two disagree, the UI tells the operator a live queue will never run."""
+    fleet["laptop"].status = Runner.DISCONNECTED
+    fleet["laptop"].last_heartbeat_at = timezone.now() - dt.timedelta(hours=2)
+    fleet["laptop"].save()
+    _rules(fleet["client"], "ace", [{
+        "source": "email", "actor": "jjackson@dimagi.com",
+        "runners": _runners_of([fleet["laptop"]]), "strict": True,
+    }])
+    parked = _queue(fleet["ace"], Turn.ORIGIN_EMAIL, "k-parked",
+                    origin_ref={"from": "jjackson@dimagi.com"})
+    # Age it past UNCLAIMABLE_GRACE — the warning deliberately ignores turns that
+    # have only just been queued, so a fresh one reports nothing at all.
+    Turn.objects.filter(pk=parked.pk).update(
+        created_at=timezone.now() - services.UNCLAIMABLE_GRACE - dt.timedelta(minutes=1)
+    )
+
+    # Nobody can claim it right now …
+    assert services.claim_next_turn(fleet["cloud"]) is None
+    # … and the warning says OFFLINE (wait for the box), never CONFIG (never runs).
+    # `kind` is the classification the UI branches on; `reason` is its prose.
+    reported = {
+        r["turn_id"]: r["kind"]
+        for r in services.unclaimable_queued_turns(fleet["laptop"].paired_by)
+    }
+    assert reported.get(str(parked.id)) == "offline"

--- a/tests/test_source_rules.py
+++ b/tests/test_source_rules.py
@@ -25,16 +25,35 @@ def _runner(name):
     return Runner.objects.create(name=name, kind=Runner.EMDASH, capabilities={})
 
 
-def _rows(agent, origin):
+def _rows(agent, origin, actor=""):
+    """Every assertion in this file passes actor="" — which is the point: a rule
+    with no actor must behave exactly as it did before actors existed."""
     defaults, priorities = services.load_assignment_rows([agent.id])
-    return [r for _rank, r in services.assignment_rows_for(agent.id, origin, defaults, priorities)]
+    return [
+        r for _rank, r in services.assignment_rows_for(agent.id, origin, actor, defaults, priorities)
+    ]
 
 
-def test_one_priority_runner_per_agent_and_source():
+def test_a_source_rule_may_now_hold_several_runners_in_rank_order():
+    """DELIBERATE RELAXATION (spec 2026-09-05). This used to raise IntegrityError:
+    the old `one_priority_runner_per_agent_source` capped a rule at one runner.
+
+    That cap could not express the operator's real case — "either of my two macOS
+    accounts, never cloud", where which account is live rotates — so a rule became
+    a rank-ordered LIST. `rank` was already reserved for this by the source spec.
+    """
     a, r1, r2 = _agent(), _runner("r1"), _runner("r2")
     RunnerAssignment.objects.create(agent=a, runner=r1, rank=0, source=Turn.ORIGIN_EMAIL)
+    RunnerAssignment.objects.create(agent=a, runner=r2, rank=1, source=Turn.ORIGIN_EMAIL)
+    assert _rows(a, Turn.ORIGIN_EMAIL) == [r1, r2]
+
+
+def test_but_the_same_runner_still_cannot_appear_twice_in_one_rule():
+    """The cap moved from the RULE to the RUNNER; it did not disappear."""
+    a, r1 = _agent(), _runner("r1")
+    RunnerAssignment.objects.create(agent=a, runner=r1, rank=0, source=Turn.ORIGIN_EMAIL)
     with pytest.raises(IntegrityError):
-        RunnerAssignment.objects.create(agent=a, runner=r2, rank=0, source=Turn.ORIGIN_EMAIL)
+        RunnerAssignment.objects.create(agent=a, runner=r1, rank=1, source=Turn.ORIGIN_EMAIL)
 
 
 def test_the_same_runner_may_be_a_default_and_a_priority():
@@ -76,7 +95,7 @@ def test_the_composed_list_is_renumbered_from_zero():
     RunnerAssignment.objects.create(agent=a, runner=laptop, rank=0)
     RunnerAssignment.objects.create(agent=a, runner=cloud, rank=0, source=Turn.ORIGIN_ACE_WEB)
     defaults, priorities = services.load_assignment_rows([a.id])
-    composed = services.assignment_rows_for(a.id, Turn.ORIGIN_ACE_WEB, defaults, priorities)
+    composed = services.assignment_rows_for(a.id, Turn.ORIGIN_ACE_WEB, "", defaults, priorities)
     assert [rank for rank, _r in composed] == [0, 1]
 
 


### PR DESCRIPTION
## Why

Multiplayer is **built and switched off, for a routing reason.**

Chat cutover, SP3 multiplayer, cross-app presence, run-execution convergence and source-aware routing have all shipped. `cloud-ec2-1` is online, ready, session-capable, and passed readiness drills for ace/echo/eva/hal on 2026-08-12/13 — the ACE drill ran `bin/ace-doctor` on the box end to end and returned *47 PASS / 13 WARN / 0 FAIL, HEALTHY*.

It has claimed **zero turns.** Of the 100 turns created since the operator paused `jj-mbp-cdp` on 2026-08-27:

```
 89  -> acedimagi-mbp-cdp
 11  -> (unclaimed)
  0  -> jj-mbp-cdp      (the pause working correctly)
  0  -> cloud-ec2-1
```

`cloud-ec2-1` is `enabled: false` on all five agents, and no agent has a single source rule — including the `ace_web` rule ace-web's deployed CloudFormation comment cites as its safety net. Sixteen canopy sessions carry `metadata.source=ace-web`, **all on 2026-07-28**: a bring-up arc ending in `ace@ round-trip: ace-web -> cloud runner` and `/ace:run bednet-spot-check`. It worked, then it was turned off, and nothing has used it since.

Because source rules are all-or-nothing per source. Turning `ace_web` or `email` toward cloud takes the operator's own debugging work with it, so the safe setting is "cloud off" — which is the setting that has held for five weeks and blocks everyone else from using any of the shipped machinery.

**Granularity is not a follow-on to multiplayer. It is its precondition.**

## What

An actor rule is the rows sharing `(agent, source, actor)`, rank-ordered. The ladder becomes:

```
explicit pin -> sticky binding -> (source, actor) -> (source, "") -> default order
```

`actor=""` is bit-for-bit today's source rule, so no existing row changes meaning and the migration cannot alter routing.

## Two things that are not true, and would have mis-routed silently

The obvious implementation — key on `Turn.enqueued_by_email` — is wrong twice:

- **On an `email` turn that field is the runner's paired account, not the sender.** It is set once, at `apps/harness/api.py:1030` as `request.user`, and the inbox watcher authenticates as the box's owner. All 63 email turns in the sample read `jjackson@dimagi.com` whoever wrote in — `enq= jjackson@dimagi.com | from= Beth Geoffroy <egeoffroy@dimagi.com>`. Keying on it collapses every correspondent onto one rule. The sender is `origin_ref["from"]`.
- **Chat turns carry no actor at all** — 30/30 empty, because `canopy_sessions/services.py` called `enqueue_turn()` without it. ace-web dispatches through that same path, so **`ace_web` turns had none either** — the single most important source here. Fixed in this PR; `send_message()` already had the user and simply never passed it.

So the actor is a *resolved* value (`apps/harness/actors.py`), not a field: `origin_ref["from"]` for mail, `enqueued_by` otherwise, `""` for the scheduler. `parseaddr`, not `<`-slicing — `'"Anthropic, PBC" <invoice+statements@mail.anthropic.com>'` is a real fleet value.

## A rule names a LIST of runners

`jj-mbp-cdp` and `acedimagi-mbp-cdp` are **two macOS accounts on the operator's own machine**, alternated as each runs out of tokens. "My work stays on my boxes, never cloud" therefore names two runners whose live one *rotates* — unsayable with one runner: strict parks whenever the named account is logged out, and non-strict falls through to a default order that puts cloud above the other laptop.

So rules became rank-ordered lists. The source spec had already reserved this, keeping `rank` on the row because *"the column stays free for a future ordered source list without another migration."* The old `one_priority_runner_per_agent_source` is replaced by `one_row_per_runner_per_agent_source_actor` — a relaxation, so it cannot fail on existing data.

**A strict rung truncates the list at itself.** Caught in spec review before it shipped: appending the default order regardless hands work straight back to the runners the rule exists to exclude, and the 60s wedged-runner grace would then promote them. `tests/test_actor_rules.py::test_a_strict_rule_truncates_the_list_so_the_defaults_cannot_leak_back` pins it.

## Notes for review

- **`unclaimable_queued_turns` resolves the actor identically** — the drift class `tests/test_claim_schedule_parity.py` exists for. A strict rule on an offline box must read `offline` (recoverable), never `config` (never runs).
- **The doorbell rings with `actor=""`, deliberately.** A Gmail push carries a mailbox, not a sender — that is only known after the `thread get` the runner does *after* the ring. Safe by `online_runners_for`'s own design (it rings every eligible runner, and the enqueue is idempotent per `(thread, messageCount)`): under a strict rule the box that *discovers* a thread may not be the one that *answers* it. Commented at the call site so it isn't re-derived as a bug.
- **Breaking change to the `PUT /runner-rules` body** (rule-level `enabled` moves onto each runner row). Safe: canopy-web's own frontend is the only caller and **there are zero rules in production** — all five agents return `[]`. Better now than after rules exist.
- **`Agent.runner_preference` is confirmed vestigial**, noted in the spec. Read only by the `0024` seed bridge; the frontend already calls it deprecated. It made Echo *look* differently configured when all five agents are identical. Retiring it is a separate cleanup.

## Testing

`2274 passed, 1 skipped` backend; `661 passed` frontend; `tsc` and `vite build` clean; generated API types regenerated. No new ruff or eslint findings (the 6 ruff / 7 eslint in these files are all present on `main`).

New coverage: `tests/test_actor_resolution.py` (19), `tests/test_actor_rules.py` (14), `tests/test_send_records_the_actor.py` (4), plus five end-to-end cases in `tests/test_source_routing_e2e.py` including the two-account case and the claim/unclaimable parity extension.

## Not in this PR

Enabling `cloud-ec2-1`. That is a config change, made after this lands and after a real ace-web run is verified on it. The intended day-one configuration — ACE as an allowlist to cloud for named colleagues, Echo cloud-default with the operator carved out — is in the spec's *Day-one configuration* section.

Spec: `docs/superpowers/specs/2026-09-05-actor-aware-runner-routing-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rffk2t9tySFjRNqRKxN2wR