### PR TITLE
runner: one CloudWatch incident spawns one turn, not two

### DIFF
--- a/runner/canopy_runner/canopy_runner/inbox.py
+++ b/runner/canopy_runner/canopy_runner/inbox.py
@@ -11,6 +11,7 @@ session (continuity) or a fresh one.
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 
 # UNREAD only — the "new email" signal. Critically NOT "all recent threads":
@@ -18,6 +19,29 @@ import subprocess
 # is a cost bomb. Idempotency (thread+messageCount) means an unread thread fires
 # exactly once until its state changes.
 DEFAULT_QUERY = "in:inbox is:unread newer_than:14d"
+
+#: A CloudWatch/SNS alarm notification subject: `ALARM: "<name>" in <region>`, and its
+#: matching `OK: "<name>" in <region>`. The quoted alarm name is what pairs the two.
+_ALARM_SUBJECT = re.compile(r'^\s*(ALARM|OK):\s*"([^"]+)"')
+
+
+def alarm_key(thread: dict) -> tuple[str, str] | None:
+    """``(state, alarm_name)`` for a CloudWatch alarm notification, else ``None``.
+
+    Deliberately narrow on BOTH axes, because everything downstream of it suppresses a
+    turn and a false positive here is a silently-dropped message:
+
+    * the sender must be SNS — a human writing ``OK: "the deploy" in staging`` is not an
+      alarm and must never be coalesced;
+    * the subject must match the CloudWatch shape exactly.
+
+    Anything unrecognised returns ``None``, which every caller treats as "enqueue
+    normally". That is the fail-open direction.
+    """
+    if "sns.amazonaws.com" not in (thread.get("from") or "").lower():
+        return None
+    m = _ALARM_SUBJECT.match(thread.get("subject") or "")
+    return (m.group(1).upper(), m.group(2)) if m else None
 
 
 class InboxError(Exception):
