### PR TITLE
Record the client the token declared, not the one the map guessed

### DIFF
--- a/runner/ec2/bootstrap_agents.sh
+++ b/runner/ec2/bootstrap_agents.sh
@@ -817,6 +817,21 @@ refresh_gmail_token() {  # <slug> <account> <client> <vault> <shared-vault> <sha
           ensure_client_creds "$tclient" "$vault" "$slug" "$shared_vault" "$shared_token"
         fi
         upsert_account_client "$account" "$tclient"
+        # Record WHICH client this token belongs to, for two consumers that both
+        # got it wrong without it.
+        #
+        # verify_mailbox falls back to the GOG_CLIENT map, and that map is the
+        # stale half of this whole story: it says `ace` while a browser-minted
+        # token declares `canopy-web`. Presenting a refresh token to Google with
+        # a DIFFERENT client's credentials returns `invalid_grant` — which reads
+        # as "token expired or revoked" and sends the next person to re-mint a
+        # token that was never the problem. Measured 2026-09-07 on cloud-ec2-1,
+        # where the readiness report said exactly that with gog_client empty.
+        #
+        # And the report itself: `gog_client` is the single most diagnostic field
+        # it carries, because which client is live is most of the diagnosis. It
+        # was blank on the first real report this system ever produced.
+        mark GOG_CLIENT_USED "$slug" "${tclient:-$client}"
       else
         warn "$slug: gog auth tokens import failed: ${importerr:-(no output)}"
         [[ -n "${GOG_KEYRING_PASSWORD:-}" ]] || \

--- a/runner/ec2/tests/test_readiness_is_observed.py
+++ b/runner/ec2/tests/test_readiness_is_observed.py
@@ -133,3 +133,24 @@ def test_one_implementation_of_the_token_rule_not_two(tmp_path):
     assert src.count("verify_mailbox \"$slug\"") == 2
     assert src.count("refresh_gmail_token() {") == 1
     assert src.count("verify_mailbox() {") == 1
+
+
+def test_the_token_declared_client_is_recorded_for_the_verify_and_the_report():
+    """`gog_client` was empty on the first real report this system produced, and
+    that emptiness is not cosmetic — it is the same missing fact that made the
+    verify use the wrong client.
+
+    A refresh token is minted FOR one OAuth client and works only with it. The
+    GOG_CLIENT map still says `ace` while a browser mint declares `canopy-web`,
+    so falling back to the map presents the token with the wrong client's
+    credentials and Google answers `invalid_grant`. That surfaces as "refresh
+    token expired or revoked" — which is false, and sends the next reader to
+    re-mint a token that was never the problem. Seen on cloud-ec2-1 2026-09-07.
+    """
+    src = SCRIPT.read_text()
+    after_import = src.split('upsert_account_client "$account" "$tclient"', 1)[1]
+    assert 'mark GOG_CLIENT_USED "$slug"' in after_import, \
+        "the client the TOKEN declared must be recorded, not left to the stale map"
+    # And verify_mailbox must prefer it over the map fallback.
+    vm = _fn("verify_mailbox")
+    assert 'GOG_CLIENT_USED[$slug]' in vm


### PR DESCRIPTION
Follow-up to #690, found *by* #690 — the first readiness report it produced was wrong in an informative way.

```json
{"mailbox_ok": false, "gog_client": "",
 "detail": "...refresh token expired or revoked: invalid_grant ... run 'gog auth add' to re-authorize"}
```

**The empty `gog_client` is the tell, and it is the same missing fact that produced the misleading error beside it.**

A refresh token is minted FOR one OAuth client and works only with that client. `verify_mailbox` fell back to the `GOG_CLIENT` map — the stale half of this whole story, which says `ace` while a browser mint declares `canopy-web`. Presenting the token with a *different* client's credentials is exactly what makes Google answer `invalid_grant`, and gog renders that as *"refresh token expired or revoked ... run `gog auth add`"*.

That advice is wrong, and expensively so: it sends the next person to re-mint a token that was never the problem, and to conclude the outage is something other than what it is. The token minted at 13:34 is very likely fine.

So the declared client is recorded where it is learned, and both consumers get it — `verify_mailbox` authenticates as the right client, and the report carries the field that is most of the diagnosis.

**This does not fix the underlying blocker.** `Canopy-Shared` is still unreadable by a per-agent key — the same report says so plainly, in the half of `detail` that is accurate. This stops the box lying about which client it tried.

199 runner tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fa4YkvrDpVGJnhn5Bn4bF
