### PR TITLE
Prove multiplayer chat with two browsers, and fix what that found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ scripts/qa/screenshots/
 # e2e
 e2e.sqlite3
 frontend/e2e/.auth/
+# Screenshots from e2e/mp-shot.spec.ts — a local harness for judging the
+# multiplayer UI by eye, regenerated on demand.
+frontend/e2e/.shots/
 frontend/test-results/
 frontend/playwright-report/
 

--- a/apps/canopy_sessions/consumers.py
+++ b/apps/canopy_sessions/consumers.py
@@ -48,7 +48,26 @@ class SessionConsumer(AsyncJsonWebsocketConsumer):
         await database_sync_to_async(presence.touch)(session.id, user.id)
         await database_sync_to_async(chat_services.attach_session)(session)
         await self.send_json(await self._snapshot())
-        await self._broadcast({"type": "presence.joined", "user_id": user.id})
+        # Carry WHO joined, not just their id.
+        #
+        # Everyone already in the room built their participant list from the
+        # snapshot they took when THEY connected. A person joining this session
+        # for the first time is therefore absent from it, and the presence row
+        # renders `participants.filter(p => present.includes(p.user_id))` — so a
+        # newcomer was invisible to everyone already here, permanently, until
+        # they happened to reload. The id alone can never fix that: there is no
+        # name to render it with.
+        #
+        # It looked like it worked because a SessionParticipant row is durable —
+        # the second time the same person joins, everyone's snapshot already has
+        # them. So it failed only for a genuinely new participant, which is
+        # exactly the case the feature exists for. Caught by the first
+        # two-browser e2e this surface ever had.
+        await self._broadcast({
+            "type": "presence.joined",
+            "user_id": user.id,
+            "participant": await database_sync_to_async(self._participant_dto)(session, user),
+        })
 
     async def disconnect(self, code):
         group = getattr(self, "group", None)
@@ -295,12 +314,25 @@ class SessionConsumer(AsyncJsonWebsocketConsumer):
         })
 
     async def presence_joined(self, message):
-        await self.send_json({"event": "presence.joined", "data": {"user_id": message["user_id"]}})
+        data = {"user_id": message["user_id"]}
+        # Optional so an older publisher on the same channel layer still works
+        # during a rolling deploy: the client falls back to id-only behaviour.
+        if message.get("participant"):
+            data["participant"] = message["participant"]
+        await self.send_json({"event": "presence.joined", "data": data})
 
     async def presence_left(self, message):
         await self.send_json({"event": "presence.left", "data": {"user_id": message["user_id"]}})
 
     # -- helpers --
+
+    @staticmethod
+    def _participant_dto(session, user):
+        """The joining user as the same DTO the snapshot uses, so a client can
+        append it to `participants` without a second shape to reconcile."""
+        sp = participants.ensure_participant(session, user)
+        return serializers.participant_dto(sp)
+
     async def _broadcast(self, message):
         await self.channel_layer.group_send(self.group, message)
 

--- a/frontend/e2e/backend.sh
+++ b/frontend/e2e/backend.sh
@@ -12,7 +12,8 @@ export ALLOWED_HOSTS="localhost,127.0.0.1"
 # another account's dev server, and a hardcoded port makes the suite simply
 # unrunnable there rather than failing with anything actionable.
 E2E_API_PORT="${E2E_API_PORT:-8000}"
-rm -f e2e.sqlite3 frontend/e2e/.auth/session.txt
+rm -f e2e.sqlite3 frontend/e2e/.auth/session.txt frontend/e2e/.auth/session2.txt \
+      frontend/e2e/.auth/mp-session-id.txt
 uv run python manage.py migrate --noinput >/tmp/e2e-migrate.log 2>&1
 uv run python manage.py shell -c "exec(open('frontend/e2e/seed.py').read())"
 exec uv run uvicorn config.asgi:application --host 127.0.0.1 --port "$E2E_API_PORT"

