### PR TITLE
The gog OAuth client is the agent's to declare, not this script's to remember

### DIFF
--- a/runner/ec2/bootstrap_agents.sh
+++ b/runner/ec2/bootstrap_agents.sh
@@ -40,11 +40,54 @@ ok()   { printf '[bootstrap-agents] OK: %s\n' "$*"; }
 warn() { printf '[bootstrap-agents] WARN: %s\n' "$*" >&2; }
 fail() { printf '[bootstrap-agents] FAIL: %s\n' "$*" >&2; }
 
-# gogcli's own account -> OAuth-client map (verified against a live ~/.config/gogcli
-# aka macOS "Library/Application Support/gogcli" config.json, `account_clients`
-# key): ace and echo keep dedicated clients; ada/eva/hal share the fleet's `canopy`
-# app. See docs/architecture/shared-gog-gdrive.md.
+# FALLBACK ONLY — the authoritative value is each agent's own `config/agent.json`
+# (`gog_client`), read by gog_client_for() below. This table exists solely for the
+# window before an agent's repo is on disk: step 2 writes the account->client map
+# BEFORE step 3 clones anything, so on a genuinely fresh box there is nothing to
+# read yet.
+#
+# It used to BE the source of truth, transcribed from one machine's live
+# ~/.config/gogcli/config.json, and it drifted: it said ace->ace and echo->echo
+# while both repos declare `canopy`. A 2026-09-05 rebuild therefore imported those
+# two agents' gmail tokens under a client nothing reads, and fetched their OAuth
+# client credential from the wrong 1Password vault — ace's readiness drill came
+# back "HEALTHY for /ace:run but BROKEN for /ace:turn". ACE's own CLAUDE.md names
+# config/agent.json as "the SINGLE source"; this now honours that.
+# See tests/test_gog_client_comes_from_the_agent.py.
 declare -A GOG_CLIENT=( [ace]=ace [ada]=canopy [echo]=echo [eva]=canopy [hal]=canopy )
+
+# The agent's OWN declaration wins. Falls back to the table, then to the slug, and
+# NEVER to empty — an empty client points gog at the wrong OAuth app silently.
+gog_client_for() {
+  local slug="$1"
+  local cfg="${AGENT_ROOT:-/opt/agents}/${slug}/config/agent.json"
+  local declared=""
+  if [[ -f "$cfg" ]]; then
+    declared="$(GOG_CFG="$cfg" python3 -c 'import json,os;print((json.load(open(os.environ["GOG_CFG"])).get("gog_client") or "").strip())' 2>/dev/null || true)"
+  fi
+  printf '%s\n' "${declared:-${GOG_CLIENT[$slug]:-$slug}}"
+}
+
+# Merge ONE account->client entry into gog's config.json. Called again per agent
+# once its clone lands, because step 2 could only ever have written the fallback.
+upsert_account_client() {
+  local email="$1" client="$2"
+  command -v gog >/dev/null 2>&1 || return 0
+  local dir; dir="$(gog_config_dir)"
+  mkdir -p "$dir"
+  UAC_CFG="$dir/config.json" UAC_EMAIL="$email" UAC_CLIENT="$client" python3 -c '
+import json, os
+path = os.environ["UAC_CFG"]
+try:
+    data = json.load(open(path))
+except Exception:
+    data = {}
+data.setdefault("account_clients", {})[os.environ["UAC_EMAIL"]] = os.environ["UAC_CLIENT"]
+with open(path, "w") as f:
+    json.dump(data, f, indent=2)
+    f.write("\n")
+'
+}
 
 # ── gog's own XDG resolution on Linux (mirrors canopy's agent_email.py
 # _default_gog_config_dir — $GOG_HOME override, else $XDG_CONFIG_HOME/gogcli, else
