### PR TITLE
The runner resolves the vault; canopy-web only custodies the key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,28 +21,11 @@ FROM python:3.12-slim
 
 # Install Node.js for the optional Claude Code CLI backend
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl ca-certificates unzip \
+    curl ca-certificates \
     && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y nodejs \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# The 1Password CLI — how an agent's secrets are imported from its vault
-# (apps/agents/vault_import.py). A static binary rather than the official Python
-# SDK on purpose: the SDK has no cp314 wheel, so it would install against this
-# image's 3.12 and fail against a local 3.14 checkout, breaking tests for a
-# reason unrelated to what they test. This is also the exact tool
-# runner/ec2/bootstrap_agents.sh runs on the box, so an op:// ref containing
-# spaces, a UUID item name, or a document filename resolves identically in both
-# places instead of nearly identically.
-ARG OP_CLI_VERSION=2.30.3
-RUN set -eux; \
-    arch="$(dpkg --print-architecture)"; \
-    curl -fsSL -o /tmp/op.zip \
-      "https://cache.agilebits.com/dist/1P/op2/pkg/v${OP_CLI_VERSION}/op_linux_${arch}_v${OP_CLI_VERSION}.zip"; \
-    unzip -o /tmp/op.zip op -d /usr/local/bin; \
-    rm -f /tmp/op.zip; \
-    chmod +x /usr/local/bin/op; \
-    op --version
 
 RUN npm install -g @anthropic-ai/claude-code
 

--- a/apps/agents/api.py
+++ b/apps/agents/api.py
@@ -25,7 +25,6 @@ from .schemas import (
     AgentRunnerRulesIn,
     AgentRunnerRowIn,
     AgentRunnersIn,
-    AgentImportOut,
     AgentRuntimeOut,
     AgentVaultIn,
     AgentVaultOut,
@@ -652,6 +651,7 @@ def resolve_agent_credentials(request: HttpRequest, slug: str):
         raise HttpError(403, "no live runner you pair is assigned to this agent")
 
     values = services.resolve_agent_credentials(agent)
+    vault, op_token = services.resolve_agent_vault(agent)
     try:
         from apps.events import services as events
 
@@ -668,7 +668,7 @@ def resolve_agent_credentials(request: HttpRequest, slug: str):
         )
     except Exception:  # noqa: BLE001 - an audit hiccup must not deny a runner its secrets
         pass
-    return AgentCredentialsResolveOut(values=values)
+    return AgentCredentialsResolveOut(values=values, op_vault=vault, op_sa_token=op_token)
 
 
 @router.get("/{slug}/vault", response=AgentVaultOut,
@@ -690,23 +690,6 @@ def set_agent_vault(request: HttpRequest, slug: str, payload: AgentVaultIn) -> A
     return services.set_agent_vault(
         agent, vault=payload.vault, service_key=payload.service_key,
     )
-
-
-@router.post("/{slug}/credentials/import", response=AgentImportOut,
-             summary="Populate this agent's secrets from its 1Password vault")
-def import_agent_credentials(request: HttpRequest, slug: str) -> AgentImportOut:
-    """Reads the vault as the agent's own service account and stores the values.
-
-    Partial success is the DESIGNED outcome: a half-provisioned vault is the
-    normal state of a new agent, so one missing ref reports itself and the other
-    forty-four still land."""
-    agent = _get_agent_or_404(request, slug)
-    if not agent.op_sa_token_enc:
-        raise HttpError(422, "set this agent's 1Password vault and service key first")
-    try:
-        return services.import_agent_credentials(agent, user=request.user)
-    except FileNotFoundError as exc:
-        raise HttpError(503, "the 1Password CLI is not available in this deployment") from exc
 
 
 # Registered AFTER the literal `status`/`resolve` paths on purpose: Django

--- a/apps/agents/schemas.py
+++ b/apps/agents/schemas.py
@@ -487,18 +487,6 @@ class AgentVaultOut(StrictModel):
     locatable: int = 0
 
 
-class AgentImportOut(StrictModel):
-    """What an import actually did — reported, never assumed.
-
-    `failures` matters as much as `imported`: a ref that no longer resolves is
-    the single most useful thing this screen can tell anyone, and an
-    all-or-nothing import would hide it behind one error."""
-
-    imported: list[str] = []
-    skipped: list[dict] = []
-    failures: list[dict] = []
-
-
 class CountOut(StrictModel):
     created: int = 0
     replaced: int = 0
@@ -530,6 +518,18 @@ class AgentCredentialStatusOut(StrictModel):
 
 
 class AgentCredentialsResolveOut(StrictModel):
-    """PLAINTEXT, for a runner. The one route that returns values."""
+    """PLAINTEXT, for a runner. The one route that returns values.
+
+    It carries the 1Password vault + service token as well, because the runner is
+    what resolves this agent's secrets — canopy-web only custodies the key. Both
+    ride this route rather than a new one so there is exactly ONE plaintext gate
+    to reason about, and one audit entry per fetch."""
 
     values: dict[str, str] = Field(default_factory=dict)
+    # Which vault this agent's secrets live in. The runner used to DERIVE this as
+    # Agent-<Slug> in bash, which is fine until an agent's vault is named
+    # anything else and silently resolves nothing.
+    op_vault: str = ""
+    # Scoped to that vault. Falls back on the box to the runner-wide token when
+    # empty, so an agent with no key of its own keeps working exactly as before.
+    op_sa_token: str = ""

--- a/apps/agents/services.py
+++ b/apps/agents/services.py
@@ -568,45 +568,9 @@ def agent_vault_status(agent):
     )
 
 
