### PR TITLE
feat(sessions): name a dispatched session after the work, not after the plumbing

### DIFF
--- a/apps/harness/dispatch.py
+++ b/apps/harness/dispatch.py
@@ -120,12 +120,20 @@ def dispatch(item: Item, *, actor_workspace_slugs: set[str]) -> list[Turn]:
         # Idempotent, so an agent that already stamped client-side (Ada does, ada#55) passes
         # through untouched and is not double-marked.
         brief = stamp_dispatched(spec.prompt or f"/{target.slug}:turn", sender=item.agent.slug)
+        # Carry the card's title so the runner can NAME the emdash session after the
+        # work rather than after its slash command — `c-retry-the-backoff-on-429`
+        # instead of `c-turn`, which is what every board dispatch would otherwise
+        # read as. `setdefault`: a producer that already chose a name keeps it, and
+        # the spec's own provenance keys are untouched (copied, not mutated — the
+        # spec is frozen and shared with the Item's stored JSON).
+        origin_ref = dict(spec.origin_ref)
+        origin_ref.setdefault("item_title", item.title)
         turn, _created = services.enqueue_turn(
             agent=target,
             origin=spec.origin,
             idempotency_key=f"item-{item.id}-{i}",
             prompt=_with_reply(brief, item),
-            origin_ref=spec.origin_ref,
+            origin_ref=origin_ref,
             routing=spec.routing,
         )
         if turn.raised_from_id is None:

--- a/apps/harness/services.py
+++ b/apps/harness/services.py
@@ -1278,7 +1278,12 @@ def fire_schedule(schedule, slot: dt.datetime) -> tuple[Turn, bool]:
             origin=Turn.ORIGIN_CANOPY_SCHEDULER,
             idempotency_key=key,
             prompt=schedule.prompt,
-            origin_ref={"schedule_id": schedule.id, "slot": slot.isoformat()},
+            # `schedule_name` is carried for the emdash session NAME. Without it the
+            # runner names a cron turn after the prompt's slash command, so every
+            # schedule an agent has reads `c-turn-<disc>` in the sidebar; with it
+            # they read `c-weekly-manager-report`, which is what the human called it.
+            origin_ref={"schedule_id": schedule.id, "slot": slot.isoformat(),
+                        "schedule_name": schedule.name},
             routing=schedule.routing,
         )
         if created and (schedule.last_slot is None or slot > schedule.last_slot):
@@ -1309,7 +1314,8 @@ def run_schedule_now(schedule) -> Turn:
             origin=Turn.ORIGIN_CANOPY_SCHEDULER,
             idempotency_key=f"sched:{schedule.id}:manual:{uuid.uuid4()}",
             prompt=schedule.prompt,
-            origin_ref={"schedule_id": schedule.id, "manual": True},
+            origin_ref={"schedule_id": schedule.id, "manual": True,
+                        "schedule_name": schedule.name},
             routing=schedule.routing,
         )
     return turn
@@ -2209,7 +2215,8 @@ def _raise_schedule_nag(schedule, turn: Turn) -> None:
         "dispatch": [{
             "prompt": schedule.prompt,
             "origin": Turn.ORIGIN_CANOPY_SCHEDULER,
-            "origin_ref": {"schedule_id": schedule.id, "manual": True},
+            "origin_ref": {"schedule_id": schedule.id, "manual": True,
+                           "schedule_name": schedule.name},
             "routing": schedule.routing,
         }],
         "idempotency_key": f"sched-nag:{schedule.id}:{turn.id}",

--- a/runner/canopy_runner/canopy_runner/execute.py
+++ b/runner/canopy_runner/canopy_runner/execute.py
@@ -18,14 +18,13 @@ the turn; a duplicate is worse than a retry, because it orphans the live context
 """
 from __future__ import annotations
 
-import datetime as dt
 import logging
 import pathlib
 import re
 import time
 from pathlib import Path
 
-from . import cdp_control, chat_bridge, dialog, emdash, hooks, readiness, transcript
+from . import cdp_control, chat_bridge, dialog, emdash, hooks, readiness, session_naming, transcript
 from .client import ClientError
 from .tail import TailReader
 
@@ -74,10 +73,6 @@ def _thread_key(turn: dict) -> str:
     return explicit or f"{_target(turn)}:{turn.get('id') or ''}"
 
 
-def _slug(text: str, n: int = 28) -> str:
-    return re.sub(r"[^a-z0-9]+", "-", (text or "").lower()).strip("-")[:n].strip("-")
-
-
 def _preview(line: str, n: int = 120) -> str:
     """Truncate a composer line for the log/event trail. It is the human's own
     half-typed words, so it is bounded rather than dropped — enough to recognise
@@ -86,18 +81,14 @@ def _preview(line: str, n: int = 120) -> str:
     return s if len(s) <= n else s[: n - 1] + "…"
 
 
