### PR TITLE
A Credentials screen that says what is stopping an agent running

### DIFF
--- a/frontend/src/api/agents.ts
+++ b/frontend/src/api/agents.ts
@@ -247,6 +247,40 @@ export async function putAgentRunners(
 // Per-source overrides on top of the default ordered list — one rule per source.
 // A separate endpoint from putAgentRunners on purpose: both live in one table,
 // and each write is scoped server-side so neither clobbers the other's rows.
+export type AgentCredentialStatusOut = Schemas['AgentCredentialStatusOut']
+
+/** Which declared refs are set — booleans and timestamps, never values. */
+export async function getAgentCredentialStatus(slug: string): Promise<AgentCredentialStatusOut[]> {
+  const res = await apiV2.GET('/api/agents/{slug}/credentials/status', {
+    params: { path: { slug } },
+  })
+  return Array.from(unwrap(res, 'getAgentCredentialStatus'))
+}
+
+/** Upsert named secrets. NON-CLOBBERING — omitted refs are untouched, so a
+ *  single-field edit cannot wipe the rest. Returns the masked status; there is
+ *  deliberately no route that reads a value back into a browser. */
+export async function setAgentCredentials(
+  slug: string,
+  values: Record<string, string>,
+): Promise<AgentCredentialStatusOut[]> {
+  const res = await apiV2.PUT('/api/agents/{slug}/credentials', {
+    params: { path: { slug } },
+    body: { values },
+  })
+  return Array.from(unwrap(res, 'setAgentCredentials'))
+}
+
+export async function deleteAgentCredential(
+  slug: string,
+  name: string,
+): Promise<AgentCredentialStatusOut[]> {
+  const res = await apiV2.DELETE('/api/agents/{slug}/credentials/{name}', {
+    params: { path: { slug, name } },
+  })
+  return Array.from(unwrap(res, 'deleteAgentCredential'))
+}
+
 export async function getAgentRunnerRules(slug: string): Promise<AgentRunnerRuleOut[]> {
   const res = await apiV2.GET('/api/agents/{slug}/runner-rules', { params: { path: { slug } } })
   return Array.from(unwrap(res, 'getAgentRunnerRules'))

--- a/frontend/src/components/agents/AgentLeftNav.tsx
+++ b/frontend/src/components/agents/AgentLeftNav.tsx
@@ -32,6 +32,7 @@ export function AgentLeftNav({ agent }: { agent: AgentDetailOut }) {
     // needs its own fetch to say "3" isn't worth a request on every rail render.
     { to: 'schedules', label: 'Schedules' },
     { to: 'syncs', label: 'Syncs', count: agent.sync_count },
+    { to: 'credentials', label: 'Credentials' },
     { to: 'work-products', label: 'Work products', count: agent.work_product_count },
     { to: 'skills', label: 'Skills', count: agent.skill_count },
   ]

--- a/frontend/src/pages/agents/AgentCredentialsSection.tsx
+++ b/frontend/src/pages/agents/AgentCredentialsSection.tsx
@@ -1,0 +1,197 @@
+import { useEffect, useState } from 'react'
+import { useOutletContext } from 'react-router-dom'
+import {
+  deleteAgentCredential,
+  getAgentCredentialStatus,
+  setAgentCredentials,
+  type AgentCredentialStatusOut,
+} from '@/api/agents'
+import type { AgentOutletContext } from '@/pages/AgentWorkspacePage'
+import { blockers, groupRefs } from '@/pages/agents/agentCredentials'
+import { WorkbenchSubHeader, WorkbenchSkeleton } from 'canopy-ui'
+
+// "What is stopping this agent from running" — a question that on 2026-09-05
+// cost an SSH to a box and a `gog auth list`. ACE's mailbox had been dead since
+// May under an OAuth client its own config warns against, and nothing surfaced
+// it until a readiness drill happened to run three weeks later.
+//
+// Values are write-only: the status route returns booleans and timestamps and
+// never plaintext, so this page can say "set" and "when" and cannot render a
+// secret. A blank field is not sent — the write is non-clobbering, and "" would
+// wipe a working credential.
+
+export function AgentCredentialsSection() {
+  const { agent } = useOutletContext<AgentOutletContext>()
+  const [rows, setRows] = useState<AgentCredentialStatusOut[] | null>(null)
+  const [draft, setDraft] = useState<Record<string, string>>({})
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setRows(null)
+    setDraft({})
+    getAgentCredentialStatus(agent.slug)
+      .then((r) => !cancelled && setRows(r))
+      .catch((e: unknown) => {
+        if (cancelled) return
+        setError(e instanceof Error ? e.message : 'Failed to load')
+        setRows([])
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [agent.slug])
+
+  const save = async (name: string) => {
+    const value = (draft[name] ?? '').trim()
+    if (!value) return
+    setBusy(true)
+    setError(null)
+    try {
+      setRows(await setAgentCredentials(agent.slug, { [name]: value }))
+      // Never keep a secret in component state once it has landed.
+      setDraft((d) => ({ ...d, [name]: '' }))
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to save')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const remove = async (name: string) => {
+    setBusy(true)
+    setError(null)
+    try {
+      setRows(await deleteAgentCredential(agent.slug, name))
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to remove')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  if (rows === null) {
+    return (
+      <div className="max-w-4xl px-6 py-8">
+        <WorkbenchSubHeader title="Credentials" />
+        <WorkbenchSkeleton />
+      </div>
+    )
+  }
+
+  const b = blockers(rows)
+  const ordered = groupRefs(rows)
+
+  return (
+    <div className="max-w-4xl px-6 py-8" data-testid="agent-credentials">
+      <WorkbenchSubHeader title="Credentials" count={rows.length} />
+
+      {b.undeclared ? (
+        // Zero refs is UNDECLARED, not provisioned — and it is the state every
+        // agent is in before someone writes a runtime.yaml. Saying "ready" here
+        // would assert a box can run it, which nobody has established.
+        <p className="text-[13px] text-muted-foreground" data-testid="agent-credentials-undeclared">
+          This agent declares no secrets. Shape lives in its repo’s{' '}
+          <code className="font-mono text-[12px]">runtime.yaml</code> and reaches canopy-web as the
+          registry’s secret refs — until it declares some, there is nothing to provision here.
+        </p>
+      ) : (
+        <>
+          {b.missing.length > 0 ? (
+            <p
+              className="mb-3 rounded-md border border-warning/40 bg-warning/10 px-2 py-1 text-[13px] text-warning"
+              data-testid="agent-credentials-blockers"
+            >
+              ⚠ {b.missing.length} declared {b.missing.length === 1 ? 'secret is' : 'secrets are'} not
+              set — this agent cannot run until they are.
+            </p>
+          ) : (
+            <p className="mb-3 text-[13px] text-success" data-testid="agent-credentials-ready">
+              ✓ Every declared secret is set.
+            </p>
+          )}
+
+          {b.stillInVault.length > 0 && (
+            // Not a blocker — resolution falls back to 1Password — but it is
+            // exactly what stops "no vault access needed" from being true yet.
+            <p className="mb-3 text-[12px] text-muted-foreground" data-testid="agent-credentials-vault">
+              {b.stillInVault.length} still resolve from 1Password. Setting them here is what removes
+              the vault from the path.
+            </p>
+          )}
+
+          <div className="space-y-2">
+            {ordered.map((r) => (
+              <div
+                key={r.name}
+                className="flex flex-wrap items-center gap-2 rounded-lg border border-border bg-card px-3 py-2"
+                data-testid={`cred-${r.name}`}
+              >
+                <span className={r.set ? 'text-success' : 'text-muted-foreground'}>
+                  {r.set ? '●' : '○'}
+                </span>
+                <span className="font-mono text-[12px] text-foreground">{r.name}</span>
+
+                {!r.declared && (
+                  // An orphan: stored, but nothing declares it any more. A live
+                  // secret nothing accounts for — hiding it is how it stays that way.
+                  <span className="rounded border border-border px-1 text-[10px] uppercase text-muted-foreground">
+                    undeclared
+                  </span>
+                )}
+                {r.set && (
+                  <span className="text-[11px] text-foreground-subtle">
+                    {r.source}
+                    {r.updated_at ? ` · ${new Date(r.updated_at).toLocaleDateString()}` : ''}
+                    {r.updated_by_email ? ` · ${r.updated_by_email}` : ''}
+                  </span>
+                )}
+
+                <input
+                  type="password"
+                  autoComplete="off"
+                  value={draft[r.name] ?? ''}
+                  onChange={(e) => setDraft((d) => ({ ...d, [r.name]: e.target.value }))}
+                  placeholder={r.set ? 'rotate…' : 'paste to set'}
+                  aria-label={`Value for ${r.name}`}
+                  className="ml-auto w-56 rounded-md border border-input bg-input px-2 py-1 font-mono text-[12px] text-foreground placeholder:text-muted-foreground"
+                />
+                <button
+                  type="button"
+                  onClick={() => void save(r.name)}
+                  disabled={busy || !(draft[r.name] ?? '').trim()}
+                  className="rounded-md bg-primary px-2 py-1 text-[12px] font-medium text-primary-foreground disabled:opacity-40"
+                >
+                  Save
+                </button>
+                {r.set && (
+                  <button
+                    type="button"
+                    onClick={() => void remove(r.name)}
+                    disabled={busy}
+                    aria-label={`Remove ${r.name}`}
+                    className="px-1 text-muted-foreground hover:text-destructive disabled:opacity-40"
+                  >
+                    ✕
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+
+      {error && (
+        <p className="mt-3 text-[13px] text-destructive" data-testid="agent-credentials-error">
+          {error}
+        </p>
+      )}
+
+      <p className="mt-4 text-[11px] text-foreground-subtle">
+        Values are write-only: encrypted at rest, and readable only by a runner this agent routes to.
+        This page can show whether a secret is set, never what is in it.
+      </p>
+    </div>
+  )
+}

--- a/frontend/src/pages/agents/agentCredentials.test.ts
+++ b/frontend/src/pages/agents/agentCredentials.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import { blockers, groupRefs, type CredRow } from './agentCredentials'
+
+// The question this screen exists to answer is "what is stopping this agent from
+// running". On 2026-09-05 that question cost an SSH to a box and a `gog auth
+// list`: ACE's mailbox had been dead since May and nothing surfaced it.
+
+const row = (over: Partial<CredRow>): CredRow => ({
+  name: 'x',
+  declared: true,
+  set: false,
+  source: 'unset',
+  updated_at: null,
+  updated_by_email: null,
+  ...over,
+})
+
+describe('blockers', () => {
+  it('names the declared refs that are not set', () => {
+    const b = blockers([
+      row({ name: 'canopy-pat', set: true, source: 'canopy-web' }),
+      row({ name: 'nova-api-key' }),
+      row({ name: 'gog-token' }),
+    ])
+    expect(b.missing).toEqual(['nova-api-key', 'gog-token'])
+  })
+
+  it('ignores an UNDECLARED ref — an orphan is not a blocker', () => {
+    // It still needs showing (a live secret nothing accounts for), but it can
+    // never be the reason a turn won't run: nothing asks for it.
+    const b = blockers([row({ name: 'retired', declared: false, set: true, source: 'canopy-web' })])
+    expect(b.missing).toEqual([])
+    expect(b.orphans).toEqual(['retired'])
+  })
+
+  it('is ready only when every declared ref is set', () => {
+    expect(blockers([row({ set: true, source: 'canopy-web' })]).ready).toBe(true)
+    expect(blockers([row({ set: false })]).ready).toBe(false)
+  })
+
+  it('an agent that declares nothing is not "ready" — it is undeclared', () => {
+    // Zero refs and zero blockers is not the same as provisioned. Reporting
+    // "ready" would say the box can run it, which nobody has established.
+    const b = blockers([])
+    expect(b.ready).toBe(false)
+    expect(b.undeclared).toBe(true)
+  })
+
+  it('counts values still coming from 1Password as a migration residual', () => {
+    // Not a blocker — resolution falls back — but it IS the thing that stops
+    // "no vault access needed" from being true yet.
+    const b = blockers([
+      row({ name: 'a', set: true, source: 'canopy-web' }),
+      row({ name: 'b', set: true, source: '1password' }),
+    ])
+    expect(b.ready).toBe(true)
+    expect(b.stillInVault).toEqual(['b'])
+  })
+})
+
+describe('groupRefs', () => {
+  it('sorts unset-and-required to the top', () => {
+    const g = groupRefs([
+      row({ name: 'set-one', set: true, source: 'canopy-web' }),
+      row({ name: 'missing-one' }),
+    ])
+    expect(g.map((r) => r.name)).toEqual(['missing-one', 'set-one'])
+  })
+
+  it('puts orphans last — they are noise relative to a blocker', () => {
+    const g = groupRefs([
+      row({ name: 'orphan', declared: false, set: true, source: 'canopy-web' }),
+      row({ name: 'set-one', set: true, source: 'canopy-web' }),
+      row({ name: 'missing-one' }),
+    ])
+    expect(g.map((r) => r.name)).toEqual(['missing-one', 'set-one', 'orphan'])
+  })
+
+  it('does not mutate the input', () => {
+    const rows = [row({ name: 'b', set: true, source: 'canopy-web' }), row({ name: 'a' })]
+    const before = JSON.stringify(rows)
+    groupRefs(rows)
+    expect(JSON.stringify(rows)).toBe(before)
+  })
+})

--- a/frontend/src/pages/agents/agentCredentials.ts
+++ b/frontend/src/pages/agents/agentCredentials.ts
@@ -1,0 +1,41 @@
+import type { components } from '@/api/generated'
+
+export type CredRow = components['schemas']['AgentCredentialStatusOut']
+
+// Pure logic behind AgentCredentialsSection, extracted so it unit-tests without
+// a renderer. The screen answers one question — "what is stopping this agent
+// from running" — which today costs an SSH to a box and a `gog auth list`.
+
+export interface Blockers {
+  /** Declared refs with no value. These are what stop a turn. */
+  missing: string[]
+  /** Stored but no longer declared — a live secret nothing accounts for. */
+  orphans: string[]
+  /** Set, but still resolving out of 1Password rather than canopy-web. */
+  stillInVault: string[]
+  ready: boolean
+  /** The agent declares nothing at all, which is NOT the same as ready. */
+  undeclared: boolean
+}
+
+export function blockers(rows: readonly CredRow[]): Blockers {
+  const declared = rows.filter((r) => r.declared)
+  const missing = declared.filter((r) => !r.set).map((r) => r.name)
+  return {
+    missing,
+    orphans: rows.filter((r) => !r.declared).map((r) => r.name),
+    stillInVault: rows.filter((r) => r.set && r.source === '1password').map((r) => r.name),
+    // An agent with zero declared refs is UNDECLARED, not provisioned. Calling
+    // that "ready" would assert a box can run it, which nobody has established —
+    // and it is the state every agent is in before someone writes a runtime.yaml.
+    ready: declared.length > 0 && missing.length === 0,
+    undeclared: declared.length === 0,
+  }
+}
+
+/** Unset-and-required first (the answer to the question), then the rest, then
+ *  orphans last — they need showing but are noise next to a blocker. */
+export function groupRefs(rows: readonly CredRow[]): CredRow[] {
+  const rank = (r: CredRow) => (!r.declared ? 2 : r.set ? 1 : 0)
+  return [...rows].sort((a, b) => rank(a) - rank(b) || a.name.localeCompare(b.name))
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -54,6 +54,11 @@ const SchedulesSection = lazy(() =>
 const AgentSyncsSection = lazy(() =>
   import('./pages/agents/AgentSyncsSection').then((m) => ({ default: m.AgentSyncsSection })),
 )
+const AgentCredentialsSection = lazy(() =>
+  import('./pages/agents/AgentCredentialsSection').then((m) => ({
+    default: m.AgentCredentialsSection,
+  })),
+)
 const AgentWorkProductsSection = lazy(() =>
   import('./pages/agents/AgentWorkProductsSection').then((m) => ({ default: m.AgentWorkProductsSection })),
 )
@@ -220,6 +225,7 @@ export const router = createBrowserRouter(guarded([
           { path: 'items', element: <LazySection><ItemsSection /></LazySection> },
           { path: 'schedules', element: <LazySection><SchedulesSection /></LazySection> },
           { path: 'syncs', element: <LazySection><AgentSyncsSection /></LazySection> },
+          { path: 'credentials', element: <LazySection><AgentCredentialsSection /></LazySection> },
           { path: 'work-products', element: <LazySection><AgentWorkProductsSection /></LazySection> },
           { path: 'skills', element: <LazySection><AgentSkillsSection /></LazySection> },
         ],


### PR DESCRIPTION
Second slice of #664; the store landed in #666. Frontend only.

## The question it answers

On 2026-09-05, "what is stopping this agent from running" cost an SSH to a box and a `gog auth list`. ACE's mailbox had been dead since **May**, under an OAuth client its own config warns against, and nothing surfaced it until a readiness drill happened to run three weeks later.

**A credential that lives only in a vault and a keyring is a credential nobody is watching.** This is the watching.

## Three states, kept distinct because the next action differs

| State | Meaning | Where it sorts |
|---|---|---|
| declared, unset | **a blocker** — the agent cannot run | top; it *is* the answer |
| stored, undeclared | an **orphan** — nothing asks for it, but it's a live secret nothing accounts for | last; shown, not hidden |
| set, `source: 1password` | not a blocker (resolution falls back) — but exactly what stops *"no vault access needed"* from being true | inline note |

An agent declaring nothing reads as **undeclared**, never "ready". Zero refs and zero blockers is not provisioned — it's the state every agent is in before someone writes a `runtime.yaml`, and calling it ready would assert a box can run it when nobody has established that.

## Write-only holds here too

The status route returns booleans and timestamps and never plaintext, so the page *can* say "set" and "when" and *cannot* render a secret. A blank field is not sent (the write is non-clobbering; `""` would wipe a working credential), and the draft is cleared the moment a value lands rather than lingering in component state.

## Testing

`680 passed`; tsc and vite build clean. The ordering and blocker logic are extracted as pure functions and tested directly — including that an undeclared orphan is *not* counted as a blocker, and that an agent with no declarations is not reported ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rffk2t9tySFjRNqRKxN2wR