-def import_agent_credentials(agent, *, user=None):
-    """Resolve every declared ref from the agent's vault and store the values.
-
-    Reports rather than raises. A vault missing one item is the normal state of a
-    half-provisioned agent; failing the whole import over it would make such an
-    agent unprovisionable AND hide which ref is the problem — the one fact worth
-    knowing here.
-    """
-    from apps.agents import vault_import
-    from apps.agents.schemas import AgentImportOut
+def resolve_agent_vault(agent) -> tuple[str, str]:
+    """PLAINTEXT vault config, for a runner. Empty token when none is set."""
     from apps.common.encryption import decrypt_secret
 
-    declared = [str(n) for n in (agent.runtime_secrets or []) if str(n).strip()]
-    items = vault_import.plan_import(declared, agent.runtime_sources or {})
-    values, failures = vault_import.resolve_items(
-        items, token=decrypt_secret(agent.op_sa_token_enc),
-    )
-    if values:
-        set_agent_credentials(agent, values, user=user)
-
-    try:
-        from apps.events import services as events
-
-        events.record(
-            [{
-                "source": "agents.credentials",
-                "kind": "agent.credentials.imported",
-                "level": "info",
-                "key": f"{agent.slug}:import",
-                "summary": f"{len(values)} imported, {len(failures)} failed for {agent.slug}",
-                "payload": {"agent": agent.slug, "imported": len(values), "failed": len(failures)},
-            }],
-            workspace=agent.workspace,
-        )
-    except Exception:  # noqa: BLE001 - an audit hiccup must not undo a good import
-        pass
-
-    return AgentImportOut(
-        imported=sorted(values),
-        skipped=[{"name": i.name, "reason": i.reason} for i in items if i.kind == "skip"],
-        failures=failures,
-    )
+    token = decrypt_secret(agent.op_sa_token_enc) if agent.op_sa_token_enc else ""
+    return agent.op_vault, token

--- a/apps/agents/vault_import.py
+++ b/apps/agents/vault_import.py
@@ -1,28 +1,24 @@
-"""Import an agent's secret VALUES from its 1Password vault into canopy-web.
+"""Where an agent's secret values live — the declaration, not the fetching.
 
-The goal, stated by Jonathan on 2026-09-05: *someone could plausibly create a
-completely new agent without direct access to the cloud box or 1Password.* The
-mint (canopy-web#675) removed the box from the mailbox path; this removes the
-vault from everything else — canopy-web ends up holding the values, and a person
-provisioning a new agent needs neither.
+canopy-web does NOT resolve these. Jonathan, 2026-09-06: *the service account and
+vault should be used on the runner… canopy-web should just store what it needs or
+to send to the runner.*
 
-WHY THE `op` CLI AND NOT THE PYTHON SDK. 1Password ships an official Python SDK
-that takes a service-account token directly, which is the obvious choice. It has
-no cp314 wheel. This deployment's image is python:3.12-slim (so it would install
-in production) while a local checkout resolves to 3.14 (so it would not) — a
-split that guarantees a test suite green in one place and broken in the other,
-for a reason unrelated to anything being tested. The CLI is a static binary with
-no Python coupling at all, and it is the SAME tool bootstrap_agents.sh already
-runs on the box, so `op://` refs with spaces, UUID item names and document
-filenames all behave identically in both places rather than nearly identically.
+A first version had canopy-web hold a service key, shell out to `op`, and store
+all 45 values. That makes canopy-web a second copy of every credential, free to
+drift from the vault and worth attacking for the whole set — the thing it was
+told twice not to become. The runner already has 1Password access and already
+resolves secrets there; what it lacked was WHICH vault, per agent (it derived
+`Agent-<Slug>` in bash) and a key scoped to it.
 