-def _task_name(agent: str, turn: dict, now=None) -> str:
-    """A HUMAN-READABLE, per-thread-UNIQUE emdash task name: agent + subject slug +
-    a short thread discriminator + MMDD-HHMM, e.g. 'hal-security-alert-6355-0714-1514'.
-    The discriminator (last chars of the thread key) is what stops two DIFFERENT threads
-    with the same subject in the same minute from colliding onto one name. Recorded in the
-    SessionLink, so reuse opens this exact name — legible, not a bare hash."""
-    stamp = (now or dt.datetime.now()).strftime("%m%d-%H%M")
-    ref = turn.get("origin_ref") or {}
-    label = _slug(ref.get("subject") or "") or _slug(turn.get("origin") or "")
-    disc = re.sub(r"[^a-z0-9]", "", _thread_key(turn).lower())[-4:]
-    bits = [agent] + ([label] if label else []) + [b for b in (disc, stamp) if b]
-    return "-".join(bits)
+def _task_name(agent: str, turn: dict) -> str:
+    """The emdash task name for this turn — see `session_naming` for the format.
+
+    Kept as a named seam rather than inlining the call: the two create sites below
+    must never name the same turn differently, and this is where `_thread_key`'s
+    definition and the naming module's copy of it are held together.
+    """
+    return session_naming.build_task_name(agent, turn)
 
 
 def _deliver_to_existing(cfg, client, runner_id, turn, task, state, work_prompt):

--- a/runner/canopy_runner/canopy_runner/execute.py
+++ b/runner/canopy_runner/canopy_runner/execute.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import logging
 import pathlib
-import re
 import time
 from pathlib import Path
 

