### PR TITLE
runner: one incident, one turn — coalesce a re-fired ALARM and a late OK

### DIFF
--- a/runner/canopy_runner/canopy_runner/inbox.py
+++ b/runner/canopy_runner/canopy_runner/inbox.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import json
 import re
 import subprocess
+import time
 
 # UNREAD only — the "new email" signal. Critically NOT "all recent threads":
 # every matched thread becomes a turn → a claude session, so an over-broad query
@@ -42,6 +43,26 @@ def alarm_key(thread: dict) -> tuple[str, str] | None:
         return None
     m = _ALARM_SUBJECT.match(thread.get("subject") or "")
     return (m.group(1).upper(), m.group(2)) if m else None
+
+
+def _alarm_incident_is_owned(box: str, key: tuple[str, str], alarming: set[str],
+                             now: float) -> bool:
+    """Does a turn already own this alarm notification's incident?
+
+    ``key`` is an `alarm_key()` result, so this is only ever asked about a genuine SNS
+    CloudWatch notification — everything else short-circuits before here and enqueues
+    normally. Returning True suppresses a turn, so every branch is written to fail toward
+    enqueueing when it does not KNOW.
+    """
+    state, name = key
+    last = _alarm_enqueued.get((box, name))
+    if state == "OK":
+        # #670's rule (its `ALARM:` is unread in this same batch) OR the same alarm fired
+        # recently enough that this is plainly its recovery.
+        return name in alarming or (last is not None and now - last < OK_PAIRING_WINDOW_S)
+    # A repeat `ALARM:` inside the window is the same incident re-notifying. The FIRST one
+    # always enqueues — there is no entry to compare against until we have enqueued once.
+    return last is not None and now - last < ALARM_REPEAT_WINDOW_S
 
 
 class InboxError(Exception):