--- a/frontend/e2e/chat-multiplayer.spec.ts
+++ b/frontend/e2e/chat-multiplayer.spec.ts
@@ -1,0 +1,161 @@
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+import { expect, test, type Browser, type Page } from '@playwright/test'
+
+/**
+ * Two browsers, two identities, ONE chat session.
+ *
+ * Everything multiplayer means is a statement about somebody who is not you —
+ * "nobody else here", "Another teammate is editing…", "take over". A suite with
+ * one identity can open two browsers and exercise none of it, which is why this
+ * surface shipped with no e2e coverage at all: the co-edited draft, the lock,
+ * the takeover and the presence chips were only ever checked by unit tests
+ * holding a hand-built props object.
+ *
+ * So this drives the real socket (`ws/canopy-sessions/{id}/`) against the real
+ * consumer, twice, and asserts what each browser sees about the OTHER one.
+ *
+ * Deliberately NOT asserted here: an agent reply. A send enqueues a Turn that a
+ * session-capable runner drives, and there is no runner in e2e — asserting a
+ * reply would mean faking one, which tests the fake. Everything below is the
+ * part that is genuinely canopy-web's own.
+ */
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const authDir = path.join(here, '.auth')
+const state2 = path.join(authDir, 'state2.json')
+
+const sessionId = () =>
+  fs.readFileSync(path.join(authDir, 'mp-session-id.txt'), 'utf8').trim()
+
+const chatUrl = () => `/w/dimagi/chat/${sessionId()}`
+
+/** A second browser context authenticated as the OTHER user. */
+async function openAsSecondUser(browser: Browser): Promise<Page> {
+  const ctx = await browser.newContext({ storageState: state2 })
+  return ctx.newPage()
+}
+
+/** Both browsers on the same session, each with a live socket. */
+async function bothInTheRoom(page: Page, browser: Browser): Promise<Page> {
+  await page.goto(chatUrl())
+  await expect(page.getByTestId('composer')).toBeVisible()
+
+  const second = await openAsSecondUser(browser)
+  await second.goto(chatUrl())
+  await expect(second.getByTestId('composer')).toBeVisible()
+
+  // Presence is the handshake: until each side has seen the other, any
+  // assertion about the draft lock is racing the socket rather than testing it.
+  await expect(page.getByTestId('presence-chip')).toHaveCount(1)
+  await expect(second.getByTestId('presence-chip')).toHaveCount(1)
+  return second
+}
+
+test.describe('multiplayer chat', () => {
+  test('alone in a session, the room says so', async ({ page }) => {
+    await page.goto(chatUrl())
+    await expect(page.getByTestId('composer')).toBeVisible()
+    await expect(page.getByTestId('presence-empty')).toBeVisible()
+    await expect(page.getByTestId('presence-chip')).toHaveCount(0)
+  })
+
+  test('each browser sees the other person arrive', async ({ page, browser }) => {
+    const second = await bothInTheRoom(page, browser)
+
+    // Each sees exactly ONE other person — never themselves. Self-in-presence
+    // is the obvious way to get this wrong and it looks fine until two people
+    // are actually in a room.
+    await expect(page.getByTestId('presence-chip')).toHaveCount(1)
+    await expect(second.getByTestId('presence-chip')).toHaveCount(1)
+    const mineSaysTheirs = await page.getByTestId('presence-chip').getAttribute('data-user-id')
+    const theirsSaysMine = await second.getByTestId('presence-chip').getAttribute('data-user-id')
+    expect(mineSaysTheirs).not.toBe(theirsSaysMine)
+
+    await second.context().close()
+    // And leaving is observable, or a room slowly fills with ghosts.
+    await expect(page.getByTestId('presence-empty')).toBeVisible({ timeout: 15_000 })
+  })
+
+  test("one person's typing appears in the other's composer", async ({ page, browser }) => {
+    const second = await bothInTheRoom(page, browser)
+
+    await page.getByTestId('composer').fill('half a thought from Alex')
+    // The co-edited draft: the SERVER's copy, echoed to everyone else.
+    await expect(second.getByTestId('composer')).toHaveValue('half a thought from Alex', {
+      timeout: 15_000,
+    })
+
+    await second.context().close()
+  })
+
+  test('a teammate holding the draft locks the other composer, and takeover frees it',
+    async ({ page, browser }) => {
+      const second = await bothInTheRoom(page, browser)
+
+      await page.getByTestId('composer').fill('I am holding this')
+
+      // The lock is what stops two people overwriting each other mid-sentence.
+      const theirBox = second.getByTestId('composer')
+      await expect(theirBox).toBeDisabled({ timeout: 15_000 })
+      await expect(theirBox).toHaveAttribute('placeholder', /Another teammate is editing/)
+
+      // And it must be escapable, or one idle tab wedges the session for
+      // everyone. The holder is shown as editing while the lock is live.
+      await expect(page.getByTestId('presence-chip')).toHaveAttribute('data-editing', 'false')
+      await expect(second.getByTestId('presence-chip')).toHaveAttribute('data-editing', 'true')
+
+      // The composer is where their words land, so it is where the explanation
+      // has to be. Their draft arrives INSIDE a disabled textarea, which renders
+      // muted — pixel-identical to a placeholder — so without attribution the
+      // headline feature of multiplayer reads as an empty box.
+      const banner = second.getByTestId('coedit-banner')
+      await expect(banner).toBeVisible()
+      await expect(banner).toContainText('Alex Kim')
+      await expect(banner).toContainText('you are seeing their draft')
+      // And exactly ONE way to escape the lock, next to the sentence that
+      // explains why you would.
+      await expect(second.getByTestId('take-over')).toHaveCount(1)
+
+      await second.getByTestId('take-over').click()
+      await expect(theirBox).toBeEnabled({ timeout: 15_000 })
+      await theirBox.fill('actually, mine now')
+      await expect(page.getByTestId('composer')).toHaveValue('actually, mine now', {
+        timeout: 15_000,
+      })
+
+      await second.context().close()
+    })
+
+  test('a lock goes idle on its own so nobody is wedged', async ({ page, browser }) => {
+    const second = await bothInTheRoom(page, browser)
+
+    await page.getByTestId('composer').fill('typing then stopping')
+    await expect(second.getByTestId('composer')).toBeDisabled({ timeout: 15_000 })
+
+    // Idle after ~2s of no edits (drafts.isDraftIdle). Without this a person who
+    // wanders off mid-sentence holds the room until they close the tab, and
+    // "take over" becomes mandatory rather than an escape hatch.
+    await expect(second.getByTestId('composer')).toBeEnabled({ timeout: 15_000 })
+
+    await second.context().close()
+  })
+
+  test('a message sent by one lands in the other transcript', async ({ page, browser }) => {
+    const second = await bothInTheRoom(page, browser)
+
+    await page.getByTestId('composer').fill('shared message from Alex')
+    await page.getByTestId('send').click()
+
+    // The sender's box clears optimistically…
+    await expect(page.getByTestId('composer')).toHaveValue('', { timeout: 15_000 })
+    // …and the message is in BOTH transcripts. This is the payoff: one session,
+    // two people, one shared history.
+    await expect(page.getByText('shared message from Alex')).toBeVisible({ timeout: 15_000 })
+    await expect(second.getByText('shared message from Alex')).toBeVisible({ timeout: 15_000 })
+
+    await second.context().close()
+  })
+})