--- a/runner/canopy_runner/canopy_runner/session_naming.py
+++ b/runner/canopy_runner/canopy_runner/session_naming.py
@@ -1,0 +1,223 @@
+"""The emdash session-name format — one owner, so the shape has a single home.
+
+WHAT A NAME IS FOR. It is read in the emdash sidebar, next to the human's own
+sessions, and it answers two questions at a glance: did the fleet start this, and
+what is it about. Everything here serves those two and nothing else.
+
+    c-<subject>-<disc>          e.g. c-issue-triage-4a4e
+
+  c-      canopy launched it. The sidebar interleaves fleet turns with sessions a
+          human opened by hand ("bednet", "close-sessions"); without a marker the
+          two are indistinguishable, and the fleet's are the ones you don't want
+          to interrupt.
+  subject WHAT it is about, from the ladder below.
+  disc    four characters of the thread key. Uniqueness, and the reason it cannot
+          be dropped: two DIFFERENT threads with the same subject used to collide
+          onto one name, and the collision was only ever masked by the timestamp
+          that used to follow it (test_execute.py has carried that case since).
+
+WHAT IS DELIBERATELY NOT IN IT. The agent/repo slug: emdash already groups tasks
+under their project, so `ace-` inside a name under `ace` is ten characters that
+say nothing. The `MMDD-HHMM` stamp: emdash shows created-at in its own column and
+sorts by it. Between them they took ~14 of a ~28-character budget, which is why
+subjects arrived truncated mid-word ("...cpu-high-i").
+
+THE LADDER is the substance of this module. The old rule was "email subject, else
+the origin word", and since most turns carry no subject, most names came out as
+the origin word — `ace-api-4a4e-0905-0920`, which says only that something used
+the API. Each rung below is a source of MEANING the turn was already carrying and
+nobody read: the board item's title, the schedule's human name, the slash command
+in the brief. `origin` stays as the floor, where it now honestly means "this turn
+told us nothing about itself".
+
+READERS OF THIS FORMAT LIVE IN ANOTHER REPO. `canopy`'s
+`orchestrator.agent_client._EMDASH_TASK` decides whether a worktree is a
+dispatched session; it cannot import this module (the CLI and the runner share no
+dependency), so it mirrors `CANOPY_PREFIX`. Keep `is_canopy_task` and that mirror
+in step — a false negative there silently detaches an agent's close-out report
+from its turn.
+"""
+from __future__ import annotations
+
+import hashlib
+import re
+
+# The marker. Mirrored in canopy's orchestrator.agent_client — see module docstring.
+CANOPY_PREFIX = "c-"
+
+# Long enough for a real sentence fragment, short enough to read in a narrow
+# sidebar. The old budget was 28 INCLUDING the agent slug; this one is the subject
+# alone, so it is a meaningful increase despite the smaller-looking number.
+SUBJECT_MAX = 34
+
+# Four characters of thread key. Not a hash of anything meaningful — just enough
+# entropy to separate same-subject threads.
+#
+# EXACTLY four, always — `_disc` pads a short key rather than emitting three. The
+# rigidity is load-bearing outside this module: emdash appends its own 5-character
+# de-dupe suffix to the WORKTREE directory (`c-issue-triage-4a4e-7ohfp`), and
+# canopy's `emdash_task_from_cwd` recovers the task id from that directory by
+# telling a 4-character tail from a 5-character one. The old format anchored that
+# on its `-MMDD-HHMM` stamp; with the stamp gone, this is what replaces it.
+DISC_LEN = 4
+
+# The stamp `dispatch_marker.stamp_dispatched` appends, plus the provenance
+# sentence beside it and the `_with_reply` delimiter. Every dispatched brief
+# carries these verbatim, so a name derived from them would be identical across
+# unrelated turns — the exact opposite of what a name is for.
+_BOILERPLATE = re.compile(
+    r"^(?:<!--.*?-->|—\s*Dispatched by\b.*|ANSWERED BY\b.*|-{3,}|#{1,6}\s*)$",
+    re.IGNORECASE,
+)
+
+# `Re:`, `Fwd:` and friends, which say nothing about the thread and used to eat
+# the front of every email-origin name ("hal-re-bednet-demo-...").
+_REPLY_NOISE = re.compile(r"^(?:re|fwd|fw|aw|sv)\s*[:\-]\s*", re.IGNORECASE)
+
+# A leading slash command: `/ada:turn`, `/canopy:issue-triage`, plain `/turn`.
+_SLASH_COMMAND = re.compile(r"^/(?:(?P<ns>[A-Za-z0-9_-]+):)?(?P<cmd>[A-Za-z0-9_-]+)")
+
+# Markdown/list scaffolding at the head of a line — bullets, quotes, numbering.
+_LINE_SCAFFOLD = re.compile(r"^\s*(?:[-*+>]\s+|\d+[.)]\s+)")
+
+
+def slugify(text: str, limit: int = SUBJECT_MAX) -> str:
+    """Lowercase, hyphenated, and cut on a WORD boundary.
+
+    The word boundary is the point: the previous implementation sliced at a fixed
+    character count and produced `...cpu-high-i`, which reads as a typo rather than
+    a truncation. A cut that lands mid-word falls back to the previous hyphen; a
+    single word longer than the budget is cut hard, because a hyphenless 60-character
+    token has no boundary to find.
+    """
+    slug = re.sub(r"[^a-z0-9]+", "-", (text or "").lower()).strip("-")
+    if len(slug) <= limit:
+        return slug
+    cut = slug[:limit]
+    if "-" in cut:
+        cut = cut[: cut.rindex("-")]
+    return cut.strip("-")
+
+
+def _thread_key(turn: dict, target: str) -> str:
+    """Mirror of execute._thread_key, which is the authority.
+
+    Duplicated rather than imported because execute imports THIS module; the pair
+    is asserted equal in tests/test_execute.py so the two cannot drift.
+    """
+    ref = turn.get("origin_ref") or {}
+    explicit = ref.get("thread_key") or ref.get("thread_id")
+    return explicit or f"{target}:{turn.get('id') or ''}"
+
+
+def _from_slash_command(prompt: str, target: str) -> str:
+    """The command a dispatched brief opens with, if it opens with one.
+
+    The namespace is dropped ONLY when it repeats the target — `/ace:issue-triage`
+    on ace is `issue-triage`, because emdash's own grouping already said "ace". A
+    FOREIGN namespace is kept: `/canopy:issue-triage` running on ace is a canopy
+    skill borrowed by ace, and that is worth the four characters.
+    """
+    for line in (prompt or "").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        m = _SLASH_COMMAND.match(line)
+        if not m:
+            return ""                      # a brief that starts with prose, not a command
+        ns, cmd = (m.group("ns") or "").lower(), m.group("cmd")
+        return cmd if not ns or ns == (target or "").lower() else f"{ns}-{cmd}"
+    return ""
+
+
+def _from_prompt_body(prompt: str) -> str:
+    """The first line of the brief that a human actually wrote.
+
+    Skips the dispatch boilerplate and any markdown scaffolding, and requires two
+    word characters so a stray `ok` or a bare delimiter cannot name a session.
+    """
+    for raw in (prompt or "").splitlines():
+        line = _LINE_SCAFFOLD.sub("", raw.strip())
+        if not line or _BOILERPLATE.match(line) or line.startswith("/"):
+            continue
+        if len(re.findall(r"\w", line)) >= 2:
+            return line
+    return ""
+
+
+def subject_for(turn: dict, target: str = "") -> str:
+    """The meaningful half of the name — first rung that yields something, wins.
+
+    Ordered by how deliberately a human chose the words. A board item's title and a
+    schedule's name were TYPED by someone to name this exact work, so they outrank
+    the brief's slash command, which is only how the work is spelled to the agent
+    (`/echo:manager-report` vs "Weekly manager report" — same turn, and the second
+    is the one worth reading in a sidebar).
+    """
+    ref = turn.get("origin_ref") or {}
+    for candidate in (
+        ref.get("item_title"),                                  # a board card someone wrote
+        ref.get("schedule_name"),                               # "Weekly manager report"
+        _REPLY_NOISE.sub("", (ref.get("subject") or "").strip()),   # an email thread
+        _from_slash_command(turn.get("prompt"), target),        # /canopy:issue-triage
+        _from_prompt_body(turn.get("prompt")),                  # the brief's own first line
+        turn.get("origin"),                                     # floor: "we were told nothing"
+    ):
+        slug = slugify(candidate or "")
+        if slug:
+            return slug
+    return ""
+
+
+def _disc(turn: dict, target: str) -> str:
+    """Exactly DISC_LEN characters of the thread key — see DISC_LEN on why exactly.
+
+    A key with too few alphanumerics to fill the budget (a hand-set `thread_key`
+    like "a:b") falls back to a digest OF that key, so the value stays derived from
+    the thread — two turns on one thread still agree, which is what reuse needs.
+    """
+    key = _thread_key(turn, target)
+    flat = re.sub(r"[^a-z0-9]", "", key.lower())
+    if len(flat) >= DISC_LEN:
+        return flat[-DISC_LEN:]
+    return hashlib.sha256(key.encode()).hexdigest()[:DISC_LEN]
+
+
+def build_task_name(target: str, turn: dict) -> str:
+    """The emdash task name for `turn`, driven under project `target`.
+
+    `target` is the emdash project (an agent slug or a repo name) — it is NOT put
+    in the name; it is read to decide whether a slash command's namespace is
+    redundant, and it keys the thread fallback.
+    """
+    bits = [b for b in (CANOPY_PREFIX.rstrip("-"), subject_for(turn, target),
+                        _disc(turn, target)) if b]
+    return "-".join(bits)
+
+
+def is_canopy_task(name: str) -> bool:
+    """True when canopy launched the session called `name`.
+
+    Accepts the LEGACY shape too (`<agent>-<subject>-<disc>-MMDD-HHMM`). The fleet
+    has live sessions carrying it and reuse resolves them by name; treating one as
+    human-typed would detach its close-out from its turn.
+    """
+    n = (name or "").strip().lower()
+    n = n[len("emdash-"):] if n.startswith("emdash-") else n
+    return n.startswith(CANOPY_PREFIX) or bool(re.search(r"-\d{4}-\d{4}$", n))
+
+
+def parse_task_name(name: str) -> dict | None:
+    """Split a CURRENT-shape name back into its parts, or None if it isn't one.
+
+    Legacy names return None deliberately: `is_canopy_task` is the question worth
+    asking about them, and inventing a subject/disc split for a shape this module
+    no longer produces would be guessing.
+    """
+    n = (name or "").strip().lower()
+    n = n[len("emdash-"):] if n.startswith("emdash-") else n
+    if not n.startswith(CANOPY_PREFIX):
+        return None
+    rest = n[len(CANOPY_PREFIX):]
+    subject, _, disc = rest.rpartition("-")
+    return {"subject": subject, "disc": disc}