@@ -111,14 +132,54 @@ def newest_sender(mailbox: str, gog_client: str, thread_id: str, *,
 #: "already tracked".
 _seen_state: dict[tuple[str, str], int] = {}
 
+#: A re-fired `ALARM:` for the same alarm name inside this window is the SAME incident.
+#:
+#: CloudWatch re-evaluates a metric alarm roughly every 60s over a SLIDING window, so a
+#: condition sitting near its threshold flips ALARM->OK->ALARM every few minutes for as
+#: long as it lasts. Each flip is a fresh notification, and because Gmail threads by
+#: subject they all land on ONE thread with a bumped `messageCount` — which is a new
+#: idempotency key, so each one enqueued another turn.
+#:
+#: Measured on hal, 2026-09-07: `labs-jj-web-cpu-high-actionable` transitioned to ALARM at
+#: 12:23:56, 12:29:21 and 12:34:21 UTC for a single incident, dispatching THREE turns onto
+#: one thread. The third had nothing left to find — the first had already diagnosed it,
+#: shipped the fix and closed the storm out.
+#:
+#: 15 minutes covers the observed re-fire spacing (~5 min) with margin. It is deliberately
+#: NOT open-ended: a genuinely sustained incident re-notifies after the window, which is
+#: the right behaviour — one look per quarter hour, not one per flip.
+ALARM_REPEAT_WINDOW_S = 15 * 60
+
+#: How long after an `ALARM:` its matching `OK:` is still that incident's recovery.
+#:
+#: Much longer than the repeat window, because the two are not the same judgment. An `OK:`
+#: is never work ON ITS OWN — its `ALARM:` owns the incident, and the agent-side rule is
+#: explicit that the `OK:` turn's whole job is to discover it should stand down. So the
+#: only question is "did this alarm recently fire", and a generous answer is the safe one.
+#:
+#: #670 answered it with "is the `ALARM:` in THIS batch", which holds only while both are
+#: unread in the same poll. On 2026-09-07 the `OK:` landed 24 minutes after its `ALARM:`,
+#: by which time the `ALARM:` thread had been read and closed out — so the batch was empty
+#: of it, the `OK:` enqueued a turn, and that session spent 65 events reading the turn
+#: procedure before stalling with nothing to do.
+OK_PAIRING_WINDOW_S = 2 * 60 * 60
+
+#: ``{(mailbox, alarm_name): wall-clock time we last ENQUEUED a turn for it}``. Written
+#: only on a real enqueue, never when coalescing — so a flapping alarm is quiet for one
+#: window and then genuinely re-notifies, rather than being suppressed forever by its own
+#: repeats. Process-local for the same reason as `_seen_state`: losing it on restart costs
+#: one redundant turn, never a dropped incident. That is the fail-open direction.
+_alarm_enqueued: dict[tuple[str, str], float] = {}
+
 
 def check_inbox(client, agent: str, *, mailbox: str, gog_client: str,
                 query: str = DEFAULT_QUERY, max_threads: int = 15, runner=subprocess.run,
-                sender_of=None, discovered_by: str = "poll") -> dict:
+                sender_of=None, discovered_by: str = "poll", clock=time.time) -> dict:
     """Enqueue an email-origin turn for each new thread state. Returns
     {"new": [thread_ids that became a NEW turn], "seen": [ids already tracked],
     "skipped": [ids whose newest message is the agent's own reply],
-    "coalesced": [SNS `OK:` ids folded into their `ALARM:` turn]} — the split matters
+    "coalesced": [SNS alarm ids folded into an existing incident's turn — an `OK:`
+    recovery, or an `ALARM:` re-firing inside ALARM_REPEAT_WINDOW_S]} — the split matters
     for logging: re-polling the same unread mail is idempotent server-side, so it must
     read as "nothing new", not as fresh work.
 
@@ -167,8 +228,17 @@ def check_inbox(client, agent: str, *, mailbox: str, gog_client: str,
             continue
         # Coalesce BEFORE `sender_of`, which is a `gog gmail thread get` subprocess —
         # the same cost-ordering reason the idempotency check sits above.
+        #
+        # Two ways one incident still reached us as several turns after #670, both
+        # measured on hal 2026-09-07 and both fixed by remembering WHEN we last enqueued
+        # for an alarm name rather than only looking inside the current batch:
+        #
+        #   * a re-fired `ALARM:` — the flip lands on the SAME Gmail thread with a bumped
+        #     messageCount, which is a new idempotency key, so it enqueued again;
+        #   * an `OK:` whose `ALARM:` was in an EARLIER batch — `alarming` is per-poll, so
+        #     a recovery arriving after its `ALARM:` was read fell straight through it.
         key = alarm_key(t)
-        if key and key[0] == "OK" and key[1] in alarming:
+        if key and _alarm_incident_is_owned(box, key, alarming, clock()):
             coalesced.append(tid)
             # Remember it so the next poll doesn't re-evaluate the same state. NOTE:
             # `_seen_state` is process-local (see its docstring), so a runner restart
@@ -200,5 +270,11 @@ def check_inbox(client, agent: str, *, mailbox: str, gog_client: str,
             prompt=f"/{agent}:turn --thread {tid}",
         )
         _seen_state[(box, tid)] = count
+        # Stamp the incident only on a real enqueue, so the window is measured from the
+        # turn that owns it. Deliberately NOT refreshed when coalescing: a re-fire must
+        # not extend its own suppression, or an alarm flapping for an hour would be
+        # reported once and then silently held down for the whole hour.
+        if key and key[0] == "ALARM":
+            _alarm_enqueued[(box, key[1])] = clock()
         (new if (res or {}).get("_created") else seen).append(tid)
     return {"new": new, "seen": seen, "skipped": skipped, "coalesced": coalesced}

--- a/runner/canopy_runner/tests/test_inbox.py
+++ b/runner/canopy_runner/tests/test_inbox.py
@@ -131,8 +131,15 @@ def _alarm_pair():
 def _clear_seen_state():
     """`_seen_state` is module-global and these tests reuse thread ids."""
     inbox._seen_state.clear()
+    inbox._alarm_enqueued.clear()
     yield
     inbox._seen_state.clear()
+    inbox._alarm_enqueued.clear()
+
+
+def _clock(t):
+    """A frozen wall clock; `t` is seconds, origin arbitrary."""
+    return lambda: float(t)
 
 
 def test_alarm_key_parses_both_states():
@@ -234,3 +241,120 @@ def test_non_alarm_mail_is_completely_unaffected():
                             runner=_runner(threads), sender_of=lambda tid: "x@y.com")
     assert res["new"] == ["thr-1", "thr-2"]
     assert res["coalesced"] == []
+
+
+# --- one incident, one turn: the REPEAT and the LATE recovery ---------------------
+#
+# From hal, 2026-09-07. `labs-jj-web-cpu-high-actionable` transitioned to ALARM at
+# 12:23:56, 12:29:21 and 12:34:21 UTC for ONE incident, and its `OK:` landed at 12:48
+# — 24 minutes after the `ALARM:`, by which time that thread had been read and closed
+# out. Result: three turns on the ALARM thread plus a fourth on the OK thread.
+
+def _alarm_thread(count):
+    """The SAME Gmail thread, re-fired: CloudWatch threads by subject, so a repeat is a
+    bumped messageCount, which was a fresh idempotency key."""
+    return [{"id": "thr-alarm", "from": SNS, "subject": _ALARM, "messageCount": count}]
+
+
+def test_refired_alarm_on_the_same_thread_does_not_enqueue_again():
+    client = FakeClient()
+    first = inbox.check_inbox(client, "hal", mailbox="hal@dimagi-ai.com", gog_client="canopy",
+                              runner=_runner(_alarm_thread(1)), sender_of=lambda tid: SNS.lower(),
+                              clock=_clock(0))
+    assert first["new"] == ["thr-alarm"]
+
+    # +5m21s and +10m25s, the real spacing of the two re-fires.
+    for t, count in ((321, 2), (625, 3)):
+        res = inbox.check_inbox(client, "hal", mailbox="hal@dimagi-ai.com", gog_client="canopy",
+                                runner=_runner(_alarm_thread(count)),
+                                sender_of=lambda tid: SNS.lower(), clock=_clock(t))
+        assert res["new"] == [], f"re-fire at +{t}s enqueued a second turn"
+        assert res["coalesced"] == ["thr-alarm"]
+
+    assert len(client.enqueued) == 1, "one incident must produce exactly one turn"
+
+
+def test_alarm_refiring_after_the_window_is_a_new_incident():
+    """The suppression is bounded on purpose — a sustained condition must re-notify."""
+    client = FakeClient()
+    inbox.check_inbox(client, "hal", mailbox="hal@dimagi-ai.com", gog_client="canopy",
+                      runner=_runner(_alarm_thread(1)), sender_of=lambda tid: SNS.lower(),
+                      clock=_clock(0))
+    res = inbox.check_inbox(client, "hal", mailbox="hal@dimagi-ai.com", gog_client="canopy",
+                            runner=_runner(_alarm_thread(2)), sender_of=lambda tid: SNS.lower(),
+                            clock=_clock(inbox.ALARM_REPEAT_WINDOW_S + 1))
+    assert res["new"] == ["thr-alarm"]
+    assert len(client.enqueued) == 2
+
+
+def test_a_coalesced_refire_does_not_extend_its_own_suppression():
+    """Otherwise an alarm flapping for an hour is reported once and then held down for
+    the whole hour by its own repeats — silence that looks like health."""
+    client = FakeClient()
+    inbox.check_inbox(client, "hal", mailbox="hal@dimagi-ai.com", gog_client="canopy",
+                      runner=_runner(_alarm_thread(1)), sender_of=lambda tid: SNS.lower(),
+                      clock=_clock(0))
+    # A re-fire near the end of the window, coalesced...
+    inbox.check_inbox(client, "hal", mailbox="hal@dimagi-ai.com", gog_client="canopy",
+                      runner=_runner(_alarm_thread(2)), sender_of=lambda tid: SNS.lower(),
+                      clock=_clock(inbox.ALARM_REPEAT_WINDOW_S - 60))
+    # ...must not push the window out: just past the ORIGINAL window, we notify again.
+    res = inbox.check_inbox(client, "hal", mailbox="hal@dimagi-ai.com", gog_client="canopy",
+                            runner=_runner(_alarm_thread(3)), sender_of=lambda tid: SNS.lower(),
+                            clock=_clock(inbox.ALARM_REPEAT_WINDOW_S + 1))
+    assert res["new"] == ["thr-alarm"]
+
+
+def test_ok_is_coalesced_even_when_its_alarm_was_an_earlier_batch():
+    """#670 paired them only within one poll, so a recovery arriving after its `ALARM:`
+    had been read fell straight through and spawned a turn with nothing to do."""
+    client = FakeClient()
+    inbox.check_inbox(client, "hal", mailbox="hal@dimagi-ai.com", gog_client="canopy",
+                      runner=_runner(_alarm_thread(1)), sender_of=lambda tid: SNS.lower(),
+                      clock=_clock(0))
+    ok_only = [{"id": "thr-ok", "from": SNS, "subject": _OK, "messageCount": 1}]
+    res = inbox.check_inbox(client, "hal", mailbox="hal@dimagi-ai.com", gog_client="canopy",
+                            runner=_runner(ok_only), sender_of=lambda tid: SNS.lower(),
+                            clock=_clock(24 * 60))          # the real 24-minute gap
+    assert res["new"] == []
+    assert res["coalesced"] == ["thr-ok"]
+    assert len(client.enqueued) == 1
+
+
+def test_ok_with_no_recent_alarm_still_enqueues():
+    """The fail-open direction: an `OK:` we cannot pair with anything is not suppressed.
+    Covers the alarm-creation `N/A -> OK` notification, which has no `ALARM:` at all."""
+    client = FakeClient()
+    ok_only = [{"id": "thr-ok", "from": SNS, "subject": _OK, "messageCount": 1}]
+    res = inbox.check_inbox(client, "hal", mailbox="hal@dimagi-ai.com", gog_client="canopy",
+                            runner=_runner(ok_only), sender_of=lambda tid: SNS.lower(),
+                            clock=_clock(0))
+    assert res["new"] == ["thr-ok"]
+
+
+def test_a_different_alarm_is_never_suppressed_by_an_unrelated_incident():
+    client = FakeClient()
+    inbox.check_inbox(client, "hal", mailbox="hal@dimagi-ai.com", gog_client="canopy",
+                      runner=_runner(_alarm_thread(1)), sender_of=lambda tid: SNS.lower(),
+                      clock=_clock(0))
+    other = [{"id": "thr-other", "from": SNS,
+              "subject": 'ALARM: "labs-jj-rds-connections-high" in US East (N. Virginia)',
+              "messageCount": 1}]
+    res = inbox.check_inbox(client, "hal", mailbox="hal@dimagi-ai.com", gog_client="canopy",
+                            runner=_runner(other), sender_of=lambda tid: SNS.lower(),
+                            clock=_clock(60))
+    assert res["new"] == ["thr-other"]
+
+
+def test_a_human_subject_that_looks_like_a_refire_is_never_suppressed():
+    """`alarm_key` gates all of this on the SNS sender; a person is never coalesced."""
+    client = FakeClient()
+    inbox.check_inbox(client, "hal", mailbox="hal@dimagi-ai.com", gog_client="canopy",
+                      runner=_runner(_alarm_thread(1)), sender_of=lambda tid: SNS.lower(),
+                      clock=_clock(0))
+    human = [{"id": "thr-human", "from": "Jonathan <jjackson@dimagi.com>",
+              "subject": _ALARM, "messageCount": 1}]
+    res = inbox.check_inbox(client, "hal", mailbox="hal@dimagi-ai.com", gog_client="canopy",
+                            runner=_runner(human), sender_of=lambda tid: "jjackson@dimagi.com",
+                            clock=_clock(60))
+    assert res["new"] == ["thr-human"]


### PR DESCRIPTION
## The gap

[#670](https://github.com/dimagi-internal/canopy-web/pull/670) collapsed an `OK:` into its `ALARM:` turn — but only when both were unread in the **same poll**. Two shapes still got through. Both were measured on hal today, *while it was working a real incident*:

**1. A re-fired `ALARM:`.** CloudWatch re-evaluates a metric alarm roughly every 60s over a *sliding* window, so a condition sitting near its threshold flips `ALARM→OK→ALARM` every few minutes. Gmail threads by subject, so every flip lands on the **same thread** with a bumped `messageCount` — which is a new idempotency key, so each one enqueued another turn.

`labs-jj-web-cpu-high-actionable` went to ALARM at **12:23:56, 12:29:21 and 12:34:21 UTC for one incident** and dispatched three turns onto one thread. The third had nothing left to find: the first had already diagnosed it, shipped the fix and closed the storm out.

**2. An `OK:` whose `ALARM:` was in an earlier batch.** `alarming` is computed per poll, so a recovery arriving after its `ALARM:` had been read fell straight through. Today's landed 24 minutes later and spawned a session that spent 65 events reading the turn procedure before stalling with nothing to do.

## The fix

Both are the same missing concept — **recency per alarm name**, rather than co-occurrence in one batch. `_alarm_enqueued` records when we last enqueued for an alarm name; a repeat `ALARM:` inside `ALARM_REPEAT_WINDOW_S` (15m) and an `OK:` inside `OK_PAIRING_WINDOW_S` (2h) are coalesced.

Two windows because they are different judgments. An `OK:` is *never* work on its own — the agent-side rule is explicit that the `OK:` turn's whole job is to discover it should stand down — so a generous window is the safe answer. A repeat `ALARM:` might eventually be a genuinely new incident, so that one is tight.

**Bounded on purpose.** The stamp is written only on a real enqueue, never when coalescing, so a re-fire cannot extend its own suppression — an alarm flapping for an hour re-notifies once per window instead of being silently held down after the first page. That failure mode (silence that looks like health) is the one worth guarding, and it has its own test.

Still no LLM and no extra subprocess — the decision is a dict lookup, preserving this module's "fixed rule, no judgment in the hot path" contract, and it fails open everywhere it doesn't know.

## Tests

7 new tests. Verified they actually gate the change rather than decorate it: reverting `_alarm_incident_is_owned` to #670's behaviour turns exactly the two real-world cases red —

```
FAILED test_refired_alarm_on_the_same_thread_does_not_enqueue_again
FAILED test_ok_is_coalesced_even_when_its_alarm_was_an_earlier_batch
2 failed, 24 passed
```

The other five pass in both worlds by design — they are the guards proving I did **not** over-suppress: a different alarm, a human whose subject looks like an alarm, an `OK:` with no recent `ALARM:` (the alarm-creation `N/A → OK` notification), a re-fire after the window, and the no-self-extension property.

- `uv run --with pytest pytest` in `runner/canopy_runner` → **608 passed**
- `uv run ruff check . --select F --ignore F403,F405` → **All checks passed!**
- `hal-ci-gates`: 1 gate fires (`ci.yml`)

One note: `test_main.py::test_global_pause_sentinel_blocks_schedule_firing` failed on my first cold run and then passed 3/3 on re-run, and a clean control at my exact base (`c7efc47`) passes 601. It patches `time.sleep` and asserts on loop behaviour, so it looks timing-sensitive on a cold venv — flagging it rather than leaving it unexplained; it is not related to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPKNGjc2aSfB5q1YE3Nsg3