### PR TITLE
The mint's return trip keeps the deployment path prefix

### DIFF
--- a/apps/agents/oauth_api.py
+++ b/apps/agents/oauth_api.py
@@ -11,6 +11,7 @@ imports it the same way it imports one a human minted at a terminal.
 """
 from __future__ import annotations
 
+from django.conf import settings
 from django.http import HttpRequest, HttpResponseRedirect
 from ninja import Router
 from ninja.errors import HttpError
@@ -66,8 +67,18 @@ def google_callback(request: HttpRequest, code: str = "", state: str = "", error
     from django.core import signing
 
     def done(agent, status: str):
-        base = f"/w/{agent.workspace.slug}/agents/{agent.slug}/credentials" if agent else "/"
-        return HttpResponseRedirect(f"{base}?google={status}")
+        # ROOT-RELATIVE IS WRONG HERE. This deployment is served under a path
+        # prefix (/canopy), so "/w/…" lands outside the app entirely — the mint
+        # succeeded, the token was stored, and the operator got a Resolver404
+        # that reads exactly like a failure. Reported by Jonathan on the first
+        # real sign-in, 2026-09-07.
+        #
+        # CANOPY_PUBLIC_BASE_URL already carries the prefix and is already the
+        # authority for the OAuth redirect_uri, so the round trip starts and ends
+        # against the same base rather than two derivations that can disagree.
+        root = settings.CANOPY_PUBLIC_BASE_URL.rstrip("/")
+        path = f"/w/{agent.workspace.slug}/agents/{agent.slug}/credentials" if agent else "/"
+        return HttpResponseRedirect(f"{root}{path}?google={status}")
 
     if not state:
         raise HttpError(400, "missing state")

--- a/tests/test_google_mint.py
+++ b/tests/test_google_mint.py
@@ -311,3 +311,36 @@ def test_a_non_member_cannot_start_a_mint(client):
     Agent.objects.create(slug="secret", name="S", workspace=ws, runtime_secrets=["gog-token"])
     client.force_login(get_user_model().objects.create_user(username="x", email="x@dimagi.com"))
     assert client.get("/api/agents/secret/google/authorize").status_code == 404
+
+
+@pytest.mark.django_db
+def test_the_return_trip_keeps_the_deployment_path_prefix(fleet, monkeypatch, settings):
+    """The mint worked and the operator saw Resolver404.
+
+    canopy-web is served under /canopy in production, so a root-relative redirect
+    lands outside the app. The token was stored, `?google=ok` was set, and the
+    page still read as a failure — the worst shape of bug on a screen whose whole
+    job is telling you whether a credential is healthy."""
+    settings.CANOPY_PUBLIC_BASE_URL = "https://labs.connect.dimagi.com/canopy"
+    monkeypatch.setattr(g, "exchange_code", lambda **kw: _google_response())
+
+    state = g.sign_state(agent_slug="ace", user_pk=fleet["user"].pk)
+    res = fleet["client"].get(CALLBACK, {"code": "c", "state": state})
+
+    assert res["Location"] == (
+        "https://labs.connect.dimagi.com/canopy"
+        "/w/connect/agents/ace/credentials?google=ok"
+    )
+
+
+@pytest.mark.django_db
+def test_a_failed_mint_returns_to_the_same_prefixed_page(fleet, monkeypatch, settings):
+    """Every exit uses the same builder — a failure that 404s is how an operator
+    concludes the whole feature is broken."""
+    settings.CANOPY_PUBLIC_BASE_URL = "https://labs.connect.dimagi.com/canopy"
+    monkeypatch.setattr(g, "exchange_code", lambda **kw: _google_response(refresh=""))
+
+    state = g.sign_state(agent_slug="ace", user_pk=fleet["user"].pk)
+    res = fleet["client"].get(CALLBACK, {"code": "c", "state": state})
+    assert res["Location"].startswith("https://labs.connect.dimagi.com/canopy/w/connect/")
+    assert res["Location"].endswith("?google=no-refresh-token")


### PR DESCRIPTION
> "did it work and the final redirect is just bad?" — Jonathan, 2026-09-07

It worked. The redirect was mine.

canopy-web is served under `/canopy` in production, so the root-relative `"/w/{ws}/agents/{slug}/credentials"` landed outside the app entirely. The mint had already written the credential and set `?google=ok` — and the operator still saw a `Resolver404`.

That's the worst shape of bug on a screen whose entire job is telling you whether a credential is healthy: it reports failure for a success, on the one surface built to be trusted about that distinction.

## The fix

The redirect builds from `CANOPY_PUBLIC_BASE_URL`, which already carries the prefix and is *already* the authority for the OAuth `redirect_uri`. The round trip now starts and ends against one base rather than two derivations free to disagree.

Both the success and failure exits go through the same builder, pinned by tests — a failure that 404s is how someone concludes the whole feature is broken.

Confirmed on the live mint: `gog-token` is `set: true`, source `canopy-web`, written by `ace@dimagi-ai.com` at 13:34:22Z.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rffk2t9tySFjRNqRKxN2wR