--- a/runner/canopy_runner/tests/test_execute.py
+++ b/runner/canopy_runner/tests/test_execute.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from canopy_runner import cdp_control, dialog, emdash, execute
+from canopy_runner import cdp_control, dialog, emdash, execute, session_naming
 from canopy_runner.client import ClientError
 
 
@@ -334,26 +334,29 @@ def test_a_project_turn_drives_the_repo_and_carries_its_tenant(monkeypatch):
     assert kw["project"] == "canopy-web" and kw["workspace"] == "canopy"
 
 
-def test_task_name_is_readable_subject_plus_stamp():
-    import datetime as dt
-    now = dt.datetime(2026, 7, 14, 15, 32)
-    # keyless turn -> thread key is '{agent}:{turn_id}', so the discriminator comes
-    # from the turn id (last 4 of 'halt1') rather than a shared 'main'.
+def test_task_name_delegates_to_the_one_format_owner():
+    """`session_naming` owns the shape; this is only the seam. The FORMAT cases
+    (the ladder, truncation, the c- marker) live in tests/test_session_naming.py —
+    asserting them here too would mean two places to update for one change."""
+    from canopy_runner import session_naming
+
     t = _turn(id="t-1", origin="email", origin_ref={"subject": "Re: Bednet demo!!"})
