### PR TITLE
Say WHY the gog client credential read failed

### DIFF
--- a/runner/ec2/bootstrap_agents.sh
+++ b/runner/ec2/bootstrap_agents.sh
@@ -220,8 +220,21 @@ except Exception:
 ensure_client_creds() {  # <client> <agent-vault> <slug>
   local client="$1" agent_vault="$2" slug="$3"
   [[ -n "$client" ]] || return 0
-  command -v op >/dev/null 2>&1 || return 0
+  if ! command -v op >/dev/null 2>&1; then
+    warn "$slug: op unavailable — cannot materialize gog client creds for $client"
+    return 0
+  fi
 
+  # NOTE the vault split, and that it crosses the per-agent key boundary:
+  # bootstrap_one_agent exports a SCOPED OP_SERVICE_ACCOUNT_TOKEN that canopy-web
+  # issues per agent, and a per-agent key can read op://Agent-<Slug> and nothing
+  # else. Both shared clients live in Canopy-Shared, so those two arms need a key
+  # this function may not hold. Measured 2026-09-07 on cloud-ec2-1: inside ONE
+  # bootstrap pass, seconds apart, op://Agent-Ace reads succeeded (op inject, the
+  # gog-token read, credentials-ace.json) while op://Canopy-Shared/gog-oauth-client-web
+  # failed — so ACE imported a browser-minted token bound to `canopy-web` and then
+  # had no client id+secret to use it with. Every gmail call died on
+  # `No auth for gmail ace@dimagi-ai.com` with a perfectly good token beside it.
   local client_vault client_item
   case "$client" in
     canopy)     client_vault="Canopy-Shared"; client_item="gog-oauth-client" ;;
@@ -234,13 +247,23 @@ ensure_client_creds() {  # <client> <agent-vault> <slug>
   [[ -f "$client_file" ]] && return 0
 
   mkdir -p "$gog_dir"
-  if op read "op://${client_vault}/${client_item}/credential" >"$client_file" 2>/dev/null \
+  # Capture op's stderr rather than discarding it — the same lesson the token
+  # import below already learned, in the same file, twenty lines down. A bare
+  # "op read ... failed" names the path that failed and nothing about WHY, so the
+  # 2026-09-07 outage above was indistinguishable from a missing item, a revoked
+  # key, a throttle, or an outage. Five diagnostic round trips to a cloud box
+  # recovered one line op had already written and this function threw away.
+  local readerr
+  if readerr="$(op read "op://${client_vault}/${client_item}/credential" 2>&1 >"$client_file")" \
      && [[ -s "$client_file" ]]; then
     chmod 0600 "$client_file"
     ok "$slug: gog client creds ($client) -> $client_file"
   else
     rm -f "$client_file"
-    warn "$slug: op read op://${client_vault}/${client_item}/credential failed — gmail may not authorize as $client"
+    warn "$slug: op read op://${client_vault}/${client_item}/credential failed: ${readerr:-(no output)}"
+    [[ "$client_vault" == "Canopy-Shared" ]] && \
+      warn "$slug: $client is a SHARED client — this needs a key that can read Canopy-Shared, which a per-agent vault key cannot"
+    warn "$slug: gmail will not authorize as $client until this resolves"
   fi
 }
 

