### PR TITLE
Credentials screen: lead with what needs a person

### DIFF
--- a/frontend/src/pages/agents/AgentCredentialsSection.tsx
+++ b/frontend/src/pages/agents/AgentCredentialsSection.tsx
@@ -8,7 +8,7 @@ import {
   type AgentCredentialStatusOut,
 } from '@/api/agents'
 import type { AgentOutletContext } from '@/pages/AgentWorkspacePage'
-import { groupRefs, summarize } from '@/pages/agents/agentCredentials'
+import { headline, sections } from '@/pages/agents/agentCredentials'
 import { declaresMailbox, mintOutcome } from '@/pages/agents/googleMint'
 import { WorkbenchSubHeader, WorkbenchSkeleton } from 'canopy-ui'
 
@@ -30,6 +30,9 @@ export function AgentCredentialsSection() {
   const [error, setError] = useState<string | null>(null)
   const [params] = useSearchParams()
   const outcome = mintOutcome(params.get('google'))
+  // Collapsed by DEFAULT. These rows are correct and need nothing; shown as a
+  // list of empty inputs they read as forty-five things to type.
+  const [showVault, setShowVault] = useState(false)
 
   useEffect(() => {
     let cancelled = false
@@ -98,8 +101,63 @@ export function AgentCredentialsSection() {
     )
   }
 
-  const s = summarize(rows)
-  const ordered = groupRefs(rows)
+  const sec = sections(rows)
+
+  // One row, used for anything this page actually manages. The vault-resolved
+  // refs get the same control once expanded — a value CAN be stored here to
+  // override the vault, it just isn't the normal case and shouldn't lead.
+  const credentialRow = (r: AgentCredentialStatusOut) => (
+    <div
+      key={r.name}
+      className="flex flex-wrap items-center gap-2 rounded-lg border border-border bg-card px-3 py-2"
+      data-testid={`cred-${r.name}`}
+    >
+      <span className={r.set ? 'text-success' : 'text-muted-foreground'}>{r.set ? '●' : '○'}</span>
+      <span className="font-mono text-[12px] text-foreground">{r.name}</span>
+
+      {!r.declared && (
+        <span className="rounded border border-destructive px-1 text-[10px] uppercase text-destructive">
+          undeclared
+        </span>
+      )}
+      {r.set && (
+        <span className="text-[11px] text-foreground-subtle">
+          {r.source}
+          {r.updated_at ? ` · ${new Date(r.updated_at).toLocaleDateString()}` : ''}
+          {r.updated_by_email ? ` · ${r.updated_by_email}` : ''}
+        </span>
+      )}
+
+      <input
+        type="password"
+        autoComplete="off"
+        value={draft[r.name] ?? ''}
+        onChange={(e) => setDraft((d) => ({ ...d, [r.name]: e.target.value }))}
+        placeholder={r.set ? 'rotate…' : 'store here instead'}
+        aria-label={`Value for ${r.name}`}
+        className="ml-auto w-56 rounded-md border border-input bg-input px-2 py-1 font-mono text-[12px] text-foreground placeholder:text-muted-foreground"
+      />
+      <button
+        type="button"
+        onClick={() => void save(r.name)}
+        disabled={busy || !(draft[r.name] ?? '').trim()}
+        className="rounded-md bg-primary px-2 py-1 text-[12px] font-medium text-primary-foreground disabled:opacity-40"
+      >
+        Save
+      </button>
+      {r.set && (
+        <button
+          type="button"
+          onClick={() => void remove(r.name)}
+          disabled={busy}
+          aria-label={`Remove ${r.name}`}
+          className="px-1 text-muted-foreground hover:text-destructive disabled:opacity-40"
+        >
+          ✕
+        </button>
+      )}
+    </div>
+  )
 
   return (
     <div className="max-w-4xl px-6 py-8" data-testid="agent-credentials">
@@ -114,32 +172,10 @@ export function AgentCredentialsSection() {
         </p>
       )}
 
-      {declaresMailbox(rows) && (
-        // The whole point of the feature: a mailbox used to need a terminal, a
-        // loopback listener and a hand-written vault item. The token this writes
-        // is the same shape a hand-minted one has, in the same slot.
-        <div className="mb-4 flex flex-wrap items-center gap-3 rounded-lg border border-border bg-card px-3 py-2">
-          <div className="text-[13px] text-foreground">
-            Google mailbox
-            <span className="ml-2 text-[12px] text-muted-foreground">
-              sign in as this agent to mint its <code className="font-mono text-[11px]">gog-token</code>
-            </span>
-          </div>
-          <button
-            type="button"
-            onClick={() => void connectMailbox()}
-            disabled={busy}
-            className="ml-auto rounded-md bg-primary px-2 py-1 text-[12px] font-medium text-primary-foreground disabled:opacity-40"
-          >
-            Connect Google mailbox
-          </button>
-        </div>
-      )}
-
-      {s.undeclared ? (
-        // Zero refs is UNDECLARED, not provisioned — and it is the state every
-        // agent is in before someone writes a runtime.yaml. Saying "ready" here
-        // would assert a box can run it, which nobody has established.
+      {rows.length === 0 ? (
+        // Zero refs is UNDECLARED, not provisioned — the state every agent is in
+        // before someone writes a runtime.yaml. Saying "ready" would assert that
+        // a box can run it, which nobody has established.
         <p className="text-[13px] text-muted-foreground" data-testid="agent-credentials-undeclared">
           This agent declares no secrets. Shape lives in its repo’s{' '}
           <code className="font-mono text-[12px]">runtime.yaml</code> and reaches canopy-web as the
@@ -147,80 +183,80 @@ export function AgentCredentialsSection() {
         </p>
       ) : (
         <>
-          {/* Reports; does not judge. canopy-web holds only the secrets that need
-              to be here — the rest live in 1Password and are resolved on the box
-              with the runner's service-account token. Framing those as missing
-              made this page report "45 blockers, this agent cannot run" about a
-              healthy ACE, which teaches people to ignore it; the one genuinely
-              dead credential then hides among the false alarms. Whether a secret
-              WORKS is a question only the box can answer — a readiness drill is
-              what answers it. */}
-          <p className="mb-3 text-[13px] text-muted-foreground" data-testid="agent-credentials-summary">
-            canopy-web stores {s.storedHere.length} of {s.declaredCount} declared secrets.
-            {s.fromVault.length > 0 && (
-              <> The other {s.fromVault.length} resolve from 1Password on the box, using the
-              runner’s service-account token.</>
-            )}
+          {/* The lede: whether this screen wants anything from the reader. */}
+          <p className="mb-4 text-[13px] text-muted-foreground" data-testid="agent-credentials-summary">
+            {headline(rows)}
           </p>
 
-          <div className="space-y-2">
-            {ordered.map((r) => (
-              <div
-                key={r.name}
-                className="flex flex-wrap items-center gap-2 rounded-lg border border-border bg-card px-3 py-2"
-                data-testid={`cred-${r.name}`}
-              >
-                <span className={r.set ? 'text-success' : 'text-muted-foreground'}>
-                  {r.set ? '●' : '○'}
-                </span>
-                <span className="font-mono text-[12px] text-foreground">{r.name}</span>
-
-                {!r.declared && (
-                  // An orphan: stored, but nothing declares it any more. A live
-                  // secret nothing accounts for — hiding it is how it stays that way.
-                  <span className="rounded border border-border px-1 text-[10px] uppercase text-muted-foreground">
-                    undeclared
+          {declaresMailbox(rows) && (
+            <section className="mb-5" data-testid="needs-you">
+              <h3 className="mb-2 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                Needs a person
+              </h3>
+              <div className="flex flex-wrap items-center gap-3 rounded-lg border border-border bg-card px-3 py-2">
+                <div className="text-[13px] text-foreground">
+                  Google mailbox
+                  <span className="ml-2 text-[12px] text-muted-foreground">
+                    a token can only be minted by signing in — nothing else here can do it for you
                   </span>
-                )}
-                {r.set && (
-                  <span className="text-[11px] text-foreground-subtle">
-                    {r.source}
-                    {r.updated_at ? ` · ${new Date(r.updated_at).toLocaleDateString()}` : ''}
-                    {r.updated_by_email ? ` · ${r.updated_by_email}` : ''}
-                  </span>
-                )}
-
-                <input
-                  type="password"
-                  autoComplete="off"
-                  value={draft[r.name] ?? ''}
-                  onChange={(e) => setDraft((d) => ({ ...d, [r.name]: e.target.value }))}
-                  placeholder={r.set ? 'rotate…' : 'paste to set'}
-                  aria-label={`Value for ${r.name}`}
-                  className="ml-auto w-56 rounded-md border border-input bg-input px-2 py-1 font-mono text-[12px] text-foreground placeholder:text-muted-foreground"
-                />
+                </div>
                 <button
                   type="button"
-                  onClick={() => void save(r.name)}
-                  disabled={busy || !(draft[r.name] ?? '').trim()}
-                  className="rounded-md bg-primary px-2 py-1 text-[12px] font-medium text-primary-foreground disabled:opacity-40"
+                  onClick={() => void connectMailbox()}
+                  disabled={busy}
+                  className="ml-auto rounded-md bg-primary px-2 py-1 text-[12px] font-medium text-primary-foreground disabled:opacity-40"
                 >
-                  Save
+                  Connect Google mailbox
                 </button>
-                {r.set && (
-                  <button
-                    type="button"
-                    onClick={() => void remove(r.name)}
-                    disabled={busy}
-                    aria-label={`Remove ${r.name}`}
-                    className="px-1 text-muted-foreground hover:text-destructive disabled:opacity-40"
-                  >
-                    ✕
-                  </button>
-                )}
               </div>
-            ))}
-          </div>
+            </section>
+          )}
+
+          {sec.orphans.length > 0 && (
+            // The only thing on this page that is actually WRONG: a live secret
+            // nothing declares any more. It must not sit below forty-five
+            // healthy rows.
+            <section className="mb-5" data-testid="orphans">
+              <h3 className="mb-2 text-[11px] font-medium uppercase tracking-wide text-destructive">
+                Stored here, no longer declared
+              </h3>
+              <div className="space-y-2">{sec.orphans.map(credentialRow)}</div>
+            </section>
+          )}
+
+          {sec.storedHere.length > 0 && (
+            <section className="mb-5">
+              <h3 className="mb-2 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                Stored in canopy-web
+              </h3>
+              <div className="space-y-2">{sec.storedHere.map(credentialRow)}</div>
+            </section>
+          )}
+
+          {sec.fromVault.length > 0 && (
+            <section>
+              <button
+                type="button"
+                onClick={() => setShowVault((v) => !v)}
+                className="text-[12px] text-muted-foreground underline-offset-2 hover:underline"
+                data-testid="toggle-vault-refs"
+                aria-expanded={showVault}
+              >
+                {showVault ? '▾' : '▸'} {sec.fromVault.length} resolve from 1Password on the
+                box {showVault ? '' : '— nothing to do'}
+              </button>
+              {showVault && (
+                <>
+                  <p className="mt-2 text-[12px] text-muted-foreground">
+                    The runner reads these with its 1Password service-account token. Storing one here
+                    would override the vault for this agent — useful for a value the vault does not
+                    have, and a second copy to keep in step otherwise.
+                  </p>
+                  <div className="mt-2 space-y-2">{sec.fromVault.map(credentialRow)}</div>
+                </>
+              )}
+            </section>
+          )}
         </>
       )}
 

--- a/frontend/src/pages/agents/agentCredentials.test.ts
+++ b/frontend/src/pages/agents/agentCredentials.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { groupRefs, summarize, type CredRow } from './agentCredentials'
+import { headline, sections, type CredRow } from './agentCredentials'
 
 // canopy-web deliberately does NOT hold most of an agent's secrets — 1Password
 // does, reached on the box with the runner's service-account token. So this
@@ -16,58 +16,52 @@ const row = (over: Partial<CredRow>): CredRow => ({
   ...over,
 })
 
-describe('summarize', () => {
-  it('splits declared refs into stored-here and expected-from-the-vault', () => {
-    const s = summarize([
-      row({ name: 'canopy-pat', set: true, source: 'canopy-web' }),
-      row({ name: 'ace-hq-api-key' }),
-      row({ name: 'nova-api-key' }),
-    ])
-    expect(s.storedHere).toEqual(['canopy-pat'])
-    expect(s.fromVault).toEqual(['ace-hq-api-key', 'nova-api-key'])
-    expect(s.declaredCount).toBe(3)
+describe('sections + headline', () => {
+  const vault = (n: string) => row({ name: n })
+  const here = (n: string) => row({ name: n, set: true, source: 'canopy-web' })
+
+  it('says nothing is wanted when every secret lives in the vault', () => {
+    // The state ACE is in, and the state most agents will stay in. The old copy
+    // ("canopy-web stores 0 of 45 declared secrets") is a fact about the store;
+    // the reader wants a fact about whether they have work to do.
+    const rows = ['a', 'b', 'c'].map(vault)
+    expect(headline(rows)).toMatch(/Nothing here needs you/)
+    expect(headline(rows)).toContain('3')
   })
 
-  it('does not treat vault-resolved refs as a deficit', () => {
-    // The state every agent is in and mostly stays in. Reporting it as missing
-    // made the page cry wolf on a healthy ACE — 45 "blockers" on an agent that
-    // runs fine — which is how the one real dead credential gets ignored.
-    const s = summarize([row({ name: 'a' }), row({ name: 'b' })])
-    expect(s.fromVault).toEqual(['a', 'b'])
-    expect('selfContained' in s).toBe(false)
-    expect('missing' in s).toBe(false)
+  it('separates the vault-resolved refs from what this page manages', () => {
+    const s = sections([vault('v1'), here('h1'), vault('v2')])
+    expect(s.fromVault.map((r) => r.name)).toEqual(['v1', 'v2'])
+    expect(s.storedHere.map((r) => r.name)).toEqual(['h1'])
+    expect(s.orphans).toEqual([])
   })
 
-  it('surfaces orphans and excludes them from the declared count', () => {
-    const s = summarize([
-      row({ name: 'declared', set: true, source: 'canopy-web' }),
-      row({ name: 'retired', declared: false, set: true, source: 'canopy-web' }),
-    ])
-    expect(s.orphans).toEqual(['retired'])
-    expect(s.declaredCount).toBe(1)
+  it('an orphan outranks everything else in the headline', () => {
+    // A live secret nothing declares is the one thing on this screen that is
+    // actually wrong, so it must not be averaged in with 45 healthy rows.
+    const rows = [vault('a'), vault('b'), row({ name: 'retired', declared: false, set: true })]
+    expect(headline(rows)).toMatch(/nothing declares/)
   })
 
-  it('an agent declaring nothing is undeclared, not provisioned', () => {
-    const s = summarize([])
-    expect(s.undeclared).toBe(true)
-    expect(s.declaredCount).toBe(0)
-  })
-})
-
-describe('groupRefs', () => {
-  it('puts what this page manages first, then vault-resolved, then orphans', () => {
-    const g = groupRefs([
-      row({ name: 'orphan', declared: false, set: true, source: 'canopy-web' }),
-      row({ name: 'vault' }),
-      row({ name: 'here', set: true, source: 'canopy-web' }),
-    ])
-    expect(g.map((r) => r.name)).toEqual(['here', 'vault', 'orphan'])
+  it('reports both sides once something is stored here', () => {
+    expect(headline([here('h'), vault('v')])).toMatch(/1 stored here; 1 resolve/)
   })
 
   it('does not mutate the input', () => {
-    const rows = [row({ name: 'b', set: true, source: 'canopy-web' }), row({ name: 'a' })]
+    const rows = [vault('b'), vault('a')]
     const before = JSON.stringify(rows)
-    groupRefs(rows)
+    sections(rows)
     expect(JSON.stringify(rows)).toBe(before)
   })
+})
+
+it('never frames a vault-resolved ref as a deficit', () => {
+  // The guard that used to sit on `summarize`, moved onto the live path when
+  // that helper was deleted. An earlier version measured "every declared secret
+  // is stored here" as the success state, which both rewarded copying all 45 of
+  // ACE's secrets into canopy-web AND made the screen announce "45 blockers —
+  // this agent cannot run" about an agent running perfectly well. A screen that
+  // cries wolf is how the one genuinely dead credential gets ignored.
+  const text = headline(['a', 'b', 'c'].map((name) => row({ name })))
+  expect(text).not.toMatch(/missing|blocker|cannot run|incomplete|not ready/i)
 })

--- a/frontend/src/pages/agents/agentCredentials.ts
+++ b/frontend/src/pages/agents/agentCredentials.ts
@@ -21,33 +21,45 @@ export type CredRow = components['schemas']['AgentCredentialStatusOut']
 // and what nothing accounts for. Whether a secret actually WORKS is a question
 // only the box can answer, and a readiness drill is what answers it.
 
-export interface CredentialSummary {
-  /** Refs the agent declares (orphans excluded). */
-  declaredCount: number
-  /** Declared and stored in canopy-web. */
-  storedHere: string[]
-  /** Declared, not stored here — expected to resolve from 1Password on the box. */
-  fromVault: string[]
-  /** Stored but no longer declared: a live secret nothing accounts for. */
-  orphans: string[]
-  /** The agent declares nothing, which is NOT the same as provisioned. */
-  undeclared: boolean
+/** What the screen is FOR, in the operator's terms rather than the store's.
+ *
+ *  The first version listed all 45 declared refs as equal rows, each with an
+ *  empty marker and a "paste to set" box. Every one of those rows was fine —
+ *  they resolve from 1Password on the box, which is the intended arrangement —
+ *  but forty-five empty inputs read as forty-five things to type. The one row
+ *  that genuinely needed a human sat at the top looking like all the others.
+ *  Jonathan's reaction on 2026-09-06 was "I'm very confused by this screen",
+ *  which is the correct reaction to it.
+ *
+ *  So: separate what needs a person from what is merely true. */
+export interface CredentialSections {
+  /** Stored here but no longer declared — a live secret nothing accounts for. */
+  orphans: CredRow[]
+  /** Declared and stored in canopy-web: what this page actually manages. */
+  storedHere: CredRow[]
+  /** Declared, resolved from the vault on the box. Correct, and not a to-do. */
+  fromVault: CredRow[]
 }
 
-export function summarize(rows: readonly CredRow[]): CredentialSummary {
-  const declared = rows.filter((r) => r.declared)
+export function sections(rows: readonly CredRow[]): CredentialSections {
+  const byName = (a: CredRow, b: CredRow) => a.name.localeCompare(b.name)
   return {
-    declaredCount: declared.length,
-    storedHere: declared.filter((r) => r.set).map((r) => r.name),
-    fromVault: declared.filter((r) => !r.set).map((r) => r.name),
-    orphans: rows.filter((r) => !r.declared).map((r) => r.name),
-    undeclared: declared.length === 0,
+    orphans: rows.filter((r) => !r.declared).sort(byName),
+    storedHere: rows.filter((r) => r.declared && r.set).sort(byName),
+    fromVault: rows.filter((r) => r.declared && !r.set).sort(byName),
   }
 }
 
-/** Stored-here first (what this page actually manages), then vault-resolved,
- *  then orphans last — they need showing, but they are noise up top. */
-export function groupRefs(rows: readonly CredRow[]): CredRow[] {
-  const rank = (r: CredRow) => (!r.declared ? 2 : r.set ? 0 : 1)
-  return [...rows].sort((a, b) => rank(a) - rank(b) || a.name.localeCompare(b.name))
+/** One line saying whether anything is wanted from the reader.
+ *  Deliberately not a count of what canopy-web holds: "stores 0 of 45" is a fact
+ *  about the store, and the reader wants a fact about their afternoon. */
+export function headline(rows: readonly CredRow[]): string {
+  const s = sections(rows)
+  if (s.orphans.length > 0) {
+    return `${s.orphans.length} stored secret(s) nothing declares any more — worth removing.`
+  }
+  if (s.storedHere.length === 0 && s.fromVault.length > 0) {
+    return `Nothing here needs you. All ${s.fromVault.length} of this agent's secrets resolve from 1Password on the box.`
+  }
+  return `${s.storedHere.length} stored here; ${s.fromVault.length} resolve from 1Password on the box.`
 }


### PR DESCRIPTION
> "I'm very confused by this screen." — Jonathan, on the live page, 2026-09-06

Correct reaction. The screen rendered ACE's 45 declared refs as 45 equal rows, each with an empty `○` and a "paste to set" box — and **every one of those rows was fine.** They resolve from 1Password on the box, which is the arrangement that was asked for. But 45 empty inputs read as 45 things to type, and the one row that genuinely needed a human sat above them looking identical to the rest.

#672 removed this screen's false *"45 blockers — this agent cannot run"* alarm. It did not remove the **layout** that produced the alarm, so the page still *showed* forty-five problems while no longer *calling* them problems.

## Now

- **The lede says whether anything is wanted from you.** "Nothing here needs you. All 45 of this agent's secrets resolve from 1Password on the box." The old copy — "canopy-web stores 0 of 45 declared secrets" — is a fact about the store; the reader wants a fact about their afternoon.
- **"Needs a person" comes first**, and holds only the Google mailbox — the one thing on the page no automation can do.
- **Orphans get their own section.** A live secret nothing declares any more is the only genuinely *wrong* state here, and it must not sit below 45 healthy rows.
- **The vault-resolved refs collapse behind one line**, expandable, with a note that storing one here overrides the vault (useful for a value the vault lacks; a second copy to keep in step otherwise).

Not addressed here, worth its own change: several declared "credentials" aren't secrets at all — `ace-avd-name`, `ace-connect-apk-version`, `ace-e2e-country-code` — and still get password inputs. Shape is `runtime.yaml`'s job, and canopy-web deliberately doesn't re-declare it, so fixing this means teaching the registry to carry a kind. Filed as follow-up rather than smuggled in.

## Tests

`summarize`/`groupRefs` are superseded by `sections`/`headline` and deleted. Their most valuable test — that a vault-resolved ref is never framed as a deficit — is **re-pinned on `headline`**, so the guard sits on the live path rather than on a helper nothing rendered. 683 frontend tests, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rffk2t9tySFjRNqRKxN2wR