### PR TITLE
runner: an alarm announcing its own creation is not a turn

### DIFF
--- a/runner/canopy_runner/canopy_runner/inbox.py
+++ b/runner/canopy_runner/canopy_runner/inbox.py
@@ -10,10 +10,13 @@ session (continuity) or a fresh one.
 """
 from __future__ import annotations
 
+import base64
+import binascii
 import json
 import re
 import subprocess
 import time
+from typing import NamedTuple
 
 # UNREAD only — the "new email" signal. Critically NOT "all recent threads":
 # every matched thread becomes a turn → a claude session, so an over-broad query
@@ -24,6 +27,22 @@ DEFAULT_QUERY = "in:inbox is:unread newer_than:14d"
 #: A CloudWatch/SNS alarm notification subject: `ALARM: "<name>" in <region>`, and its
 #: matching `OK: "<name>" in <region>`. The quoted alarm name is what pairs the two.
 _ALARM_SUBJECT = re.compile(r'^\s*(ALARM|OK):\s*"([^"]+)"')
+
+#: An alarm announcing its OWN CREATION, in the body of an otherwise ordinary `OK:`.
+#:
+#: CloudWatch emails every alarm carrying `OKActions` the moment it is created, and the
+#: subject is indistinguishable from a real recovery — same `OK: "<name>" in <region>`
+#: shape, same SNS sender. Only the body separates them, and it is unambiguous: a real
+#: recovery always names a concrete prior state (`ALARM -> OK`, `INSUFFICIENT_DATA -> OK`),
+#: while a creation has no prior state at all.
+#:
+#: So every monitoring PR that adds an alerting alarm used to dispatch a full agent
+#: session on a non-event. Measured on hal twice in two days —
+#: `labs-jj-web-cpu-high-actionable` (2026-09-06, connect-labs#1463) and
+#: `labs-jj-web-worker-kill-rate-actionable` (2026-09-07, connect-labs#1537, emailed
+#: 8 minutes after that PR merged). See #688.
+_ALARM_CREATION = re.compile(r"^\s*-?\s*State Change:\s*N/A\s*->\s*OK\s*$",
+                             re.MULTILINE)
 
 
 def alarm_key(thread: dict) -> tuple[str, str] | None:
@@ -89,11 +108,54 @@ def search_threads(mailbox: str, gog_client: str, query: str = DEFAULT_QUERY,
         raise InboxError(f"non-JSON from gog gmail search: {(r.stdout or '')[:150]!r}") from exc
 
 
-def newest_sender(mailbox: str, gog_client: str, thread_id: str, *,
-                  runner=subprocess.run) -> str | None:
-    """Return the From value of a thread's NEWEST message, lowercased — or None if it
-    can't be determined (gog missing/failed/timed-out, or an unparseable thread). None
-    is the fail-open signal: the caller enqueues rather than risk dropping a real reply."""
+class ThreadFacts(NamedTuple):
+    """What one `gog gmail thread get` tells us about a thread's NEWEST message.
+
+    Both fields fail OPEN — `newest_from=None` and `is_alarm_creation=False` are the
+    "we don't know" values, and every caller treats them as "enqueue normally".
+    """
+
+    #: The newest message's `From`, lowercased, or None if undeterminable.
+    newest_from: str | None = None
+    #: True only when the body positively identifies an alarm announcing its own
+    #: creation (see `_ALARM_CREATION`). Never a guess.
+    is_alarm_creation: bool = False
+
+
+def _decoded_body(msg: dict) -> str:
+    """The newest message's text body, or "" when it can't be decoded.
+
+    `gog gmail thread get --json` hands back the raw Gmail payload, so the body is
+    base64url in `payload.body.data` for a `text/plain` mail and in a part for a
+    multipart one. Anything unexpected returns "" — which reads as "not a creation
+    notice" and enqueues, the fail-open direction.
+    """
+    payload = msg.get("payload") or {}
+    chunks = [payload] + list(payload.get("parts") or [])
+    out = []
+    for p in chunks:
+        if (p.get("mimeType") or "").startswith("text/") or p is payload:
+            data = (p.get("body") or {}).get("data")
+            if not data:
+                continue
+            try:
+                out.append(base64.urlsafe_b64decode(data + "==").decode("utf-8", "replace"))
+            except (binascii.Error, ValueError):
+                continue
+    return "\n".join(out)
+
+
+def thread_facts(mailbox: str, gog_client: str, thread_id: str, *,
+                 runner=subprocess.run) -> ThreadFacts:
+    """ONE `gog gmail thread get`, every fact the enqueue decision needs.
+
+    This subprocess is the expensive call in this module, and it already returns the
+    whole message — headers AND body. It used to be spent on the `From` header alone
+    and the rest discarded, which is why the alarm-creation check in #688 was believed
+    to cost a body read it does not: the read is already paid for, only the parse is
+    new. Keep it that way — anything else the hot path needs from a thread belongs
+    here, not in a second fetch.
+    """
     try:
         r = runner(
             ["gog", "gmail", "thread", "get", thread_id, "--account", mailbox,
@@ -101,21 +163,32 @@ def newest_sender(mailbox: str, gog_client: str, thread_id: str, *,
             capture_output=True, text=True, timeout=45,
         )
     except (FileNotFoundError, subprocess.TimeoutExpired):
-        return None
+        return ThreadFacts()
     if r.returncode != 0:
-        return None
+        return ThreadFacts()
     try:
         data = json.loads(r.stdout or "{}")
     except ValueError:
-        return None
+        return ThreadFacts()
     msgs = data.get("messages") or (data.get("thread") or {}).get("messages") or []
     if not msgs:
-        return None
-    headers = (msgs[-1].get("payload") or {}).get("headers") or []
-    for h in headers:
+        return ThreadFacts()
+    newest = msgs[-1]
+    sender = None
+    for h in (newest.get("payload") or {}).get("headers") or []:
         if h.get("name", "").lower() == "from":
-            return (h.get("value") or "").lower()
-    return None
+            sender = (h.get("value") or "").lower()
+            break
+    return ThreadFacts(newest_from=sender,
+                       is_alarm_creation=bool(_ALARM_CREATION.search(_decoded_body(newest))))
+
+
+def newest_sender(mailbox: str, gog_client: str, thread_id: str, *,
+                  runner=subprocess.run) -> str | None:
+    """Return the From value of a thread's NEWEST message, lowercased — or None if it
+    can't be determined (gog missing/failed/timed-out, or an unparseable thread). None
+    is the fail-open signal: the caller enqueues rather than risk dropping a real reply."""
+    return thread_facts(mailbox, gog_client, thread_id, runner=runner).newest_from
 
 
 #: Thread states this runner has already turned into a turn, as
@@ -174,12 +247,16 @@ _alarm_enqueued: dict[tuple[str, str], float] = {}
 
 def check_inbox(client, agent: str, *, mailbox: str, gog_client: str,
                 query: str = DEFAULT_QUERY, max_threads: int = 15, runner=subprocess.run,
-                sender_of=None, discovered_by: str = "poll", clock=time.time) -> dict:
+                sender_of=None, facts_of=None, discovered_by: str = "poll",
+                clock=time.time) -> dict:
     """Enqueue an email-origin turn for each new thread state. Returns
     {"new": [thread_ids that became a NEW turn], "seen": [ids already tracked],
     "skipped": [ids whose newest message is the agent's own reply],
     "coalesced": [SNS alarm ids folded into an existing incident's turn — an `OK:`
-    recovery, or an `ALARM:` re-firing inside ALARM_REPEAT_WINDOW_S]} — the split matters
+    recovery, or an `ALARM:` re-firing inside ALARM_REPEAT_WINDOW_S],
+    "created": [SNS `OK:` ids that are an alarm announcing its OWN creation — a
+    non-event, in its own bucket because there is no incident to fold it into]}
+    — the split matters
     for logging: re-polling the same unread mail is idempotent server-side, so it must
     read as "nothing new", not as fresh work.
 