-    assert execute._task_name("hal", t, now=now) == "hal-re-bednet-demo-alt1-0714-1532"
-    # no subject -> agent + stamp
-    assert execute._task_name("hal", _turn(id="t-1", origin="manual", origin_ref={}), now=now) == "hal-manual-alt1-0714-1532"
+    assert execute._task_name("hal", t) == session_naming.build_task_name("hal", t)
+    assert execute._task_name("hal", t).startswith("c-")
 
 
-def test_task_name_distinguishes_threads_with_same_subject():
-    """The observed bug: two DIFFERENT threads with the same subject in the same minute
-    got the same name. The thread discriminator must keep them distinct."""
-    import datetime as dt
-    now = dt.datetime(2026, 7, 14, 15, 14)
-    t1 = _turn(origin="email", origin_ref={"subject": "Security alert", "thread_id": "19f4c06eeb986355"})
-    t2 = _turn(origin="email", origin_ref={"subject": "Security alert", "thread_id": "19f425675a9855a4"})
-    n1 = execute._task_name("hal", t1, now=now)
-    n2 = execute._task_name("hal", t2, now=now)
-    assert n1 == "hal-security-alert-6355-0714-1514"
-    assert n2 == "hal-security-alert-55a4-0714-1514"
-    assert n1 != n2
+def test_the_naming_modules_thread_key_matches_executes():
+    """session_naming carries its own copy of _thread_key (execute imports it, so
+    the dependency cannot run the other way). If the two ever disagree, a turn gets
+    one discriminator when it is named and another when its session is resolved —
+    reuse would open a different session than the one it recorded. Pin them here.
+
+    Both branches: an explicit thread_key (continue-this-session) and the keyless
+    fresh-per-turn fallback, which is the one that derives from the turn id.
+    """
+    for turn in (
+        _turn(id="t-1", origin_ref={"thread_key": "phone:jj:hal"}),
+        _turn(id="t-1", origin_ref={"thread_id": "19f4c06eeb986355"}),
+        _turn(id="t-1", origin_ref={}),
+    ):
+        assert session_naming._thread_key(turn, "hal") == execute._thread_key(turn)

