### PR TITLE
The browser OAuth mint is blocked on a Google client, not on code

### DIFF
--- a/docs/superpowers/specs/2026-09-05-agent-credentials-design.md
+++ b/docs/superpowers/specs/2026-09-05-agent-credentials-design.md
@@ -117,6 +117,48 @@ GET  /api/agents/{slug}/oauth/google/callback -> stores refresh token as `gog-to
   with that client*, so recording which client produced it turns an invisible
   mismatch into a rendered fact.
 
+### BLOCKED, measured 2026-09-05 — and not on code
+
+The browser mint cannot be built against the **shared `canopy` OAuth client**.
+Probed directly against Google's authorize endpoint with that client id and a
+canopy-web redirect:
+
+```
+redirect_uri = https://labs.connect.dimagi.com/canopy/api/agents/ace/oauth/google/callback
+-> Error 400: redirect_uri_mismatch  ("Access blocked")
+```
+
+The stored credential is `{client_id, client_secret}` and nothing else — no
+`redirect_uris`, no `auth_uri` — because `gog` is a CLI and authorises over a
+**loopback** redirect. A server-side web redirect is a different registration,
+and on a *Desktop-app* client type Google will not permit an https redirect at
+all.
+
+So the remaining work is an **administrative step in the Google Cloud project
+that owns the client**, and it is one of:
+
+1. **Register the callback** on the existing `canopy` client — only possible if
+   it is a Web-application client, which the loopback usage suggests it is not.
+2. **Create a new Web-application OAuth client for canopy-web** (recommended) —
+   a separate surface deserves a separate client, and it keeps the CLI's
+   loopback client unchanged.
+
+**Option 2 has a consequence this spec must state, because it is the same trap
+that cost a mailbox on 2026-09-05:** a token minted under a *new* web client
+**will not work** with `gog --client canopy`. A token is minted FOR a client and
+works only with that client. So adopting option 2 means the agent's gog client
+becomes the new one, and every place that names `canopy` — `config/agent.json`,
+`runtime.yaml`, the box's `account_clients` map — has to move together, or the
+box authenticates against a client the token was never issued for.
+
+That is precisely why the design stamps each stored token with its minting
+client: it turns this from an invisible mismatch into a rendered fact.
+
+**Until one of those is done, the terminal path (`gog login`) remains the only
+way to mint an agent's Google token**, and ACE's mailbox stays dead. Everything
+else in this spec — the store, the status screen, the resolve gate — is
+independent of it and has shipped (#666, #667).
+
 **Claude credentials stay out of scope.** `claude setup-token` is Anthropic's flow
 and not ours to embed, and the Claude login is **runner-level, not agent-level** —
 the agent brings its identity, not its AI subscription (both `runtime.yaml` files


### PR DESCRIPTION
Docs only. I probed this **before** building it, which turned out to be the whole point.

## What I found

The browser mint cannot be built against the shared `canopy` OAuth client. Asked Google directly, with that client id and a canopy-web redirect:

```
redirect_uri = https://labs.connect.dimagi.com/canopy/api/agents/ace/oauth/google/callback
→ Error 400: redirect_uri_mismatch  ("Access blocked")
```

The stored credential is `{client_id, client_secret}` and **nothing else** — no `redirect_uris`, no `auth_uri` — because `gog` is a CLI and authorises over a **loopback** redirect. A server-side web redirect is a different registration, and a *Desktop-app* client cannot take an https redirect at all.

So the remaining work is **administrative, in the Google Cloud project**, not in this repo:

1. **Register the callback** on the existing `canopy` client — only possible if it's a Web-application client, which its loopback usage suggests it isn't; or
2. **Create a new Web-application OAuth client for canopy-web** (recommended) — a separate surface deserves its own client, and it leaves the CLI's loopback client untouched.

## Option 2 carries the trap that already cost a mailbox today

A token minted under a **new** client will not work with `gog --client canopy`. *A token is minted FOR a client and works only with that client* — the lesson from #661/#662 this morning, where I made the opposite assumption and broke echo's mailbox.

So adopting option 2 means the agent's gog client becomes the new one, and every place naming `canopy` — `config/agent.json`, `runtime.yaml`, the box's `account_clients` map — has to move **together**, or the box authenticates against a client the token was never issued for.

That is exactly why the design stamps each stored token with its minting client: it turns an invisible mismatch into a rendered fact.

## What this doesn't block

The store, the status screen and the `resolve` gate (#666, #667) are independent of the mint and have shipped. Until one of the two options above happens, `gog login` remains the only way to mint an agent's Google token — and **ACE's mailbox stays dead**.

I'd rather record a measured blocker than open a draft PR of 400 lines that cannot merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rffk2t9tySFjRNqRKxN2wR