@@ -186,7 +229,7 @@ step2_gog_config() {
   local slugs=(); IFS=',' read -ra slugs <<<"$AGENT_SLUGS"
   local pairs=()
   for slug in "${slugs[@]}"; do
-    local client="${GOG_CLIENT[$slug]:-$slug}"
+    local client; client="$(gog_client_for "$slug")"
     pairs+=("${slug}@dimagi-ai.com=${client}")
   done
   python3 - "$cfg" "${pairs[@]}" <<'PY'
@@ -363,7 +406,6 @@ run_agent_provisioner() {
 bootstrap_one_agent() {
   local slug="$1"
   local dest="$AGENT_ROOT/$slug"
-  local client="${GOG_CLIENT[$slug]:-$slug}"
   local account="${slug}@dimagi-ai.com"
   local vault; vault="$(vault_name "$slug")"
 
@@ -374,6 +416,14 @@ bootstrap_one_agent() {
     FAILED_AGENTS+=("$slug")
     return
   fi
+
+  # NOW the agent's own config/agent.json is on disk, so its declared gog_client
+  # is readable for the first time. Step 2 ran before any clone existed and could
+  # only write the fallback, so re-assert the authoritative value here — otherwise
+  # config.json keeps saying `ace` while the token below is imported under
+  # `canopy`, and the two disagree forever.
+  local client; client="$(gog_client_for "$slug")"
+  upsert_account_client "$account" "$client"
   ok "$slug: repo at $dest"
 
   # Provision the agent's env the 1Password-NATIVE way: `op inject` resolves the

--- a/runner/ec2/tests/test_gog_client_comes_from_the_agent.py
+++ b/runner/ec2/tests/test_gog_client_comes_from_the_agent.py
@@ -1,0 +1,132 @@
+"""The gog OAuth client is the AGENT's to declare, not this script's to remember.
+
+THE INCIDENT. A deliberate from-scratch cloud rebuild on 2026-09-05 came up with
+ace and echo unable to send or read email. `bootstrap_agents.sh` carried a
+hardcoded table:
+
+    declare -A GOG_CLIENT=( [ace]=ace [ada]=canopy [echo]=echo [eva]=canopy [hal]=canopy )
+
+whose own comment says it was "verified against a live ~/.config/gogcli
+config.json" — a transcription of one machine at one moment. Every one of the five
+agents declares `"gog_client": "canopy"` in its own `config/agent.json`, which
+ACE's CLAUDE.md names as "the SINGLE source". The table disagreed for exactly two
+of them, so their gmail tokens were imported under a client nothing reads, their
+OAuth client credential was fetched from the wrong 1Password vault
+(`Agent-Ace` instead of `Canopy-Shared`), and ace's readiness drill came back
+"HEALTHY for /ace:run but BROKEN for /ace:turn".
+
+It had gone unnoticed because the previous box was hand-repaired after ITS
+bootstrap — the same shape as the tarball break `test_install_gog.py` records: a
+latent defect that only fires on a rebuild, and that a rebuild therefore exists
+to find.
+
+Ordering is load-bearing. Step 2 writes the account->client map BEFORE step 3
+clones anything, so on a genuinely fresh box there is no `config/agent.json` to
+read yet. The resolution therefore has to happen again per agent, after its clone
+lands — which is what `bootstrap_one_agent` does and what the last test here pins.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+
+import pytest
+
+SCRIPT = pathlib.Path(__file__).resolve().parent.parent / "bootstrap_agents.sh"
+
+# The script uses `declare -A`, which macOS's system bash 3.2 does not have at all.
+# The EC2 box and CI both run bash 5, so these run for real there; skipping is the
+# honest answer on a dev mac rather than silently testing a rewritten script.
+_HAS_ASSOC = subprocess.run(
+    ["bash", "-c", "declare -A _t=( [k]=v ) 2>/dev/null && echo yes"],
+    capture_output=True, text=True,
+).stdout.strip() == "yes"
+pytestmark = pytest.mark.skipif(
+    not _HAS_ASSOC, reason="bash lacks associative arrays (macOS ships 3.2; the box and CI run 5)"
+)
+
+
+def _agent_repo(root: pathlib.Path, slug: str, gog_client: str | None) -> None:
+    d = root / slug / "config"
+    d.mkdir(parents=True)
+    body: dict = {"email": f"{slug}@dimagi-ai.com"}
+    if gog_client is not None:
+        body["gog_client"] = gog_client
+    (d / "agent.json").write_text(json.dumps(body))
+
+
+def _extract_function(path: pathlib.Path, name: str) -> str:
+    """The literal text of one top-level bash function — same approach as
+    test_install_gog.py, because the script ends in an unconditional `main "$@"`
+    and sourcing it would run the whole bootstrap."""
+    lines = path.read_text().splitlines()
+    start = next(i for i, l in enumerate(lines) if l.startswith(f"{name}() {{"))
+    end = next(i for i in range(start + 1, len(lines)) if lines[i] == "}")
+    return "\n".join(lines[start:end + 1])
+
+
+def _resolve(root: pathlib.Path, slug: str) -> str:
+    """Run the real `gog_client_for` against a fake agent root."""
+    decl = next(l for l in SCRIPT.read_text().splitlines()
+                if l.startswith("declare -A GOG_CLIENT="))
+    fn = _extract_function(SCRIPT, "gog_client_for")
+    res = subprocess.run(
+        ["bash", "-c", f'set -euo pipefail\nAGENT_ROOT="{root}"\n{decl}\n{fn}\ngog_client_for {slug}'],
+        capture_output=True, text=True, timeout=60,
+    )
+    assert res.returncode == 0, f"{res.stdout}\n{res.stderr}"
+    return res.stdout.strip()
+
+
+def test_the_agents_own_declaration_wins_over_the_hardcoded_table(tmp_path):
+    """ace declares canopy; the table said `ace`. The declaration is the source."""
+    _agent_repo(tmp_path, "ace", "canopy")
+    assert _resolve(tmp_path, "ace") == "canopy"
+
+
+def test_every_fleet_agent_resolves_to_canopy_when_it_says_so(tmp_path):
+    for slug in ("ace", "ada", "echo", "eva", "hal"):
+        _agent_repo(tmp_path, slug, "canopy")
+    for slug in ("ace", "ada", "echo", "eva", "hal"):
+        assert _resolve(tmp_path, slug) == "canopy", f"{slug} did not honour its own config"
+
+
+def test_a_genuinely_dedicated_client_is_still_honoured(tmp_path):
+    """The fix is 'read the declaration', not 'hardcode canopy instead' — an agent
+    that really does keep its own client must still get it."""
+    _agent_repo(tmp_path, "echo", "echo")
+    assert _resolve(tmp_path, "echo") == "echo"
+
+
+@pytest.mark.parametrize("declared", [None, ""])
+def test_a_missing_or_empty_declaration_falls_back_to_the_table(tmp_path, declared):
+    """Step 2 runs BEFORE any clone exists, so 'no config/agent.json yet' is a
+    normal first-boot state, not an error. It must not resolve to empty — an empty
+    client silently sends gog at the wrong app, which is the failure this whole
+    module is about."""
+    _agent_repo(tmp_path, "eva", declared)
+    assert _resolve(tmp_path, "eva") == "canopy"
+
+
+def test_an_unclonable_agent_directory_falls_back_rather_than_failing(tmp_path):
+    """No repo at all — the first-boot case for every agent."""
+    assert _resolve(tmp_path, "hal") == "canopy"
+    assert _resolve(tmp_path, "ace") == "ace"  # the table's value, until the clone lands
+
+
+def test_bootstrap_rewrites_the_map_after_the_clone_lands():
+    """The ordering guarantee. Step 2 can only ever write the fallback on a fresh
+    box, so bootstrap_one_agent must upsert the authoritative value once the
+    agent's own config is on disk — otherwise config.json keeps saying `ace` while
+    the token is imported under `canopy`, and they disagree forever."""
+    text = SCRIPT.read_text()
+    assert "upsert_account_client" in text, (
+        "no per-agent upsert: the account->client map is written once, before any "
+        "clone exists, so it can never see an agent's own declaration"
+    )
+    body = text[text.index("bootstrap_one_agent() {"):]
+    body = body[: body.index("\n}\n")]
+    assert "upsert_account_client" in body, (
+        "bootstrap_one_agent does not re-assert the client after cloning"
+    )


### PR DESCRIPTION
Found by the destroy-and-rebuild of `cloud-ec2-1` on 2026-09-05. This is the defect that exercise existed to find.

## What happened

The fresh box came up online, ready, claiming turns — and with **ace and echo unable to send or read email**. ace's readiness drill:

> `bin/ace-doctor`: 50 PASS / 16 WARN / 0 FAIL. Verdict **HEALTHY for `/ace:run` but BROKEN for `/ace:turn`** — the gog Gmail token for ace@dimagi-ai.com (client=canopy) cannot authenticate, so ACE cannot send or read email in this environment.

echo's independently reported the same drift: *"config/agent.json pins gog_client to canopy but the actual token lives under a client literally named echo — the same class of drift called out in CLAUDE.md as a prior incident."*

## Root cause

`bootstrap_agents.sh:47`:

```bash
declare -A GOG_CLIENT=( [ace]=ace [ada]=canopy [echo]=echo [eva]=canopy [hal]=canopy )
```

Its own comment says it was *"verified against a live ~/.config/gogcli config.json"* — a transcription of one machine at one moment, kept as the source of truth.

Verified on the box, all five agents' own `config/agent.json`:

```
ace   email=ace@dimagi-ai.com    gog_client='canopy'
ada   email=ada@dimagi-ai.com    gog_client='canopy'
echo  email=echo@dimagi-ai.com   gog_client='canopy'
eva   email=eva@dimagi-ai.com    gog_client='canopy'
hal   email=hal@dimagi-ai.com    gog_client='canopy'
```

versus what bootstrap wrote to `~/.config/gogcli/config.json`:

```
ace  -> "ace"     ← wrong      ada -> "canopy"
echo -> "echo"    ← wrong      eva -> "canopy"   hal -> "canopy"
```

ACE's CLAUDE.md names `config/agent.json` as **"the SINGLE source"** and states the client *"is the SHARED fleet client `canopy`, not `ace`"*. So the two wrong entries also sent `bootstrap_one_agent` at the wrong 1Password vault for the OAuth client credential (`Agent-Ace` instead of `Canopy-Shared`, via the `client_vault` branch).

## Why nobody noticed

The previous box's ace drill (2026-08-13) reported *"Auth liveness passed for … the gog/canopy email engine"* — almost certainly because it had been hand-repaired after its own bootstrap. Same shape as the tarball break `test_install_gog.py` records:

> a latent break that only fires on a rebuild, which is exactly the property that makes rebuilding worth testing.

That is now twice.

## The fix

`gog_client_for <slug>` reads the agent's declaration, falling back to the table, then the slug, and **never to empty** — an empty client points gog at the wrong OAuth app silently.

**Ordering is load-bearing.** Step 2 writes the account→client map *before* step 3 clones anything, so on a genuinely fresh box there is nothing to read yet. The table therefore stays as the first-boot fallback, and `bootstrap_one_agent` re-asserts the authoritative value via `upsert_account_client` once the clone lands. Without that second pass, `config.json` keeps saying `ace` while the token is imported under `canopy`, and the two disagree forever. A test pins that ordering rather than trusting the comment.

The fix deliberately is *"read the declaration"*, not *"hardcode canopy instead"* — an agent that genuinely keeps its own client still gets it (asserted).

## Testing

`149 passed, 7 skipped` in `runner/ec2/tests/`. The 7 skip on macOS's bash 3.2, which has no associative arrays at all; CI runs ubuntu/bash 5 where they execute for real. **They were not run green locally, so the stronger evidence is this** — the resolver executed on the live box (bash 5.2.21) against the real clones:

```
ace -> canopy   ada -> canopy   echo -> canopy   eva -> canopy   hal -> canopy
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rffk2t9tySFjRNqRKxN2wR