-WHAT IS NEVER IMPORTED. A ref the agent declares `local_only` (per-human tokens
-minted on a workstation) has no vault copy to read and must not be invented here.
+So canopy-web is the custodian: it stores the vault name and the service token,
+hands both to the runner over the existing credential-resolve route, and keeps
+only the secrets that genuinely originate here — the browser-minted gog-token.
+This module is what remains: a read of the declaration, used to say how much of
+an agent the runner will be able to resolve.
 """
 from __future__ import annotations
 
-import os
-import subprocess
 from dataclasses import dataclass
 
 
@@ -63,52 +59,3 @@ def plan_import(declared: list[str], sources: dict) -> list[ImportItem]:
         else:
             out.append(ImportItem(name, "skip", reason="no op: or value: in the declaration"))
     return out
-
-
-def op_read(ref: str, *, token: str, timeout: int = 30) -> str:
-    """Resolve one op:// reference as the given service account.
-
-    The token goes in the ENVIRONMENT, never argv — anything on a command line is
-    readable by every other process on the host via /proc.
-    """
-    env = {**os.environ, "OP_SERVICE_ACCOUNT_TOKEN": token}
-    res = subprocess.run(
-        ["op", "read", ref], capture_output=True, text=True, env=env, timeout=timeout,
-    )
-    if res.returncode != 0:
-        raise RuntimeError((res.stderr or "op read failed").strip().splitlines()[-1][:300])
-    return res.stdout.rstrip("\n")
-
-
-def resolve_items(items: list[ImportItem], *, token: str, reader=None) -> tuple[dict, list[dict]]:
-    """Run the plan. Returns (values to store, per-ref failures).
-
-    One ref failing must not abandon the other forty-four: a vault that is missing
-    a single item is the normal state of a half-provisioned agent, and an
-    all-or-nothing import would make it unprovisionable. Failures are REPORTED,
-    which is the part that makes a stale ref visible instead of silent.
-    """
-    # Resolved at CALL time, not bound as a default: a default argument captures
-    # op_read at import, which silently makes the real path unsubstitutable and
-    # means a test that thinks it is exercising this loop is shelling out to a
-    # binary instead. Caught by its own test.
-    reader = reader or op_read
-
-    values: dict[str, str] = {}
-    failures: list[dict] = []
-    for item in items:
-        if item.kind == "value":
-            values[item.name] = item.value
-        elif item.kind == "op":
-            try:
-                got = reader(item.ref, token=token)
-            except Exception as exc:  # noqa: BLE001 - reported per ref, never fatal
-                failures.append({"name": item.name, "ref": item.ref, "error": str(exc)})
-                continue
-            if got:
-                values[item.name] = got
-            else:
-                # An empty read is a MISS, not a value. Storing "" would make the
-                # screen show the ref as set while it resolves to nothing.
-                failures.append({"name": item.name, "ref": item.ref, "error": "resolved empty"})
-    return values, failures

--- a/frontend/src/api/agents.ts
+++ b/frontend/src/api/agents.ts
@@ -309,16 +309,6 @@ export async function setAgentVault(slug: string, body: { vault?: string; servic
   return unwrap(res, 'setAgentVault')
 }
 
-/** Populate this agent's secrets from its 1Password vault. Partial success is
- *  the designed outcome — the result reports what could NOT be read, which is
- *  the most useful thing this screen can say. */
-export async function importAgentCredentials(slug: string) {
-  const res = await apiV2.POST('/api/agents/{slug}/credentials/import', {
-    params: { path: { slug } },
-  })
-  return unwrap(res, 'importAgentCredentials')
-}
-
 export async function getAgentRunnerRules(slug: string): Promise<AgentRunnerRuleOut[]> {
   const res = await apiV2.GET('/api/agents/{slug}/runner-rules', { params: { path: { slug } } })
   return Array.from(unwrap(res, 'getAgentRunnerRules'))

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -1846,30 +1846,6 @@ export interface paths {
         readonly patch?: never;
         readonly trace?: never;
     };
-    readonly "/api/agents/{slug}/credentials/import": {
-        readonly parameters: {
-            readonly query?: never;
-            readonly header?: never;
-            readonly path?: never;
-            readonly cookie?: never;
-        };
-        readonly get?: never;
-        readonly put?: never;
-        /**
-         * Populate this agent's secrets from its 1Password vault
-         * @description Reads the vault as the agent's own service account and stores the values.
-         *
-         *     Partial success is the DESIGNED outcome: a half-provisioned vault is the
-         *     normal state of a new agent, so one missing ref reports itself and the other
-         *     forty-four still land.
-         */
-        readonly post: operations["apps_agents_api_import_agent_credentials"];
-        readonly delete?: never;
-        readonly options?: never;
-        readonly head?: never;
-        readonly patch?: never;
-        readonly trace?: never;
-    };
     readonly "/api/agents/{slug}/credentials/{name}": {
         readonly parameters: {
             readonly query?: never;
@@ -7363,12 +7339,27 @@ export interface components {
         /**
          * AgentCredentialsResolveOut
          * @description PLAINTEXT, for a runner. The one route that returns values.
+         *
+         *     It carries the 1Password vault + service token as well, because the runner is
+         *     what resolves this agent's secrets — canopy-web only custodies the key. Both
+         *     ride this route rather than a new one so there is exactly ONE plaintext gate
+         *     to reason about, and one audit entry per fetch.
          */
         readonly AgentCredentialsResolveOut: {
             /** Values */
             readonly values?: {
                 readonly [key: string]: string;
             };
+            /**
+             * Op Vault
+             * @default
+             */
+            readonly op_vault: string;
+            /**
+             * Op Sa Token
+             * @default
+             */
+            readonly op_sa_token: string;
         };
         /** AgentVaultOut */
         readonly AgentVaultOut: {
@@ -7404,35 +7395,6 @@ export interface components {
             readonly vault?: string | null;
             /** Service Key */
             readonly service_key?: string | null;
-        };
-        /**
-         * AgentImportOut
-         * @description What an import actually did — reported, never assumed.
-         *
-         *     `failures` matters as much as `imported`: a ref that no longer resolves is
-         *     the single most useful thing this screen can tell anyone, and an
-         *     all-or-nothing import would hide it behind one error.
-         */
-        readonly AgentImportOut: {
-            /**
-             * Imported
-             * @default []
-             */
-            readonly imported: readonly string[];
-            /**
-             * Skipped
-             * @default []
-             */
-            readonly skipped: readonly {
-                readonly [key: string]: unknown;
-            }[];
-            /**
-             * Failures
-             * @default []
-             */
-            readonly failures: readonly {
-                readonly [key: string]: unknown;
-            }[];
         };
         /** Page[RunSummary] */
         readonly Page_RunSummary_: {
@@ -12678,28 +12640,6 @@ export interface operations {
                 };
                 content: {
                     readonly "application/json": components["schemas"]["AgentVaultOut"];
-                };
-            };
-        };
-    };
-    readonly apps_agents_api_import_agent_credentials: {
-        readonly parameters: {
-            readonly query?: never;
-            readonly header?: never;
-            readonly path: {
-                readonly slug: string;
-            };
-            readonly cookie?: never;
-        };
-        readonly requestBody?: never;
-        readonly responses: {
-            /** @description OK */
-            readonly 200: {
-                headers: {
-                    readonly [name: string]: unknown;
-                };
-                content: {
-                    readonly "application/json": components["schemas"]["AgentImportOut"];
                 };
             };
         };

--- a/frontend/src/pages/agents/AgentCredentialsSection.tsx
+++ b/frontend/src/pages/agents/AgentCredentialsSection.tsx
@@ -51,12 +51,6 @@ export function AgentCredentialsSection() {
     }
   }, [agent.slug])
 
-  const reload = () => {
-    getAgentCredentialStatus(agent.slug)
-      .then(setRows)
-      .catch(() => {})
-  }
-
   const save = async (name: string) => {
     const value = (draft[name] ?? '').trim()
     if (!value) return
@@ -195,7 +189,7 @@ export function AgentCredentialsSection() {
             {headline(rows)}
           </p>
 
-          <AgentVaultSection slug={agent.slug} onImported={reload} />
+          <AgentVaultSection slug={agent.slug} />
 
           {declaresMailbox(rows) && (
             <section className="mb-5" data-testid="needs-you">

--- a/frontend/src/pages/agents/AgentVaultSection.tsx
+++ b/frontend/src/pages/agents/AgentVaultSection.tsx
@@ -1,32 +1,29 @@
 import { useEffect, useState } from 'react'
-import { getAgentVault, importAgentCredentials, setAgentVault } from '@/api/agents'
+import { getAgentVault, setAgentVault } from '@/api/agents'
 
 // The 1Password half of the credentials screen.
 //
-// Jonathan, 2026-09-06: "we should have 45 stored secrets for now… and then we
-// can offer a 1pass vault and a service key." Nobody is pasting 45 secrets by
-// hand, so getting to 45 stored has to be an import — and for canopy-web to
-// import, it needs vault access of its own. That is what these two fields are.
+// canopy-web CUSTODIES this pair; it does not use it. Jonathan, 2026-09-06: "the
+// service account and vault should be used on the runner… canopy-web should just
+// store what it needs or to send to the runner." An earlier version had this page
+// import all 45 secrets into canopy-web, which makes it a second copy of every
+// credential — the thing it was told twice not to become. The runner already has
+// 1Password access; what it lacked was WHICH vault per agent (it derived
+// Agent-<Slug> in bash) and a key scoped to it.
 //
-// The key is PER AGENT, not fleet-wide. One key that reads every vault is
-// simpler to operate and makes canopy-web worth attacking for every agent's
-// secrets at once; this bounds a compromise to the one agent whose key was taken.
+// The key is PER AGENT rather than fleet-wide: one key that reads every vault
+// makes canopy-web worth attacking for every agent's secrets at once, where this
+// bounds a compromise to the one agent whose key was taken.
 
-interface Result {
-  imported: string[]
-  skipped: { name?: string; reason?: string }[]
-  failures: { name?: string; ref?: string; error?: string }[]
-}
-
-export function AgentVaultSection({ slug, onImported }: { slug: string; onImported: () => void }) {
+export function AgentVaultSection({ slug }: { slug: string }) {
   const [vault, setVault] = useState('')
   const [keySet, setKeySet] = useState(false)
   const [declared, setDeclared] = useState(0)
   const [locatable, setLocatable] = useState(0)
   const [key, setKey] = useState('')
   const [busy, setBusy] = useState(false)
+  const [saved, setSaved] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [result, setResult] = useState<Result | null>(null)
 
   useEffect(() => {
     let off = false
@@ -47,6 +44,7 @@ export function AgentVaultSection({ slug, onImported }: { slug: string; onImport
   const save = async () => {
     setBusy(true)
     setError(null)
+    setSaved(false)
     try {
       // A blank key is OMITTED, not sent as "". Sending it would turn a rename
       // into a de-provisioning.
@@ -58,22 +56,9 @@ export function AgentVaultSection({ slug, onImported }: { slug: string; onImport
       setDeclared(v.declared ?? 0)
       setLocatable(v.locatable ?? 0)
       setKey('')
+      setSaved(true)
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Could not save')
-    } finally {
-      setBusy(false)
-    }
-  }
-
-  const runImport = async () => {
-    setBusy(true)
-    setError(null)
-    setResult(null)
-    try {
-      setResult((await importAgentCredentials(slug)) as Result)
-      onImported()
-    } catch (e) {
-      setError(e instanceof Error ? e.message : 'Import failed')
     } finally {
       setBusy(false)
     }
@@ -112,64 +97,31 @@ export function AgentVaultSection({ slug, onImported }: { slug: string; onImport
             type="button"
             onClick={() => void save()}
             disabled={busy}
-            className="rounded-md border border-border px-2 py-1 text-[12px] text-foreground disabled:opacity-40"
+            className="ml-auto rounded-md bg-primary px-2 py-1 text-[12px] font-medium text-primary-foreground disabled:opacity-40"
           >
             Save
-          </button>
-          <button
-            type="button"
-            onClick={() => void runImport()}
-            disabled={busy || !keySet}
-            title={keySet ? '' : 'Set a service key first'}
-            className="ml-auto rounded-md bg-primary px-2 py-1 text-[12px] font-medium text-primary-foreground disabled:opacity-40"
-            data-testid="import-from-1password"
-          >
-            Import secrets from 1Password
           </button>
         </div>
 
         <p className="mt-2 text-[11px] text-foreground-subtle">
-          A service account scoped to this one vault. canopy-web reads it only to import; the key is
-          encrypted at rest and never returned to a browser.
+          A service account scoped to this one vault. <strong>The runner uses it</strong> — canopy-web
+          holds it and hands it to a runner this agent routes to, and never resolves secrets itself.
+          Encrypted at rest, never returned to a browser.
         </p>
 
-        {declared > 0 && locatable < declared && (
-          // Says WHY an import would skip. Both causes render as "45 skipped"
-          // and have completely different fixes — an empty vault vs. a source
-          // map that never reached this deployment.
+        {declared > 0 && (
           <p className="mt-1 text-[11px] text-muted-foreground" data-testid="locatable-note">
             {locatable === 0
-              ? `This deployment has no source map for ${declared} refs — nothing to import until the agent's runtime.yaml is pushed here.`
-              : `${locatable} of ${declared} refs say where their value lives; the rest would be skipped.`}
+              ? `No source map for ${declared} refs — canopy-web cannot say where this agent's secrets live.`
+              : `${locatable} of ${declared} declared refs resolve from this vault on the runner.`}
           </p>
         )}
 
-        {result && (
-          // Failures are shown as prominently as successes on purpose: a ref
-          // that no longer resolves is the single most useful thing this screen
-          // can tell anyone, and it is exactly what a silent partial import hides.
-          <div className="mt-3 space-y-1 text-[12px]" data-testid="import-result">
-            <p className="text-success">Imported {result.imported.length}.</p>
-            {result.failures.length > 0 && (
-              <div className="text-destructive">
-                <p>{result.failures.length} could not be read:</p>
-                <ul className="ml-4 list-disc">
-                  {result.failures.map((f) => (
-                    <li key={f.name}>
-                      <code className="font-mono text-[11px]">{f.name}</code> — {f.error}
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            )}
-            {result.skipped.length > 0 && (
-              <p className="text-muted-foreground">
-                {result.skipped.length} skipped ({result.skipped.map((s) => s.name).join(', ')}).
-              </p>
-            )}
-          </div>
+        {saved && !error && (
+          <p className="mt-2 text-[12px] text-success">
+            Saved. A runner picks this up on its next bootstrap.
+          </p>
         )}
-
         {error && <p className="mt-2 text-[12px] text-destructive">{error}</p>}
       </div>
     </section>

--- a/runner/ec2/bootstrap_agents.sh
+++ b/runner/ec2/bootstrap_agents.sh
@@ -249,6 +249,34 @@ vault_name() {  # ace -> Agent-Ace (bash 5, shipped on Ubuntu 24.04: ${var^} tit
   printf 'Agent-%s\n' "${slug^}"
 }
 
+# Ask canopy-web which vault this agent's secrets live in, and for a service
+# token scoped to it. Prints "<vault>\t<token>"; either half may be empty.
+#
+# canopy-web is the CUSTODIAN of this pair, not the consumer: it stores the vault
+# name and the key, and the RUNNER does the resolving (Jonathan, 2026-09-06 —
+# "the service account and vault should be used on the runner"). That keeps
+# canopy-web from becoming a second copy of every agent's credentials.
+#
+# Both halves ride /credentials/resolve because that route already carries the
+# only plaintext gate in the system — bearer-only, caller must pair a live runner
+# this agent routes to, every read audited. A second route would be a second gate
+# to keep correct.
+agent_vault_config() {  # <slug> -> "<vault>\t<token>"
+  local slug="$1" base="${CANOPY_BASE_URL:-}" tok="${CANOPY_TOKEN:-}"
+  [[ -n "$base" && -n "$tok" ]] || { printf '\t\n'; return 0; }
+  local body
+  body="$(curl -fsSL --max-time 20 -H "Authorization: Bearer $tok" \
+          "${base%/}/api/agents/${slug}/credentials/resolve" 2>/dev/null)" || { printf '\t\n'; return 0; }
+  BODY="$body" python3 -c '
+import json, os
+try:
+    d = json.loads(os.environ["BODY"])
+except Exception:
+    d = {}
+print("%s\t%s" % (d.get("op_vault") or "", d.get("op_sa_token") or ""))
+' 2>/dev/null || printf '\t\n'
+}
+
 FAILED_AGENTS=()
 READY_AGENTS=()
 
@@ -554,7 +582,20 @@ bootstrap_one_agent() {
   local dest="$AGENT_ROOT/$slug"
   local client="${GOG_CLIENT[$slug]:-$slug}"
   local account="${slug}@dimagi-ai.com"
-  local vault; vault="$(vault_name "$slug")"
+  # Vault + key from canopy-web when it has them; otherwise the derived name and
+  # the runner-wide token, so an agent nobody has configured behaves exactly as
+  # it did before this existed.
+  local vault op_token cfg
+  cfg="$(agent_vault_config "$slug")"
+  vault="${cfg%%$'\t'*}"; op_token="${cfg#*$'\t'}"
+  if [[ -n "$vault" ]]; then
+    ok "$slug: vault $vault (from canopy-web)"
+  else
+    vault="$(vault_name "$slug")"
+  fi
+  # Scoped key wins over the runner-wide one for THIS agent's reads only.
+  local OP_SERVICE_ACCOUNT_TOKEN="${op_token:-${OP_SERVICE_ACCOUNT_TOKEN:-}}"
+  export OP_SERVICE_ACCOUNT_TOKEN
 
   log "── agent $slug ──"
 

--- a/tests/test_agent_vault.py
+++ b/tests/test_agent_vault.py
@@ -1,21 +1,28 @@
-"""Importing an agent's secrets from its own 1Password vault.
+"""The vault an agent's secrets live in — custodied here, RESOLVED on the runner.
 
-The goal (Jonathan, 2026-09-05): *someone could plausibly create a completely new
-agent without direct access to the cloud box or 1Password.* The browser mint took
-the box out of the mailbox path; this takes the vault out of everything else.
+Jonathan, 2026-09-06: *the service account and vault should be used on the
+runner… canopy-web should just store what it needs or to send to the runner.*
 
-The per-agent key was Jonathan's explicit choice on 2026-09-06 over a single
-fleet-wide token. One key that reads every vault is simpler to operate and makes
-canopy-web worth attacking for every agent's secrets at once; a scoped key bounds
-a compromise to one agent.
+A first version made canopy-web the resolver — it held the key, shelled out to
+`op`, and stored all 45 values. That turns canopy-web into a second copy of every
+credential, free to drift from the vault and worth attacking for the whole set.
+The runner already has 1Password access and already resolves secrets there; what
+it lacked was WHICH vault per agent (it derived `Agent-<Slug>` in bash) and a key
+scoped to it.
+
+So: canopy-web stores the pair and hands it to the runner over the one route that
+already carries a plaintext gate. The per-agent scoping was Jonathan's explicit
+choice over a fleet-wide token — one key that reads every vault makes canopy-web
+worth attacking for every agent at once.
 """
 from __future__ import annotations
 
 import pytest
 from django.contrib.auth import get_user_model
