### PR TITLE
The account→client map comes from the token, which names its own client

### DIFF
--- a/runner/ec2/bootstrap_agents.sh
+++ b/runner/ec2/bootstrap_agents.sh
@@ -155,6 +155,54 @@ agent_repo_url() {  # slug -> clone url; registry pointer, else the org conventi
   printf '%s\n' "${url:-https://github.com/${AGENT_REPO_ORG:-dimagi-internal}/${slug}}"
 }
 
+# THE authoritative account->client answer: the token names its own client.
+#
+# A gog token is JSON carrying {email, client, services, scopes, refresh_token},
+# and `client` is the OAuth app it was minted for. A token works ONLY with that
+# client, so nothing else can be authoritative — not this file's table, and not
+# the agent's config/agent.json, which states INTENT. Making that declaration
+# authoritative on 2026-09-05 pointed echo at `canopy`, whose client had no token
+# for it, and broke a working mailbox (canopy-web#661, reverted in #662).
+#
+# The table below survives only as the FIRST-BOOT fallback: step 2 writes the map
+# before step 3 has fetched any token, so there is a window with nothing to read.
+# Never returns empty — an empty client points gog at the wrong app silently.
+# Merge ONE account->client entry into gog's config.json, once the token has
+# told us the truth. Step 2 writes the whole map before any token exists.
+upsert_account_client() {
+  local email="$1" client="$2"
+  [[ -n "$email" && -n "$client" ]] || return 0
+  command -v gog >/dev/null 2>&1 || return 0
+  local dir; dir="$(gog_config_dir)"
+  mkdir -p "$dir"
+  UAC_CFG="$dir/config.json" UAC_EMAIL="$email" UAC_CLIENT="$client" python3 -c '
+import json, os
+path = os.environ["UAC_CFG"]
+try:
+    data = json.load(open(path))
+except Exception:
+    data = {}
+data.setdefault("account_clients", {})[os.environ["UAC_EMAIL"]] = os.environ["UAC_CLIENT"]
+with open(path, "w") as f:
+    json.dump(data, f, indent=2)
+    f.write("\n")
+'
+}
+
+token_client() {  # <token-file> <slug>
+  local tokfile="$1" slug="$2" declared=""
+  if [[ -s "$tokfile" ]]; then
+    declared="$(TOKF="$tokfile" python3 -c '
+import json, os
+try:
+    print((json.load(open(os.environ["TOKF"])).get("client") or "").strip())
+except Exception:
+    pass
+' 2>/dev/null || true)"
+  fi
+  printf '%s\n' "${declared:-${GOG_CLIENT[$slug]:-$slug}}"
+}
+
 vault_name() {  # ace -> Agent-Ace (bash 5, shipped on Ubuntu 24.04: ${var^} title-cases)
   local slug="$1"
   printf 'Agent-%s\n' "${slug^}"
@@ -535,6 +583,13 @@ bootstrap_one_agent() {
       local importerr
       if importerr="$(gog auth tokens import "$tokfile" 2>&1 >/dev/null)"; then
         ok "$slug: gmail token imported"
+        # The token has just told us which client it belongs to. Step 2 could
+        # only have written the fallback, so correct the map from the fact.
+        local tclient; tclient="$(token_client "$tokfile" "$slug")"
+        if [[ -n "$tclient" && "$tclient" != "$client" ]]; then
+          warn "$slug: token declares client '$tclient', map said '$client' — using the token"
+        fi
+        upsert_account_client "$account" "$tclient"
       else
         warn "$slug: gog auth tokens import failed: ${importerr:-(no output)}"
         [[ -n "${GOG_KEYRING_PASSWORD:-}" ]] || \

--- a/runner/ec2/tests/test_gog_client_from_token.py
+++ b/runner/ec2/tests/test_gog_client_from_token.py
@@ -1,0 +1,102 @@
+"""The account->client map comes from the TOKEN, which declares its own client.
+
+Settled 2026-09-06 by reading a real `op://Agent-Ace/gog-token` item:
+
+    {"email": "ace@dimagi-ai.com", "client": "ace",
+     "services": [...], "scopes": [...], "refresh_token": "..."}
+
+A gog token carries the client it was minted for. That is the authoritative
+answer, and neither of the two things this fleet has used is:
+
+  - the HARDCODED table in bootstrap_agents.sh drifted (it is right for echo,
+    wrong for nothing yet — but nothing keeps it honest);
+  - `config/agent.json`'s `gog_client` is INTENT, not fact. On 2026-09-05 a fix
+    made that authoritative, pointed echo at `canopy`, and broke a working
+    mailbox — a token is minted FOR a client and works only with that client
+    (reverted in canopy-web#662).
+
+So: read the token. It cannot drift from itself. The table stays only as the
+first-boot fallback, for the window before any token has been fetched.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+
+import pytest
+
+SCRIPT = pathlib.Path(__file__).resolve().parent.parent / "bootstrap_agents.sh"
+
+_HAS_ASSOC = subprocess.run(
+    ["bash", "-c", "declare -A _t=( [k]=v ) 2>/dev/null && echo yes"],
+    capture_output=True, text=True,
+).stdout.strip() == "yes"
+pytestmark = pytest.mark.skipif(
+    not _HAS_ASSOC, reason="bash lacks associative arrays (macOS ships 3.2; the box and CI run 5)"
+)
+
+
+def _fn(name: str) -> str:
+    lines = SCRIPT.read_text().splitlines()
+    start = next(i for i, l in enumerate(lines) if l.startswith(f"{name}() {{"))
+    end = next(i for i in range(start + 1, len(lines)) if lines[i] == "}")
+    return "\n".join(lines[start:end + 1])
+
+
+def _run(tokfile: str, slug: str) -> str:
+    decl = next(l for l in SCRIPT.read_text().splitlines()
+                if l.startswith("declare -A GOG_CLIENT="))
+    script = f'set -euo pipefail\n{decl}\n{_fn("token_client")}\ntoken_client "{tokfile}" {slug}'
+    res = subprocess.run(["bash", "-c", script], capture_output=True, text=True, timeout=60)
+    assert res.returncode == 0, f"{res.stdout}\n{res.stderr}"
+    return res.stdout.strip()
+
+
+def _tok(tmp: pathlib.Path, body) -> str:
+    p = tmp / "tok.json"
+    p.write_text(body if isinstance(body, str) else json.dumps(body))
+    return str(p)
+
+
+def test_the_token_names_its_own_client(tmp_path):
+    """The real shape, from a live Agent-Ace item."""
+    f = _tok(tmp_path, {
+        "email": "ace@dimagi-ai.com", "client": "ace",
+        "services": ["docs", "drive", "gmail", "sheets"],
+        "scopes": ["https://www.googleapis.com/auth/drive"],
+        "created_at": "2026-05-01T00:00:00Z", "refresh_token": "x",
+    })
+    assert _run(f, "ace") == "ace"
+
+
+def test_a_token_minted_under_the_shared_client_says_so(tmp_path):
+    f = _tok(tmp_path, {"email": "eva@dimagi-ai.com", "client": "canopy", "refresh_token": "x"})
+    assert _run(f, "eva") == "canopy"
+
+
+@pytest.mark.parametrize("body", [
+    {"email": "hal@dimagi-ai.com", "refresh_token": "x"},   # no client field
+    {"email": "hal@dimagi-ai.com", "client": "", "refresh_token": "x"},
+    "not json at all",
+    "",
+])
+def test_anything_unreadable_falls_back_to_the_table(tmp_path, body):
+    """Never empty: an empty client silently points gog at the wrong OAuth app,
+    which is the whole failure class this exists to close."""
+    assert _run(_tok(tmp_path, body), "hal") == "canopy"
+
+
+def test_a_missing_file_falls_back_rather_than_failing(tmp_path):
+    """First boot: no token has been fetched yet."""
+    assert _run(str(tmp_path / "nope.json"), "ace") == "ace"
+
+
+def test_the_fallback_is_the_table_not_the_agents_declaration():
+    """Guards the 2026-09-05 regression from coming back. config/agent.json's
+    gog_client is intent; the token is fact. Nothing here may read that file."""
+    body = SCRIPT.read_text()
+    fn = _fn("token_client")
+    assert "agent.json" not in fn, "token_client must not consult the agent's declaration"
+    assert "gog_client" not in fn
+    assert "GOG_CLIENT[" in fn, "the hardcoded table is the fallback"

--- a/runner/ec2/tests/test_gog_client_from_token.py
+++ b/runner/ec2/tests/test_gog_client_from_token.py
@@ -95,7 +95,6 @@ def test_a_missing_file_falls_back_rather_than_failing(tmp_path):
 def test_the_fallback_is_the_table_not_the_agents_declaration():
     """Guards the 2026-09-05 regression from coming back. config/agent.json's
     gog_client is intent; the token is fact. Nothing here may read that file."""
-    body = SCRIPT.read_text()
     fn = _fn("token_client")
     assert "agent.json" not in fn, "token_client must not consult the agent's declaration"
     assert "gog_client" not in fn


### PR DESCRIPTION
Settles a question that cost a mailbox yesterday. I read an actual `op://Agent-Ace/gog-token` item:

```json
{ "email": "ace@dimagi-ai.com", "client": "ace",
  "services": ["docs","drive","gmail","sheets"],
  "scopes": [...], "created_at": "...", "refresh_token": "..." }
```

**A gog token carries the OAuth client it was minted for**, and works only with that client. So the token is authoritative — and neither thing this fleet has used is:

- the **hardcoded table** in `bootstrap_agents.sh` has nothing keeping it honest;
- **`config/agent.json`'s `gog_client`** states *intent*, not fact. Making it authoritative yesterday (#661) pointed echo at `canopy`, which had no token for it, and broke a working mailbox. Reverted in #662.

Reading the token cannot drift from itself. The table survives only as the **first-boot fallback** — step 2 writes the map before step 3 has fetched anything — and the resolver never returns empty, because an empty client points gog at the wrong app silently, which is the failure class this closes.

When the token disagrees with the map, it now **says so and uses the token**. The mismatch that was invisible all of yesterday becomes a logged line.

## What it incidentally proves

ACE's token is wrong twice: `client: ace`, and `services` is `[docs, drive, gmail, sheets]` — missing the `calendar`, `slides` and `forms` that ACE's `config/agent.json` declares it needs. Re-minting fixes both, and that's the same act as the Google-client work in #668.

## Testing

`8/8` new tests on **real bash 5** (docker `bash:5`; macOS ships 3.2 so they skip locally). `149 passed, 19 skipped` in the full `runner/ec2` suite.

One test is a guard rather than a behaviour: it asserts `token_client` never reads `agent.json` or `gog_client`, so yesterday's regression cannot quietly return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rffk2t9tySFjRNqRKxN2wR