--- a/runner/ec2/tests/test_client_creds_says_why.py
+++ b/runner/ec2/tests/test_client_creds_says_why.py
@@ -1,0 +1,127 @@
+"""When `op read` fails, the box must say WHY — not just that it failed.
+
+A gog token is useless without its OAuth client's id+secret, and those two
+travel separately: the token arrives from the vault or from canopy-web, while
+`credentials-<client>.json` is always an `op read`. So a silent failure in
+ensure_client_creds leaves a perfectly good token that cannot authorize
+anything, and every gmail call dies on `No auth for gmail <mailbox>`.
+
+Measured 2026-09-07 on cloud-ec2-1, and the reason this file exists. In ONE
+bootstrap pass, seconds apart:
+
+    14:08:38  OK: ace: using canopy-web's token (newer: 1788788062 > 1777670602)
+    14:08:38  OK: ace: gmail token imported
+    14:08:39  WARN: ace: op read op://Canopy-Shared/gog-oauth-client-web/credential failed
+
+op://Agent-Ace reads succeeded throughout that same pass — `op inject`, the
+gog-token read, and credentials-ace.json were all written. Only the
+Canopy-Shared arm failed, because bootstrap_one_agent exports a per-agent
+scoped key and a per-agent key cannot read the shared vault.
+
+None of that was visible. The WARN named the path and swallowed op's reason
+(`2>/dev/null`), so the failure was indistinguishable from a missing item, a
+revoked key, a throttle, or a 1Password outage — and recovering the one line op
+had already written took five diagnostic round trips to the box.
+
+The token import twenty lines below already carries this exact lesson in a
+comment ("Swallowing it here is what hid a fleet-wide failure for weeks").
+These tests hold ensure_client_creds to the same standard.
+"""
+from __future__ import annotations
+
+import pathlib
+import shlex
+import subprocess
+
+SCRIPT = pathlib.Path(__file__).resolve().parent.parent / "bootstrap_agents.sh"
+
+# Deliberately NOT skipped on bash 3.2, unlike its sibling in this directory.
+# That skip exists because token_created_at's caller needs associative arrays;
+# ensure_client_creds uses none, so these run on a macOS laptop as well as on
+# the box. The sibling's tests reached CI unexecuted by anyone — the epoch bug
+# CI caught had been sitting in a green local run. Fewer skips, fewer of those.
+
+
+def _fn(name: str) -> str:
+    lines = SCRIPT.read_text().splitlines()
+    start = next(i for i, line in enumerate(lines) if line.startswith(f"{name}() {{"))
+    end = next(i for i in range(start + 1, len(lines)) if lines[i] == "}")
+    return "\n".join(lines[start:end + 1])
+
+
+def _run(tmp_path, client, *, op_stderr=None, op_present=True, op_stdout=""):
+    """Drive ensure_client_creds with a stubbed `op`, and return its log output.
+
+    The stub writes op_stdout to the credential file and op_stderr to stderr,
+    exiting non-zero when op_stderr is set — the shape of a real failed read.
+    """
+    gog_dir = tmp_path / "gogcli"
+    stub_dir = tmp_path / "bin"
+    stub_dir.mkdir()
+    if op_present:
+        op = stub_dir / "op"
+        if op_stderr is None:
+            op.write_text(f'#!/usr/bin/env bash\nprintf %s {shlex.quote(op_stdout)}\n')
+        else:
+            op.write_text(f'#!/usr/bin/env bash\nprintf %s {shlex.quote(op_stderr)} >&2\nexit 1\n')
+        op.chmod(0o755)
+
+    # A MINIMAL PATH, not an append to the caller's. `op` is a normal laptop
+    # install (/opt/homebrew/bin/op), so inheriting PATH would let the
+    # absent-op case find the REAL binary — the test would then exercise
+    # 1Password instead of the branch it names, and could make a live request.
+    script = f"""
+set -uo pipefail
+export PATH="{stub_dir}:/usr/bin:/bin"
+ok()   {{ echo "OK: $*"; }}
+warn() {{ echo "WARN: $*"; }}
+gog_config_dir() {{ printf '%s\\n' "{gog_dir}"; }}
+{_fn("ensure_client_creds")}
+ensure_client_creds "{client}" "Agent-Ace" "ace"
+"""
+    res = subprocess.run(["bash", "-c", script], capture_output=True, text=True, timeout=60)
+    return res.stdout
+
+
+REAL_OP_ERROR = (
+    '[ERROR] 2026/09/07 14:08:39 could not read secret '
+    '"op://Canopy-Shared/gog-oauth-client-web/credential": '
+    'error initializing client: No accounts configured for use with 1Password CLI'
+)
+
+
+def test_the_reason_op_gave_reaches_the_log(tmp_path):
+    """The whole point: op's own words, not a bare "failed"."""
+    out = _run(tmp_path, "canopy-web", op_stderr=REAL_OP_ERROR)
+    assert "No accounts configured for use with 1Password CLI" in out
+
+
+def test_a_shared_client_failure_names_the_vault_boundary(tmp_path):
+    """`canopy` and `canopy-web` read Canopy-Shared while the surrounding pass
+    holds a per-agent key. That is the actual defect behind the outage, so the
+    warning has to point at it rather than leaving the reader to rediscover it."""
+    out = _run(tmp_path, "canopy-web", op_stderr=REAL_OP_ERROR)
+    assert "Canopy-Shared" in out
+    assert "per-agent" in out
+
+
+def test_a_per_agent_client_does_not_claim_a_shared_vault_problem(tmp_path):
+    """The `*)` arm reads the agent's OWN vault, which the scoped key CAN read.
+    Blaming the shared vault there would send the next reader somewhere wrong."""
+    out = _run(tmp_path, "ace", op_stderr="some other failure")
+    assert "some other failure" in out
+    assert "per-agent" not in out
+
+
+def test_success_still_reports_success(tmp_path):
+    out = _run(tmp_path, "canopy-web", op_stdout='{"installed":{"client_id":"x"}}')
+    assert "OK: ace: gog client creds (canopy-web)" in out
+    assert "WARN" not in out
+
+
+def test_a_missing_op_is_not_silent(tmp_path):
+    """It used to `return 0` with no output at all — the one branch that left no
+    trace whatsoever, on a box where op is installed by cloud-init and could
+    plausibly be absent on a rebuild."""
+    out = _run(tmp_path, "canopy-web", op_present=False)
+    assert "op unavailable" in out


