### PR TITLE
An explicit-only runner can still fetch the agent's credentials

### DIFF
--- a/apps/agents/services.py
+++ b/apps/agents/services.py
@@ -521,8 +521,24 @@ def caller_runs_agent(user, agent) -> bool:
     """
     from apps.harness.models import Runner, RunnerAssignment
 
+    # ASSIGNED, not necessarily ENABLED. `enabled=False` removes a runner from
+    # the automatic rotation — it stops being a fallback — but it does NOT stop
+    # work being directed there: `claim_next_turn` checks `pinned_runner` first
+    # and returns before any assignment lookup ("a pin trumps everything below
+    # it"). That combination IS the explicit-only runner Jonathan asked for on
+    # 2026-09-06: "I don't want it to fire ace commands as a fall back, only if
+    # we explicit trigger it."
+    #
+    # So requiring `enabled=True` here contradicted the claim path: a pinned turn
+    # would land on the box, which would then be refused the very secrets it
+    # needs to run the agent — a failure at the far end of a long round trip,
+    # reading as a broken agent rather than a routing rule.
+    #
+    # The trust boundary is unchanged in substance: an assignment row at all
+    # means this agent's work may be directed at this runner, and the caller must
+    # still PAIR it. Disabling governs automatic routing, not trust.
     return RunnerAssignment.objects.filter(
-        agent=agent, enabled=True, runner__paired_by=user,
+        agent=agent, runner__paired_by=user,
     ).exclude(runner__status=Runner.RETIRED).exists()
 
 

--- a/tests/test_agent_vault.py
+++ b/tests/test_agent_vault.py
@@ -235,3 +235,42 @@ def _pat_for(user) -> str:
 
     raw, _ = PersonalToken.create_for_user(user=user, label="test")
     return raw
+
+
+# --- the explicit-only runner ---------------------------------------------------
+
+def test_a_disabled_assignment_still_gets_credentials(fleet):
+    """The explicit-only runner. Jonathan, 2026-09-06: "I don't want it to fire
+    ace commands as a fall back, only if we explicit trigger it."
+
+    `enabled=False` takes a runner out of the automatic rotation, but
+    claim_next_turn checks `pinned_runner` BEFORE any assignment lookup, so a
+    pinned turn still lands there. Refusing it credentials would let the turn
+    arrive and then fail at the far end of a long round trip, which reads as a
+    broken agent rather than a routing rule."""
+    from apps.harness.models import RunnerAssignment
+
+    RunnerAssignment.objects.filter(agent=fleet["agent"]).update(enabled=False)
+    _set_vault(fleet["client"], vault="Agent-Ace", service_key="ops_tok")
+
+    res = Client().get(
+        "/api/agents/ace/credentials/resolve",
+        HTTP_AUTHORIZATION=f"Bearer {_pat_for(fleet['user'])}",
+    )
+    assert res.status_code == 200
+    assert res.json()["op_vault"] == "Agent-Ace"
+
+
+def test_no_assignment_at_all_is_still_refused(fleet):
+    """Disabling loosens automatic ROUTING, not trust. A runner this agent's work
+    can never be directed at — pinned or otherwise — gets nothing."""
+    from apps.harness.models import RunnerAssignment
+
+    RunnerAssignment.objects.filter(agent=fleet["agent"]).delete()
+    _set_vault(fleet["client"], vault="Agent-Ace", service_key="ops_tok")
+
+    res = Client().get(
+        "/api/agents/ace/credentials/resolve",
+        HTTP_AUTHORIZATION=f"Bearer {_pat_for(fleet['user'])}",
+    )
+    assert res.status_code == 403


### PR DESCRIPTION
> "I don't want it to fire ace commands as a fall back, only if we explicit trigger it, but I want you to also start testing it explicitly" — Jonathan, 2026-09-06

**That state already exists and needs no new field.** `enabled=False` removes a runner from the automatic rotation, and `claim_next_turn` checks `pinned_runner` *first* — *"a pin trumps everything below it"*, returning before any assignment lookup. Disabled-plus-pinnable **is** the explicit-only runner.

## What contradicted it

The credential gate required `enabled=True`. So a pinned turn would land on the box, and the box would then be refused the very secrets it needs to run the agent — a failure at the far end of a long round trip, reading as a broken agent rather than as a routing rule.

That's not hypothetical: it's the 403 a live probe hit against `cloud-ec2-1` today.

## The change

The gate now asks whether the runner is **assigned at all**. The trust boundary is unchanged in substance — an assignment row means this agent's work may be directed at this runner, and the caller must still **pair** it. Disabling governs automatic routing, not trust.

A runner with **no** assignment is still refused; a second test pins that, so this doesn't quietly become "any paired runner can read any agent's secrets."

2336 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rffk2t9tySFjRNqRKxN2wR