--- a/runner/canopy_runner/tests/test_session_naming.py
+++ b/runner/canopy_runner/tests/test_session_naming.py
@@ -1,0 +1,199 @@
+"""The emdash session-name format, exercised as the one thing it is: a format.
+
+Every assertion here is a name a human reads in the emdash sidebar. The old shape
+(`<agent>-<subject>-<disc>-<MMDD>-<HHMM>`) spent its budget on two things emdash
+already shows — the project group and the created-at column — and fell back to the
+bare origin word (`ace-api-4a4e-0905-0920`) whenever no email subject existed, which
+is most turns. See docs/superpowers/specs for the ladder's rationale.
+"""
+import pytest
+
+from canopy_runner import session_naming as sn
+
+
+def _turn(**kw):
+    t = {"id": "t-abc123", "origin": "api", "origin_ref": {}, "prompt": ""}
+    t.update(kw)
+    return t
+
+
+# --- the marker -------------------------------------------------------------
+
+def test_every_name_declares_canopy_launched_it():
+    """The prefix is the whole point: a glance at the sidebar separates work the
+    fleet started from work a human typed."""
+    name = sn.build_task_name("ace", _turn())
+    assert name.startswith("c-")
+    assert sn.is_canopy_task(name)
+
+
+def test_a_human_typed_name_is_not_a_canopy_task():
+    for human in ("improve-session-names", "close-sessions", "bednet", "cron-stuff"):
+        assert not sn.is_canopy_task(human)
+
+
+def test_legacy_stamped_names_are_still_recognised():
+    """Names created before the prefix existed keep working — the fleet has live
+    sessions carrying them, and reuse resolves by name."""
+    assert sn.is_canopy_task("ace-api-4a4e-0905-0920")
+    assert sn.is_canopy_task("hal-security-alert-6355-0714-1514")
+    assert sn.is_canopy_task("emdash-echo-api-611f-0901-1248")
+
+
+# --- the ladder -------------------------------------------------------------
+
+def test_board_item_title_wins():
+    t = _turn(origin_ref={"item_title": "Retry the backoff on 429", "thread_id": "abcd1234"})
+    assert sn.build_task_name("ace", t) == "c-retry-the-backoff-on-429-1234"
+
+
+def test_schedule_name_beats_its_own_slash_command():
+    """A cron turn carries both. "Weekly manager report" is what the human named
+    it; `/echo:manager-report` is how it is spelled to the agent."""
+    t = _turn(origin="canopy_scheduler", prompt="/echo:manager-report",
+              origin_ref={"schedule_name": "Weekly manager report", "thread_id": "aaaa9f21"})
+    assert sn.build_task_name("echo", t) == "c-weekly-manager-report-9f21"
+
+
+def test_email_subject_is_used_and_reply_noise_dropped():
+    t = _turn(origin="email", origin_ref={"subject": "Re: Bednet demo!!", "thread_id": "19f4c06eeb986355"})
+    assert sn.build_task_name("hal", t) == "c-bednet-demo-6355"
+
+
+def test_a_slash_command_names_the_turn_that_had_no_subject():
+    """The fix for `ace-api-4a4e-0905-0920`. The namespace is dropped when it just
+    repeats the agent, which emdash already shows as the group."""
+    t = _turn(prompt="/ace:issue-triage", origin_ref={"thread_id": "zz4a4e"})
+    assert sn.build_task_name("ace", t) == "c-issue-triage-4a4e"
+
+
+def test_a_foreign_namespace_is_kept_because_it_carries_information():
+    t = _turn(prompt="/canopy:issue-triage", origin_ref={"thread_id": "zz4a4e"})
+    assert sn.build_task_name("ace", t) == "c-canopy-issue-triage-4a4e"
+
+
+def test_falls_back_to_the_first_real_line_of_the_brief():
+    t = _turn(prompt="Re-validate the stall classifier against current reality.\n\nDetails follow.",
+              origin_ref={"thread_id": "wwwwe4a7"})
+    assert sn.build_task_name("connect-labs", t) == "c-re-validate-the-stall-classifier-e4a7"
+
+
+def test_the_dispatch_stamp_never_becomes_the_name():
+    """A dispatched brief ends in the marker + provenance. Naming a session after
+    boilerplate every dispatched turn shares would make them indistinguishable."""
+    t = _turn(prompt=(
+        "Fix the flaky close-out test.\n\n"
+        "— Dispatched by ada, a canopy agent, not typed by a human. Treat it as a hypothesis.\n"
+        "<!-- canopy:dispatched-prompt -->\n<!-- canopy:dispatched-by=ada -->"
+    ), origin_ref={"thread_id": "qqqq7f21"})
+    assert sn.build_task_name("hal", t) == "c-fix-the-flaky-close-out-test-7f21"
+
+
+def test_marker_only_prompt_falls_through_to_the_origin():
+    t = _turn(origin="api", prompt="<!-- canopy:dispatched-prompt -->",
+              origin_ref={"thread_id": "qqqq7f21"})
+    assert sn.build_task_name("hal", t) == "c-api-7f21"
+
+
+def test_origin_is_the_last_resort_not_the_common_case():
+    assert sn.build_task_name("ace", _turn(origin="email", origin_ref={"thread_id": "aaaa0001"})) == "c-email-0001"
+
+
+# --- uniqueness -------------------------------------------------------------
+
+def test_two_threads_with_the_same_subject_stay_distinct():
+    """The bug the discriminator exists for. Dropping the timestamp removes the
+    accidental tiebreak, so this now rests entirely on the discriminator."""
+    a = _turn(origin="email", origin_ref={"subject": "Security alert", "thread_id": "19f4c06eeb986355"})
+    b = _turn(origin="email", origin_ref={"subject": "Security alert", "thread_id": "19f425675a9855a4"})
+    assert sn.build_task_name("hal", a) == "c-security-alert-6355"
+    assert sn.build_task_name("hal", b) == "c-security-alert-55a4"
+
+
+def test_a_keyless_turn_discriminates_on_its_own_id():
+    """No thread_key means fresh-per-turn, so the turn id is the discriminator —
+    two cron fires of one schedule must not collide onto a single name."""
+    one = sn.build_task_name("echo", _turn(id="t-0001", origin_ref={"schedule_name": "Nightly sweep"}))
+    two = sn.build_task_name("echo", _turn(id="t-0002", origin_ref={"schedule_name": "Nightly sweep"}))
+    assert one != two
+    assert one.startswith("c-nightly-sweep-")
+
+
+# --- shape ------------------------------------------------------------------
+
+def test_long_subjects_truncate_on_a_word_boundary():
+    """`hal-alarm-labs-jj-web-cpu-high-i-...` cut mid-word. Names are read, not parsed."""
+    t = _turn(origin="email", origin_ref={
+        "subject": "Alarm: labs-jj-web CPU utilization is critically high right now",
+        "thread_id": "aaaaea9d"})
+    name = sn.build_task_name("hal", t)
+    assert name == "c-alarm-labs-jj-web-cpu-utilization-ea9d"
+    assert not name.replace("-ea9d", "").endswith("-")
+
+
+def test_names_are_lowercase_slug_safe():
+    t = _turn(origin_ref={"item_title": "Ship  the  “Fix”: réponse (v2)!", "thread_id": "aaaa0001"})
+    name = sn.build_task_name("ace", t)
+    assert name == "c-ship-the-fix-r-ponse-v2-0001"
+
+
+@pytest.mark.parametrize("subject", ["", "   ", "!!!", "---"])
+def test_an_empty_or_punctuation_only_subject_does_not_produce_a_dangling_name(subject):
+    t = _turn(origin="email", origin_ref={"subject": subject, "thread_id": "aaaa0001"})
+    assert sn.build_task_name("hal", t) == "c-email-0001"
+
+
+def test_the_agent_prefix_is_gone_because_emdash_groups_by_project():
+    name = sn.build_task_name("ace", _turn(prompt="/ace:issue-triage"))
+    assert not name.startswith("c-ace-")
+
+
+def test_no_timestamp_in_the_name():
+    """emdash shows created-at in its own column; ten characters of MMDD-HHMM were
+    the other half of why subjects got truncated."""
+    import re
+    name = sn.build_task_name("hal", _turn(origin="email", origin_ref={"subject": "Security alert"}))
+    assert not re.search(r"-\d{4}-\d{4}$", name)
+
+
+# --- parse ------------------------------------------------------------------
+
+def test_parse_round_trips_what_build_produced():
+    t = _turn(origin="email", origin_ref={"subject": "Security alert", "thread_id": "19f4c06eeb986355"})
+    name = sn.build_task_name("hal", t)
+    assert sn.parse_task_name(name) == {"subject": "security-alert", "disc": "6355"}
+
+
+def test_parse_declines_a_human_name():
+    assert sn.parse_task_name("improve-session-names") is None
+
+
+# --- the discriminator is a fixed-width field, not just entropy ---------------
+
+def test_the_discriminator_is_always_exactly_four_characters():
+    """Load-bearing outside this module: canopy recovers the task id from the
+    worktree directory by telling this 4-char tail from emdash's 5-char de-dupe
+    suffix. A 3-char disc would make `c-foo-abc-1me7x` unsplittable."""
+    for turn in (
+        _turn(origin_ref={"thread_id": "a"}),
+        _turn(origin_ref={"thread_key": "x:y"}),
+        _turn(id="1", origin_ref={}),
+        _turn(origin_ref={"thread_id": "19f4c06eeb986355"}),
+    ):
+        name = sn.build_task_name("hal", turn)
+        assert len(name.rsplit("-", 1)[1]) == sn.DISC_LEN, name
+
+
+def test_a_short_thread_key_still_agrees_with_itself():
+    """Reuse re-derives the name, so a padded disc must be deterministic and stay
+    tied to the thread — not random."""
+    t = _turn(origin_ref={"thread_key": "x:y"})
+    assert sn.build_task_name("hal", t) == sn.build_task_name("hal", dict(t))
+
+
+def test_a_worktree_suffix_can_be_told_from_the_discriminator():
+    """The property canopy's emdash_task_from_cwd depends on."""
+    name = sn.build_task_name("ace", _turn(prompt="/ace:issue-triage",
+                                           origin_ref={"thread_id": "zz4a4e"}))
+    worktree = f"{name}-1me7x"          # emdash's 5-char de-dupe suffix
+    assert worktree.rsplit("-", 1)[0] == name