+from django.test import Client
 
 from apps.agents import vault_import as vi
-from apps.agents.models import Agent, AgentCredential
+from apps.agents.models import Agent
 from apps.workspaces.models import Workspace, WorkspaceMembership
 
 pytestmark = pytest.mark.django_db
@@ -63,50 +70,6 @@ def test_a_ref_with_no_declared_source_is_skipped_not_guessed():
 
 # --- resolving -----------------------------------------------------------------
 
-def test_one_bad_ref_does_not_abandon_the_others():
-    """A vault missing one item is the normal state of a half-provisioned agent.
-    All-or-nothing would make such an agent unprovisionable."""
-    def reader(ref, *, token):
-        if "gog-token" in ref:
-            raise RuntimeError("isn't an item in the vault")
-        return "value-for-" + ref.rsplit("/", 2)[1]
-
-    values, failures = vi.resolve_items(vi.plan_import(DECLARED, SOURCES), token="t", reader=reader)
-    assert values["canopy-pat"] == "value-for-canopy-pat"
-    assert values["ace-hq-base-url"] == "https://www.commcarehq.org"
-    assert [f["name"] for f in failures] == ["gog-token"]
-    assert "isn't an item" in failures[0]["error"]
-
-
-def test_an_empty_read_is_a_failure_not_a_value():
-    """Storing "" would show the ref as SET while it resolves to nothing — the
-    provisioned-looking-but-dead state this whole effort exists to surface."""
-    values, failures = vi.resolve_items(
-        vi.plan_import(["canopy-pat"], SOURCES), token="t", reader=lambda ref, *, token: "",
-    )
-    assert values == {}
-    assert failures[0]["error"] == "resolved empty"
-
-
-def test_the_service_key_never_reaches_a_command_line(monkeypatch):
-    """argv is world-readable via /proc. The token goes in the environment."""
-    seen = {}
-
-    class Res:
-        returncode, stdout, stderr = 0, "v", ""
-
-    def fake_run(cmd, **kw):
-        seen["cmd"], seen["env"] = cmd, kw.get("env", {})
-        return Res()
-
-    monkeypatch.setattr(vi.subprocess, "run", fake_run)
-    vi.op_read("op://V/i/f", token="ops_supersecret")
-    assert "ops_supersecret" not in " ".join(seen["cmd"])
-    assert seen["env"]["OP_SERVICE_ACCOUNT_TOKEN"] == "ops_supersecret"
-
-
-# --- through the API -----------------------------------------------------------
-
 @pytest.fixture
 def fleet(client):
     jj = get_user_model().objects.create_user(username="jj", email="jj@dimagi.com")
