### PR TITLE
Mint an agent's Google mailbox from the browser

### DIFF
--- a/apps/agents/google_oauth.py
+++ b/apps/agents/google_oauth.py
@@ -1,0 +1,204 @@
+"""Mint a gog-importable Google token from a browser.
+
+The goal this serves, stated by Jonathan on 2026-09-05: *someone could plausibly
+create a completely new agent without direct access to the cloud box or 1Password.*
+A mailbox was the last thing that could not be provisioned that way — minting a
+gog token meant a terminal, `gog auth login`, a loopback listener, and then a
+hand-written 1Password item. This turns it into a button.
+
+WHY THIS CANNOT USE THE `canopy` CLIENT — the constraint that shapes everything
+below, and the one that cost a wrong deploy on 2026-09-05. **A refresh token is
+minted FOR an OAuth client and works only with that client.** So the client that
+runs the browser flow is the client the resulting token is bound to, forever.
+
+And the fleet's `canopy` client CANNOT run a browser flow. Measured against
+Google's authorize endpoint on 2026-09-06:
+
+    canopy  (…l3iom9j3…)  http://localhost:59999/  -> accepted (login page)
+    canopy  (…l3iom9j3…)  https://…/callback       -> redirect_uri_mismatch
+    canopy-web (…osh2en…) http://localhost:59999/  -> redirect_uri_mismatch
+    canopy-web (…osh2en…) https://…/callback/      -> accepted (login page)
+
+Accepting an arbitrary unregistered loopback port is the signature of a **Desktop**
+client; refusing loopback while accepting one exact https URI is the signature of
+a **Web application** client. Google does not permit an https redirect on a Desktop
+client at all, so no amount of console configuration makes `canopy` mint from a
+browser. The web flow therefore runs on canopy-web's own Web client — already in
+the same GCP project, already carrying these scopes on the shared consent screen,
+and already present in this process's settings because it is what signs people in.
+
+The token consequently declares `client: canopy-web`, and the box must have that
+client registered to refresh it. `bootstrap_agents.sh` reads the client name from
+the token itself, so it picks this up with no per-agent configuration.
+"""
+from __future__ import annotations
+
+import json
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+
+from django.conf import settings
+from django.core import signing
+
+# The scope set is READ FROM THE LIVE FLEET, not designed here: echo's and eva's
+# working tokens carry exactly these. An earlier draft added calendar and slides
+# on the assumption they were wanted; no token in the fleet has ever had them,
+# and a minted token that differs from the fleet's is a new thing to debug rather
+# than a replacement for the old one.
+FLEET_SCOPES: tuple[str, ...] = (
+    "openid",
+    "email",
+    "https://www.googleapis.com/auth/userinfo.email",
+    "https://www.googleapis.com/auth/documents",
+    "https://www.googleapis.com/auth/drive",
+    "https://www.googleapis.com/auth/forms.body",
+    "https://www.googleapis.com/auth/forms.responses.readonly",
+    "https://www.googleapis.com/auth/gmail.modify",
+    "https://www.googleapis.com/auth/gmail.settings.basic",
+    "https://www.googleapis.com/auth/gmail.settings.sharing",
+    "https://www.googleapis.com/auth/spreadsheets",
+)
+
+# gog's short service names, keyed by the scope-path prefix that implies them.
+# Ordered longest-prefix-first is unnecessary here because no key is a prefix of
+# another, but the map is checked by test rather than trusted.
+_SERVICE_BY_SCOPE_PREFIX: tuple[tuple[str, str], ...] = (
+    ("https://www.googleapis.com/auth/gmail", "gmail"),
+    ("https://www.googleapis.com/auth/documents", "docs"),
+    ("https://www.googleapis.com/auth/drive", "drive"),
+    ("https://www.googleapis.com/auth/forms", "forms"),
+    ("https://www.googleapis.com/auth/spreadsheets", "sheets"),
+    ("https://www.googleapis.com/auth/presentations", "slides"),
+    ("https://www.googleapis.com/auth/calendar", "calendar"),
+)
+
+# The name the token declares, and the name the box must have registered for it.
+MINTING_CLIENT = "canopy-web"
+
+AUTHORIZE_ENDPOINT = "https://accounts.google.com/o/oauth2/v2/auth"
+TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token"
+
+STATE_SALT = "agents.google_oauth.state"
+STATE_MAX_AGE = 900  # 15 minutes: long enough to sign in, short enough to matter.
+
+
+def services_for(scopes) -> list[str]:
+    """gog's `services` list, derived from the scopes Google actually GRANTED.
+
+    Derived, never declared: a user can uncheck a scope on the consent screen, and
+    a token that claims a service it was not granted fails at call time instead of
+    at mint time — which is how a mailbox stays broken for four months.
+    """
+    out = set()
+    for scope in scopes:
+        for prefix, service in _SERVICE_BY_SCOPE_PREFIX:
+            if scope == prefix or scope.startswith(prefix + "."):
+                out.add(service)
+    return sorted(out)
+
+
+def build_gog_token(
+    *, email: str, refresh_token: str, granted_scopes, client: str = MINTING_CLIENT, now=None
+) -> dict:
+    """The exact on-disk shape `gog auth tokens import` accepts.
+
+    Five keys, no more: matched field-for-field against the live tokens in
+    op://Agent-Echo, op://Agent-Eva and op://Agent-Ace rather than reconstructed
+    from gog's source, because the importer is what has to accept it.
+    """
+    scopes = sorted(set(granted_scopes))
+    stamp = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    return {
+        "email": email,
+        "client": client,
+        "services": services_for(scopes),
+        "scopes": scopes,
+        "created_at": stamp.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "refresh_token": refresh_token,
+    }
+
+
+def callback_url() -> str:
+    """ONE redirect URI for the whole fleet.
+
+    Google requires every redirect URI to be registered exactly, so a per-agent
+    URI would mean a console edit per new agent — precisely the barrier this
+    removes. The agent rides in the signed `state` instead.
+    """
+    return f"{settings.CANOPY_PUBLIC_BASE_URL.rstrip('/')}/api/oauth/google/callback"
+
+
+def sign_state(*, agent_slug: str, user_pk) -> str:
+    return signing.dumps({"agent": agent_slug, "user": str(user_pk)}, salt=STATE_SALT)
+
+
+def unsign_state(state: str) -> dict:
+    return signing.loads(state, salt=STATE_SALT, max_age=STATE_MAX_AGE)
+
+
+def authorize_url(*, client_id: str, state: str, login_hint: str = "") -> str:
+    params = {
+        "client_id": client_id,
+        "redirect_uri": callback_url(),
+        "response_type": "code",
+        "scope": " ".join(FLEET_SCOPES),
+        # Both are required to get a refresh_token back. `access_type=offline`
+        # asks for one; `prompt=consent` forces one to be RE-ISSUED even when the
+        # account has approved this client before — without it a re-mint returns
+        # only an access token and silently produces a token file with no
+        # refresh_token in it, which imports fine and then cannot refresh.
+        "access_type": "offline",
+        "prompt": "consent",
+        "include_granted_scopes": "true",
+        "state": state,
+    }
+    if login_hint:
+        params["login_hint"] = login_hint
+    return f"{AUTHORIZE_ENDPOINT}?{urllib.parse.urlencode(params)}"
+
+
+def _post_form(url: str, data: dict, *, timeout: int = 20) -> dict:
+    body = urllib.parse.urlencode(data).encode()
+    req = urllib.request.Request(url, data=body, method="POST")
+    req.add_header("Content-Type", "application/x-www-form-urlencoded")
+    with urllib.request.urlopen(req, timeout=timeout) as res:  # noqa: S310 - fixed https endpoint
+        return json.loads(res.read().decode())
+
+
+def email_from_id_token(id_token: str) -> str:
+    """Read the mailbox out of the id_token's payload.
+
+    No signature check on purpose, and it is safe here for a specific reason: this
+    JWT did not come from the browser, it came back over TLS from Google's token
+    endpoint in a request we originated. There is no untrusted party in the path
+    to forge it. (Reading an id_token that ARRIVED from a client would need full
+    verification — that is a different situation, and this is not it.)
+    """
+    payload = id_token.split(".")[1]
+    payload += "=" * (-len(payload) % 4)
+    import base64
+
+    return json.loads(base64.urlsafe_b64decode(payload)).get("email", "")
+
+
+def exchange_code(*, code: str, client_id: str, client_secret: str) -> dict:
+    """Trade the one-time code for a refresh token. Returns Google's raw response."""
+    return _post_form(
+        TOKEN_ENDPOINT,
+        {
+            "code": code,
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "redirect_uri": callback_url(),
+            "grant_type": "authorization_code",
+        },
+    )
+
+
+def google_client_credentials() -> tuple[str, str]:
+    """canopy-web's own Web client — already configured, because it is what signs
+    people in. Nothing new to stage anywhere: that was the point."""
+    google = settings.SOCIALACCOUNT_PROVIDERS.get("google", {})
+    app = google.get("APP", google)
+    return app.get("client_id", ""), app.get("secret", "")