--- a/tests/test_item_dispatch.py
+++ b/tests/test_item_dispatch.py
@@ -206,3 +206,36 @@ def test_no_reply_means_no_delimiters(ada, hal):
     item = _item(ada, dispatch=[{"target_agent": "hal", "prompt": "FINDING: x"}])
     turn = dispatch(item, actor_workspace_slugs={ada.workspace_id})[0]
     assert HUMAN_REPLY_OPEN not in turn.prompt
+
+
+def test_the_cards_title_rides_along_so_the_session_can_be_named_after_it(ada):
+    """The runner names the emdash session from `origin_ref`, and the card's title
+    is the most deliberate description of the work anyone wrote. Without this the
+    name falls back down the ladder to the slash command, so every board dispatch
+    reads `c-turn-<disc>` regardless of what it is for."""
+    item = _item(ada, title="Retry the backoff on 429", dispatch=[{"prompt": "/ada:turn"}])
+
+    turns = dispatch(item, actor_workspace_slugs={wsvc.DEFAULT_WORKSPACE_SLUG})
+
+    assert turns[0].origin_ref["item_title"] == "Retry the backoff on 429"
+
+
+def test_an_explicit_item_title_in_the_spec_is_not_overwritten(ada):
+    """A producer that already named the work keeps its own words — this only
+    fills a gap."""
+    item = _item(ada, title="Card title",
+                 dispatch=[{"prompt": "/ada:turn", "origin_ref": {"item_title": "Chosen name"}}])
+
+    turns = dispatch(item, actor_workspace_slugs={wsvc.DEFAULT_WORKSPACE_SLUG})
+
+    assert turns[0].origin_ref["item_title"] == "Chosen name"
+
+
+def test_carrying_the_title_does_not_disturb_the_specs_own_provenance(ada):
+    item = _item(ada, title="Retry the backoff",
+                 dispatch=[{"prompt": "/ada:turn", "origin_ref": {"evidence": "http://x/1"}}])
+
+    turns = dispatch(item, actor_workspace_slugs={wsvc.DEFAULT_WORKSPACE_SLUG})
+
+    assert turns[0].origin_ref["evidence"] == "http://x/1"
+    assert turns[0].origin_ref["item_title"] == "Retry the backoff"

