### PR TITLE
Ask Google for the scopes agents declare, not the ones old tokens carry

### DIFF
--- a/apps/agents/google_oauth.py
+++ b/apps/agents/google_oauth.py
@@ -41,12 +41,30 @@ from datetime import datetime, timezone
 from django.conf import settings
 from django.core import signing
 
-# The scope set is READ FROM THE LIVE FLEET, not designed here: echo's and eva's
-# working tokens carry exactly these. An earlier draft added calendar and slides
-# on the assumption they were wanted; no token in the fleet has ever had them,
-# and a minted token that differs from the fleet's is a new thing to debug rather
-# than a replacement for the old one.
-FLEET_SCOPES: tuple[str, ...] = (
+# What to ASK Google for. The authority is what agents DECLARE they need, not
+# what the incumbent tokens happen to carry — a distinction that cost a wrong
+# reading on 2026-09-06.
+#
+# The live tokens (op://Agent-Echo, op://Agent-Eva) carry gmail, docs, drive,
+# forms and sheets, so a first version requested exactly those, reasoning that a
+# token unlike the fleet's is a new thing to debug. That inverted the evidence.
+# Those tokens are a record of what was minted, not of what is required, and
+# ace's config/agent.json says so in as many words:
+#
+#     gog_services: [gmail, calendar, drive, docs, slides, sheets, forms]
+#     "ACE needs `slides` … and `calendar`, neither of which is in canopy's
+#      fleet default."
+#
+# So the fleet default is KNOWN INSUFFICIENT for at least one agent already, and
+# minting from it would hand ACE a token that authorizes cleanly and then fails
+# its first slides call — the same shape of silent breakage this feature exists
+# to end. Ask for the union instead.
+#
+# Over-requesting is close to free and under-requesting is not: an unused grant
+# costs a line on the consent screen, while a missing one is a live agent failing
+# mid-run, and re-minting means re-consenting. `services_for` derives the truth
+# from what Google actually GRANTED, so the token never overstates itself.
+_BASE_SCOPES: tuple[str, ...] = (
     "openid",
     "email",
     "https://www.googleapis.com/auth/userinfo.email",
@@ -59,6 +77,16 @@ FLEET_SCOPES: tuple[str, ...] = (
     "https://www.googleapis.com/auth/gmail.settings.sharing",
     "https://www.googleapis.com/auth/spreadsheets",
 )
+
+# Declared by an agent, absent from every live token. Named separately so the
+# reason survives: these are the two that ace's own config calls out as missing
+# from the fleet default.
+_DECLARED_BEYOND_THE_FLEET: tuple[str, ...] = (
+    "https://www.googleapis.com/auth/calendar",
+    "https://www.googleapis.com/auth/presentations",
+)
+
+FLEET_SCOPES: tuple[str, ...] = _BASE_SCOPES + _DECLARED_BEYOND_THE_FLEET
 
 # gog's short service names, keyed by the scope-path prefix that implies them.
 # Ordered longest-prefix-first is unnecessary here because no key is a prefix of

--- a/tests/test_google_mint.py
+++ b/tests/test_google_mint.py
@@ -38,11 +38,33 @@ LIVE_FLEET_SCOPES = [
 ]
 
 
-def test_the_requested_scopes_are_the_ones_the_fleet_actually_uses():
-    """Asking for MORE than the fleet uses is not free: every extra scope is one
-    more thing on the consent screen and one more way a re-mint diverges from the
-    token it replaces."""
-    assert set(g.FLEET_SCOPES) == set(LIVE_FLEET_SCOPES)
+# ace/config/agent.json, verbatim — the DECLARATION of what its mailbox must be
+# able to do, alongside the note that two of them are missing from the fleet
+# default. This is the authority on scope, not the incumbent tokens.
+ACE_DECLARED_SERVICES = ["gmail", "calendar", "drive", "docs", "slides", "sheets", "forms"]
+
+
+def test_the_request_covers_every_service_an_agent_declares():
+    """The correction that matters. A first version requested exactly what the
+    live tokens carry — but those record what was MINTED, not what is needed, and
+    ace's config says the fleet default is insufficient for it. Minting from that
+    set hands ACE a token that authorizes cleanly and fails its first slides
+    call: the silent breakage this feature exists to end, reintroduced by the
+    feature itself."""
+    granted = g.services_for(g.FLEET_SCOPES)
+    assert set(ACE_DECLARED_SERVICES) <= set(granted), (
+        f"declared but not requested: {sorted(set(ACE_DECLARED_SERVICES) - set(granted))}"
+    )
+
+
+def test_the_request_is_a_superset_of_what_the_live_fleet_already_has():
+    """A re-mint must not take capability AWAY from a working mailbox."""
+    assert set(LIVE_FLEET_SCOPES) <= set(g.FLEET_SCOPES)
+
+
+def test_calendar_and_slides_are_asked_for_because_an_agent_declares_them():
+    assert "https://www.googleapis.com/auth/calendar" in g.FLEET_SCOPES
+    assert "https://www.googleapis.com/auth/presentations" in g.FLEET_SCOPES
 
 
 def test_services_are_derived_from_the_granted_scopes_not_declared():


### PR DESCRIPTION
A correction to #675, which read its evidence backwards.

#675 took the requested scope set from the live tokens in `op://Agent-Echo` and `op://Agent-Eva` — gmail, docs, drive, forms, sheets — and argued that requesting anything more would make a minted token "unlike every other token in the fleet."

Those tokens record what was **minted**, not what is **required**. `ace/config/agent.json` says so directly:

```
gog_services: [gmail, calendar, drive, docs, slides, sheets, forms]
"ACE needs `slides` … and `calendar`, neither of which is in canopy's fleet default."
```

So the fleet default is already known-insufficient for an agent in the fleet — and plausibly a second reason ACE's mailbox is broken, independent of its dead token. Minting from that set would have handed ACE a token that authorizes cleanly and fails its first slides call: the silent breakage the feature exists to end, reintroduced by the feature.

## The change

Request the union. The asymmetry is the argument — an unused grant costs one line on a consent screen; a missing one is a live agent failing mid-run, and re-minting means re-consenting.

`services_for` is unchanged and still derives `services` from what Google actually **granted**, so a token never overstates itself regardless of what was asked for.

Verified against Google's authorize endpoint 2026-09-06: the full union, calendar and presentations included, is accepted on canopy-web's client with **no consent-screen change**.

## Tests

The scope test now asserts against the **declaration** (superset over ace's `gog_services`) instead of against the incumbent tokens, plus a new check that a re-mint can never take capability away from a working mailbox. 2320 backend passed, 683 frontend, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rffk2t9tySFjRNqRKxN2wR