@@ -116,12 +79,20 @@ def fleet(client):
         slug="ace", name="ACE", workspace=ws,
         runtime_secrets=DECLARED, runtime_sources=SOURCES,
     )
+    # A live runner this agent routes to — the gate `resolve` checks. Without the
+    # ASSIGNMENT a paired runner gets nothing, which is the point: plaintext
+    # follows routing, not ownership.
+    from django.utils import timezone
+
+    from apps.harness.models import Runner, RunnerAssignment
+
+    runner = Runner.objects.create(
+        name="cloud-ec2-1", kind=Runner.CLOUD, paired_by=jj, status=Runner.ONLINE,
+        last_heartbeat_at=timezone.now(), capabilities={},
+    )
+    RunnerAssignment.objects.create(agent=agent, runner=runner, rank=0)
     client.force_login(jj)
     return {"client": client, "agent": agent, "user": jj}
-
-
-def _set_vault(client, **body):
-    return client.put("/api/agents/ace/vault", data=body, content_type="application/json")
 
 
 def test_the_service_key_is_encrypted_and_never_read_back(fleet):
@@ -144,37 +115,6 @@ def test_renaming_the_vault_does_not_wipe_the_key(fleet):
     assert fleet["agent"].op_sa_token_enc
 
 
-def test_import_refuses_before_a_key_is_set(fleet):
-    assert fleet["client"].post("/api/agents/ace/credentials/import").status_code == 422
-
-
-def test_import_stores_values_and_reports_what_it_could_not_get(fleet, monkeypatch):
-    _set_vault(fleet["client"], vault="Agent-Ace", service_key="ops_tok")
-
-    def reader(ref, *, token):
-        if "gog-token" in ref:
-            raise RuntimeError("stale ref")
-        return "resolved"
-
-    monkeypatch.setattr(vi, "op_read", reader)
-    res = fleet["client"].post("/api/agents/ace/credentials/import")
-    assert res.status_code == 200
-    body = res.json()
-
-    assert "canopy-pat" in body["imported"]
-    assert "ace-hq-base-url" in body["imported"]
-    assert [f["name"] for f in body["failures"]] == ["gog-token"]
-    assert {s["name"] for s in body["skipped"]} == {"ace-web-pat-token", "undeclared-source"}
-    assert AgentCredential.objects.filter(agent=fleet["agent"], name="canopy-pat").exists()
-
-
-def test_an_import_never_returns_a_value_to_the_browser(fleet, monkeypatch):
-    _set_vault(fleet["client"], vault="Agent-Ace", service_key="ops_tok")
-    monkeypatch.setattr(vi, "op_read", lambda ref, *, token: "SUPERSECRET")
-    res = fleet["client"].post("/api/agents/ace/credentials/import")
-    assert "SUPERSECRET" not in res.content.decode()
-
-
 def test_a_non_member_cannot_set_a_vault_or_import(client):
     owner = get_user_model().objects.create_user(username="o", email="o@dimagi.com")
     ws = Workspace.objects.create(slug="p", display_name="P", created_by=owner)
