### PR TITLE
Read the fleet roster from canopy-web, not three hardcoded copies

### DIFF
--- a/runner/ec2/bootstrap_agents.sh
+++ b/runner/ec2/bootstrap_agents.sh
@@ -75,6 +75,86 @@ gog_config_dir() {
   fi
 }
 
+# ── The fleet roster comes from canopy-web (Agent Runtime Registry) ────────────
+# It used to be pinned in THREE places — the AgentSlugs CFN parameter, AGENT_SLUGS
+# in runner.env, and this script's default — so adding an agent meant editing the
+# CloudFormation stack. canopy-web already serves the answer
+# (`GET /api/agents/{slug}/runtime`: "what a runner needs from canopy-web to run
+# this agent"); nothing consumed it. Now it does, and AGENT_SLUGS is the OFFLINE
+# fallback rather than the source. Register an agent in canopy-web and the next
+# bootstrap picks it up — no stack change, no SSH.
+#
+# Spec: docs/superpowers/specs/2026-07-20-agent-runtime-registry-design.md
+#
+# EVERY failure path here yields an EMPTY registry, never a non-zero exit: under
+# `set -e` an unreachable canopy-web would otherwise abort bootstrap and strand a
+# box that could perfectly well provision the agents it already knows.
+_REGISTRY_CACHE=""
+_REGISTRY_READ=""
+
+agent_registry() {  # -> "slug<TAB>repo_url" per agent, or nothing
+  # `:-` so the function does not depend on the initialisers above having run
+  # (extracted-function tests, and any future sourcing order).
+  if [[ -n "${_REGISTRY_READ:-}" ]]; then
+    printf '%s' "${_REGISTRY_CACHE:-}"
+    return 0
+  fi
+  _REGISTRY_READ=1
+  local base="${CANOPY_BASE_URL:-}" tok="${CANOPY_TOKEN:-}"
+  [[ -n "$base" && -n "$tok" ]] || return 0
+  local list
+  list="$(curl -fsSL --max-time 20 -H "Authorization: Bearer $tok" \
+          "${base%/}/api/agents/?limit=200" 2>/dev/null)" || return 0
+  local slugs
+  slugs="$(printf '%s' "$list" | python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    raise SystemExit(0)
+items = d.get("items") if isinstance(d, dict) else d
+for a in (items or []):
+    slug = (a or {}).get("slug") or ""
+    if slug:
+        print(slug)
+' 2>/dev/null)" || return 0
+  [[ -n "$slugs" ]] || return 0
+  local out="" slug rt repo
+  while IFS= read -r slug; do
+    [[ -n "$slug" ]] || continue
+    # The repo pointer lives on /runtime, not on the list payload.
+    rt="$(curl -fsSL --max-time 20 -H "Authorization: Bearer $tok" \
+          "${base%/}/api/agents/${slug}/runtime" 2>/dev/null)" || continue
+    repo="$(printf '%s' "$rt" | python3 -c '
+import json, sys
+try:
+    print((json.load(sys.stdin).get("repo_url") or "").strip())
+except Exception:
+    pass
+' 2>/dev/null)" || repo=""
+    out+="${slug}"$'\t'"${repo}"$'\n'
+  done <<<"$slugs"
+  _REGISTRY_CACHE="$out"
+  printf '%s' "$out"
+}
+
+resolve_roster() {  # -> comma-joined slugs; registry first, AGENT_SLUGS offline
+  local reg; reg="$(agent_registry)"
+  local slugs
+  slugs="$(printf '%s' "$reg" | cut -f1 | grep -v '^$' | paste -sd, - 2>/dev/null || true)"
+  # An EMPTY registry is treated as "could not read", not as "provision nothing":
+  # a canopy-web with zero agents is indistinguishable from an outage, and the
+  # second reading would strand the box.
+  printf '%s\n' "${slugs:-${AGENT_SLUGS:-}}"
+}
+
+agent_repo_url() {  # slug -> clone url; registry pointer, else the org convention
+  local slug="$1" reg url
+  reg="$(agent_registry)"
+  url="$(printf '%s' "$reg" | awk -F'\t' -v s="$slug" '$1==s {print $2; exit}')"
+  printf '%s\n' "${url:-https://github.com/${AGENT_REPO_ORG:-dimagi-internal}/${slug}}"
+}
+
 vault_name() {  # ace -> Agent-Ace (bash 5, shipped on Ubuntu 24.04: ${var^} title-cases)
   local slug="$1"
   printf 'Agent-%s\n' "${slug^}"
@@ -201,6 +281,8 @@ step2_gog_config() {
   # Bash associative arrays don't cross into a heredoc's subshell, so resolve
   # slug->client->email into plain "email=client" pairs here and hand those to
   # python (below) to merge into config.json's `account_clients` map.
+  # Registry-first (see agent_registry above); AGENT_SLUGS is the offline fallback.
+  AGENT_SLUGS="$(resolve_roster)"
   local slugs=(); IFS=',' read -ra slugs <<<"$AGENT_SLUGS"
   local pairs=()
   for slug in "${slugs[@]}"; do
@@ -387,7 +469,8 @@ bootstrap_one_agent() {
 
   log "── agent $slug ──"
 
-  if ! clone_or_pull "https://github.com/${AGENT_REPO_ORG}/${slug}.git" "$dest"; then
+  local repo_url; repo_url="$(agent_repo_url "$slug")"
+  if ! clone_or_pull "${repo_url%.git}.git" "$dest"; then
     fail "$slug: clone/pull of ${AGENT_REPO_ORG}/${slug} failed (private repo — is the staged GitHub token valid?)"
     FAILED_AGENTS+=("$slug")
     return

--- a/runner/ec2/tests/test_agent_registry_roster.py
+++ b/runner/ec2/tests/test_agent_registry_roster.py
@@ -1,0 +1,178 @@
+"""The fleet roster comes from canopy-web, not from three hardcoded copies.
+
+Adding a sixth agent used to mean editing CloudFormation. The roster was pinned in
+THREE places — the `AgentSlugs` CFN parameter, `AGENT_SLUGS` in the box's
+runner.env, and this script's own default — so "create a new agent" required
+access to the stack, which is the friction the Agent Runtime Registry
+(docs/superpowers/specs/2026-07-20-agent-runtime-registry-design.md) exists to
+remove. canopy-web already serves the answer at `GET /api/agents/{slug}/runtime`
+("what a runner needs from canopy-web to run this agent"); nothing consumed it.
+
+Now the registry is authoritative when reachable, and AGENT_SLUGS is the OFFLINE
+fallback. That inversion is the whole point: register an agent in canopy-web and
+the next bootstrap picks it up, with no stack change and no SSH.
+
+Degrading safely is the load-bearing property. A box that cannot reach canopy-web
+at boot must still bootstrap the agents it already knows about — so every failure
+path here (no env, HTTP error, malformed body, timeout) yields an EMPTY registry
+and the caller falls back, rather than aborting under `set -e` and taking the
+whole fleet down with it.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+
+import pytest
+
+SCRIPT = pathlib.Path(__file__).resolve().parent.parent / "bootstrap_agents.sh"
+
+_HAS_ASSOC = subprocess.run(
+    ["bash", "-c", "declare -A _t=( [k]=v ) 2>/dev/null && echo yes"],
+    capture_output=True, text=True,
+).stdout.strip() == "yes"
+pytestmark = pytest.mark.skipif(
+    not _HAS_ASSOC, reason="bash lacks associative arrays (macOS ships 3.2; the box and CI run 5)"
+)
+
+
+def _extract_function(name: str) -> str:
+    lines = SCRIPT.read_text().splitlines()
+    start = next(i for i, l in enumerate(lines) if l.startswith(f"{name}() {{"))
+    end = next(i for i in range(start + 1, len(lines)) if lines[i] == "}")
+    return "\n".join(lines[start:end + 1])
+
+
+def _fake_curl(tmp: pathlib.Path, *, slugs, repos, fail=False, garbage=False) -> pathlib.Path:
+    state = tmp / "state"
+    state.mkdir(exist_ok=True)
+    (state / "list.json").write_text(json.dumps({"items": [{"slug": s} for s in slugs]}))
+    (state / "repos.json").write_text(json.dumps(repos))
+    curl = tmp / "bin" / "curl"
+    curl.parent.mkdir(exist_ok=True)
+    curl.write_text(f'''#!/usr/bin/env python3
+import json, sys, pathlib
+STATE = pathlib.Path({str(state)!r})
+if {fail!r}:
+    sys.exit(22)                      # curl -f on an HTTP error
+url = next(a for a in sys.argv[1:] if a.startswith("http"))
+if {garbage!r}:
+    print("<html>not json</html>"); raise SystemExit
+if url.endswith("/runtime"):
+    slug = url.rstrip("/").split("/")[-2]
+    repos = json.loads((STATE / "repos.json").read_text())
+    print(json.dumps({{"slug": slug, "repo_url": repos.get(slug, ""), "repo_ref": "main",
+                       "engine": "any", "secret_refs": [], "workspace": "connect"}}))
+else:
+    print((STATE / "list.json").read_text())
+''')
+    curl.chmod(0o755)
+    return curl.parent
+
+
+def _run(tmp: pathlib.Path, fn: str, call: str, *, env_extra=None, **curl_kw) -> str:
+    """`fn` names the function under test for readability; all three are injected."""
+    del fn
+    bindir = _fake_curl(tmp, **curl_kw)
+    env = {
+        "PATH": f"{bindir}:/usr/bin:/bin",
+        "CANOPY_BASE_URL": "https://canopy.test/canopy",
+        "CANOPY_TOKEN": "t0ken",
+        "AGENT_SLUGS": "ace,ada,echo,eva,hal",
+        "AGENT_REPO_ORG": "dimagi-internal",
+    }
+    env.update(env_extra or {})
+    # resolve_roster and agent_repo_url both call agent_registry, so inject the
+    # whole trio rather than the one under test.
+    defs = "\n".join(
+        _extract_function(n) for n in ("agent_registry", "resolve_roster", "agent_repo_url")
+    )
+    res = subprocess.run(
+        ["bash", "-c", f"set -euo pipefail\n{defs}\n{call}"],
+        capture_output=True, text=True, timeout=60, env=env,
+    )
+    assert res.returncode == 0, f"exited {res.returncode}\n{res.stdout}\n{res.stderr}"
+    return res.stdout.strip()
+
+
+# --- the registry read ---------------------------------------------------------
+
+def test_the_registry_yields_slug_and_repo_for_every_agent(tmp_path):
+    out = _run(
+        tmp_path, "agent_registry", "agent_registry",
+        slugs=["ace", "echo"],
+        repos={"ace": "https://github.com/dimagi-internal/ace",
+               "echo": "https://github.com/dimagi-internal/echo"},
+    )
+    assert out.splitlines() == [
+        "ace\thttps://github.com/dimagi-internal/ace",
+        "echo\thttps://github.com/dimagi-internal/echo",
+    ]
+
+
+def test_a_NEW_agent_needs_no_stack_change(tmp_path):
+    """The point of the exercise: `scout` exists only in canopy-web, and is not in
+    AGENT_SLUGS, the CFN parameter, or this script."""
+    out = _run(
+        tmp_path, "agent_registry", "agent_registry",
+        slugs=["ace", "scout"],
+        repos={"ace": "https://github.com/dimagi-internal/ace",
+               "scout": "https://github.com/dimagi-internal/scout"},
+    )
+    assert "scout\thttps://github.com/dimagi-internal/scout" in out.splitlines()
+
+
+@pytest.mark.parametrize("kw,env", [
+    (dict(fail=True), {}),                                    # HTTP error
+    (dict(garbage=True), {}),                                 # not JSON
+    ({}, {"CANOPY_BASE_URL": ""}),                            # unconfigured
+    ({}, {"CANOPY_TOKEN": ""}),                               # no token
+])
+def test_every_failure_path_yields_an_empty_registry_and_exits_clean(tmp_path, kw, env):
+    """Under `set -e` a non-zero here would abort bootstrap entirely — a box that
+    cannot reach canopy-web must still provision the agents it already knows."""
+    assert _run(tmp_path, "agent_registry", "agent_registry",
+                slugs=["ace"], repos={"ace": "u"}, env_extra=env, **kw) == ""
+
+
+# --- what the roster resolves to ----------------------------------------------
+
+def test_the_registry_roster_wins_over_the_hardcoded_env(tmp_path):
+    out = _run(
+        tmp_path, "resolve_roster", "resolve_roster",
+        slugs=["ace", "scout"], repos={"ace": "u1", "scout": "u2"},
+    )
+    assert out == "ace,scout", "AGENT_SLUGS should not override a reachable registry"
+
+
+def test_an_unreachable_registry_falls_back_to_the_env_roster(tmp_path):
+    out = _run(
+        tmp_path, "resolve_roster", "resolve_roster",
+        slugs=["ace"], repos={}, fail=True,
+    )
+    assert out == "ace,ada,echo,eva,hal"
+
+
+def test_an_empty_registry_falls_back_rather_than_provisioning_nothing(tmp_path):
+    """A canopy-web with zero agents must not silently mean "bootstrap nothing" —
+    that is indistinguishable from an outage and would strand the box."""
+    out = _run(tmp_path, "resolve_roster", "resolve_roster", slugs=[], repos={})
+    assert out == "ace,ada,echo,eva,hal"
+
+
+# --- the clone pointer ---------------------------------------------------------
+
+def test_the_clone_url_comes_from_the_registry(tmp_path):
+    out = _run(
+        tmp_path, "agent_repo_url", 'agent_repo_url scout',
+        slugs=["scout"], repos={"scout": "https://github.com/someone-else/scout-fork"},
+    )
+    assert out == "https://github.com/someone-else/scout-fork"
+
+
+def test_the_clone_url_falls_back_to_the_org_convention(tmp_path):
+    """No registry (or no repo_url on the record) → the historical convention."""
+    out = _run(tmp_path, "agent_repo_url", "agent_repo_url hal",
+               slugs=["hal"], repos={}, fail=True)
+    assert out == "https://github.com/dimagi-internal/hal"


### PR DESCRIPTION
Connects two ends that were both already built and never wired together.

## The gap

canopy-web has served `GET /api/agents/{slug}/runtime` since the **Agent Runtime Registry** spec (2026-07-20) — *"what a runner needs from canopy-web to run this agent"*: repo pointer, engine, secret refs, tenant. The schema shipped. **Nothing ever consumed it, and the registry sat empty** (`repo_url=(empty)`, `secret_refs=[]` on all five agents).

Meanwhile `bootstrap_agents.sh` never called canopy-web at all. The roster was pinned in **three** places:

- the `AgentSlugs` CloudFormation parameter
- `AGENT_SLUGS` in the box's `runner.env`
- this script's own default

So adding a sixth agent meant editing the stack, and *"create a new agent"* required CFN access plus SSH.

## The change

The registry is authoritative when reachable; `AGENT_SLUGS` becomes the **offline fallback**. That inversion is the point: register an agent in canopy-web and the next bootstrap picks it up — no stack change.

The repo pointer comes from `/runtime` too, so an agent can live in a different org or a fork without touching the box. (Registry now populated for all five as part of this.)

## Degrading safely is load-bearing

Every failure path — no `CANOPY_BASE_URL`/`CANOPY_TOKEN`, HTTP error, malformed body, timeout — yields an **empty registry and a fallback, never a non-zero exit**. Under `set -e` an unreachable canopy-web would otherwise abort bootstrap and strand a box that could perfectly well provision the agents it already knows.

An **empty** registry is likewise read as *"could not read"*, not *"provision nothing"* — zero agents is indistinguishable from an outage, and the second reading strands the box just as thoroughly. Both are asserted.

## Verification

The 11 new tests skip on macOS's bash 3.2 (no associative arrays), so they were run **on the box** (bash 5.2.21) — `11 passed` — and then the functions were executed against the **real** canopy-web from that box:

```
=== live registry read from https://labs.connect.dimagi.com/canopy ===
ace   https://github.com/dimagi-internal/ace
ada   https://github.com/dimagi-internal/ada
echo  https://github.com/dimagi-internal/echo
eva   https://github.com/dimagi-internal/eva
hal   https://github.com/dimagi-internal/hal
=== resolved roster ===        ace,ada,echo,eva,hal
=== clone url for ace ===      https://github.com/dimagi-internal/ace
```

`149 passed, 11 skipped` locally in `runner/ec2/tests/`.

## Scoped out, deliberately

- **Consuming `runtime.yaml`** — only `echo` has one, and it's a good prototype (plugins, tools, env, ~12 secret refs, preflight). Making the reconciler honour it is the next slice, and it wants the other four written first.
- **Moving secret VALUES off 1Password into canopy-web.** The precedent exists (`RunnerCredential` already stores Claude/GitHub/1P tokens Fernet-encrypted at rest), so an agent-level equivalent is mechanically straightforward — but it's a security-architecture decision with real blast radius, and it's Jonathan's call, not a follow-on.

Neither is blocked by this; both get easier once the box reads the registry at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rffk2t9tySFjRNqRKxN2wR