@@ -189,17 +266,25 @@ def check_inbox(client, agent: str, *, mailbox: str, gog_client: str,
     unread WITHOUT a new inbound message (a human nudge, a Gmail label reshuffle), the
     watcher would see a fresh (thread, count) and fire a turn whose "trigger" is the
     agent's own last reply. So: if the newest message in a thread is from the agent
-    itself, it has already had the last word — skip it. `sender_of(thread_id) -> str|None`
-    is injectable for tests; it defaults to a live `newest_sender` lookup and fails open
-    (None -> enqueue) so an unreadable thread never silently drops a real reply."""
-    if sender_of is None:
-        def sender_of(tid: str) -> str | None:
-            return newest_sender(mailbox, gog_client, tid, runner=runner)
+    itself, it has already had the last word — skip it. `facts_of(thread_id) ->
+    ThreadFacts` is injectable for tests; it defaults to a live `thread_facts` lookup
+    and fails open (unknown -> enqueue) so an unreadable thread never silently drops a
+    real reply. `sender_of(thread_id) -> str|None` is the narrower legacy seam, kept
+    because existing callers and tests inject it; supplying it opts out of every fact
+    that needs the body, so a `sender_of`-injected call behaves exactly as before."""
+    if facts_of is None:
+        if sender_of is not None:
+            def facts_of(tid: str) -> ThreadFacts:
+                return ThreadFacts(newest_from=sender_of(tid))
+        else:
+            def facts_of(tid: str) -> ThreadFacts:
+                return thread_facts(mailbox, gog_client, tid, runner=runner)
     threads = search_threads(mailbox, gog_client, query, max_threads, runner=runner)
     new: list[str] = []
     seen: list[str] = []
     skipped: list[str] = []
     coalesced: list[str] = []
+    created: list[str] = []
     box = mailbox.lower()
     # ONE INCIDENT, ONE TURN. CloudWatch emits `ALARM:` and `OK:` as two Gmail threads
     # (the subjects differ), so one alarm transition used to enqueue two turns — and the
@@ -248,7 +333,18 @@ def check_inbox(client, agent: str, *, mailbox: str, gog_client: str,
             # marks the whole storm read.
             _seen_state[(box, tid)] = count
             continue
-        latest = sender_of(tid)
+        facts = facts_of(tid)
+        # An alarm announcing its OWN creation. This is the one check that needs the
+        # body, and it is deliberately placed AFTER the two cheap guards above and on
+        # the SAME fetch as the sender — so it costs no subprocess this path was not
+        # already paying for (see `thread_facts`). Narrow on purpose: only an `OK:`
+        # from SNS (`alarm_key`) whose body says `N/A -> OK`. A real recovery names a
+        # concrete prior state and still fires. #688.
+        if key and key[0] == "OK" and facts.is_alarm_creation:
+            created.append(tid)
+            _seen_state[(box, tid)] = count
+            continue
+        latest = facts.newest_from
         if latest and box in latest:
             skipped.append(tid)
             # Remember it, so a thread the agent already answered does not cost a
@@ -277,4 +373,5 @@ def check_inbox(client, agent: str, *, mailbox: str, gog_client: str,
         if key and key[0] == "ALARM":
             _alarm_enqueued[(box, key[1])] = clock()
         (new if (res or {}).get("_created") else seen).append(tid)
-    return {"new": new, "seen": seen, "skipped": skipped, "coalesced": coalesced}
+    return {"new": new, "seen": seen, "skipped": skipped, "coalesced": coalesced,
+            "created": created}

--- a/runner/canopy_runner/canopy_runner/main.py
+++ b/runner/canopy_runner/canopy_runner/main.py
@@ -215,6 +215,7 @@ def _maybe_check_inboxes(cfg: Config, client: Client, now_fn=time.time,
             n_new, n_seen = len(res["new"]), len(res["seen"])
             n_skip = len(res.get("skipped", []))
             n_coal = len(res.get("coalesced", []))
+            n_created = len(res.get("created", []))
             # Log EVERY poll, not just ones that enqueue — otherwise a healthy poll that
             # finds nothing new is silent and you can't tell polling is happening at all.
             # `skipped` = unread threads whose newest message is the agent's own reply
@@ -223,10 +224,14 @@ def _maybe_check_inboxes(cfg: Config, client: Client, now_fn=time.time,
             # `coalesced` = a CloudWatch `OK:` folded into its `ALARM:` turn (one incident,
             # one session). Logged rather than silent: suppressing a turn is exactly the
             # kind of behaviour that must be visible when someone asks why no turn fired.
+            # `created` = an alarm announcing its own creation — no incident to fold into,
+            # so it gets its own count for the same visibility reason.
             logger.info("inbox[%s]: %s — %d unread (%d NEW -> session, %d already tracked, "
-                        "%d skipped: agent's own reply, %d coalesced: alarm OK: into its ALARM:)",
+                        "%d skipped: agent's own reply, %d coalesced: alarm OK: into its "
+                        "ALARM:, %d alarm self-creation notices)",
                         agent, "RUNG" if agent in rung_slugs else "polled",
-                        n_new + n_seen + n_skip + n_coal, n_new, n_seen, n_skip, n_coal)
+                        n_new + n_seen + n_skip + n_coal + n_created,
+                        n_new, n_seen, n_skip, n_coal, n_created)
         except Exception as exc:  # noqa: BLE001 — one bad inbox never kills the loop
             logger.warning("inbox check for %s failed: %s", agent, exc)
         finally:

--- a/runner/canopy_runner/tests/test_inbox.py
+++ b/runner/canopy_runner/tests/test_inbox.py
@@ -1,4 +1,5 @@
 """Deterministic inbox trigger — gmail threads → email-origin turns."""
+import base64
 import json
 from types import SimpleNamespace
 
@@ -48,7 +49,7 @@ def test_idempotency_key_includes_message_count():
 
 def test_empty_inbox_enqueues_nothing():
     client = FakeClient()
-    assert inbox.check_inbox(client, "hal", mailbox="m", gog_client="c", runner=_runner([])) == {"new": [], "seen": [], "skipped": [], "coalesced": []}
+    assert inbox.check_inbox(client, "hal", mailbox="m", gog_client="c", runner=_runner([])) == {"new": [], "seen": [], "skipped": [], "coalesced": [], "created": []}
     assert client.enqueued == []
 
 
@@ -358,3 +359,151 @@ def test_a_human_subject_that_looks_like_a_refire_is_never_suppressed():
                             runner=_runner(human), sender_of=lambda tid: "jjackson@dimagi.com",
                             clock=_clock(60))
     assert res["new"] == ["thr-human"]
+
+
+# --- An alarm announcing its OWN CREATION is not an incident (#688) ----------------
+#
+# CloudWatch emails every alarm carrying `OKActions` the moment it is created, under a
+# subject indistinguishable from a real recovery. Only the body separates them. Bodies
+# below are the real 2026-09-07 `labs-jj-web-worker-kill-rate-actionable` notice, which
+# burned a full hal session, and its real-recovery counterpart.
+
+_CREATION_OK = 'OK: "labs-jj-web-worker-kill-rate-actionable" in US East (N. Virginia)'
+
+_CREATION_BODY = (
+    "You are receiving this email because your Amazon CloudWatch Alarm "
+    '"labs-jj-web-worker-kill-rate-actionable" in the US East (N. Virginia) region has '
+    "transitioned to OK state on Monday 07 September, 2026 15:12:35 UTC, because "
+    '"arn:aws:cloudwatch:us-east-1:858923557655:alarm:'
+    'labs-jj-web-worker-kill-rate-actionable was created and its alarm rule evaluates '
+    'to OK".\r\n\r\nAlarm Details:\r\n'
+    "- Name:                       labs-jj-web-worker-kill-rate-actionable\r\n"
+    "- State Change:               N/A -> OK\r\n"
+    "- Timestamp:                  Monday 07 September, 2026 15:12:35 UTC\r\n"
+)
+
+_RECOVERY_BODY = (
+    "You are receiving this email because your Amazon CloudWatch Alarm "
+    '"labs-jj-web-cpu-high" ... has transitioned to OK state.\r\n\r\nAlarm Details:\r\n'
+    "- Name:                       labs-jj-web-cpu-high\r\n"
+    "- State Change:               ALARM -> OK\r\n"
+)
+
+
+def _b64(s: str) -> str:
+    return base64.urlsafe_b64encode(s.encode()).decode().rstrip("=")
+
+
+def _thread_get_payload(body: str, frm: str = SNS, *, parts=False) -> str:
+    """The shape `gog gmail thread get --json` actually returns."""
+    payload = {"mimeType": "text/plain", "headers": [{"name": "From", "value": frm}]}
+    if parts:
+        payload["mimeType"] = "multipart/alternative"
+        payload["body"] = {}
+        payload["parts"] = [{"mimeType": "text/plain", "body": {"data": _b64(body)}}]
+    else:
+        payload["body"] = {"data": _b64(body), "size": len(body)}
+    return json.dumps({"messages": [{"payload": payload}]})
+
+
+def _dual_runner(threads, body, frm=SNS, *, parts=False):
+    """`gog gmail search` -> the thread list; `gog gmail thread get` -> one message.
+
+    Exercises the REAL `thread_facts` path rather than the `facts_of` seam, so these
+    tests would still catch a regression in the base64 decode or the marker regex.
+    """
+    search = json.dumps({"threads": threads})
+    got = _thread_get_payload(body, frm, parts=parts)
+
+    def run(cmd, capture_output, text, timeout):
+        out = got if "thread" in cmd else search
+        return SimpleNamespace(returncode=0, stdout=out, stderr="")
+    return run
+
+
+def test_alarm_creation_notice_does_not_fire_a_turn():
+    """The bug in #688: `labs-jj-web-worker-kill-rate-actionable` had never fired, so
+    there was no `ALARM:` to pair with and the notice enqueued a full session."""
+    client = FakeClient()
+    threads = [{"id": "thr-created", "from": SNS, "subject": _CREATION_OK,
+                "messageCount": 1}]
+    res = inbox.check_inbox(client, "hal", mailbox="hal@dimagi-ai.com", gog_client="canopy",
+                            runner=_dual_runner(threads, _CREATION_BODY))
+    assert res["created"] == ["thr-created"]
+    assert res["new"] == []
+    assert client.enqueued == []
+
+
+def test_creation_notice_is_detected_inside_a_multipart_body():
+    client = FakeClient()
+    threads = [{"id": "thr-created", "from": SNS, "subject": _CREATION_OK,
+                "messageCount": 1}]
+    res = inbox.check_inbox(client, "hal", mailbox="hal@dimagi-ai.com", gog_client="canopy",
+                            runner=_dual_runner(threads, _CREATION_BODY, parts=True))
+    assert res["created"] == ["thr-created"]
+
+
+def test_a_real_recovery_still_fires():
+    """The load-bearing half: suppression must be narrow. A genuine `OK:` names a
+    concrete prior state and is the only signal there is, so it still becomes a turn."""
+    client = FakeClient()
+    threads = [{"id": "thr-ok", "from": SNS, "subject": _OK, "messageCount": 1}]
+    res = inbox.check_inbox(client, "hal", mailbox="hal@dimagi-ai.com", gog_client="canopy",
+                            runner=_dual_runner(threads, _RECOVERY_BODY))
+    assert res["new"] == ["thr-ok"]
+    assert res["created"] == []
+
+
+def test_creation_body_on_a_non_sns_sender_is_never_suppressed():
+    """`alarm_key` gates this on the SNS sender, like every other alarm rule here."""
+    client = FakeClient()
+    human = "Jonathan <jjackson@dimagi.com>"
+    threads = [{"id": "thr-human", "from": human, "subject": _CREATION_OK,
+                "messageCount": 1}]
+    res = inbox.check_inbox(client, "hal", mailbox="hal@dimagi-ai.com", gog_client="canopy",
+                            runner=_dual_runner(threads, _CREATION_BODY, frm=human))
+    assert res["new"] == ["thr-human"]
+    assert res["created"] == []
+
+
+def test_creation_marker_in_an_ALARM_subject_is_not_suppressed():
+    """Only an `OK:` can be a creation notice. An `ALARM:` is always an incident."""
+    client = FakeClient()
+    threads = [{"id": "thr-alarm", "from": SNS, "subject": _ALARM, "messageCount": 1}]
+    res = inbox.check_inbox(client, "hal", mailbox="hal@dimagi-ai.com", gog_client="canopy",
+                            runner=_dual_runner(threads, _CREATION_BODY))
+    assert res["new"] == ["thr-alarm"]
+    assert res["created"] == []
+
+
+def test_thread_facts_returns_sender_and_creation_flag_from_one_fetch():
+    facts = inbox.thread_facts(
+        "hal@dimagi-ai.com", "canopy", "thr-created",
+        runner=_dual_runner([], _CREATION_BODY))
+    assert facts.newest_from == SNS.lower()
+    assert facts.is_alarm_creation is True
+
+
+def test_thread_facts_fails_open_on_an_undecodable_body():
+    """Unknown must read as 'not a creation notice' — i.e. enqueue."""
+    def run(cmd, capture_output, text, timeout):
+        payload = json.dumps({"messages": [{"payload": {
+            "mimeType": "text/plain",
+            "headers": [{"name": "From", "value": SNS}],
+            "body": {"data": "!!!not base64!!!"}}}]})
+        return SimpleNamespace(returncode=0, stdout=payload, stderr="")
+    facts = inbox.thread_facts("hal@dimagi-ai.com", "canopy", "t", runner=run)
+    assert facts.newest_from == SNS.lower()
+    assert facts.is_alarm_creation is False
+
+
+def test_sender_of_injection_opts_out_of_body_facts():
+    """The legacy seam is unchanged: callers injecting `sender_of` get exactly the old
+    behaviour, body-derived facts included (i.e. excluded)."""
+    client = FakeClient()
+    threads = [{"id": "thr-created", "from": SNS, "subject": _CREATION_OK,
+                "messageCount": 1}]
+    res = inbox.check_inbox(client, "hal", mailbox="hal@dimagi-ai.com", gog_client="canopy",
+                            runner=_runner(threads), sender_of=lambda tid: SNS.lower())
+    assert res["new"] == ["thr-created"]
+    assert res["created"] == []


### PR DESCRIPTION
Closes #688.

## The bug

CloudWatch emails **every alarm carrying `OKActions` the moment it is created**, and the subject is indistinguishable from a real recovery:

```
Subject: OK: "labs-jj-web-worker-kill-rate-actionable" in US East (N. Virginia)
State Change:            N/A -> OK
Reason for State Change: ...was created and its alarm rule evaluates to OK
```

The alarm has never fired, so it is not in `alarming` and has no `_alarm_enqueued` entry — `_alarm_incident_is_owned()` correctly says "I don't know" and the notice falls through to `enqueue_turn()`. **Every monitoring PR that adds an alerting alarm dispatched a full agent session on a non-event.** Twice in two days on hal:

| Date | Alarm | Created by |
|---|---|---|
| 2026-09-06 | `labs-jj-web-cpu-high-actionable` | connect-labs#1463 |
| 2026-09-07 | `labs-jj-web-worker-kill-rate-actionable` | connect-labs#1537 — merged 15:04 UTC, emailed 15:12 UTC |

The second one dispatched the session that filed #688.

## Why this wasn't fixed here before

Hal's `skills/turn` carries a prose rule for it, noting the runner will not filter it **by design**: this classifier is deliberately subject-only, because a body read is the expensive subprocess the module is ordered to avoid.

That constraint is real as written and **does not apply**. `newest_sender()` already runs `gog gmail thread get --json` for every thread that reaches it — the whole payload, body included — and throws away everything except the `From` header. The read is already paid for; only the parse is new. (The Gmail `snippet` is *not* enough: it truncates at ~200 chars, before the `was created` clause.)

## The change

- **One fetch, two facts.** `thread_facts()` returns `(newest_from, is_alarm_creation)` from the call `newest_sender()` was already making; `newest_sender()` stays as a thin wrapper.
- **Suppress narrowly:** only an `alarm_key()` state of `OK` (so SNS sender + CloudWatch subject shape already proven) whose body matches `State Change: N/A -> OK`. A real recovery names a concrete prior state and still fires.
- **Placed after the two cheap guards**, preserving the module's cost ordering — the check runs only where a `thread get` was going to happen anyway.
- **Fail open everywhere**, unchanged: fetch failure, decode failure, parse failure, or an unrecognised body all enqueue exactly as today. `test_lone_ok_with_no_matching_alarm_still_fires` is untouched and green.
- **Its own `created` bucket**, not `coalesced` — nothing was folded into an incident, because there is no incident. Counted in the runner's per-poll log line for the same reason `coalesced` is: suppressing a turn must be visible.
- The legacy `sender_of=` seam still works and opts out of body-derived facts, so existing callers and tests behave exactly as before.

## Verification

**Gates** — `bin/hal-ci-gates` says only `ci.yml` fires on these paths (`regen-openapi.yml` excluded by its `paths:` filter; the other three have no push/PR trigger). Both gates my change can affect, with their own output:

- `uv run ruff check . --select F --ignore F403,F405` → `All checks passed!`
- `uv run --with pytest pytest` in `runner/canopy_runner` → **616 passed** (was 607)
- root `pytest` sets `--ignore=runner`, so it cannot be affected; frontend untouched.

**The guard is load-bearing, not decorative.** Stubbing the suppression to `if False:` turns exactly the two new end-to-end tests red (`614 passed, 2 failed`); restoring it returns 616 green.

**Against production**, via `thread_facts` on the real mailbox:

| thread | classified | what it is |
|---|---|---|
| `1a07c6da44a09cad` | `creation=True` | the notice that spawned the filing session |
| `1a07bd74de275246` | `creation=False` | a genuine `OK:` recovery |
| `1a07bd33ea332c85` | `creation=False` | a genuine `ALARM:` |

New tests cover: the creation notice end-to-end, a multipart body, a genuine recovery still firing, a non-SNS sender with the same body never suppressed, an `ALARM:` subject never suppressed, `thread_facts` returning both facts from one fetch, fail-open on an undecodable body, and the legacy `sender_of` seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEqN2khGoPXWMhDiTR6uqX