@@ -185,7 +125,6 @@ def test_a_non_member_cannot_set_a_vault_or_import(client):
     assert client.put(
         "/api/agents/secret/vault", data={"vault": "V"}, content_type="application/json",
     ).status_code == 404
-    assert client.post("/api/agents/secret/credentials/import").status_code == 404
 
 
 def test_runtime_sources_survives_a_plugin_reupsert(fleet):
@@ -227,3 +166,72 @@ def test_an_agent_with_no_source_map_reports_zero_locatable(fleet):
     Agent.objects.filter(slug="ace").update(runtime_sources={})
     v = fleet["client"].get("/api/agents/ace/vault").json()
     assert v["declared"] > 0 and v["locatable"] == 0
+
+
+# --- the runner is what resolves -----------------------------------------------
+
+def test_a_runner_gets_the_vault_and_key_with_the_values(fleet):
+    """One route, one gate. The runner needs the vault config and any stored
+    value in the same breath, and a second plaintext route would be a second
+    boundary to keep correct."""
+    _set_vault(fleet["client"], vault="Agent-Ace", service_key="ops_tok")
+    _put(fleet["client"], {"gog-token": "minted-in-the-browser"})
+
+    res = Client().get(
+        "/api/agents/ace/credentials/resolve",
+        HTTP_AUTHORIZATION=f"Bearer {_pat_for(fleet['user'])}",
+    )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["op_vault"] == "Agent-Ace"
+    assert body["op_sa_token"] == "ops_tok"
+    assert body["values"]["gog-token"] == "minted-in-the-browser"
+
+
+def test_the_browser_never_sees_the_service_key(fleet):
+    """`resolve` is bearer-only; the vault status route reports key_set and never
+    the key itself."""
+    _set_vault(fleet["client"], vault="Agent-Ace", service_key="ops_tok")
+
+    assert "ops_tok" not in fleet["client"].get("/api/agents/ace/vault").content.decode()
+    denied = fleet["client"].get("/api/agents/ace/credentials/resolve")
+    assert denied.status_code in (401, 403)
+    assert "ops_tok" not in denied.content.decode()
+
+
+def test_an_agent_with_no_key_resolves_to_empty_not_an_error(fleet):
+    """The box falls back to the runner-wide token, so an unconfigured agent must
+    keep working exactly as it did before any of this existed."""
+    res = Client().get(
+        "/api/agents/ace/credentials/resolve",
+        HTTP_AUTHORIZATION=f"Bearer {_pat_for(fleet['user'])}",
+    )
+    assert res.status_code == 200
+    assert res.json()["op_sa_token"] == ""
+
+
+def test_canopy_web_stores_nothing_it_was_not_given(fleet):
+    """The whole correction. There is no path here that populates credentials
+    from the vault — what canopy-web holds is only what someone or something
+    explicitly wrote to it (the browser mint, a paste)."""
+    _set_vault(fleet["client"], vault="Agent-Ace", service_key="ops_tok")
+    rows = fleet["client"].get("/api/agents/ace/credentials/status").json()
+    assert [r["name"] for r in rows if r["set"]] == []
+
+
+def _set_vault(client, **body):
+    return client.put("/api/agents/ace/vault", data=body, content_type="application/json")
+
+
+def _put(client, values):
+    return client.put(
+        "/api/agents/ace/credentials",
+        data={"values": values}, content_type="application/json",
+    )
+
+
+def _pat_for(user) -> str:
+    from apps.tokens.models import PersonalToken
+
+    raw, _ = PersonalToken.create_for_user(user=user, label="test")
+    return raw