--- a/tests/test_schedule_services.py
+++ b/tests/test_schedule_services.py
@@ -37,7 +37,8 @@ def test_fire_creates_a_cron_turn_and_advances_last_slot(schedule):
     assert turn.origin == Turn.ORIGIN_CANOPY_SCHEDULER
     assert turn.status == Turn.QUEUED
     assert turn.prompt == "/echo:manager-report"
-    assert turn.origin_ref == {"schedule_id": schedule.id, "slot": SLOT_A.isoformat()}
+    assert turn.origin_ref == {"schedule_id": schedule.id, "slot": SLOT_A.isoformat(),
+                               "schedule_name": "Weekly manager report"}
     assert turn.idempotency_key == f"sched:{schedule.id}:{SLOT_A.isoformat()}"
     schedule.refresh_from_db()
     assert schedule.last_slot == SLOT_A
@@ -261,3 +262,15 @@ def test_run_now_supersedes_an_open_slot_so_the_work_never_runs_twice(schedule):
     assert services.latest_occurrence_turn(schedule).pk == manual.pk
     schedule.refresh_from_db()
     assert schedule.last_slot == SLOT_A  # cadence untouched — the next slot still fires
+
+
+def test_the_schedules_name_rides_along_for_the_session_name(schedule):
+    """The runner names the emdash session from `origin_ref`. `schedule_id` is a
+    number it cannot resolve (it is Django-free and never queries), so without the
+    name here every scheduled turn falls down the naming ladder to its slash
+    command and an agent's schedules become indistinguishable in the sidebar."""
+    fired, _ = services.fire_schedule(schedule, SLOT_A)
+    manual = services.run_schedule_now(schedule)
+
+    assert fired.origin_ref["schedule_name"] == "Weekly manager report"
+    assert manual.origin_ref["schedule_name"] == "Weekly manager report"


### PR DESCRIPTION
An emdash session name is read in a sidebar next to the human's own sessions, and it should answer two things: did the fleet start this, and what is it about. The old format answered neither well.

| Before | After |
|---|---|
| `ace-api-4a4e-0905-0920` | `c-canopy-issue-triage-4a4e` |
| `hal-alarm-labs-jj-web-cpu-high-i-ea9d-0905-1359` | `c-alarm-labs-jj-web-cpu-high-ea9d` |
| `connect-labs-api-e4a7-0729-0927` | `c-re-validate-the-stall-classifier-e4a7` |
| `echo-canopy-scheduler-c4e0-0810-0721` | `c-weekly-manager-report-c4e0` |
| `ada-api-2146-0904-1204` | `c-only-close-sessions-ada-dispatched-2146` |

(Left column is real, from emdash's own `tasks` table.)

## Three faults, all visible in those rows

- The label fell back to the bare **origin word** whenever no email subject existed — which is most turns, so most names read `api` and said nothing.
- The agent slug and an `MMDD-HHMM` stamp took ~14 of a ~28-character budget to restate emdash's own project grouping and created-at column. That is why subjects arrived cut mid-word (`cpu-high-i`).
- Nothing marked a name as ours, so fleet work and hand-typed sessions were indistinguishable in the sidebar.

## What changed

`c-` is the marker. The subject now comes off a **ladder** over meaning the turn was already carrying and nobody read — board card title, schedule name, email subject, the brief's slash command, the brief's first real line — with `origin` demoted to a floor where it honestly means "this turn told us nothing about itself". Truncation is on a word boundary.

`apps/harness/dispatch.py` and `services.py` put the card title and schedule name into `origin_ref` so the runner can reach them (the runner is Django-free and cannot resolve a `schedule_id`).

The format now has **one owner** — `canopy_runner.session_naming` — rather than living inline in `execute.py`. It is a format with readers in another repo, so it gets a home, a `parse`/`is_canopy_task` counterpart, and its own tests. The discriminator is fixed at exactly 4 characters because that, against emdash's 5-character de-dupe suffix, is what lets those readers recover a task id from a worktree directory now that the timestamp is gone.

## Sequencing

Merge the two reader PRs **first** — they accept both shapes:
- dimagi-internal/canopy#613 (`emdash_task_from_cwd`)
- dimagi-internal/ada#66 (`ada-run-cursor`)

Existing sessions are **not** renamed.

## Tests

`uv run pytest`: 1655 passed, 1 skipped. Runner suite: 601 passed (24 new naming cases, plus a seam test pinning `session_naming._thread_key` to `execute._thread_key` so the duplicated helper cannot drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JfGXZEi4bXm46fL4r4ePZc