### PR DESCRIPTION
## What happened

A browser-minted token reached `cloud-ec2-1` and still could not authenticate. The token half of #684 worked exactly as designed; the half that runs one second later did not, and its warning named the path and threw the reason away.

One bootstrap pass, 2026-09-07, seconds apart:

```
14:08:38  OK: ace: using canopy-web's token (newer: 1788788062 > 1777670602)
14:08:38  OK: ace: gmail token imported
14:08:39  WARN: ace: op read op://Canopy-Shared/gog-oauth-client-web/credential failed
```

A refresh token is useless without its OAuth client's id+secret, and the two travel separately. So `gog gmail search` returned `No auth for gmail ace@dimagi-ai.com` — **the same string as having no token at all**, with a perfectly good token sitting beside it. That collision is what made this expensive to diagnose.

## The boundary underneath it

`bootstrap_one_agent` exports a per-agent scoped `OP_SERVICE_ACCOUNT_TOKEN` (#678/#681), and a per-agent key reads `op://Agent-<Slug>` and nothing else. But `ensure_client_creds` routes the two SHARED clients — `canopy` and `canopy-web` — to `Canopy-Shared`.

Evidence they collide, from that single pass: every `op://Agent-Ace` read succeeded (`op inject`, the `gog-token` read, `credentials-ace.json` written at 14:08) while the one `Canopy-Shared` read failed. Confirmed independently — the runner service has no runner-wide `OP_SERVICE_ACCOUNT_TOKEN` at all (absent from `runner.env`, the unit's `Environment=`, and the live process's `/proc/<pid>/environ`), so the `${op_token:-${OP_SERVICE_ACCOUNT_TOKEN:-}}` fallback has nothing to fall back to.

**This PR does not fix that boundary.** How the shared OAuth client should reach a box holding only a per-agent key is a decision, not a bug fix, and it wants a person — see below.

## What this PR does fix: the boundary was invisible

`2>/dev/null` meant a missing item, a revoked key, a throttle and a 1Password outage all rendered as the same eleven words. Recovering the one line `op` had already written took five diagnostic round trips to a cloud box.

The token import twenty lines below already carries this lesson in a comment — *"Swallowing it here is what hid a fleet-wide failure for weeks"*. Same mistake, same file, one function up.

Now:
- op's own stderr reaches the log
- a `Canopy-Shared` failure names the per-agent-key boundary as the likely cause
- a missing `op` warns instead of `return 0` — it was the one branch that left no trace at all

## Tests

Five, four of which fail against the unpatched script (the fifth is the success path, correctly unchanged).

Two deliberate departures from the sibling test file:
- **They run on bash 3.2 as well as 5.** `ensure_client_creds` uses no associative arrays, so the sibling's skip does not apply — and that skip is why CI was the first thing ever to execute those tests, which is how a hand-typed epoch got in.
- **Minimal `PATH`, not an inherited one.** `op` is a normal laptop install at `/opt/homebrew/bin/op`; inheriting `PATH` would let the absent-op case find the real binary and make a live 1Password request instead of testing the branch it names.

## The decision left open

Three ways to close the boundary, for whoever picks:

1. **Grant the per-agent service accounts read on `Canopy-Shared`.** Smallest change. That vault holds a shared OAuth client id+secret, not agent secrets, and every agent legitimately needs it.
2. **Serve the shared client creds from canopy-web's `/credentials/resolve`,** as #684 already does for the token. Most consistent with where this is heading; takes 1Password out of this path entirely.
3. **Restore a runner-wide token as the fallback the code already reaches for.** Reintroduces the broad key the per-agent split existed to remove — noted for completeness, not recommended.

Worth knowing either way: `ada`, `eva` and `hal` use client `canopy`, which is also `Canopy-Shared`. They are fine only because their `credentials-canopy.json` predates the split (Sep 5) and `ensure_client_creds` short-circuits on an existing file. **The first one of them that needs a re-fetch hits this same wall.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fa4YkvrDpVGJnhn5Bn4bF