### PR TITLE
Accept runtime_sources on the agent upsert

### DIFF
--- a/apps/agents/schemas.py
+++ b/apps/agents/schemas.py
@@ -34,6 +34,11 @@ class AgentIn(StrictModel):
     repo_ref: str | None = Field(default=None, max_length=120)
     runtime_engine: Literal["emdash", "cloud_p", "any"] | None = None
     runtime_secrets: list[str] | None = None
+    # WHERE each declared secret's value lives, mirrored from runtime.yaml:
+    # {"gog-token": {"op": "op://Agent-Ace/gog-token/credential"}}. Without it
+    # the vault importer can only guess a convention, and a guess here resolves
+    # to the WRONG credential rather than failing (ace#2060).
+    runtime_sources: dict | None = None
     # Ordered runner-kind preference, e.g. ["cloud","emdash"]. None = leave unchanged.
     runner_preference: list[str] | None = None
 

--- a/apps/agents/services.py
+++ b/apps/agents/services.py
@@ -52,7 +52,8 @@ def upsert_agent(data, *, workspace) -> Agent:
     # ONLY when explicitly provided. The plugin re-upserts agents on every sync
     # with these fields absent (None) — a plain default would clobber runtime
     # config back to empty on each heartbeat. Configure once, keep it.
-    for field in ("repo_url", "repo_ref", "runtime_engine", "runtime_secrets", "runner_preference"):
+    for field in ("repo_url", "repo_ref", "runtime_engine", "runtime_secrets",
+                  "runtime_sources", "runner_preference"):
         value = getattr(data, field, None)
         if value is not None:
             defaults[field] = value

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -6490,6 +6490,10 @@ export interface components {
             readonly runtime_engine?: ("emdash" | "cloud_p" | "any") | null;
             /** Runtime Secrets */
             readonly runtime_secrets?: readonly string[] | null;
+            /** Runtime Sources */
+            readonly runtime_sources?: {
+                readonly [key: string]: unknown;
+            } | null;
             /** Runner Preference */
             readonly runner_preference?: readonly string[] | null;
         };

--- a/tests/test_vault_import.py
+++ b/tests/test_vault_import.py
@@ -186,3 +186,28 @@ def test_a_non_member_cannot_set_a_vault_or_import(client):
         "/api/agents/secret/vault", data={"vault": "V"}, content_type="application/json",
     ).status_code == 404
     assert client.post("/api/agents/secret/credentials/import").status_code == 404
+
+
+def test_runtime_sources_survives_a_plugin_reupsert(fleet):
+    """The registry fields are written only when PRESENT. An agent plugin
+    re-upserts itself on every sync with these omitted, and a plain default would
+    clobber the source map back to empty on each heartbeat — which would silently
+    turn every subsequent import into a 45-way skip."""
+    from apps.agents import services as svc
+    from apps.agents.schemas import AgentIn
+
+    svc.upsert_agent(AgentIn(slug="ace", name="ACE"), workspace=fleet["agent"].workspace)
+    fleet["agent"].refresh_from_db()
+    assert fleet["agent"].runtime_sources == SOURCES
+
+
+def test_runtime_sources_can_be_pushed_with_the_agent(fleet):
+    from apps.agents import services as svc
+    from apps.agents.schemas import AgentIn
+
+    svc.upsert_agent(
+        AgentIn(slug="ace", name="ACE", runtime_sources={"x": {"op": "op://V/i/f"}}),
+        workspace=fleet["agent"].workspace,
+    )
+    fleet["agent"].refresh_from_db()
+    assert fleet["agent"].runtime_sources == {"x": {"op": "op://V/i/f"}}


### PR DESCRIPTION
#678 added the importer and the model field but nothing that **fills** it. Nothing in this repo reads an agent's `runtime.yaml`, so `runtime_sources` would have stayed empty and every import would have been a 45-way skip — the feature would have shipped looking complete and doing nothing.

`runtime_sources` joins the other registry fields in the write-only-when-present set. That guard is load-bearing here specifically: an agent plugin re-upserts itself on every sync with these fields omitted, so a plain default would clobber the source map back to empty **on each heartbeat** and silently turn imports back into skips. Pinned by a test.

## Still open

canopy-web does not *fetch* `runtime.yaml` from the agent's repo — the map has to be pushed. Doing the fetch means reading a private repo, which needs a GitHub credential canopy-web doesn't currently hold. That's a separate decision, not a line of code, so I'm naming it rather than implying it's handled.

2334 backend tests, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rffk2t9tySFjRNqRKxN2wR