### PR DESCRIPTION
> "the service account and vault should be used on the runner, but we don't need to import everything and store it in canopy-web right? canopy-web should just store what it needs or to send to the runner" — Jonathan, 2026-09-06

Correct, and it's the second time — the first was *"I don't wnat to store all the passowrds on canopy-web, just the ones we need and a service token for 1pass"*. I read the later *"we should have 45 stored secrets for now"* as overriding that rather than refining it, and built canopy-web as the **resolver**: it held the key, shelled out to `op`, and stored all 45 values. That makes canopy-web a second copy of every credential — free to drift from the vault, and worth attacking for the whole set.

## What was actually missing

The runner already had 1Password access and already resolved secrets there. What it lacked was:

- **which vault, per agent** — it derived `Agent-<Slug>` in bash, fine until a vault is named anything else and silently resolves nothing;
- **a key scoped to that vault**, rather than only the runner-wide one.

## canopy-web as custodian

- `Agent.op_vault` + `Agent.op_sa_token_enc` stay. That *is* "a service token for 1pass", stored where a person can set it from a browser.
- Both ride **`/credentials/resolve`** to the runner, alongside whatever values canopy-web genuinely holds. One route, because that one already carries the only plaintext gate in the system — bearer-only, caller must pair a live runner this agent routes to, every read audited. A second route would be a second boundary to keep correct.
- `bootstrap_agents.sh` asks for the pair per agent and **falls back** to the derived name and the runner-wide token, so an agent nobody has configured behaves exactly as before.

## Removed

The import endpoint, the `op` CLI from the image, and the resolving half of `vault_import`. What remains of that module is the *declaration* — where each value lives — used only to report how much of an agent the runner will resolve.

What canopy-web stores now is what it was always supposed to: the vault pointer, the service token, and secrets that genuinely originate here (the browser-minted `gog-token`). A test pins that **no path populates credentials from a vault at all**.

2334 backend tests, 683 frontend, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rffk2t9tySFjRNqRKxN2wR