@@ -93,7 +117,8 @@ def check_inbox(client, agent: str, *, mailbox: str, gog_client: str,
                 sender_of=None, discovered_by: str = "poll") -> dict:
     """Enqueue an email-origin turn for each new thread state. Returns
     {"new": [thread_ids that became a NEW turn], "seen": [ids already tracked],
-    "skipped": [ids whose newest message is the agent's own reply]} — the split matters
+    "skipped": [ids whose newest message is the agent's own reply],
+    "coalesced": [SNS `OK:` ids folded into their `ALARM:` turn]} — the split matters
     for logging: re-polling the same unread mail is idempotent server-side, so it must
     read as "nothing new", not as fresh work.
 
@@ -113,7 +138,22 @@ def check_inbox(client, agent: str, *, mailbox: str, gog_client: str,
     new: list[str] = []
     seen: list[str] = []
     skipped: list[str] = []
+    coalesced: list[str] = []
     box = mailbox.lower()
+    # ONE INCIDENT, ONE TURN. CloudWatch emits `ALARM:` and `OK:` as two Gmail threads
+    # (the subjects differ), so one alarm transition used to enqueue two turns — and the
+    # `OK:` half can never produce a finding: its `ALARM:` already owns the incident, so
+    # the second session's whole job is to discover it should stand down.
+    #
+    # Measured on hal, 2026-08-31 -> 09-05: 10 sessions for 5 incidents, the `OK:` halves
+    # burning 3,186 of 7,232 transcript events to conclude "not mine" (one of them 1,362
+    # events, having taken over from a stalled owner and died on a usage limit).
+    #
+    # So an `OK:` whose alarm ALSO has an `ALARM:` thread in this batch is coalesced into
+    # that turn. Deterministic and free — both threads are already in hand, so this costs
+    # no extra subprocess and no LLM judgment, preserving this module's "fixed rule, no
+    # judgment in the hot path" contract.
+    alarming = {k[1] for k in (alarm_key(t) for t in threads) if k and k[0] == "ALARM"}
     for t in threads:
         tid = t.get("id")
         if not tid:
@@ -124,6 +164,19 @@ def check_inbox(client, agent: str, *, mailbox: str, gog_client: str,
         # be no-ops, and the subprocess is the expensive one.
         if _seen_state.get((box, tid)) == count:
             seen.append(tid)
+            continue
+        # Coalesce BEFORE `sender_of`, which is a `gog gmail thread get` subprocess —
+        # the same cost-ordering reason the idempotency check sits above.
+        key = alarm_key(t)
+        if key and key[0] == "OK" and key[1] in alarming:
+            coalesced.append(tid)
+            # Remember it so the next poll doesn't re-evaluate the same state. NOTE:
+            # `_seen_state` is process-local (see its docstring), so a runner restart
+            # while this `OK:` is still unread can fire one turn for it. That is exactly
+            # today's behaviour — strictly never worse — and closing it properly belongs
+            # on the agent side: the `ALARM:` owner groups the storm by alarm name and
+            # marks the whole storm read.
+            _seen_state[(box, tid)] = count
             continue
         latest = sender_of(tid)
         if latest and box in latest:
@@ -148,4 +201,4 @@ def check_inbox(client, agent: str, *, mailbox: str, gog_client: str,
         )
         _seen_state[(box, tid)] = count
         (new if (res or {}).get("_created") else seen).append(tid)
-    return {"new": new, "seen": seen, "skipped": skipped}
+    return {"new": new, "seen": seen, "skipped": skipped, "coalesced": coalesced}

--- a/runner/canopy_runner/canopy_runner/main.py
+++ b/runner/canopy_runner/canopy_runner/main.py
@@ -214,15 +214,19 @@ def _maybe_check_inboxes(cfg: Config, client: Client, now_fn=time.time,
             )
             n_new, n_seen = len(res["new"]), len(res["seen"])
             n_skip = len(res.get("skipped", []))
+            n_coal = len(res.get("coalesced", []))
             # Log EVERY poll, not just ones that enqueue — otherwise a healthy poll that
             # finds nothing new is silent and you can't tell polling is happening at all.
             # `skipped` = unread threads whose newest message is the agent's own reply
             # (already had the last word), suppressed so a re-marked-unread thread can't
             # manufacture a turn with no new inbound.
+            # `coalesced` = a CloudWatch `OK:` folded into its `ALARM:` turn (one incident,
+            # one session). Logged rather than silent: suppressing a turn is exactly the
+            # kind of behaviour that must be visible when someone asks why no turn fired.
             logger.info("inbox[%s]: %s — %d unread (%d NEW -> session, %d already tracked, "
-                        "%d skipped: agent's own reply)",
+                        "%d skipped: agent's own reply, %d coalesced: alarm OK: into its ALARM:)",
                         agent, "RUNG" if agent in rung_slugs else "polled",
-                        n_new + n_seen + n_skip, n_new, n_seen, n_skip)
+                        n_new + n_seen + n_skip + n_coal, n_new, n_seen, n_skip, n_coal)
         except Exception as exc:  # noqa: BLE001 — one bad inbox never kills the loop
             logger.warning("inbox check for %s failed: %s", agent, exc)
         finally:

--- a/runner/canopy_runner/tests/test_inbox.py
+++ b/runner/canopy_runner/tests/test_inbox.py
@@ -48,7 +48,7 @@ def test_idempotency_key_includes_message_count():
 
 def test_empty_inbox_enqueues_nothing():
     client = FakeClient()
-    assert inbox.check_inbox(client, "hal", mailbox="m", gog_client="c", runner=_runner([])) == {"new": [], "seen": [], "skipped": []}
+    assert inbox.check_inbox(client, "hal", mailbox="m", gog_client="c", runner=_runner([])) == {"new": [], "seen": [], "skipped": [], "coalesced": []}
     assert client.enqueued == []
 
 
@@ -108,3 +108,129 @@ def test_newest_sender_returns_none_on_gog_failure():
     def fail(cmd, capture_output, text, timeout):
         return SimpleNamespace(returncode=1, stdout="", stderr="boom")
     assert inbox.newest_sender("m", "c", "thr-1", runner=fail) is None
+
+
+# --- CloudWatch alarm pairs: one incident, one turn -------------------------------
+#
+# Real subjects and sender from the 2026-09-05 `labs-jj-web-cpu-high` incident, which
+# spawned two hal sessions for one alarm transition.
+
+SNS = "Labs Alerts <no-reply@sns.amazonaws.com>"
+_ALARM = 'ALARM: "labs-jj-web-cpu-high" in US East (N. Virginia)'
+_OK = 'OK: "labs-jj-web-cpu-high" in US East (N. Virginia)'
+
+
+def _alarm_pair():
+    return [
+        {"id": "thr-alarm", "from": SNS, "subject": _ALARM, "messageCount": 1},
+        {"id": "thr-ok", "from": SNS, "subject": _OK, "messageCount": 1},
+    ]
+
+
+@pytest.fixture(autouse=True)
+def _clear_seen_state():
+    """`_seen_state` is module-global and these tests reuse thread ids."""
+    inbox._seen_state.clear()
+    yield
+    inbox._seen_state.clear()
+
+
+def test_alarm_key_parses_both_states():
+    assert inbox.alarm_key({"from": SNS, "subject": _ALARM}) == ("ALARM", "labs-jj-web-cpu-high")
+    assert inbox.alarm_key({"from": SNS, "subject": _OK}) == ("OK", "labs-jj-web-cpu-high")
+
+
+def test_alarm_key_ignores_non_sns_sender():
+    """A human writing `OK: "the deploy"` is not an alarm and must never be coalesced."""
+    assert inbox.alarm_key({"from": "Jonathan <jjackson@dimagi.com>",
+                            "subject": 'OK: "the deploy" in staging'}) is None
+
+
+def test_alarm_key_ignores_unparseable_subject():
+    assert inbox.alarm_key({"from": SNS, "subject": "your monthly AWS bill"}) is None
+    assert inbox.alarm_key({"from": SNS, "subject": "OK: no quotes here"}) is None
+
+
+def test_ok_thread_is_coalesced_into_its_alarm_turn():
+    """The bug: ALARM: and OK: are two threads for ONE incident, so a single transition
+    enqueued two turns — and the OK: half can never produce a finding."""
+    client = FakeClient()
+    res = inbox.check_inbox(client, "hal", mailbox="hal@dimagi-ai.com", gog_client="canopy",
+                            runner=_runner(_alarm_pair()), sender_of=lambda tid: SNS.lower())
+    assert res["new"] == ["thr-alarm"]
+    assert res["coalesced"] == ["thr-ok"]
+    assert [e["prompt"] for e in client.enqueued] == ["/hal:turn --thread thr-alarm"]
+
+
+def test_coalescing_holds_regardless_of_thread_order():
+    """The OK: arrives BEFORE its ALARM: in the batch — the pairing is by alarm name,
+    not by position, so ordering must not change the outcome."""
+    client = FakeClient()
+    threads = list(reversed(_alarm_pair()))
+    res = inbox.check_inbox(client, "hal", mailbox="hal@dimagi-ai.com", gog_client="canopy",
+                            runner=_runner(threads), sender_of=lambda tid: SNS.lower())
+    assert res["new"] == ["thr-alarm"]
+    assert res["coalesced"] == ["thr-ok"]
+
+
+def test_lone_ok_with_no_matching_alarm_still_fires():
+    """Fail-open: an OK: whose ALARM: is not in the batch is the only signal there is,
+    so it must still become a turn. Never silently drop a message."""
+    client = FakeClient()
+    threads = [{"id": "thr-ok", "from": SNS, "subject": _OK, "messageCount": 1}]
+    res = inbox.check_inbox(client, "hal", mailbox="hal@dimagi-ai.com", gog_client="canopy",
+                            runner=_runner(threads), sender_of=lambda tid: SNS.lower())
+    assert res["new"] == ["thr-ok"]
+    assert res["coalesced"] == []
+
+
+def test_ok_for_a_different_alarm_is_not_coalesced():
+    """Pairing is per alarm NAME — an unrelated alarm's OK: must not be swallowed by a
+    live ALARM: for something else."""
+    client = FakeClient()
+    threads = _alarm_pair() + [
+        {"id": "thr-other-ok", "from": SNS, "messageCount": 1,
+         "subject": 'OK: "labs-jj-web-worker-crash-loop" in US East (N. Virginia)'},
+    ]
+    res = inbox.check_inbox(client, "hal", mailbox="hal@dimagi-ai.com", gog_client="canopy",
+                            runner=_runner(threads), sender_of=lambda tid: SNS.lower())
+    assert res["new"] == ["thr-alarm", "thr-other-ok"]
+    assert res["coalesced"] == ["thr-ok"]
+
+
+def test_alarm_thread_itself_is_never_coalesced():
+    """Only the OK: side is ever suppressed; the ALARM: always owns the incident."""
+    client = FakeClient()
+    threads = [{"id": "thr-alarm", "from": SNS, "subject": _ALARM, "messageCount": 1}]
+    res = inbox.check_inbox(client, "hal", mailbox="hal@dimagi-ai.com", gog_client="canopy",
+                            runner=_runner(threads), sender_of=lambda tid: SNS.lower())
+    assert res["new"] == ["thr-alarm"]
+    assert res["coalesced"] == []
+
+
+def test_coalescing_skips_the_thread_get_subprocess():
+    """The coalesce check sits ABOVE `sender_of` (a `gog gmail thread get` subprocess),
+    so a suppressed OK: must not cost one."""
+    looked_up = []
+
+    def sender_of(tid):
+        looked_up.append(tid)
+        return SNS.lower()
+
+    inbox.check_inbox(FakeClient(), "hal", mailbox="hal@dimagi-ai.com", gog_client="canopy",
+                      runner=_runner(_alarm_pair()), sender_of=sender_of)
+    assert "thr-ok" not in looked_up
+
+
+def test_non_alarm_mail_is_completely_unaffected():
+    """The regression guard: ordinary human mail must route exactly as before."""
+    client = FakeClient()
+    threads = [
+        {"id": "thr-1", "from": "Jonathan <jjackson@dimagi.com>", "subject": "re: bednet",
+         "messageCount": 3},
+        {"id": "thr-2", "from": "x@y.com", "subject": "hi", "messageCount": 1},
+    ]
+    res = inbox.check_inbox(client, "hal", mailbox="hal@dimagi-ai.com", gog_client="canopy",
+                            runner=_runner(threads), sender_of=lambda tid: "x@y.com")
+    assert res["new"] == ["thr-1", "thr-2"]
+    assert res["coalesced"] == []


### PR DESCRIPTION
Closes #669.

## What this fixes

CloudWatch emits `ALARM:` and `OK:` as **two Gmail threads** — the subjects differ — and `check_inbox` enqueues one turn per thread state. So every alarm transition spawned **two Claude sessions for one incident**, and the `OK:` half can never produce a finding: its `ALARM:` already owns the incident, so the second session's entire job is to discover it should stand down.

Measured on hal, 2026-08-31 → 09-05 — **10 sessions for 5 incidents**:

| Date | Alarm | `ALARM:` | `OK:` |
|---|---|---:|---:|
| 08-31 | `labs-jj-web-cpu-high` | 204 | 222 |
| 09-01 | `labs-jj-web-cpu-high` | 1,510 | **1,362** |
| 09-02 | `labs-jj-web-cpu-high` | 796 | 432 |
| 09-04 | `labs-jj-web-worker-crash-loop` | 1,344 | 954 |
| 09-05 | `labs-jj-web-cpu-high` | 192 | 216 |
| | **totals** | **4,046** | **3,186** |

The `OK:` halves burned **3,186 of 7,232 transcript events (44%)** to conclude "not mine". The 09-01 one is the worst case: it identified the owner correctly, took over anyway because that owner had stalled, inherited the stall's cause (expired AWS SSO), and died on a usage limit.

hal's turn skill has a stand-down procedure for this and **it works** — today's pair resolved in ~200 events each. But it is a runtime patch on a dispatch bug: it still costs a whole session, worktree and model context to reach "not mine".

## The change

An `OK:` whose alarm **also has an `ALARM:` thread in the same batch** is coalesced into that turn.

- Pairing is by the **quoted alarm name**, restricted to **SNS senders** — a human writing `OK: "the deploy" in staging` can never be coalesced.
- Sits **above** the `sender_of` call (a `gog gmail thread get` subprocess), so a suppressed thread costs nothing — the same cost-ordering as the existing idempotency check.
- No LLM and no extra subprocess: both threads are already in hand. The module's "fixed rule, no judgment in the hot path" contract is preserved.
- Reported in a new `coalesced` bucket and **logged**, not silent — "why did no turn fire" has to be answerable from the runner log.

**Fails open in every direction.** A non-SNS sender, an unparseable subject, or an `OK:` with no matching `ALARM:` enqueues exactly as before. Nothing is ever silently dropped.

## Known limits (documented, deliberately not fixed here)

1. `_seen_state` is process-local, so a runner restart while a coalesced `OK:` is still unread can fire one turn for it. That is *today's* behaviour — strictly never worse.
2. A coalesced `OK:` stays unread until a turn reads it. Closing that belongs on the agent side: the `ALARM:` owner already groups the storm by alarm name, so it marks the whole storm read. Shipping alongside as a hal skill change.

I deliberately did **not** add a mailbox mutation to the runner — it currently only reads and enqueues, and adding a write to the hot path is an architecture change that shouldn't ride along inside a bug fix.

## Verification

Gate denominator computed with `bin/hal-ci-gates` — only `ci.yml` fires (`regen-openapi.yml`'s paths filter excludes every changed file).

- `uv run --with pytest pytest` in `runner/canopy_runner` → **574 passed**
- `uv run ruff check . --select F --ignore F403,F405` → **All checks passed!**

9 new tests, built on the **real subjects and sender** from the 2026-09-05 incident: both-states parsing, non-SNS rejection, unparseable subjects, coalescing, order-independence, lone-`OK:` fail-open, per-alarm-name isolation, `ALARM:`-never-coalesced, the skipped-subprocess assertion, and a regression guard that ordinary human mail is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DkJ11u4M9XwGkPzV33sQd4