### PR TITLE
canopy-web is not the vault — report, don't judge

### DIFF
--- a/docs/superpowers/specs/2026-09-05-agent-credentials-design.md
+++ b/docs/superpowers/specs/2026-09-05-agent-credentials-design.md
@@ -1,7 +1,7 @@
 # Agent credentials in canopy-web — creating an agent without 1Password or the box
 
 **Date:** 2026-09-05
-**Status:** Design — approved in direction, not yet built
+**Status:** Shipped (#666, #667) — scope AMENDED 2026-09-06, see below
 **Builds on:** `2026-07-20-agent-runtime-registry-design.md` (the registry + reconciler;
 its **secret store** half is what this replaces for the agent layer)
 **Depends on:** #663 (the box reads its roster from canopy-web), `echo/runtime.yaml`,
@@ -31,6 +31,44 @@ ACE's own config warns against, and nothing surfaced that until a drill ran thre
 weeks later. Nobody could see the state of a credential without SSH-ing to a box and
 running `gog auth list`. **Credentials that only exist in a vault and a keyring are
 credentials nobody is watching.**
+
+## AMENDED 2026-09-06 — canopy-web is not the vault
+
+> *"I don't want to store all the passwords on canopy-web, just the ones we need
+> and a service token for 1pass."* — Jonathan
+
+The original decision below ("canopy-web becomes the agent secret store") is
+**too broad and is superseded.** Copying all 45 of ACE's secrets into canopy-web
+creates a second copy of every credential, free to drift from the vault, in a
+system that thereby becomes worth attacking. 1Password already does rotation,
+sharing and audit; canopy-web should not re-do it.
+
+**The corrected split:**
+
+| Lives in | What |
+|---|---|
+| **1Password** | Substantially everything — it stays the vault |
+| **canopy-web (runner)** | The **1Password service-account token** (`RunnerCredential.op_sa_token`), which is the key that lets a box resolve the rest. Already shipped, with a browser form as of #665 |
+| **canopy-web (agent)** | Only secrets that genuinely need to be there — canopy's own PAT, and anything canopy-web itself mints |
+
+This turns out to require *less* building, not more: the runner-level SA token
+already existed and the box already fetches it from canopy-web
+(`cloud_runner.py:1601`). What was wrong was the **framing**, not the mechanism.
+
+**Consequence for the status screen (#667, corrected):** a ref resolving from
+1Password is the NORMAL, intended state — not a migration residual and not a
+deficit. The first draft measured `selfContained` ("every declared secret is
+stored here") and rendered it as success, which rewards exactly the duplication
+this amendment rejects. Worse, it reported *"45 blockers — this agent cannot
+run"* about an agent running perfectly well. A screen that cries wolf is how the
+one genuinely dead credential goes unnoticed, which is the failure the screen
+exists to prevent. It now reports what canopy-web holds and says the rest come
+from the vault; whether a secret WORKS is a question only the box can answer, and
+a readiness drill is what answers it.
+
+**What still gets simpler for a new agent:** the person standing one up needs no
+box access, and needs vault access only to put that agent's secrets somewhere
+1Password already governs — not to hand-provision a machine.
 
 ## Decisions
 

--- a/frontend/src/pages/agents/AgentCredentialsSection.tsx
+++ b/frontend/src/pages/agents/AgentCredentialsSection.tsx
@@ -7,7 +7,7 @@ import {
   type AgentCredentialStatusOut,
 } from '@/api/agents'
 import type { AgentOutletContext } from '@/pages/AgentWorkspacePage'
-import { blockers, groupRefs } from '@/pages/agents/agentCredentials'
+import { groupRefs, summarize } from '@/pages/agents/agentCredentials'
 import { WorkbenchSubHeader, WorkbenchSkeleton } from 'canopy-ui'
 
 // "What is stopping this agent from running" — a question that on 2026-09-05
@@ -80,14 +80,14 @@ export function AgentCredentialsSection() {
     )
   }
 
-  const b = blockers(rows)
+  const s = summarize(rows)
   const ordered = groupRefs(rows)
 
   return (
     <div className="max-w-4xl px-6 py-8" data-testid="agent-credentials">
       <WorkbenchSubHeader title="Credentials" count={rows.length} />
 
-      {b.undeclared ? (
+      {s.undeclared ? (
         // Zero refs is UNDECLARED, not provisioned — and it is the state every
         // agent is in before someone writes a runtime.yaml. Saying "ready" here
         // would assert a box can run it, which nobody has established.
@@ -98,28 +98,21 @@ export function AgentCredentialsSection() {
         </p>
       ) : (
         <>
-          {b.missing.length > 0 ? (
-            <p
-              className="mb-3 rounded-md border border-warning/40 bg-warning/10 px-2 py-1 text-[13px] text-warning"
-              data-testid="agent-credentials-blockers"
-            >
-              ⚠ {b.missing.length} declared {b.missing.length === 1 ? 'secret is' : 'secrets are'} not
-              set — this agent cannot run until they are.
-            </p>
-          ) : (
-            <p className="mb-3 text-[13px] text-success" data-testid="agent-credentials-ready">
-              ✓ Every declared secret is set.
-            </p>
-          )}
-
-          {b.stillInVault.length > 0 && (
-            // Not a blocker — resolution falls back to 1Password — but it is
-            // exactly what stops "no vault access needed" from being true yet.
-            <p className="mb-3 text-[12px] text-muted-foreground" data-testid="agent-credentials-vault">
-              {b.stillInVault.length} still resolve from 1Password. Setting them here is what removes
-              the vault from the path.
-            </p>
-          )}
+          {/* Reports; does not judge. canopy-web holds only the secrets that need
+              to be here — the rest live in 1Password and are resolved on the box
+              with the runner's service-account token. Framing those as missing
+              made this page report "45 blockers, this agent cannot run" about a
+              healthy ACE, which teaches people to ignore it; the one genuinely
+              dead credential then hides among the false alarms. Whether a secret
+              WORKS is a question only the box can answer — a readiness drill is
+              what answers it. */}
+          <p className="mb-3 text-[13px] text-muted-foreground" data-testid="agent-credentials-summary">
+            canopy-web stores {s.storedHere.length} of {s.declaredCount} declared secrets.
+            {s.fromVault.length > 0 && (
+              <> The other {s.fromVault.length} resolve from 1Password on the box, using the
+              runner’s service-account token.</>
+            )}
+          </p>
 
           <div className="space-y-2">
             {ordered.map((r) => (

--- a/frontend/src/pages/agents/agentCredentials.test.ts
+++ b/frontend/src/pages/agents/agentCredentials.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { blockers, groupRefs, type CredRow } from './agentCredentials'
+import { groupRefs, summarize, type CredRow } from './agentCredentials'
 
-// The question this screen exists to answer is "what is stopping this agent from
-// running". On 2026-09-05 that question cost an SSH to a box and a `gog auth
-// list`: ACE's mailbox had been dead since May and nothing surfaced it.
+// canopy-web deliberately does NOT hold most of an agent's secrets — 1Password
+// does, reached on the box with the runner's service-account token. So this
+// screen reports what canopy-web holds; it does not judge whether the agent can
+// run, which is a question only the box can answer.
 
 const row = (over: Partial<CredRow>): CredRow => ({
   name: 'x',
@@ -15,65 +16,52 @@ const row = (over: Partial<CredRow>): CredRow => ({
   ...over,
 })
 
-describe('blockers', () => {
-  it('names the declared refs that are not set', () => {
-    const b = blockers([
+describe('summarize', () => {
+  it('splits declared refs into stored-here and expected-from-the-vault', () => {
+    const s = summarize([
       row({ name: 'canopy-pat', set: true, source: 'canopy-web' }),
+      row({ name: 'ace-hq-api-key' }),
       row({ name: 'nova-api-key' }),
-      row({ name: 'gog-token' }),
     ])
-    expect(b.missing).toEqual(['nova-api-key', 'gog-token'])
+    expect(s.storedHere).toEqual(['canopy-pat'])
+    expect(s.fromVault).toEqual(['ace-hq-api-key', 'nova-api-key'])
+    expect(s.declaredCount).toBe(3)
   })
 
-  it('ignores an UNDECLARED ref — an orphan is not a blocker', () => {
-    // It still needs showing (a live secret nothing accounts for), but it can
-    // never be the reason a turn won't run: nothing asks for it.
-    const b = blockers([row({ name: 'retired', declared: false, set: true, source: 'canopy-web' })])
-    expect(b.missing).toEqual([])
-    expect(b.orphans).toEqual(['retired'])
+  it('does not treat vault-resolved refs as a deficit', () => {
+    // The state every agent is in and mostly stays in. Reporting it as missing
+    // made the page cry wolf on a healthy ACE — 45 "blockers" on an agent that
+    // runs fine — which is how the one real dead credential gets ignored.
+    const s = summarize([row({ name: 'a' }), row({ name: 'b' })])
+    expect(s.fromVault).toEqual(['a', 'b'])
+    expect('selfContained' in s).toBe(false)
+    expect('missing' in s).toBe(false)
   })
 
-  it('is ready only when every declared ref is set', () => {
-    expect(blockers([row({ set: true, source: 'canopy-web' })]).ready).toBe(true)
-    expect(blockers([row({ set: false })]).ready).toBe(false)
-  })
-
-  it('an agent that declares nothing is not "ready" — it is undeclared', () => {
-    // Zero refs and zero blockers is not the same as provisioned. Reporting
-    // "ready" would say the box can run it, which nobody has established.
-    const b = blockers([])
-    expect(b.ready).toBe(false)
-    expect(b.undeclared).toBe(true)
-  })
-
-  it('counts values still coming from 1Password as a migration residual', () => {
-    // Not a blocker — resolution falls back — but it IS the thing that stops
-    // "no vault access needed" from being true yet.
-    const b = blockers([
-      row({ name: 'a', set: true, source: 'canopy-web' }),
-      row({ name: 'b', set: true, source: '1password' }),
+  it('surfaces orphans and excludes them from the declared count', () => {
+    const s = summarize([
+      row({ name: 'declared', set: true, source: 'canopy-web' }),
+      row({ name: 'retired', declared: false, set: true, source: 'canopy-web' }),
     ])
-    expect(b.ready).toBe(true)
-    expect(b.stillInVault).toEqual(['b'])
+    expect(s.orphans).toEqual(['retired'])
+    expect(s.declaredCount).toBe(1)
+  })
+
+  it('an agent declaring nothing is undeclared, not provisioned', () => {
+    const s = summarize([])
+    expect(s.undeclared).toBe(true)
+    expect(s.declaredCount).toBe(0)
   })
 })
 
 describe('groupRefs', () => {
-  it('sorts unset-and-required to the top', () => {
-    const g = groupRefs([
-      row({ name: 'set-one', set: true, source: 'canopy-web' }),
-      row({ name: 'missing-one' }),
-    ])
-    expect(g.map((r) => r.name)).toEqual(['missing-one', 'set-one'])
-  })
-
-  it('puts orphans last — they are noise relative to a blocker', () => {
+  it('puts what this page manages first, then vault-resolved, then orphans', () => {
     const g = groupRefs([
       row({ name: 'orphan', declared: false, set: true, source: 'canopy-web' }),
-      row({ name: 'set-one', set: true, source: 'canopy-web' }),
-      row({ name: 'missing-one' }),
+      row({ name: 'vault' }),
+      row({ name: 'here', set: true, source: 'canopy-web' }),
     ])
-    expect(g.map((r) => r.name)).toEqual(['missing-one', 'set-one', 'orphan'])
+    expect(g.map((r) => r.name)).toEqual(['here', 'vault', 'orphan'])
   })
 
   it('does not mutate the input', () => {

--- a/frontend/src/pages/agents/agentCredentials.ts
+++ b/frontend/src/pages/agents/agentCredentials.ts
@@ -2,40 +2,52 @@ import type { components } from '@/api/generated'
 
 export type CredRow = components['schemas']['AgentCredentialStatusOut']
 
-// Pure logic behind AgentCredentialsSection, extracted so it unit-tests without
-// a renderer. The screen answers one question — "what is stopping this agent
-// from running" — which today costs an SSH to a box and a `gog auth list`.
+// Pure logic behind AgentCredentialsSection.
+//
+// WHAT THIS SCREEN IS NOT. It is not "is this agent provisioned". canopy-web
+// cannot see 1Password, and by design it does not hold most of an agent's
+// secrets — the vault does, reached on the box with the runner's 1Password
+// service-account token (RunnerCredential.op_sa_token, set on the Runners tab).
+//
+// A first draft measured `selfContained` — "every declared secret is stored
+// here" — and rendered it as the success state. That rewards copying all 45 of
+// ACE's secrets into canopy-web: a second copy of every credential, free to
+// drift from the vault, in a system that then becomes worth attacking. It also
+// reported "45 blockers, this agent cannot run" about an agent running
+// perfectly well, which is how a screen teaches people to ignore it — and the
+// one genuinely dead credential then hides among the false alarms.
+//
+// So this reports rather than judges: what canopy-web holds, what it does not,
+// and what nothing accounts for. Whether a secret actually WORKS is a question
+// only the box can answer, and a readiness drill is what answers it.
 
-export interface Blockers {
-  /** Declared refs with no value. These are what stop a turn. */
-  missing: string[]
-  /** Stored but no longer declared — a live secret nothing accounts for. */
+export interface CredentialSummary {
+  /** Refs the agent declares (orphans excluded). */
+  declaredCount: number
+  /** Declared and stored in canopy-web. */
+  storedHere: string[]
+  /** Declared, not stored here — expected to resolve from 1Password on the box. */
+  fromVault: string[]
+  /** Stored but no longer declared: a live secret nothing accounts for. */
   orphans: string[]
-  /** Set, but still resolving out of 1Password rather than canopy-web. */
-  stillInVault: string[]
-  ready: boolean
-  /** The agent declares nothing at all, which is NOT the same as ready. */
+  /** The agent declares nothing, which is NOT the same as provisioned. */
   undeclared: boolean
 }
 
-export function blockers(rows: readonly CredRow[]): Blockers {
+export function summarize(rows: readonly CredRow[]): CredentialSummary {
   const declared = rows.filter((r) => r.declared)
-  const missing = declared.filter((r) => !r.set).map((r) => r.name)
   return {
-    missing,
+    declaredCount: declared.length,
+    storedHere: declared.filter((r) => r.set).map((r) => r.name),
+    fromVault: declared.filter((r) => !r.set).map((r) => r.name),
     orphans: rows.filter((r) => !r.declared).map((r) => r.name),
-    stillInVault: rows.filter((r) => r.set && r.source === '1password').map((r) => r.name),
-    // An agent with zero declared refs is UNDECLARED, not provisioned. Calling
-    // that "ready" would assert a box can run it, which nobody has established —
-    // and it is the state every agent is in before someone writes a runtime.yaml.
-    ready: declared.length > 0 && missing.length === 0,
     undeclared: declared.length === 0,
   }
 }
 
-/** Unset-and-required first (the answer to the question), then the rest, then
- *  orphans last — they need showing but are noise next to a blocker. */
+/** Stored-here first (what this page actually manages), then vault-resolved,
+ *  then orphans last — they need showing, but they are noise up top. */
 export function groupRefs(rows: readonly CredRow[]): CredRow[] {
-  const rank = (r: CredRow) => (!r.declared ? 2 : r.set ? 1 : 0)
+  const rank = (r: CredRow) => (!r.declared ? 2 : r.set ? 0 : 1)
   return [...rows].sort((a, b) => rank(a) - rank(b) || a.name.localeCompare(b.name))
 }


### PR DESCRIPTION
Operator correction, caught before the wrong metric got used:

> *"I don't want to store all the passwords on canopy-web, just the ones we need and a service token for 1pass."*

## What was too broad

#664's decision — *canopy-web becomes THE agent secret store* — would have copied all 45 of ACE's secrets here. That's a **second copy of every credential**, free to drift from the vault, in a system that thereby becomes worth attacking. 1Password already does rotation, sharing and audit; canopy-web shouldn't re-do it.

## The corrected split

| Lives in | What |
|---|---|
| **1Password** | Substantially everything — it stays the vault |
| **canopy-web (runner)** | The **1Password service-account token** — the key that lets a box resolve the rest |
| **canopy-web (agent)** | Only what genuinely needs to be here — canopy's own PAT, and anything canopy-web mints |

This needs **less** building, not more. `RunnerCredential.op_sa_token` already existed, the box already fetches it (`cloud_runner.py:1601`), and #665 already gave it a browser form. What was wrong was the framing, not the mechanism.

## The screen stops judging

The first draft measured `selfContained` — *"every declared secret is stored here"* — and rendered it as **success**. That rewards exactly the duplication being rejected.

It also reported **"45 blockers — this agent cannot run"** about ACE, which runs perfectly well. canopy-web cannot see 1Password, so it read "not stored here" as "not resolvable". **A screen that cries wolf is how the one genuinely dead credential goes unnoticed** — which is the failure the screen exists to prevent. (ACE's real dead token has been invisible since May; that's the case it's for.)

It now reports what canopy-web holds and says plainly that the rest resolve from the vault via the runner's token. Whether a secret *works* is a question only the box can answer, and a readiness drill is what answers it.

## Testing

`678 passed`; tsc and vite build clean. The tests now assert the *absence* of the old judgement — `'selfContained' in s` and `'missing' in s` are both false — so the framing can't quietly come back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rffk2t9tySFjRNqRKxN2wR