### PR TITLE
Say how much of an agent canopy-web can actually locate

### DIFF
--- a/apps/agents/api.py
+++ b/apps/agents/api.py
@@ -675,7 +675,7 @@ def resolve_agent_credentials(request: HttpRequest, slug: str):
             summary="This agent's 1Password vault (masked — never the key)")
 def get_agent_vault(request: HttpRequest, slug: str) -> AgentVaultOut:
     agent = _get_agent_or_404(request, slug)
-    return AgentVaultOut(vault=agent.op_vault, key_set=bool(agent.op_sa_token_enc))
+    return services.agent_vault_status(agent)
 
 
 @router.put("/{slug}/vault", response=AgentVaultOut,

--- a/apps/agents/schemas.py
+++ b/apps/agents/schemas.py
@@ -479,6 +479,12 @@ class AgentVaultIn(StrictModel):
 class AgentVaultOut(StrictModel):
     vault: str = ""
     key_set: bool = False
+    # How many declared refs canopy-web can actually LOCATE. Without this an
+    # import that returns "45 skipped" is unexplainable from the UI: the cause is
+    # always that runtime.yaml's source map never reached this deployment, and
+    # nothing on the screen could say so.
+    declared: int = 0
+    locatable: int = 0
 
 
 class AgentImportOut(StrictModel):

--- a/apps/agents/services.py
+++ b/apps/agents/services.py
@@ -546,7 +546,27 @@ def set_agent_vault(agent, *, vault=None, service_key=None):
         fields.append("op_sa_token_enc")
     if fields:
         agent.save(update_fields=[*fields, "updated_at"])
-    return AgentVaultOut(vault=agent.op_vault, key_set=bool(agent.op_sa_token_enc))
+    return agent_vault_status(agent)
+
+
+def agent_vault_status(agent):
+    """Vault config plus how much of the agent is actually locatable.
+
+    `locatable` is the number of declared refs that carry a source. It is the
+    difference between "the import found nothing" and "this deployment was never
+    told where anything lives" — the same failure with two completely different
+    fixes."""
+    from apps.agents import vault_import
+    from apps.agents.schemas import AgentVaultOut
+
+    declared = [str(n) for n in (agent.runtime_secrets or []) if str(n).strip()]
+    plan = vault_import.plan_import(declared, agent.runtime_sources or {})
+    return AgentVaultOut(
+        vault=agent.op_vault,
+        key_set=bool(agent.op_sa_token_enc),
+        declared=len(declared),
+        locatable=sum(1 for i in plan if i.kind in ("op", "value")),
+    )
 
 
 def import_agent_credentials(agent, *, user=None):

--- a/apps/agents/services.py
+++ b/apps/agents/services.py
@@ -534,7 +534,6 @@ def set_agent_vault(agent, *, vault=None, service_key=None):
     Non-clobbering on the KEY specifically: renaming a vault must not silently
     wipe the credential that reads it, which is the shape of every other
     credential write here."""
-    from apps.agents.schemas import AgentVaultOut
     from apps.common.encryption import encrypt_secret
 
     fields = []

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -7382,6 +7382,16 @@ export interface components {
              * @default false
              */
             readonly key_set: boolean;
+            /**
+             * Declared
+             * @default 0
+             */
+            readonly declared: number;
+            /**
+             * Locatable
+             * @default 0
+             */
+            readonly locatable: number;
         };
         /**
          * AgentVaultIn

--- a/frontend/src/pages/agents/AgentVaultSection.tsx
+++ b/frontend/src/pages/agents/AgentVaultSection.tsx
@@ -21,6 +21,8 @@ interface Result {
 export function AgentVaultSection({ slug, onImported }: { slug: string; onImported: () => void }) {
   const [vault, setVault] = useState('')
   const [keySet, setKeySet] = useState(false)
+  const [declared, setDeclared] = useState(0)
+  const [locatable, setLocatable] = useState(0)
   const [key, setKey] = useState('')
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -33,6 +35,8 @@ export function AgentVaultSection({ slug, onImported }: { slug: string; onImport
         if (off) return
         setVault(v.vault ?? '')
         setKeySet(Boolean(v.key_set))
+        setDeclared(v.declared ?? 0)
+        setLocatable(v.locatable ?? 0)
       })
       .catch(() => {})
     return () => {
@@ -51,6 +55,8 @@ export function AgentVaultSection({ slug, onImported }: { slug: string; onImport
         ...(key.trim() ? { service_key: key.trim() } : {}),
       })
       setKeySet(Boolean(v.key_set))
+      setDeclared(v.declared ?? 0)
+      setLocatable(v.locatable ?? 0)
       setKey('')
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Could not save')
@@ -126,6 +132,17 @@ export function AgentVaultSection({ slug, onImported }: { slug: string; onImport
           A service account scoped to this one vault. canopy-web reads it only to import; the key is
           encrypted at rest and never returned to a browser.
         </p>
+
+        {declared > 0 && locatable < declared && (
+          // Says WHY an import would skip. Both causes render as "45 skipped"
+          // and have completely different fixes — an empty vault vs. a source
+          // map that never reached this deployment.
+          <p className="mt-1 text-[11px] text-muted-foreground" data-testid="locatable-note">
+            {locatable === 0
+              ? `This deployment has no source map for ${declared} refs — nothing to import until the agent's runtime.yaml is pushed here.`
+              : `${locatable} of ${declared} refs say where their value lives; the rest would be skipped.`}
+          </p>
+        )}
 
         {result && (
           // Failures are shown as prominently as successes on purpose: a ref

--- a/tests/test_vault_import.py
+++ b/tests/test_vault_import.py
@@ -211,3 +211,19 @@ def test_runtime_sources_can_be_pushed_with_the_agent(fleet):
     )
     fleet["agent"].refresh_from_db()
     assert fleet["agent"].runtime_sources == {"x": {"op": "op://V/i/f"}}
+
+
+def test_vault_status_says_how_much_is_locatable(fleet):
+    """An import that returns "45 skipped" has two completely different causes —
+    the vault is empty, or this deployment was never told where anything lives —
+    and nothing on the screen could tell them apart."""
+    v = fleet["client"].get("/api/agents/ace/vault").json()
+    assert v["declared"] == len(DECLARED)
+    # local_only and the undeclared-source ref are not locatable.
+    assert v["locatable"] == 3
+
+
+def test_an_agent_with_no_source_map_reports_zero_locatable(fleet):
+    Agent.objects.filter(slug="ace").update(runtime_sources={})
+    v = fleet["client"].get("/api/agents/ace/vault").json()
+    assert v["declared"] > 0 and v["locatable"] == 0


### PR DESCRIPTION
An import returning **"45 skipped"** had two completely different causes — the vault is empty, or this deployment was never told where anything lives — and nothing on the screen could tell them apart. They have completely different fixes.

The vault status now reports `declared` and `locatable`, and the UI says which case you're in:

> *This deployment has no source map for 45 refs — nothing to import until the agent's runtime.yaml is pushed here.*

Found by pushing ACE's real source map to production and discovering **no route could confirm it had landed** — not `/agents/ace/`, not `/runtime`, not `/vault`.

2336 backend tests, 683 frontend, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rffk2t9tySFjRNqRKxN2wR