### PR TITLE
The box takes the NEWEST gog token, from the vault or canopy-web

### DIFF
--- a/runner/ec2/bootstrap_agents.sh
+++ b/runner/ec2/bootstrap_agents.sh
@@ -244,6 +244,58 @@ ensure_client_creds() {  # <client> <agent-vault> <slug>
   fi
 }
 
+# A gog token can now arrive from TWO places, and the box must not silently
+# prefer the stale one.
+#
+#   op://<vault>/gog-token/credential   the vault copy, minted at a terminal
+#   canopy-web /credentials/resolve     minted in a browser ("Connect Google
+#                                       mailbox"), which is the whole point of
+#                                       provisioning an agent without 1Password
+#
+# canopy-web CANNOT write back to the vault — its service account is read-only,
+# deliberately — so a browser mint lands in canopy-web only, and a box that reads
+# the vault alone keeps the old token forever. Measured 2026-09-07: a token
+# minted at 13:34Z was invisible to this box, which still held one from
+# 2026-05-01 under a client whose mailbox had been dead for four months.
+#
+# NEWEST WINS, decided by the token's own `created_at`. Not "prefer canopy-web",
+# which would make a fresh vault rotation lose to a stale browser mint; not
+# "prefer the vault", which loses every browser mint. The token already declares
+# its own client and its own age — the same reason `token_client` reads it rather
+# than consulting a table (canopy-web#673).
+token_created_at() {  # <file> -> epoch seconds, 0 when absent/unparseable
+  local f="$1"
+  [[ -s "$f" ]] || { printf '0\n'; return 0; }
+  TOKF="$f" python3 -c '
+import json, os, calendar, time
+try:
+    v = (json.load(open(os.environ["TOKF"])).get("created_at") or "").strip()
+    print(int(calendar.timegm(time.strptime(v, "%Y-%m-%dT%H:%M:%SZ"))) if v else 0)
+except Exception:
+    print(0)
+' 2>/dev/null || printf '0\n'
+}
+
+# Write canopy-web's stored gog-token for <slug> to <outfile>. Empty file when
+# canopy-web has none, which is the normal case for an agent nobody has minted.
+fetch_canopy_web_token() {  # <slug> <outfile>
+  local slug="$1" out="$2" base="${CANOPY_BASE_URL:-}" tok="${CANOPY_TOKEN:-}"
+  : >"$out"
+  [[ -n "$base" && -n "$tok" ]] || return 0
+  local body
+  body="$(curl -fsSL --max-time 20 -H "Authorization: Bearer $tok" \
+          "${base%/}/api/agents/${slug}/credentials/resolve" 2>/dev/null)" || return 0
+  BODY="$body" OUT="$out" python3 -c '
+import json, os
+try:
+    v = json.loads(os.environ["BODY"]).get("values", {}).get("gog-token")
+except Exception:
+    v = None
+if v:
+    open(os.environ["OUT"], "w").write(v)
+' 2>/dev/null || true
+}
+
 vault_name() {  # ace -> Agent-Ace (bash 5, shipped on Ubuntu 24.04: ${var^} title-cases)
   local slug="$1"
   printf 'Agent-%s\n' "${slug^}"
@@ -641,9 +693,27 @@ bootstrap_one_agent() {
   elif gog gmail search --account "$account" --client "$client" in:inbox --max 1 >/dev/null 2>&1; then
     ok "$slug: gmail token already live (account=$account client=$client)"
   else
-    log "$slug: gmail token not live — importing from op://${vault}/gog-token/credential"
+    log "$slug: gmail token not live — taking the NEWEST of the vault and canopy-web"
     local tokfile; tokfile="$(mktemp)"
-    if op read "op://${vault}/gog-token/credential" >"$tokfile" 2>/dev/null && [[ -s "$tokfile" ]]; then
+    local vaultfile webfile; vaultfile="$(mktemp)"; webfile="$(mktemp)"
+    op read "op://${vault}/gog-token/credential" >"$vaultfile" 2>/dev/null || : >"$vaultfile"
+    fetch_canopy_web_token "$slug" "$webfile"
+
+    # Both 0 (no python3, unparseable dates, or neither store has one) falls to
+    # the vault copy — today's behaviour. Degrading toward the OLD path is the
+    # right direction: it can leave a stale token in place, where degrading the
+    # other way would import canopy-web's copy over a good vault rotation.
+    local vage wage; vage="$(token_created_at "$vaultfile")"; wage="$(token_created_at "$webfile")"
+    if (( wage > vage )); then
+      cp "$webfile" "$tokfile"
+      ok "$slug: using canopy-web's token (newer: $wage > $vage)"
+    else
+      cp "$vaultfile" "$tokfile"
+      (( vage > 0 )) && log "$slug: using the vault's token (canopy-web has none newer)"
+    fi
+    rm -f "$vaultfile" "$webfile"
+
+    if [[ -s "$tokfile" ]]; then
       # Capture stderr instead of discarding it. Swallowing it here is what hid a
       # fleet-wide failure for weeks: the `file` keyring backend wants a password
       # it can only PROMPT for, so on this TTY-less box EVERY import died with
@@ -671,7 +741,7 @@ bootstrap_one_agent() {
           warn "$slug: GOG_KEYRING_PASSWORD is unset — stage it with ./secrets.sh gog"
       fi
     else
-      warn "$slug: op read op://${vault}/gog-token/credential failed — is the item staged for this vault?"
+      warn "$slug: no gog token anywhere — neither op://${vault}/gog-token/credential nor canopy-web has one for $slug"
     fi
     shred -u "$tokfile" 2>/dev/null || rm -f "$tokfile"  # never leave the token on disk, even on failure
   fi

--- a/runner/ec2/tests/test_newest_gog_token_wins.py
+++ b/runner/ec2/tests/test_newest_gog_token_wins.py
@@ -1,0 +1,118 @@
+"""A gog token can arrive from two stores; the box must not prefer the stale one.
+
+    op://<vault>/gog-token/credential   minted at a terminal
+    canopy-web /credentials/resolve     minted in a browser
+
+canopy-web CANNOT write back to the vault — its service account is read-only by
+design — so a browser mint lands in canopy-web only. A box reading the vault
+alone keeps the old token forever.
+
+Measured 2026-09-07 and the reason this exists: a token minted in canopy-web at
+13:34Z was invisible to cloud-ec2-1, which still held one created 2026-05-01
+under a client whose mailbox had been dead for four months. `gog auth list` on
+the box showed `ace@dimagi-ai.com / client=ace / 2026-05-01T21:23:22Z` while
+canopy-web reported the credential freshly set.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+
+import pytest
+
+SCRIPT = pathlib.Path(__file__).resolve().parent.parent / "bootstrap_agents.sh"
+
+_HAS_ASSOC = subprocess.run(
+    ["bash", "-c", "declare -A _t=( [k]=v ) 2>/dev/null && echo yes"],
+    capture_output=True, text=True,
+).stdout.strip() == "yes"
+pytestmark = pytest.mark.skipif(
+    not _HAS_ASSOC, reason="bash lacks associative arrays (macOS ships 3.2; the box and CI run 5)"
+)
+
+
+def _fn(name: str) -> str:
+    lines = SCRIPT.read_text().splitlines()
+    start = next(i for i, l in enumerate(lines) if l.startswith(f"{name}() {{"))
+    end = next(i for i in range(start + 1, len(lines)) if lines[i] == "}")
+    return "\n".join(lines[start:end + 1])
+
+
+def _created_at(tmp_path, body) -> int:
+    f = tmp_path / "tok.json"
+    f.write_text(body if isinstance(body, str) else json.dumps(body))
+    script = f'set -uo pipefail\n{_fn("token_created_at")}\ntoken_created_at "{f}"'
+    res = subprocess.run(["bash", "-c", script], capture_output=True, text=True, timeout=60)
+    return int((res.stdout or "0").strip() or 0)
+
+
+def test_a_real_timestamp_parses(tmp_path):
+    # eva's live token, verbatim.
+    assert _created_at(tmp_path, {"created_at": "2026-07-24T04:09:54Z"}) == 1784779794
+
+
+def test_the_may_token_is_older_than_the_september_mint(tmp_path):
+    """The exact pair that was live on the box."""
+    stale = _created_at(tmp_path, {"created_at": "2026-05-01T21:23:22Z"})
+    fresh = _created_at(tmp_path, {"created_at": "2026-09-07T13:34:22Z"})
+    assert 0 < stale < fresh
+
+
+def test_a_missing_or_junk_token_sorts_oldest_rather_than_erroring(tmp_path):
+    """0 must lose to any real timestamp — an unparseable token that sorted
+    NEWEST would silently beat a good one, which is the failure this whole
+    comparison exists to prevent."""
+    assert _created_at(tmp_path, "") == 0
+    assert _created_at(tmp_path, "not json at all") == 0
+    assert _created_at(tmp_path, {"no_created_at": True}) == 0
+    assert _created_at(tmp_path, {"created_at": "24 July 2026"}) == 0
+    assert 0 < _created_at(tmp_path, {"created_at": "2026-05-01T21:23:22Z"})
+
+
+def test_a_missing_file_is_zero_not_a_failure(tmp_path):
+    script = f'set -uo pipefail\n{_fn("token_created_at")}\ntoken_created_at "{tmp_path}/nope.json"'
+    res = subprocess.run(["bash", "-c", script], capture_output=True, text=True, timeout=60)
+    assert res.returncode == 0 and res.stdout.strip() == "0"
+
+
+def test_the_import_compares_both_stores_before_choosing():
+    """Guards the regression directly: reading only the vault is what stranded a
+    freshly minted token."""
+    body = _fn("bootstrap_one_agent")
+    assert "fetch_canopy_web_token" in body, "canopy-web's copy must be considered"
+    assert "token_created_at" in body, "the choice must be by age, not by source"
+    # Not "canopy-web always wins" — that would lose a fresh vault rotation to a
+    # stale browser mint. The comparison is the point.
+    assert "wage > vage" in body
+
+
+def test_canopy_web_is_read_through_the_gated_route():
+    body = _fn("fetch_canopy_web_token")
+    assert "/credentials/resolve" in body
+    assert "Authorization: Bearer" in body
+
+
+def test_a_canopy_web_miss_leaves_an_empty_file_not_a_stale_one(tmp_path):
+    """An agent nobody has minted is the normal case. A leftover file from a
+    previous agent's fetch would import the WRONG mailbox's token."""
+    out = tmp_path / "web.json"
+    out.write_text('{"created_at":"2099-01-01T00:00:00Z"}')  # would win if not cleared
+    script = f'''
+set -uo pipefail
+CANOPY_BASE_URL=""; CANOPY_TOKEN=""
+{_fn("fetch_canopy_web_token")}
+fetch_canopy_web_token ace "{out}"
+'''
+    subprocess.run(["bash", "-c", script], capture_output=True, text=True, timeout=60)
+    assert out.read_text() == ""
+
+
+def test_it_degrades_toward_the_vault_when_ages_are_unknowable():
+    """Discovered by running the comparison in an image without python3: every
+    token scored 0, so `wage > vage` is false and the vault copy wins — which is
+    exactly today's behaviour. That direction is the safe one (a stale token
+    stays put); the reverse would import canopy-web's copy over a good vault
+    rotation. Stated in the script so it stays deliberate rather than lucky."""
+    body = _fn("bootstrap_one_agent")
+    assert "wage > vage" in body, "the vault must be the else-branch, not canopy-web"

--- a/runner/ec2/tests/test_newest_gog_token_wins.py
+++ b/runner/ec2/tests/test_newest_gog_token_wins.py
@@ -48,8 +48,18 @@ def _created_at(tmp_path, body) -> int:
 
 
 def test_a_real_timestamp_parses(tmp_path):
-    # eva's live token, verbatim.
-    assert _created_at(tmp_path, {"created_at": "2026-07-24T04:09:54Z"}) == 1784779794
+    """eva's live token, verbatim — and the expected value is DERIVED, not typed.
+
+    A hand-computed epoch here was wrong by exactly 86400 on the first run: it
+    added nothing the ordering tests don't already cover, and gave CI a magic
+    number to disagree with. Deriving it still tests something real, because the
+    parsing under test happens in bash + a subprocess, not here."""
+    import calendar
+    import time
+
+    stamp = "2026-07-24T04:09:54Z"
+    expected = calendar.timegm(time.strptime(stamp, "%Y-%m-%dT%H:%M:%SZ"))
+    assert _created_at(tmp_path, {"created_at": stamp}) == expected
 
 
 def test_the_may_token_is_older_than_the_september_mint(tmp_path):


### PR DESCRIPTION
**A browser mint could not reach the box, and the screen said it had.**

Measured today. Jonathan clicked *Connect Google mailbox*; the token stored correctly (canopy-web: `set=true`, `13:34:22Z`, by `ace@dimagi-ai.com`). A pinned read-only turn on `cloud-ec2-1` then reported:

```
ace@dimagi-ai.com | client=ace | 2026-05-01T21:23:22Z
gog gmail search → No auth for gmail ace@dimagi-ai.com
```

The four-month-dead token, still in place.

## Cause: two stores, no link

`bootstrap_agents.sh` imported `gog-token` from `op://<vault>/gog-token/credential`. The mint writes to canopy-web. canopy-web **cannot write back** — its 1Password service account is read-only, deliberately — so a browser mint lands in canopy-web only, and a box reading the vault alone keeps the old token forever.

Every part worked. Nothing joined them.

## Newest wins, by the token's own `created_at`

Not *"prefer canopy-web"* — that loses a fresh vault rotation to a stale browser mint. Not *"prefer the vault"* — that loses every browser mint. The token already declares its own **client** for exactly this reason (#673); it declares its own **age** too, and that's a fact rather than a policy.

## Degradation is deliberate, not lucky

When neither age parses, both score `0`, the comparison is false, and the vault copy wins — today's behaviour. That direction leaves a stale token in place; the reverse would import canopy-web's copy over a good rotation.

Found by running the comparison in an image without `python3`, where every token scored `0` — my verification was wrong before the code was, and it surfaced the branch worth stating.

Verified on `bash 5.2 + python3 3.12` (matching the box): stale `1777670602` < fresh `1788788062`, junk `0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rffk2t9tySFjRNqRKxN2wR