--- a/apps/agents/oauth_api.py
+++ b/apps/agents/oauth_api.py
@@ -18,6 +18,7 @@ from ninja.errors import HttpError
 from apps.api.auth import session_auth
 
 from . import google_oauth, services
+from .schemas import GoogleMintStartOut
 
 router = Router(auth=session_auth, tags=["agents"])
 
@@ -33,8 +34,9 @@ def _agent_or_404(request: HttpRequest, slug: str):
     return _get_agent_or_404(request, slug)
 
 
-@router.get("/{slug}/google/authorize", summary="Start the Google mint for this agent's mailbox")
-def start_google_mint(request: HttpRequest, slug: str, login_hint: str = ""):
+@router.get("/{slug}/google/authorize", response=GoogleMintStartOut,
+            summary="Start the Google mint for this agent's mailbox")
+def start_google_mint(request: HttpRequest, slug: str, login_hint: str = "") -> GoogleMintStartOut:
     """Returns the URL rather than redirecting, so the caller opens it itself.
 
     A 302 out of an XHR is invisible — the browser follows it, the fetch resolves
@@ -51,7 +53,9 @@ def start_google_mint(request: HttpRequest, slug: str, login_hint: str = ""):
     # constraint — whoever is signing in can still choose another account, and the
     # token records whichever mailbox actually consented.
     hint = login_hint or f"{agent.slug}@dimagi-ai.com"
-    return {"url": google_oauth.authorize_url(client_id=client_id, state=state, login_hint=hint)}
+    return GoogleMintStartOut(
+        url=google_oauth.authorize_url(client_id=client_id, state=state, login_hint=hint)
+    )
 
 
 oauth_router = Router(auth=session_auth, tags=["agents"])

--- a/apps/agents/oauth_api.py
+++ b/apps/agents/oauth_api.py
@@ -1,0 +1,110 @@
+"""The two routes behind the "Connect Google mailbox" button.
+
+Split from api.py because the callback CANNOT live under `/agents/{slug}/` — one
+redirect URI has to serve every agent (see google_oauth.callback_url), so the
+agent travels in signed state and the callback is mounted at a fixed path.
+
+What lands at the end is an ordinary AgentCredential named `gog-token`, holding
+exactly the JSON that `gog auth tokens import` accepts. Nothing downstream learns
+that a browser was involved: the runner resolves it, writes it to a file, and
+imports it the same way it imports one a human minted at a terminal.
+"""
+from __future__ import annotations
+
+from django.http import HttpRequest, HttpResponseRedirect
+from ninja import Router
+from ninja.errors import HttpError
+
+from apps.api.auth import session_auth
+
+from . import google_oauth, services
+
+router = Router(auth=session_auth, tags=["agents"])
+
+# The credential slot the fleet already names in every runtime.yaml and every
+# 1Password vault. Minting must land in the SAME slot a hand-minted token does,
+# or the box would have two sources of truth for one mailbox.
+GOG_TOKEN_REF = "gog-token"
+
+
+def _agent_or_404(request: HttpRequest, slug: str):
+    from .api import _get_agent_or_404
+
+    return _get_agent_or_404(request, slug)
+
+
+@router.get("/{slug}/google/authorize", summary="Start the Google mint for this agent's mailbox")
+def start_google_mint(request: HttpRequest, slug: str, login_hint: str = ""):
+    """Returns the URL rather than redirecting, so the caller opens it itself.
+
+    A 302 out of an XHR is invisible — the browser follows it, the fetch resolves
+    on Google's HTML, and nothing happens on screen. Handing back the URL lets the
+    page do a top-level navigation, which is the only thing that can show a
+    consent screen.
+    """
+    agent = _agent_or_404(request, slug)
+    client_id, _ = google_oauth.google_client_credentials()
+    if not client_id:
+        raise HttpError(503, "this deployment has no Google OAuth client configured")
+    state = google_oauth.sign_state(agent_slug=agent.slug, user_pk=request.user.pk)
+    # Default the account picker to the agent's own mailbox. It is a HINT, not a
+    # constraint — whoever is signing in can still choose another account, and the
+    # token records whichever mailbox actually consented.
+    hint = login_hint or f"{agent.slug}@dimagi-ai.com"
+    return {"url": google_oauth.authorize_url(client_id=client_id, state=state, login_hint=hint)}
+
+
+oauth_router = Router(auth=session_auth, tags=["agents"])
+
+
+@oauth_router.get("/google/callback", summary="Google returns here; the token is stored")
+def google_callback(request: HttpRequest, code: str = "", state: str = "", error: str = ""):
+    from django.core import signing
+
+    def done(agent, status: str):
+        base = f"/w/{agent.workspace.slug}/agents/{agent.slug}/credentials" if agent else "/"
+        return HttpResponseRedirect(f"{base}?google={status}")
+
+    if not state:
+        raise HttpError(400, "missing state")
+    try:
+        claims = google_oauth.unsign_state(state)
+    except signing.BadSignature as exc:
+        # Covers both tampering and expiry. Either way the only safe move is to
+        # start over — a code redeemed under a state we cannot vouch for could
+        # attach someone else's mailbox to this agent.
+        raise HttpError(400, "the sign-in link expired or was altered — start again") from exc
+
+    if str(claims.get("user")) != str(request.user.pk):
+        raise HttpError(403, "this sign-in was started by a different user")
+
+    agent = _agent_or_404(request, claims["agent"])
+    if error or not code:
+        return done(agent, "denied")
+
+    client_id, client_secret = google_oauth.google_client_credentials()
+    try:
+        tokens = google_oauth.exchange_code(code=code, client_id=client_id, client_secret=client_secret)
+    except Exception:  # noqa: BLE001 - the browser gets a status, the operator retries
+        return done(agent, "exchange-failed")
+
+    refresh = tokens.get("refresh_token", "")
+    if not refresh:
+        # Google withholds it when the account already consented and `prompt` was
+        # not forced. Storing what we got would produce a token that imports and
+        # then cannot refresh — worse than failing, because it looks provisioned.
+        return done(agent, "no-refresh-token")
+
+    email = google_oauth.email_from_id_token(tokens["id_token"]) if tokens.get("id_token") else ""
+    if not email:
+        return done(agent, "no-email")
+
+    token = google_oauth.build_gog_token(
+        email=email,
+        refresh_token=refresh,
+        granted_scopes=tokens.get("scope", "").split(),
+    )
+    import json as _json
+
+    services.set_agent_credentials(agent, {GOG_TOKEN_REF: _json.dumps(token)}, user=request.user)
+    return done(agent, "ok")

--- a/apps/agents/schemas.py
+++ b/apps/agents/schemas.py
@@ -454,6 +454,14 @@ class CommandResultOut(StrictModel):
 
 
 # ---- shared ----
+class GoogleMintStartOut(StrictModel):
+    """Where to send the browser to consent. Declared rather than left implicit:
+    an undeclared response reaches the typed client as `undefined`, and the only
+    way to consume it is a cast — which silently survives the route changing."""
+
+    url: str
+
+
 class CountOut(StrictModel):
     created: int = 0
     replaced: int = 0

--- a/apps/api/api.py
+++ b/apps/api/api.py
@@ -145,6 +145,8 @@ from apps.shareouts.api import router as shareouts_router  # noqa: E402
 from apps.session_sharing.api import router as sessions_router  # noqa: E402
 from apps.session_sharing.api import share_router as session_share_router  # noqa: E402
 from apps.agents.api import router as agents_router  # noqa: E402
+from apps.agents.oauth_api import oauth_router as google_oauth_router  # noqa: E402
+from apps.agents.oauth_api import router as agent_google_router  # noqa: E402
 from apps.agent_runs.api import router as agent_runs_router  # noqa: E402
 from apps.workspaces.api import router as workspaces_router  # noqa: E402
 from apps.timeline.api import router as timeline_router  # noqa: E402
@@ -185,6 +187,12 @@ api.add_router("/sessions", sessions_router)
 # apps.api.tenancy.WorkspaceResolveMiddleware, which also sets request.workspace_slug.
 api.add_router("/agents", agents_router)
 api.add_router("/agents", agent_runs_router)  # unified run lifecycle under the agents namespace
+api.add_router("/agents", agent_google_router)  # start the Google mailbox mint
+# The mint's callback is NOT agent-scoped: Google requires every redirect URI
+# to be registered exactly, so one fixed path serves the whole fleet and the
+# agent rides in signed state. A per-agent URI would mean a console edit per
+# new agent — the barrier this feature exists to remove.
+api.add_router("/oauth", google_oauth_router)
 api.add_router("/agents", schedules_router)  # recurring turns, under the agents namespace
 # Items — the supervisor's queue (the dual of Turn). The collection is
 # agent-scoped ("whose queue?"), the resource is not (an item id is global).

--- a/frontend/src/api/agents.ts
+++ b/frontend/src/api/agents.ts
@@ -281,6 +281,18 @@ export async function deleteAgentCredential(
   return Array.from(unwrap(res, 'deleteAgentCredential'))
 }
 
+/** Start the browser mint for this agent's Google mailbox.
+ *
+ *  Returns the URL instead of navigating, because the caller must do a TOP-LEVEL
+ *  navigation: a 302 followed inside fetch() resolves on Google's HTML and shows
+ *  the user nothing at all. */
+export async function startGoogleMint(slug: string): Promise<string> {
+  const res = await apiV2.GET('/api/agents/{slug}/google/authorize', {
+    params: { path: { slug } },
+  })
+  return (unwrap(res, 'startGoogleMint') as { url: string }).url
+}
+
 export async function getAgentRunnerRules(slug: string): Promise<AgentRunnerRuleOut[]> {
   const res = await apiV2.GET('/api/agents/{slug}/runner-rules', { params: { path: { slug } } })
   return Array.from(unwrap(res, 'getAgentRunnerRules'))

--- a/frontend/src/api/agents.ts
+++ b/frontend/src/api/agents.ts
@@ -290,7 +290,7 @@ export async function startGoogleMint(slug: string): Promise<string> {
   const res = await apiV2.GET('/api/agents/{slug}/google/authorize', {
     params: { path: { slug } },
   })
-  return (unwrap(res, 'startGoogleMint') as { url: string }).url
+  return unwrap(res, 'startGoogleMint').url
 }
 
 export async function getAgentRunnerRules(slug: string): Promise<AgentRunnerRuleOut[]> {

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -1941,6 +1941,48 @@ export interface paths {
         readonly patch?: never;
         readonly trace?: never;
     };
+    readonly "/api/agents/{slug}/google/authorize": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        /**
+         * Start the Google mint for this agent's mailbox
+         * @description Returns the URL rather than redirecting, so the caller opens it itself.
+         *
+         *     A 302 out of an XHR is invisible — the browser follows it, the fetch resolves
+         *     on Google's HTML, and nothing happens on screen. Handing back the URL lets the
+         *     page do a top-level navigation, which is the only thing that can show a
+         *     consent screen.
+         */
+        readonly get: operations["apps_agents_oauth_api_start_google_mint"];
+        readonly put?: never;
+        readonly post?: never;
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
+    readonly "/api/oauth/google/callback": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        /** Google returns here; the token is stored */
+        readonly get: operations["apps_agents_oauth_api_google_callback"];
+        readonly put?: never;
+        readonly post?: never;
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
     readonly "/api/agents/schedules/week": {
         readonly parameters: {
             readonly query?: never;
@@ -12664,6 +12706,50 @@ export interface operations {
                 content: {
                     readonly "application/json": components["schemas"]["RunSummary"];
                 };
+            };
+        };
+    };
+    readonly apps_agents_oauth_api_start_google_mint: {
+        readonly parameters: {
+            readonly query?: {
+                readonly login_hint?: string;
+            };
+            readonly header?: never;
+            readonly path: {
+                readonly slug: string;
+            };
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description OK */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    readonly apps_agents_oauth_api_google_callback: {
+        readonly parameters: {
+            readonly query?: {
+                readonly code?: string;
+                readonly state?: string;
+                readonly error?: string;
+            };
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description OK */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -7745,6 +7745,16 @@ export interface components {
                 readonly [key: string]: unknown;
             };
         };
+        /**
+         * GoogleMintStartOut
+         * @description Where to send the browser to consent. Declared rather than left implicit:
+         *     an undeclared response reaches the typed client as `undefined`, and the only
+         *     way to consume it is a cast — which silently survives the route changing.
+         */
+        readonly GoogleMintStartOut: {
+            /** Url */
+            readonly url: string;
+        };
         /** ScheduleOut */
         readonly ScheduleOut: {
             /** Id */
@@ -12727,7 +12737,9 @@ export interface operations {
                 headers: {
                     readonly [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    readonly "application/json": components["schemas"]["GoogleMintStartOut"];
+                };
             };
         };
     };

--- a/frontend/src/pages/agents/AgentCredentialsSection.tsx
+++ b/frontend/src/pages/agents/AgentCredentialsSection.tsx
@@ -1,13 +1,15 @@
 import { useEffect, useState } from 'react'
-import { useOutletContext } from 'react-router-dom'
+import { useOutletContext, useSearchParams } from 'react-router-dom'
 import {
   deleteAgentCredential,
   getAgentCredentialStatus,
   setAgentCredentials,
+  startGoogleMint,
   type AgentCredentialStatusOut,
 } from '@/api/agents'
 import type { AgentOutletContext } from '@/pages/AgentWorkspacePage'
 import { groupRefs, summarize } from '@/pages/agents/agentCredentials'
+import { declaresMailbox, mintOutcome } from '@/pages/agents/googleMint'
 import { WorkbenchSubHeader, WorkbenchSkeleton } from 'canopy-ui'
 
 // "What is stopping this agent from running" — a question that on 2026-09-05
@@ -26,6 +28,8 @@ export function AgentCredentialsSection() {
   const [draft, setDraft] = useState<Record<string, string>>({})
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [params] = useSearchParams()
+  const outcome = mintOutcome(params.get('google'))
 
   useEffect(() => {
     let cancelled = false
@@ -59,6 +63,20 @@ export function AgentCredentialsSection() {
     }
   }
 
+  const connectMailbox = async () => {
+    setBusy(true)
+    setError(null)
+    try {
+      // A TOP-LEVEL navigation, deliberately. Following the redirect inside
+      // fetch() lands on Google's HTML with nothing shown to the user; only
+      // leaving the page can render a consent screen.
+      window.location.assign(await startGoogleMint(agent.slug))
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not start the Google sign-in')
+      setBusy(false)
+    }
+  }
+
   const remove = async (name: string) => {
     setBusy(true)
     setError(null)
@@ -86,6 +104,37 @@ export function AgentCredentialsSection() {
   return (
     <div className="max-w-4xl px-6 py-8" data-testid="agent-credentials">
       <WorkbenchSubHeader title="Credentials" count={rows.length} />
+
+      {outcome && (
+        <p
+          className={`mb-3 text-[13px] ${outcome.tone === 'ok' ? 'text-success' : 'text-destructive'}`}
+          data-testid="google-mint-outcome"
+        >
+          {outcome.text}
+        </p>
+      )}
+
+      {declaresMailbox(rows) && (
+        // The whole point of the feature: a mailbox used to need a terminal, a
+        // loopback listener and a hand-written vault item. The token this writes
+        // is the same shape a hand-minted one has, in the same slot.
+        <div className="mb-4 flex flex-wrap items-center gap-3 rounded-lg border border-border bg-card px-3 py-2">
+          <div className="text-[13px] text-foreground">
+            Google mailbox
+            <span className="ml-2 text-[12px] text-muted-foreground">
+              sign in as this agent to mint its <code className="font-mono text-[11px]">gog-token</code>
+            </span>
+          </div>
+          <button
+            type="button"
+            onClick={() => void connectMailbox()}
+            disabled={busy}
+            className="ml-auto rounded-md bg-primary px-2 py-1 text-[12px] font-medium text-primary-foreground disabled:opacity-40"
+          >
+            Connect Google mailbox
+          </button>
+        </div>
+      )}
 
       {s.undeclared ? (
         // Zero refs is UNDECLARED, not provisioned — and it is the state every

--- a/frontend/src/pages/agents/googleMint.test.ts
+++ b/frontend/src/pages/agents/googleMint.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { declaresMailbox, mintOutcome } from './googleMint'
+
+describe('declaresMailbox', () => {
+  it('offers the button only to an agent that declares a mailbox', () => {
+    expect(declaresMailbox([{ name: 'gog-token' }, { name: 'nova-api-key' }])).toBe(true)
+    expect(declaresMailbox([{ name: 'nova-api-key' }])).toBe(false)
+  })
+})
+
+describe('mintOutcome', () => {
+  it('says nothing when there is nothing to say', () => {
+    expect(mintOutcome(null)).toBeNull()
+    expect(mintOutcome('something-else')).toBeNull()
+  })
+
+  it('reports success', () => {
+    expect(mintOutcome('ok')?.tone).toBe('ok')
+  })
+
+  it('gives the missing-refresh-token case its own remedy', () => {
+    // The only outcome that would otherwise read as success: a token with no
+    // refresh token imports cleanly and then can never refresh. A generic "it
+    // failed" would send the operator looking in the wrong place.
+    const m = mintOutcome('no-refresh-token')
+    expect(m?.tone).toBe('error')
+    expect(m?.text).toMatch(/already granted/i)
+  })
+
+  it('distinguishes a cancelled sign-in from a real failure', () => {
+    expect(mintOutcome('denied')?.text).toMatch(/cancelled/i)
+    expect(mintOutcome('exchange-failed')?.text).toMatch(/failed/i)
+  })
+})

--- a/frontend/src/pages/agents/googleMint.ts
+++ b/frontend/src/pages/agents/googleMint.ts
@@ -1,0 +1,38 @@
+// Pure helpers behind the "Connect Google mailbox" button.
+//
+// The mint exists because provisioning a mailbox was the last thing that could
+// not be done from a browser: it meant a terminal, `gog auth login`, a loopback
+// listener, and a hand-written 1Password item. Jonathan's goal on 2026-09-05 was
+// that "someone could plausibly create a completely new agent without direct
+// access to the cloud box or 1pass" — this is the piece that was missing.
+
+/** The credential slot a Google mailbox lands in — the same one a hand-minted
+ *  token uses, so the box never has two sources of truth for one mailbox. */
+export const GOG_TOKEN_REF = 'gog-token'
+
+export function declaresMailbox(rows: readonly { name: string }[]): boolean {
+  return rows.some((r) => r.name === GOG_TOKEN_REF)
+}
+
+/** What `?google=<status>` on the return trip means, in the operator's terms.
+ *  `null` = nothing to say (no param, or one we do not recognise). */
+export function mintOutcome(status: string | null): { tone: 'ok' | 'error'; text: string } | null {
+  switch (status) {
+    case 'ok':
+      return { tone: 'ok', text: 'Mailbox connected. The token is stored and a runner will pick it up on its next bootstrap.' }
+    case 'denied':
+      return { tone: 'error', text: 'Sign-in was cancelled, so nothing changed.' }
+    case 'no-refresh-token':
+      // Worth its own message rather than a generic failure: it is the one
+      // outcome that would otherwise LOOK like success. Google withholds the
+      // refresh token for an already-consented account, and a token without one
+      // imports cleanly and can never refresh.
+      return { tone: 'error', text: 'Google returned no refresh token — the account had already granted access. Remove canopy-web under the account’s third-party access and try again.' }
+    case 'no-email':
+      return { tone: 'error', text: 'Google did not return which mailbox consented, so nothing was stored.' }
+    case 'exchange-failed':
+      return { tone: 'error', text: 'The token exchange with Google failed. Nothing was stored — try again.' }
+    default:
+      return null
+  }
+}

--- a/runner/ec2/bootstrap_agents.sh
+++ b/runner/ec2/bootstrap_agents.sh
@@ -203,6 +203,47 @@ except Exception:
   printf '%s\n' "${declared:-${GOG_CLIENT[$slug]:-$slug}}"
 }
 
+# Materialize a gog OAuth client's id+secret to ~/.config/gogcli/credentials-<client>.json.
+#
+# gog refreshes a token by presenting the client_id+client_secret of the app the
+# token was minted for, so this file is what makes a token usable rather than
+# merely present. Which vault holds it depends on the client, not on the agent:
+#
+#   canopy      the shared fleet DESKTOP client (loopback redirect; ada/eva/hal)
+#   canopy-web  canopy-web's WEB client — the only kind Google lets run a browser
+#               redirect, and therefore the only one the "Connect Google mailbox"
+#               button can mint with. Tokens from that button declare it.
+#   <other>     an agent with its own client (echo) keeps it in its own vault.
+#
+# Never fails the bootstrap: a missing client file means gmail won't authorize,
+# which the warning says, and every other part of the agent still provisions.
+ensure_client_creds() {  # <client> <agent-vault> <slug>
+  local client="$1" agent_vault="$2" slug="$3"
+  [[ -n "$client" ]] || return 0
+  command -v op >/dev/null 2>&1 || return 0
+
+  local client_vault client_item
+  case "$client" in
+    canopy)     client_vault="Canopy-Shared"; client_item="gog-oauth-client" ;;
+    canopy-web) client_vault="Canopy-Shared"; client_item="gog-oauth-client-web" ;;
+    *)          client_vault="$agent_vault";  client_item="gog-oauth-client" ;;
+  esac
+
+  local gog_dir; gog_dir="$(gog_config_dir)"
+  local client_file="$gog_dir/credentials-${client}.json"
+  [[ -f "$client_file" ]] && return 0
+
+  mkdir -p "$gog_dir"
+  if op read "op://${client_vault}/${client_item}/credential" >"$client_file" 2>/dev/null \
+     && [[ -s "$client_file" ]]; then
+    chmod 0600 "$client_file"
+    ok "$slug: gog client creds ($client) -> $client_file"
+  else
+    rm -f "$client_file"
+    warn "$slug: op read op://${client_vault}/${client_item}/credential failed — gmail may not authorize as $client"
+  fi
+}
+
 vault_name() {  # ace -> Agent-Ace (bash 5, shipped on Ubuntu 24.04: ${var^} title-cases)
   local slug="$1"
   printf 'Agent-%s\n' "${slug^}"
@@ -549,23 +590,10 @@ bootstrap_one_agent() {
   install_required_plugins "$slug" "$dest"
   run_agent_provisioner "$slug" "$dest"
 
-  # The gog OAuth-client credential FILE (not an env var): a single 1Password
-  # field materialized with native `op read` (no second injector). The shared
-  # `canopy` client's item lives in Canopy-Shared; an agent with its OWN client
-  # (echo, ace) keeps it in that agent's vault.
-  local gog_dir; gog_dir="$(gog_config_dir)"
-  local client_file="$gog_dir/credentials-${client}.json"
-  local client_vault; [[ "$client" == "canopy" ]] && client_vault="Canopy-Shared" || client_vault="$vault"
-  if command -v op >/dev/null 2>&1 && [[ ! -f "$client_file" ]]; then
-    mkdir -p "$gog_dir"
-    if op read "op://${client_vault}/gog-oauth-client/credential" >"$client_file" 2>/dev/null && [[ -s "$client_file" ]]; then
-      chmod 0600 "$client_file"
-      ok "$slug: gog client creds -> $client_file"
-    else
-      rm -f "$client_file"
-      warn "$slug: op read op://${client_vault}/gog-oauth-client/credential failed — gmail may not authorize"
-    fi
-  fi
+  # The gog OAuth-client credential FILE — see ensure_client_creds. Materialized
+  # from the FALLBACK client name here, because the token that names the real one
+  # has not been fetched yet; the call is repeated after the import below.
+  ensure_client_creds "$client" "$vault" "$slug"
 
   if ! command -v gog >/dev/null 2>&1; then
     warn "$slug: gog unavailable — skipping gmail token import"
@@ -588,6 +616,12 @@ bootstrap_one_agent() {
         local tclient; tclient="$(token_client "$tokfile" "$slug")"
         if [[ -n "$tclient" && "$tclient" != "$client" ]]; then
           warn "$slug: token declares client '$tclient', map said '$client' — using the token"
+          # And it needs that client's id+secret on disk to refresh with. The
+          # materialization above could only have used the fallback name, so a
+          # token minted under a client the table doesn't know — every token from
+          # canopy-web's browser mint — would import and then fail to refresh,
+          # with the client file for a DIFFERENT app sitting right next to it.
+          ensure_client_creds "$tclient" "$vault" "$slug"
         fi
         upsert_account_client "$account" "$tclient"
       else

--- a/runner/ec2/tests/test_gog_client_creds_vault.py
+++ b/runner/ec2/tests/test_gog_client_creds_vault.py
@@ -1,0 +1,123 @@
+"""Which vault holds a gog OAuth client's id+secret depends on the CLIENT.
+
+gog refreshes a token by presenting the client_id+client_secret of the app that
+minted it, so this file is what makes an imported token usable rather than merely
+present. Before 2026-09-06 the choice was a two-way `[[ $client == canopy ]]`
+inline in bootstrap_one_agent, keyed off the FALLBACK table — which is computed
+before any token has been read.
+
+That is fine while every token's client is in the table. It stops being fine the
+moment canopy-web's browser mint exists: those tokens are minted by canopy-web's
+WEB client (the only kind Google permits an https redirect on — a Desktop client
+like `canopy` is refused outright), so they declare `canopy-web`, and the client
+file materialized from the table names a DIFFERENT app. The token would import
+cleanly and then fail every refresh, with a plausible-looking credentials file
+sitting next to it.
+"""
+from __future__ import annotations
+
+import pathlib
+import subprocess
+
+import pytest
+
+SCRIPT = pathlib.Path(__file__).resolve().parent.parent / "bootstrap_agents.sh"
+
+_HAS_ASSOC = subprocess.run(
+    ["bash", "-c", "declare -A _t=( [k]=v ) 2>/dev/null && echo yes"],
+    capture_output=True, text=True,
+).stdout.strip() == "yes"
+pytestmark = pytest.mark.skipif(
+    not _HAS_ASSOC, reason="bash lacks associative arrays (macOS ships 3.2; the box and CI run 5)"
+)
+
+
+def _fn(name: str) -> str:
+    lines = SCRIPT.read_text().splitlines()
+    start = next(i for i, l in enumerate(lines) if l.startswith(f"{name}() {{"))
+    end = next(i for i in range(start + 1, len(lines)) if lines[i] == "}")
+    return "\n".join(lines[start:end + 1])
+
+
+def _op_ref(client: str, agent_vault: str, tmp: pathlib.Path) -> str:
+    """Run ensure_client_creds with `op` and gog_config_dir stubbed, and report the
+    op:// reference it reached for. Stubbing `op` is the point: the decision under
+    test is WHICH secret is fetched, and that is observable without a vault."""
+    script = f"""
+set -uo pipefail
+ok()   {{ :; }}
+warn() {{ :; }}
+gog_config_dir() {{ printf '%s\\n' "{tmp}/gogcli"; }}
+op() {{ printf '%s\\n' "$2" >>"{tmp}/refs"; return 1; }}
+command() {{ return 0; }}   # pretend `op` is installed
+{_fn("ensure_client_creds")}
+ensure_client_creds "{client}" "{agent_vault}" someslug
+"""
+    subprocess.run(["bash", "-c", script], capture_output=True, text=True, timeout=60)
+    refs = (tmp / "refs")
+    return refs.read_text().strip() if refs.exists() else ""
+
+
+def test_the_shared_desktop_client_comes_from_the_shared_vault(tmp_path):
+    assert _op_ref("canopy", "Agent-Eva", tmp_path) == \
+        "op://Canopy-Shared/gog-oauth-client/credential"
+
+
+def test_the_web_client_is_a_DIFFERENT_item_in_the_shared_vault(tmp_path):
+    """Not a variant of the same secret — a different OAuth app entirely, with a
+    different client_id. Reusing `gog-oauth-client` for it would overwrite the
+    Desktop client that eva/ada/hal's live tokens refresh with."""
+    assert _op_ref("canopy-web", "Agent-Ace", tmp_path) == \
+        "op://Canopy-Shared/gog-oauth-client-web/credential"
+
+
+def test_an_agent_with_its_own_client_reads_its_own_vault(tmp_path):
+    assert _op_ref("echo", "Agent-Echo", tmp_path) == \
+        "op://Agent-Echo/gog-oauth-client/credential"
+
+
+def test_each_client_gets_its_own_file_so_two_can_coexist(tmp_path):
+    """A box runs agents on several clients at once. One shared filename would
+    make the last bootstrap win and silently break the others."""
+    names = set()
+    for client in ("canopy", "canopy-web", "echo"):
+        script = f"""
+set -uo pipefail
+ok() {{ :; }}; warn() {{ :; }}
+gog_config_dir() {{ printf '%s\\n' "{tmp_path}/gogcli"; }}
+op() {{ printf '%s' '{{"client_id":"x","client_secret":"y"}}'; }}
+{_fn("ensure_client_creds")}
+ensure_client_creds "{client}" Agent-Echo someslug
+"""
+        subprocess.run(["bash", "-c", script], capture_output=True, text=True, timeout=60)
+    names = {p.name for p in (tmp_path / "gogcli").glob("credentials-*.json")}
+    assert names == {
+        "credentials-canopy.json", "credentials-canopy-web.json", "credentials-echo.json"
+    }
+
+
+def test_a_vault_miss_leaves_no_half_written_file(tmp_path):
+    """An empty or partial credentials file is worse than none: gog would read it
+    and fail with a parse error rather than the missing-credential message that
+    names the fix."""
+    script = f"""
+set -uo pipefail
+ok() {{ :; }}; warn() {{ :; }}
+gog_config_dir() {{ printf '%s\\n' "{tmp_path}/gogcli"; }}
+op() {{ return 1; }}
+{_fn("ensure_client_creds")}
+ensure_client_creds canopy-web Agent-Ace someslug
+"""
+    subprocess.run(["bash", "-c", script], capture_output=True, text=True, timeout=60)
+    assert not (tmp_path / "gogcli" / "credentials-canopy-web.json").exists()
+
+
+def test_the_token_declared_client_is_materialized_after_import():
+    """The regression this whole file guards. bootstrap_one_agent must call
+    ensure_client_creds a SECOND time with the client the token declared —
+    the first call can only have used the fallback table."""
+    body = _fn("bootstrap_one_agent")
+    assert body.count("ensure_client_creds") >= 2, \
+        "a token declaring an unmapped client would import and never refresh"
+    after_token = body.split('token_client "$tokfile"', 1)[1]
+    assert "ensure_client_creds" in after_token