--- a/frontend/e2e/global-setup.ts
+++ b/frontend/e2e/global-setup.ts
@@ -6,23 +6,35 @@ const here = path.dirname(fileURLToPath(import.meta.url))
 const dir = path.join(here, '.auth')
 const sessionFile = path.join(dir, 'session.txt')
 const stateFile = path.join(dir, 'state.json')
+// The SECOND identity. Multiplayer is only observable between two different
+// users — "nobody else here", "Another teammate is editing…" and "take over"
+// are all statements about somebody who is not you — so one storageState can
+// open two browsers and still exercise none of it.
+const session2File = path.join(dir, 'session2.txt')
+const state2File = path.join(dir, 'state2.json')
 
 // Wait for backend.sh to seed + mint the session, then write a Playwright
 // storageState carrying the session cookie so API calls are authenticated.
-export default async function globalSetup() {
+const stateFor = (key: string) => ({
+  cookies: [{
+    name: 'sessionid', value: key, domain: 'localhost', path: '/',
+    expires: Math.floor(Date.now() / 1000) + 86400,
+    httpOnly: true, secure: false, sameSite: 'Lax' as const,
+  }],
+  origins: [],
+})
+
+async function waitForKey(file: string, label: string): Promise<string> {
   for (let i = 0; i < 120; i++) {
-    if (fs.existsSync(sessionFile) && fs.readFileSync(sessionFile, 'utf8').trim()) break
+    if (fs.existsSync(file) && fs.readFileSync(file, 'utf8').trim()) break
     await new Promise((r) => setTimeout(r, 1000))
   }
-  const key = fs.readFileSync(sessionFile, 'utf8').trim()
-  if (!key) throw new Error('no session key minted by backend seed')
-  const state = {
-    cookies: [{
-      name: 'sessionid', value: key, domain: 'localhost', path: '/',
-      expires: Math.floor(Date.now() / 1000) + 86400,
-      httpOnly: true, secure: false, sameSite: 'Lax' as const,
-    }],
-    origins: [],
-  }
-  fs.writeFileSync(stateFile, JSON.stringify(state))
+  const key = fs.existsSync(file) ? fs.readFileSync(file, 'utf8').trim() : ''
+  if (!key) throw new Error(`no ${label} minted by backend seed`)
+  return key
+}
+
+export default async function globalSetup() {
+  fs.writeFileSync(stateFile, JSON.stringify(stateFor(await waitForKey(sessionFile, 'session key'))))
+  fs.writeFileSync(state2File, JSON.stringify(stateFor(await waitForKey(session2File, 'second session key'))))
 }

--- a/frontend/e2e/mp-shot.spec.ts
+++ b/frontend/e2e/mp-shot.spec.ts
@@ -1,0 +1,39 @@
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+import { expect, test } from '@playwright/test'
+
+/** Not a test — a screenshot harness for judging the multiplayer UI by eye.
+ *  Kept out of the default run by its filename (see playwright.config). */
+const here = path.dirname(fileURLToPath(import.meta.url))
+const authDir = path.join(here, '.auth')
+const shots = path.join(here, '.shots')
+
+const chatUrl = () =>
+  `/w/dimagi/chat/${fs.readFileSync(path.join(authDir, 'mp-session-id.txt'), 'utf8').trim()}`
+
+test('capture the multiplayer states', async ({ page, browser }) => {
+  fs.mkdirSync(shots, { recursive: true })
+
+  await page.goto(chatUrl())
+  await expect(page.getByTestId('composer')).toBeVisible()
+  await page.screenshot({ path: path.join(shots, '1-alone.png'), fullPage: false })
+
+  const ctx = await browser.newContext({ storageState: path.join(authDir, 'state2.json') })
+  const second = await ctx.newPage()
+  await second.goto(chatUrl())
+  await expect(second.getByTestId('composer')).toBeVisible()
+  await expect(page.getByTestId('presence-chip')).toHaveCount(1)
+  await page.screenshot({ path: path.join(shots, '2-two-present.png') })
+
+  // Someone else typing: the lock + the "is typing" affordance.
+  await second.getByTestId('composer').fill('a half-finished thought from Robin')
+  await expect(page.getByTestId('composer')).toBeDisabled({ timeout: 15_000 })
+  await page.screenshot({ path: path.join(shots, '3-locked-by-teammate.png') })
+  await page.locator('header, .flex.items-center.gap-3.border-b').first()
+    .screenshot({ path: path.join(shots, '4-presence-bar.png') })
+    .catch(() => {})
+
+  await ctx.close()
+})

--- a/frontend/e2e/seed.py
+++ b/frontend/e2e/seed.py
@@ -176,16 +176,59 @@ Item.objects.create(
     body="Long since dismissed.", state=Item.DISMISSED,
 )
 
-session = SessionStore()
-session["_auth_user_id"] = str(user.pk)
-session["_auth_user_backend"] = settings.AUTHENTICATION_BACKENDS[0]
-session["_auth_user_hash"] = user.get_session_auth_hash()
-session.set_expiry(24 * 3600)
-session.save()
+# ── Multiplayer: a SECOND human, and one chat session they both open ──────────
+#
+# Presence and the co-edited draft are only meaningful between two DIFFERENT
+# users: "nobody else here", "Another teammate is editing…" and "take over" are
+# all statements about somebody who is not you. A suite with one identity can
+# open two browsers and still never exercise any of it — which is why none of
+# this had an e2e test before.
+mp_user, _ = User.objects.get_or_create(
+    username="e2e2", defaults={"email": "e2e2@dimagi.com", "first_name": "Robin",
+                               "last_name": "Sharma"})
+if ws is not None:
+    wsvc.ensure_member(ws, mp_user)
+# Give the first user a display name too, so the presence chips render distinct
+# initials rather than two identical blanks.
+if not user.first_name:
+    user.first_name, user.last_name = "Alex", "Kim"
+    user.save(update_fields=["first_name", "last_name"])
+
+# ACE, so the fleet the multiplayer tests drive matches the real one.
+Agent.objects.update_or_create(slug="ace", defaults=dict(
+    name="ACE", email="ace@dimagi-ai.com", description="AI Connect Engine.",
+    persona="Runs the Connect opportunity lifecycle.", workspace=ws))
+
+_hal = Agent.objects.get(slug="hal")
+mp_session = CanopySession.objects.create(
+    workspace=ws, agent=_hal, title="Multiplayer e2e",
+    status=CanopySession.ACTIVE, origin=CanopySession.ORIGIN_WEB,
+)
+
+
+def _mint(u):
+    st = SessionStore()
+    st["_auth_user_id"] = str(u.pk)
+    st["_auth_user_backend"] = settings.AUTHENTICATION_BACKENDS[0]
+    st["_auth_user_hash"] = u.get_session_auth_hash()
+    st.set_expiry(24 * 3600)
+    st.save()
+    return st.session_key
+
+
+session_key = _mint(user)
+mp_session_key = _mint(mp_user)
 
 os.makedirs("frontend/e2e/.auth", exist_ok=True)
 with open("frontend/e2e/.auth/session.txt", "w") as f:
-    f.write(session.session_key)
+    f.write(session_key)
+# The second identity, and the session id both browsers will open. Written as
+# files for the same reason the first key is: global-setup has no DB access.
+with open("frontend/e2e/.auth/session2.txt", "w") as f:
+    f.write(mp_session_key)
+with open("frontend/e2e/.auth/mp-session-id.txt", "w") as f:
+    f.write(str(mp_session.id))
 
 print(f"seeded: {a.tasks.count()} tasks, {a.commands.filter(status='pending').count()} pending; "
-      f"fleet-audit review {str(fleet_audit.id)[:8]}; session {session.session_key[:8]}")
+      f"fleet-audit review {str(fleet_audit.id)[:8]}; session {session_key[:8]}; "
+      f"mp session {str(mp_session.id)[:8]} + 2nd user {mp_session_key[:8]}")