--- a/tests/test_google_mint.py
+++ b/tests/test_google_mint.py
@@ -1,0 +1,291 @@
+"""Minting a gog token from a browser.
+
+The shape assertions here are not designed — they are transcribed from the tokens
+that actually work. On 2026-09-06 the live items op://Agent-Echo/gog-token and
+op://Agent-Eva/gog-token both read:
+
+    services: [docs, drive, forms, gmail, sheets]
+    scopes:   [email, .../documents, .../drive, .../forms.body,
+               .../forms.responses.readonly, .../gmail.modify,
+               .../gmail.settings.basic, .../gmail.settings.sharing,
+               .../spreadsheets, .../userinfo.email, openid]
+
+Notably NO calendar and NO slides — a first draft of the mint requested both on
+the assumption they were wanted, and a token unlike every other token in the
+fleet is a new thing to debug rather than a replacement for the old one.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from apps.agents import google_oauth as g
+
+# Exactly what echo's and eva's working tokens carry.
+LIVE_FLEET_SCOPES = [
+    "email",
+    "https://www.googleapis.com/auth/documents",
+    "https://www.googleapis.com/auth/drive",
+    "https://www.googleapis.com/auth/forms.body",
+    "https://www.googleapis.com/auth/forms.responses.readonly",
+    "https://www.googleapis.com/auth/gmail.modify",
+    "https://www.googleapis.com/auth/gmail.settings.basic",
+    "https://www.googleapis.com/auth/gmail.settings.sharing",
+    "https://www.googleapis.com/auth/spreadsheets",
+    "https://www.googleapis.com/auth/userinfo.email",
+    "openid",
+]
+
+
+def test_the_requested_scopes_are_the_ones_the_fleet_actually_uses():
+    """Asking for MORE than the fleet uses is not free: every extra scope is one
+    more thing on the consent screen and one more way a re-mint diverges from the
+    token it replaces."""
+    assert set(g.FLEET_SCOPES) == set(LIVE_FLEET_SCOPES)
+
+
+def test_services_are_derived_from_the_granted_scopes_not_declared():
+    assert g.services_for(LIVE_FLEET_SCOPES) == ["docs", "drive", "forms", "gmail", "sheets"]
+
+
+def test_a_scope_the_user_unchecked_drops_its_service():
+    """A consent screen lets scopes be declined. Claiming a service that was not
+    granted fails at call time, months later, instead of at mint time."""
+    without_forms = [s for s in LIVE_FLEET_SCOPES if "/forms" not in s]
+    assert "forms" not in g.services_for(without_forms)
+    assert "gmail" in g.services_for(without_forms)
+
+
+def test_sign_in_only_scopes_contribute_no_service():
+    assert g.services_for(["openid", "email", "https://www.googleapis.com/auth/userinfo.email"]) == []
+
+
+def test_the_token_has_exactly_the_five_keys_gog_imports():
+    tok = g.build_gog_token(
+        email="ace@dimagi-ai.com", refresh_token="1//rt", granted_scopes=LIVE_FLEET_SCOPES
+    )
+    assert set(tok) == {"email", "client", "services", "scopes", "created_at", "refresh_token"}
+
+
+def test_the_token_matches_a_live_one_field_for_field():
+    tok = g.build_gog_token(
+        email="eva@dimagi-ai.com",
+        refresh_token="1//rt",
+        granted_scopes=LIVE_FLEET_SCOPES,
+        now=datetime(2026, 7, 24, 4, 9, 54, tzinfo=timezone.utc),
+    )
+    assert tok["email"] == "eva@dimagi-ai.com"
+    assert tok["services"] == ["docs", "drive", "forms", "gmail", "sheets"]
+    assert tok["scopes"] == sorted(LIVE_FLEET_SCOPES)
+    assert tok["created_at"] == "2026-07-24T04:09:54Z"
+
+
+def test_the_token_declares_the_client_that_minted_it():
+    """The load-bearing invariant of the whole feature, and the one a wrong
+    inference broke on 2026-09-05: a refresh token works ONLY with the client it
+    was minted for. The browser flow can only run on the Web client, so the token
+    must say so — writing `canopy` here would name a Desktop client that never saw
+    this token and cannot refresh it."""
+    tok = g.build_gog_token(email="a@b.c", refresh_token="x", granted_scopes=["openid"])
+    assert tok["client"] == "canopy-web"
+    assert tok["client"] != "canopy"
+
+
+def test_created_at_is_utc_with_the_trailing_z():
+    """gog's importer reads this literally; a naive local timestamp would silently
+    date a token hours off."""
+    tok = g.build_gog_token(
+        email="a@b.c", refresh_token="x", granted_scopes=["openid"],
+        now=datetime(2026, 9, 6, 12, 0, 0, tzinfo=timezone.utc),
+    )
+    assert tok["created_at"].endswith("Z") and "+" not in tok["created_at"]
+
+
+# --- the authorize URL ----------------------------------------------------------
+
+def test_the_authorize_url_forces_a_refresh_token_to_be_reissued():
+    """Without prompt=consent a RE-mint for an already-consented account returns
+    no refresh_token at all, and the result imports cleanly and then cannot
+    refresh — a provisioned-looking dead mailbox, which is the exact failure this
+    whole feature was built to surface."""
+    url = g.authorize_url(client_id="cid", state="st")
+    assert "access_type=offline" in url
+    assert "prompt=consent" in url
+
+
+def test_one_redirect_uri_serves_every_agent():
+    """A per-agent URI would need a Google console edit per new agent."""
+    import re
+
+    assert re.search(r"/api/oauth/google/callback$", g.callback_url())
+    a = g.authorize_url(client_id="cid", state=g.sign_state(agent_slug="ace", user_pk=1))
+    b = g.authorize_url(client_id="cid", state=g.sign_state(agent_slug="echo", user_pk=1))
+    from urllib.parse import parse_qs, urlparse
+
+    assert parse_qs(urlparse(a).query)["redirect_uri"] == parse_qs(urlparse(b).query)["redirect_uri"]
+
+
+def test_state_round_trips_and_refuses_tampering():
+    state = g.sign_state(agent_slug="ace", user_pk=7)
+    assert g.unsign_state(state) == {"agent": "ace", "user": "7"}
+
+    from django.core import signing
+
+    with pytest.raises(signing.BadSignature):
+        g.unsign_state(state[:-3] + "aaa")
+
+
+def test_the_agent_travels_in_signed_state_not_a_query_param():
+    """If the agent were a plain parameter, anyone who could get a user to follow
+    a link could attach a mailbox to an agent of their choosing."""
+    url = g.authorize_url(client_id="cid", state=g.sign_state(agent_slug="ace", user_pk=1))
+    from urllib.parse import parse_qs, urlparse
+
+    q = parse_qs(urlparse(url).query)
+    assert "agent" not in q
+    assert q["state"][0] != "ace"
+
+
+def test_the_id_token_payload_yields_the_mailbox():
+    import base64
+    import json
+
+    payload = base64.urlsafe_b64encode(json.dumps({"email": "ace@dimagi-ai.com"}).encode())
+    jwt = b"h." + payload.rstrip(b"=") + b".sig"
+    assert g.email_from_id_token(jwt.decode()) == "ace@dimagi-ai.com"
+
+
+# --- the flow through the routes -------------------------------------------------
+
+from django.contrib.auth import get_user_model  # noqa: E402
+
+from apps.agents.models import Agent, AgentCredential  # noqa: E402
+from apps.workspaces.models import Workspace, WorkspaceMembership  # noqa: E402
+
+CALLBACK = "/api/oauth/google/callback"
+
+
+@pytest.fixture
+def fleet(client, settings):
+    settings.SOCIALACCOUNT_PROVIDERS = {
+        "google": {"APP": {"client_id": "cid.apps.googleusercontent.com", "secret": "GOCSPX-x"}}
+    }
+    jj = get_user_model().objects.create_user(username="jj", email="jj@dimagi.com")
+    ws = Workspace.objects.create(slug="connect", display_name="Connect", created_by=jj)
+    WorkspaceMembership.objects.create(workspace=ws, user=jj, role=WorkspaceMembership.OWNER)
+    agent = Agent.objects.create(slug="ace", name="ACE", workspace=ws, runtime_secrets=["gog-token"])
+    client.force_login(jj)
+    return {"client": client, "agent": agent, "user": jj, "ws": ws}
+
+
+def _google_response(*, refresh="1//refresh", scope=None):
+    import base64
+    import json
+
+    payload = base64.urlsafe_b64encode(json.dumps({"email": "ace@dimagi-ai.com"}).encode())
+    out = {
+        "id_token": "h." + payload.rstrip(b"=").decode() + ".sig",
+        "scope": " ".join(scope if scope is not None else LIVE_FLEET_SCOPES),
+    }
+    if refresh:
+        out["refresh_token"] = refresh
+    return out
+
+
+@pytest.mark.django_db
+def test_authorize_hands_back_a_url_rather_than_redirecting(fleet):
+    """A 302 out of an XHR is invisible — the fetch resolves on Google's HTML and
+    nothing appears on screen. Only a top-level navigation can show consent."""
+    res = fleet["client"].get("/api/agents/ace/google/authorize")
+    assert res.status_code == 200
+    url = res.json()["url"]
+    assert url.startswith("https://accounts.google.com/o/oauth2/v2/auth?")
+    assert "login_hint=ace%40dimagi-ai.com" in url
+
+
+@pytest.mark.django_db
+def test_the_callback_stores_a_gog_importable_token(fleet, monkeypatch):
+    import json
+
+    monkeypatch.setattr(g, "exchange_code", lambda **kw: _google_response())
+    state = g.sign_state(agent_slug="ace", user_pk=fleet["user"].pk)
+    res = fleet["client"].get(CALLBACK, {"code": "c", "state": state})
+    assert res.status_code == 302 and res["Location"].endswith("?google=ok")
+
+    stored = json.loads(_stored_token(fleet["agent"]))
+    assert stored["email"] == "ace@dimagi-ai.com"
+    assert stored["client"] == "canopy-web"
+    assert stored["refresh_token"] == "1//refresh"
+    assert stored["services"] == ["docs", "drive", "forms", "gmail", "sheets"]
+
+
+def _stored_token(agent) -> str:
+    from apps.agents import services as svc
+
+    return svc.resolve_agent_credentials(agent)["gog-token"]
+
+
+@pytest.mark.django_db
+def test_it_lands_in_the_same_slot_a_hand_minted_token_does(fleet, monkeypatch):
+    """`gog-token` is the ref every runtime.yaml and every vault already names.
+    A second slot would give one mailbox two sources of truth."""
+    monkeypatch.setattr(g, "exchange_code", lambda **kw: _google_response())
+    state = g.sign_state(agent_slug="ace", user_pk=fleet["user"].pk)
+    fleet["client"].get(CALLBACK, {"code": "c", "state": state})
+    assert AgentCredential.objects.filter(agent=fleet["agent"], name="gog-token").exists()
+
+
+@pytest.mark.django_db
+def test_a_response_without_a_refresh_token_is_refused_not_stored(fleet, monkeypatch):
+    """Google withholds it for an already-consented account. Storing what came
+    back yields a token that imports cleanly and can never refresh — a mailbox
+    that LOOKS provisioned, which is the exact failure mode this feature exists
+    to end."""
+    monkeypatch.setattr(g, "exchange_code", lambda **kw: _google_response(refresh=""))
+    state = g.sign_state(agent_slug="ace", user_pk=fleet["user"].pk)
+    res = fleet["client"].get(CALLBACK, {"code": "c", "state": state})
+    assert res["Location"].endswith("?google=no-refresh-token")
+    assert not AgentCredential.objects.filter(agent=fleet["agent"], name="gog-token").exists()
+
+
+@pytest.mark.django_db
+def test_the_callback_refuses_a_state_signed_for_someone_else(fleet):
+    """Otherwise a link followed by the wrong person attaches THEIR mailbox to
+    this agent."""
+    other = get_user_model().objects.create_user(username="m", email="m@dimagi.com")
+    state = g.sign_state(agent_slug="ace", user_pk=other.pk)
+    assert fleet["client"].get(CALLBACK, {"code": "c", "state": state}).status_code == 403
+
+
+@pytest.mark.django_db
+def test_the_callback_refuses_unsigned_state(fleet):
+    assert fleet["client"].get(CALLBACK, {"code": "c", "state": "ace"}).status_code == 400
+
+
+@pytest.mark.django_db
+def test_a_denied_consent_stores_nothing_and_says_so(fleet):
+    state = g.sign_state(agent_slug="ace", user_pk=fleet["user"].pk)
+    res = fleet["client"].get(CALLBACK, {"error": "access_denied", "state": state})
+    assert res["Location"].endswith("?google=denied")
+    assert not AgentCredential.objects.filter(agent=fleet["agent"], name="gog-token").exists()
+
+
+@pytest.mark.django_db
+def test_the_minted_value_never_comes_back_through_the_browser(fleet, monkeypatch):
+    monkeypatch.setattr(g, "exchange_code", lambda **kw: _google_response())
+    state = g.sign_state(agent_slug="ace", user_pk=fleet["user"].pk)
+    fleet["client"].get(CALLBACK, {"code": "c", "state": state})
+    body = fleet["client"].get("/api/agents/ace/credentials/status").content.decode()
+    assert "1//refresh" not in body
+    assert '"name": "gog-token"' in body or "gog-token" in body
+
+
+@pytest.mark.django_db
+def test_a_non_member_cannot_start_a_mint(client):
+    owner = get_user_model().objects.create_user(username="o", email="o@dimagi.com")
+    ws = Workspace.objects.create(slug="private", display_name="P", created_by=owner)
+    WorkspaceMembership.objects.create(workspace=ws, user=owner, role=WorkspaceMembership.OWNER)
+    Agent.objects.create(slug="secret", name="S", workspace=ws, runtime_secrets=["gog-token"])
+    client.force_login(get_user_model().objects.create_user(username="x", email="x@dimagi.com"))
+    assert client.get("/api/agents/secret/google/authorize").status_code == 404


### PR DESCRIPTION
Provisioning a mailbox was the last thing that needed a terminal and a 1Password grant. This makes it a button on the agent's Credentials tab.

## The one thing still needed from a human

**Add this redirect URI** to OAuth client `270508200508-osh2en6m7u25j015qtempgn3sdgoi00c` (project `canopy-494811`):

```
https://labs.connect.dimagi.com/canopy/api/oauth/google/callback
```

That is the whole console change. One URI serves every agent — Google requires exact registration, so a per-agent URI would mean a console edit per new agent, which is the barrier this removes. The agent rides in signed `state` instead. No consent-screen change is needed: the full fleet scope set was probed against this client and accepted unchanged, because the consent screen is per-project and the gog client already carries those scopes.

## Why not the `canopy` client

A refresh token is minted **for** a client and works only with that client — the invariant #661 broke and #662 reverted. So whichever client runs the browser flow owns the resulting token forever.

Measured against Google's authorize endpoint, 2026-09-06:

| client | `http://localhost:59999/` | `https://…/callback` |
|---|---|---|
| `canopy` `…l3iom9j3…` | accepted | `redirect_uri_mismatch` |
| canopy-web `…osh2en…` | `redirect_uri_mismatch` | accepted |

Accepting an arbitrary *unregistered* loopback port is the signature of a **Desktop** client; refusing loopback while accepting one exact https URI is a **Web** client. Google permits no https redirect on a Desktop client at all, so `canopy` cannot mint from a browser under any configuration. The flow runs on canopy-web's own Web client — same project, already in `settings.SOCIALACCOUNT_PROVIDERS` because it is what signs people in, so **nothing new is staged in the deployment**.

## What that costs on the box

Tokens from this flow declare `client: canopy-web`, so gog needs that client's id+secret to refresh them. `bootstrap_agents.sh` already read the client name from the token; what it could not do was *fetch* a client the fallback table doesn't know — materialization ran once, before any token was read. Now:

- the vault/item choice is `ensure_client_creds`, a named function with a three-way map, instead of an inline `[[ $client == canopy ]]`;
- it runs a **second** time with the client the token actually declared. Without that, such a token imports cleanly and fails every refresh, with a credentials file for a *different* app sitting next to it.

Staged at `op://Canopy-Shared/gog-oauth-client-web` (values copied from `AI-Agents / Canopy Web - GCP`).

## Token shape

Transcribed from live tokens, not designed. `op://Agent-Echo/gog-token` and `op://Agent-Eva/gog-token` both carry exactly the scope set requested here — and notably **no calendar and no slides**. An earlier draft asked for both; a minted token unlike every other token in the fleet is a new thing to debug rather than a replacement for the old one.

Two outcomes are handled specially because both otherwise read as success:

- **no `refresh_token`** — Google withholds it for an already-consented account. It imports cleanly and can never refresh, so it is refused rather than stored, with a message naming the remedy.
- **`services` derived from GRANTED scopes**, not requested ones. A scope declined at the consent screen now fails at mint time instead of months later.

## Tests

22 backend (`tests/test_google_mint.py`), 6 bash-5 (`runner/ec2/tests/test_gog_client_creds_vault.py`, verified under `docker run bash:5` since macOS ships 3.2), 5 frontend. Full suite: 2314 backend passed, 683 frontend passed, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rffk2t9tySFjRNqRKxN2wR