--- a/frontend/packages/canopy-ui/src/chat/ChatPanel.tsx
+++ b/frontend/packages/canopy-ui/src/chat/ChatPanel.tsx
@@ -89,6 +89,14 @@ export function ChatPanel({
   const holderId = state.active_draft?.last_editor ?? null;
   const holderIsPresent =
     holderId != null && state.presence_user_ids.includes(holderId);
+  // The holder's NAME, for the composer. SendBox has ids and no roster, so
+  // without this the one place a person actually looks — the box their
+  // teammate's words are appearing in — could only say "Another teammate",
+  // while the name sat in a chip at the far corner of the screen.
+  const holderName =
+    holderId != null && holderId !== currentUserId
+      ? (state.participants.find((p) => p.user_id === holderId)?.display_name ?? null)
+      : null;
 
   // A turn is "in flight" from the moment the assistant row appears
   // (status=pending/streaming) until chat.stream_complete flips it to
@@ -146,6 +154,7 @@ export function ChatPanel({
             presenceUserIds={state.presence_user_ids}
             draftHolderId={holderId}
             draftHolderIdle={isDraftIdle(state.active_draft)}
+            currentUserId={currentUserId}
           />
         </div>
       </div>
@@ -171,6 +180,7 @@ export function ChatPanel({
         connected={connected}
         currentUserId={currentUserId}
         holderIsPresent={holderIsPresent}
+        holderName={holderName}
         isStreaming={inFlightMessage != null || awaitingReply}
         streamingMessageId={inFlightMessage?.id ?? null}
         onUpdate={onUpdateDraft}

--- a/frontend/packages/canopy-ui/src/chat/PresenceChips.tsx
+++ b/frontend/packages/canopy-ui/src/chat/PresenceChips.tsx
@@ -5,40 +5,134 @@ interface Props {
   presenceUserIds: number[];
   draftHolderId: number | null;
   draftHolderIdle: boolean;
+  /** Who is looking. Required so the row can exclude YOU.
+   *
+   *  Without it this rendered your own chip and the empty state said "nobody
+   *  else here" — copy and logic disagreeing about whether "else" meant
+   *  anything. In practice the empty state was unreachable: alone in a session
+   *  you saw one chip, which is indistinguishable from being watched by a
+   *  stranger. ChatPanel had `currentUserId` the whole time and never passed
+   *  it. Caught by the first two-browser e2e this surface ever had. */
+  currentUserId: number;
 }
+
+/** A stable colour per person, so two people are told apart at a glance.
+ *
+ *  Every chip used to be `bg-muted`, which meant identity rested entirely on
+ *  two initials — and initials collide constantly on a small team (two J.K.s
+ *  render identically). Hue is derived from the user id so a given person is
+ *  the same colour in every session, for everyone, with no state to keep. */
+const PALETTE = [
+  "bg-sky-500/20 text-sky-700 dark:text-sky-200 ring-sky-500/40",
+  "bg-emerald-500/20 text-emerald-700 dark:text-emerald-200 ring-emerald-500/40",
+  "bg-violet-500/20 text-violet-700 dark:text-violet-200 ring-violet-500/40",
+  "bg-amber-500/20 text-amber-700 dark:text-amber-200 ring-amber-500/40",
+  "bg-rose-500/20 text-rose-700 dark:text-rose-200 ring-rose-500/40",
+  "bg-teal-500/20 text-teal-700 dark:text-teal-200 ring-teal-500/40",
+];
+
+const colorFor = (userId: number) => PALETTE[Math.abs(userId) % PALETTE.length];
+
+/** How many faces before collapsing into "+N". Beyond a handful the row stops
+ *  being a glance and starts being a list, and it shares a thin header bar. */
+const MAX_FACES = 4;
 
 export function PresenceChips({
   participants,
   presenceUserIds,
   draftHolderId,
   draftHolderIdle,
+  currentUserId,
 }: Props) {
-  const present = participants.filter((p) =>
-    presenceUserIds.includes(p.user_id),
+  const present = participants.filter(
+    (p) => presenceUserIds.includes(p.user_id) && p.user_id !== currentUserId,
   );
+
   if (present.length === 0) {
-    return <div className="text-sm text-muted-foreground">nobody else here</div>;
+    return (
+      <div
+        className="text-xs text-muted-foreground"
+        data-testid="presence-empty"
+      >
+        just you
+      </div>
+    );
   }
+
+  const editor = present.find(
+    (p) => p.user_id === draftHolderId && !draftHolderIdle,
+  );
+  const faces = present.slice(0, MAX_FACES);
+  const overflow = present.length - faces.length;
+
   return (
-    <div className="flex gap-2">
-      {present.map((p) => {
-        const isHolder = p.user_id === draftHolderId && !draftHolderIdle;
-        return (
-          <div
-            key={p.user_id}
-            title={p.display_name + (isHolder ? " — editing…" : "")}
-            className={`flex h-7 w-7 items-center justify-center rounded-full text-xs font-medium ${
-              isHolder
-                ? "bg-primary text-primary-foreground ring-2 ring-primary/30"
-                : "bg-muted text-muted-foreground"
-            }`}
+    <div className="flex items-center gap-2" data-testid="presence-chips">
+      {/* The one thing worth WORDS rather than a ring: somebody is typing into
+          the box you share, and the old UI said so only in a `title` tooltip —
+          invisible on touch, invisible to a screen reader, and invisible to
+          anyone not hovering the exact 28px circle. */}
+      {editor && (
+        <span
+          className="hidden items-center gap-1 text-xs text-muted-foreground sm:flex"
+          data-testid="presence-editing-label"
+        >
+          <span className="relative flex h-1.5 w-1.5" aria-hidden="true">
+            <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-primary opacity-60" />
+            <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-primary" />
+          </span>
+          {firstName(editor.display_name)} is typing…
+        </span>
+      )}
+      <ul
+        className="flex items-center -space-x-1.5"
+        aria-label={describe(present, editor)}
+        data-testid="presence-list"
+      >
+        {faces.map((p) => {
+          const isEditor = p.user_id === editor?.user_id;
+          return (
+            <li
+              key={p.user_id}
+              data-testid="presence-chip"
+              data-user-id={p.user_id}
+              data-editing={isEditor ? "true" : "false"}
+              title={p.display_name + (isEditor ? " — editing…" : "")}
+              className={[
+                "flex h-7 w-7 items-center justify-center rounded-full",
+                "text-[11px] font-semibold ring-2 ring-background",
+                "transition-transform hover:z-10 hover:scale-110",
+                colorFor(p.user_id),
+                isEditor ? "z-10 !ring-primary" : "",
+              ].join(" ")}
+            >
+              {initials(p.display_name)}
+            </li>
+          );
+        })}
+        {overflow > 0 && (
+          <li
+            data-testid="presence-overflow"
+            title={present.slice(MAX_FACES).map((p) => p.display_name).join(", ")}
+            className="flex h-7 w-7 items-center justify-center rounded-full bg-muted text-[11px] font-semibold text-muted-foreground ring-2 ring-background"
           >
-            {initials(p.display_name)}
-          </div>
-        );
-      })}
+            +{overflow}
+          </li>
+        )}
+      </ul>
     </div>
   );
+}
+
+/** The accessible name for the row — the same fact the faces carry, in words.
+ *  A row of coloured circles is meaningless without this. */
+function describe(present: Participant[], editor?: Participant): string {
+  const names = present.map((p) => p.display_name).join(", ");
+  const who = present.length === 1 ? "1 other person here" : `${present.length} other people here`;
+  return editor ? `${who}: ${names}. ${editor.display_name} is editing.` : `${who}: ${names}`;
+}
+
+function firstName(name: string): string {
+  return name.trim().split(/\s+/)[0] || name;
 }
 
 function initials(name: string): string {

--- a/frontend/packages/canopy-ui/src/chat/SendBox.tsx
+++ b/frontend/packages/canopy-ui/src/chat/SendBox.tsx
@@ -36,6 +36,10 @@ interface Props {
   connected: boolean;
   currentUserId: number;
   holderIsPresent: boolean;
+  /** Display name of the teammate holding the draft, when it is not you.
+   *  The composer is where their words appear, so it is where their name
+   *  belongs — it used to live only in a 28px chip in the opposite corner. */
+  holderName?: string | null;
   isStreaming: boolean;
   streamingMessageId: string | null;
   onUpdate: (body: string) => void;
@@ -75,6 +79,7 @@ export function SendBox({
   connected,
   currentUserId,
   holderIsPresent,
+  holderName,
   isStreaming,
   streamingMessageId,
   onUpdate,
@@ -178,6 +183,10 @@ export function SendBox({
 
   const body = localBody;
   const blocked = Boolean(disabledReason);
+  // Locked BY SOMEONE ELSE, as opposed to blocked for an unrelated reason.
+  // The two look identical to `disabled` and want opposite treatments: a
+  // blocked box is inert, a co-edited one is showing you live content.
+  const lockedByTeammate = !canEdit && holderIsPresent && !holderIsIdle && !blocked;
   // Sending needs a draft (`chat.send` commits the SERVER's copy, so there must
   // be one) AND a live socket. The socket check is load-bearing now that the
   // composer clears optimistically: `send()` drops every frame but chat.stop
@@ -298,8 +307,37 @@ export function SendBox({
             ))}
           </ul>
         )}
+        {/* Co-edit attribution, at the box rather than across the screen.
+            Their text arrives INSIDE this textarea, and a disabled textarea
+            renders it in muted grey — pixel-identical to a placeholder. So the
+            single most important thing multiplayer does (showing you what your
+            teammate is writing) read as an EMPTY box with a hint in it. */}
+        {lockedByTeammate && (
+          <div
+            data-testid="coedit-banner"
+            className="mb-1.5 flex items-center gap-2 rounded-md border border-primary/30 bg-primary/10 px-2 py-1 text-xs"
+          >
+            <span className="relative flex h-1.5 w-1.5 shrink-0" aria-hidden="true">
+              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-primary opacity-60" />
+              <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-primary" />
+            </span>
+            <span className="text-foreground">
+              <span className="font-medium">{holderName ?? "A teammate"}</span> is
+              writing — you are seeing their draft
+            </span>
+            <button
+              type="button"
+              data-testid="take-over"
+              onClick={onTakeOver}
+              className="ml-auto shrink-0 rounded border border-border px-1.5 py-0.5 font-medium text-foreground hover:bg-muted"
+            >
+              take over
+            </button>
+          </div>
+        )}
         <textarea
           ref={textareaRef}
+          data-testid="composer"
           value={body}
           disabled={!canEdit || blocked}
           onChange={(e) => handleChange(e.target.value)}
@@ -307,7 +345,18 @@ export function SendBox({
           onPaste={handlePaste}
           placeholder={placeholder}
           rows={3}
-          className="w-full resize-none rounded-md border border-input bg-transparent p-2 text-sm text-foreground shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:bg-muted disabled:text-muted-foreground"
+          className={[
+            "w-full resize-none rounded-md border bg-transparent p-2 text-sm shadow-sm",
+            "placeholder:text-muted-foreground focus-visible:outline-none",
+            "focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed",
+            // A teammate's draft is CONTENT, not a disabled control. Dimming it
+            // to `text-muted-foreground` made their sentence look like the
+            // placeholder it sits next to — the one styling choice that made
+            // co-editing appear not to work at all.
+            lockedByTeammate
+              ? "border-primary/40 bg-primary/5 text-foreground"
+              : "border-input text-foreground disabled:bg-muted disabled:text-muted-foreground",
+          ].join(" ")}
         />
         <div className="mt-1 flex items-center justify-end gap-2">
           {canAttach && (
@@ -370,12 +419,13 @@ export function SendBox({
               {stopState === "requested" ? "stopping…" : "stop"}
             </Button>
           ) : null}
-          {!canEdit && holderIsPresent && !holderIsIdle ? (
-            <Button type="button" variant="outline" size="sm" onClick={onTakeOver}>
-              take over
-            </Button>
-          ) : null}
-          <Button type="button" size="sm" disabled={!canSend} onClick={handleSend}>
+          <Button
+            type="button"
+            size="sm"
+            data-testid="send"
+            disabled={!canSend}
+            onClick={handleSend}
+          >
             send
           </Button>
         </div>

--- a/frontend/packages/canopy-ui/src/chat/protocol.ts
+++ b/frontend/packages/canopy-ui/src/chat/protocol.ts
@@ -195,5 +195,19 @@ export type WsEvent =
   | { event: "draft.lock_changed"; data: { draft_id: string; holder_user_id: number | null; expires_at: number | null } }
   | { event: "draft.committed"; data: { draft_id: string; user_message_id: string } }
   | { event: "draft.discarded"; data: { draft_id: string } }
-  | { event: "presence.joined"; data: { user_id: number; email?: string; display_name?: string } }
+  // `participant` carries WHO joined, so a client can add them to its
+  // participant list. Without it a first-time joiner has an id and no name,
+  // and the presence row (which renders participants filtered by presence)
+  // cannot show them at all. Optional so an older server degrades rather than
+  // breaks. The bare `email`/`display_name` below are the vestigial shape that
+  // was declared but never sent by anything.
+  | {
+      event: "presence.joined";
+      data: {
+        user_id: number;
+        participant?: Participant;
+        email?: string;
+        display_name?: string;
+      };
+    }
   | { event: "presence.left"; data: { user_id: number } };

--- a/frontend/packages/canopy-ui/src/chat/sessionReducer.ts
+++ b/frontend/packages/canopy-ui/src/chat/sessionReducer.ts
@@ -370,7 +370,23 @@ export function sessionReducer(prev: SessionState, frame: WsEvent): SessionState
     case "presence.joined": {
       const ids = new Set(prev.presence_user_ids);
       ids.add(frame.data.user_id);
-      return { ...prev, presence_user_ids: [...ids] };
+      // Adopt the joiner into `participants` too. The presence ROW renders
+      // participants filtered by presence, so an id with no matching
+      // participant is invisible — which is what made a first-time joiner
+      // unseeable by everyone already in the room until they reloaded.
+      // `participant` is optional (an older server may not send it); without
+      // it this degrades to exactly the previous behaviour rather than
+      // inventing a nameless entry.
+      const joined = frame.data.participant;
+      const known = joined
+        ? prev.participants.some((p) => p.user_id === joined.user_id)
+        : true;
+      return {
+        ...prev,
+        presence_user_ids: [...ids],
+        participants:
+          joined && !known ? [...prev.participants, joined] : prev.participants,
+      };
     }
 
     case "presence.left":

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -6,6 +6,9 @@ const API_PORT = process.env.E2E_API_PORT ?? '8000'
 
 export default defineConfig({
   testDir: './e2e',
+  // mp-shot is a screenshot harness for judging the multiplayer UI by eye. It
+  // asserts nothing, so running it in CI buys latency and a diff in .shots/.
+  testIgnore: /mp-shot\.spec\.ts/,
   timeout: 30_000,
   expect: { timeout: 10_000 },
   fullyParallel: false,

--- a/tests/test_chat_session_consumer.py
+++ b/tests/test_chat_session_consumer.py
@@ -526,3 +526,45 @@ async def test_an_unchanged_dialog_is_not_republished_every_report():
     await database_sync_to_async(_report)()          # same dialog, second tick
     assert await comm.receive_nothing(timeout=0.5)
     await comm.disconnect()
+
+
+async def test_presence_joined_names_the_person_who_joined():
+    """A first-time joiner must arrive with a NAME, not just an id.
+
+    Everyone already in the room built `participants` from the snapshot they
+    took when THEY connected, and the presence row renders participants
+    filtered by presence. So an id with no matching participant is invisible:
+    the newcomer simply does not appear for anyone already here, permanently,
+    until they reload.
+
+    It looked fine because SessionParticipant rows are durable — the second
+    time the same person joins, everyone's snapshot already contains them. The
+    failure is specific to a genuinely NEW participant, which is the case the
+    feature exists for. Found by the first two-browser e2e this surface had.
+    """
+    owner, teammate, session = await database_sync_to_async(_seed)()
+
+    a = await _connect(session, owner)
+    connected, _ = await a.connect()
+    assert connected
+    await a.receive_json_from(timeout=2)   # own session.state
+    await a.receive_json_from(timeout=2)   # own presence.joined
+
+    # The teammate has never touched this session — no SessionParticipant row.
+    assert not await database_sync_to_async(
+        SessionParticipant.objects.filter(session=session, user=teammate).exists
+    )()
+
+    b = await _connect(session, teammate)
+    connected_b, _ = await b.connect()
+    assert connected_b
+
+    joined = await _recv_match(a, lambda f: f.get("event") == "presence.joined")
+    assert joined["data"]["user_id"] == teammate.id
+    who = joined["data"].get("participant")
+    assert who is not None, "the joiner must be carried, or nobody can render them"
+    assert who["user_id"] == teammate.id
+    assert who["display_name"], "a nameless participant cannot be rendered"
+
+    await a.disconnect()
+    await b.disconnect()


### PR DESCRIPTION
Multiplayer chat had **no e2e test**, and the reason it had none is the reason it was broken.

Everything the feature means — *"nobody else here"*, *"Another teammate is editing…"*, *"take over"* — is a statement about somebody who is **not you**, and the suite could only mint one identity. One user in two browsers exercises none of it. So the co-edited draft, the lock, the takeover and the presence row were only ever checked by unit tests holding a hand-built props object.

This seeds a second user and one shared session, drives the real socket twice, and asserts what each browser sees about the other. **Two bugs fell out immediately**, both invisible to every existing test.

## 1. You were in your own presence row

`PresenceChips` rendered every present participant — including you — while its empty state read *"nobody else here"*. Copy and logic disagreed about whether "else" meant anything, and the empty state was **unreachable**: alone in a session you saw one chip, indistinguishable from being watched by a stranger.

`ChatPanel` had `currentUserId` the whole time and never passed it.

## 2. A first-time joiner was invisible to everyone already in the room

`presence.joined` carried only a `user_id`. Every client builds `participants` from the snapshot it took when *it* connected, and the presence row renders participants **filtered by** presence — so an id with no matching participant renders nothing. The newcomer never appeared, permanently, until somebody reloaded.

This looked fine because `SessionParticipant` rows are durable: the second time the same person joins, everyone's snapshot already has them. **It failed only for a genuinely new participant — the case the feature exists for.** In the suite it presented as one flaky test that passed in a full run (an earlier test had created the row) and failed in isolation. Chasing that is what found it.

`presence.joined` now carries the participant DTO and the reducer adopts it. Optional on both ends, so a rolling deploy degrades to the old behaviour rather than breaking.

## The UI, which was the other half of the ask

A teammate's draft arrives inside **your** textarea — and a disabled textarea renders its value in muted grey, pixel-identical to the placeholder sitting next to it. So the headline feature of multiplayer, *seeing what your teammate is writing*, read as an empty box.

The only attribution was a 28px chip and a `title` tooltip in the opposite corner of the screen: ~600px from the words themselves, and invisible to touch and to a screen reader.

**Before / after** (same moment — a teammate mid-sentence):

| | |
|---|---|
| before | their text muted grey, no attribution, two `take over` buttons |
| after | full-contrast text in a tinted co-edit field, named banner above the composer, one control |

Now:
- their draft keeps **full contrast** and a tinted co-edit border
- a banner directly above the composer names them — *"Robin Sharma is writing — you are seeing their draft"*
- **one** take-over control, beside the sentence explaining why you would press it. The old footer button rendered under exactly this condition, so with the banner it was two controls for one action six inches apart
- presence chips get a **stable per-person colour** (identity rested entirely on two initials, and initials collide), a live *"is typing…"* label, an accessible name for the row, and `+N` overflow

## Tests

**6 e2e:** alone in a session; each browser sees the other arrive *and leave*; typing propagates; the lock and takeover; the lock self-releases so nobody is wedged; a message lands in both transcripts. Plus a consumer test pinning the join payload — **verified to fail against the unpatched consumer**.

Screenshot harness in `e2e/mp-shot.spec.ts`, excluded from CI (it asserts nothing).

**47 e2e, 2357 backend, 151 unit green.**

## Note for review

`e2e/seed.py` now mints two session keys and a shared session id; `backend.sh` clears them so a stale key can't survive a rebuilt DB and authenticate as nobody.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fa4YkvrDpVGJnhn5Bn4bF
