### PR TITLE
The live-sessions feed names the agent, and keeps project meaningful

### DIFF
--- a/apps/harness/schemas.py
+++ b/apps/harness/schemas.py
@@ -300,7 +300,13 @@ class ReportSessionsIn(Schema):
 class EmdashSessionOut(Schema):
     id: uuid.UUID
     emdash_task: str
+    #: `SessionView.project` carries `emdash_project`, so this stays meaningful
+    #: for an agent-owned row whose stored column the XOR necessarily cleared.
     project: str
+    #: Whose work this is. Absent until now, which every consumer doing
+    #: `.get("agent")` read as `agent: null` — indistinguishable from "known to
+    #: belong to nobody" — leaving `project` as the only thing to guess from.
+    agent: str | None
     status: str
     last_interacted_at: dt.datetime | None
     recent_messages: list

--- a/apps/harness/services.py
+++ b/apps/harness/services.py
@@ -1962,6 +1962,7 @@ class SessionView:
     id: str
     emdash_task: str
     project: str
+    agent: "str | None"
     status: str
     last_interacted_at: object
     recent_messages: list
@@ -1997,7 +1998,7 @@ def list_visible_sessions(user) -> list[SessionView]:
             session__status=Session.ACTIVE,
             live_seen_at__gte=stale_cutoff(),
         )
-        .select_related("runner", "session")
+        .select_related("runner", "session", "session__agent")
         .order_by("-last_interacted_at")
     )
     out = []
@@ -2008,7 +2009,13 @@ def list_visible_sessions(user) -> list[SessionView]:
             SessionView(
                 id=str(b.session_id),
                 emdash_task=b.session_key,
-                project=b.session.project,
+                # `emdash_project`, not the raw column: a session targets an
+                # agent XOR a project, so an agent-owned row has project="" and
+                # reading it directly answered "" for every ACE run. The derived
+                # value is the one that never moved — and it is the same half of
+                # the identity a runner resolves a transcript by.
+                project=b.session.emdash_project,
+                agent=(b.session.agent.slug if b.session.agent_id else None),
                 status=b.status,
                 last_interacted_at=b.last_interacted_at,
                 recent_messages=b.tail,

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -9303,6 +9303,8 @@ export interface components {
             readonly emdash_task: string;
             /** Project */
             readonly project: string;
+            /** Agent */
+            readonly agent: string | null;
             /** Status */
             readonly status: string;
             /** Last Interacted At */

--- a/tests/test_harness_emdash_sessions.py
+++ b/tests/test_harness_emdash_sessions.py
@@ -616,3 +616,46 @@ def test_the_reuse_key_the_report_loop_uses_does_not_move():
     assert again.pk == first.pk, "the second report forked a new binding"
     assert again.session_id == first.session_id, "the second report forked a new session"
     assert again.emdash_project == "ace"
+
+
+def test_the_feed_names_the_agent_and_keeps_project_meaningful():
+    """The feed is what a consumer builds "find the active ACE runs" on, so it
+    has to say WHOSE run each one is.
+
+    It carried no `agent` field at all, which every consumer reads as
+    `agent: null` — indistinguishable from "known to belong to nobody". The only
+    signal was `project`, and once #694 attributed these rows to their agent the
+    XOR constraint necessarily cleared that column, so a field reading it
+    directly began answering "" for every agent-owned run. Strictly less than
+    before. `emdash_project` is the value that never moved.
+    """
+    from django.test import Client
+
+    from apps.agents.models import Agent
+
+    jj = _user("jj")
+    runner_ws = _ws("dimagi", jj)
+    agent_ws = _ws("connect", jj)
+    Agent.objects.create(slug="ace", name="ACE", workspace=agent_ws)
+    runner = _runner(jj, runner_ws)
+    c = Client()
+    c.force_login(jj)
+
+    assert _report(c, runner.id, [
+        {"emdash_task": "ace-kmc-metrics", "project": "ace", "status": "in_progress",
+         "last_interacted_at": "2026-09-08T05:17:00Z"},
+        {"emdash_task": "ddd", "project": "canopy-web", "status": "in_progress",
+         "last_interacted_at": "2026-09-08T05:10:00Z"},
+    ]).status_code == 200
+
+    rows = {r["emdash_task"]: r for r in c.get("/api/harness/sessions").json()}
+
+    mine = rows["ace-kmc-metrics"]
+    assert mine["agent"] == "ace", "the feed must say whose run this is"
+    assert mine["project"] == "ace", "project stays meaningful via emdash_project"
+
+    # A repo checkout that is nobody's agent: null agent is the TRUE answer here,
+    # and the project is its own.
+    theirs = rows["ddd"]
+    assert theirs["agent"] is None
+    assert theirs["project"] == "canopy-web"


### PR DESCRIPTION
#694 attributed runner-reported sessions to the agent whose project names them. It also — **necessarily** — cleared `Session.project`, because a session targets an agent XOR a project.

What I missed: the **feed reads that raw column**, and carries no agent field at all.

So after #694 deployed, every ACE run in `GET /api/harness/sessions` reported `project: ""` **and no owner whatsoever**. Strictly less than before: the one signal a consumer had for *"whose run is this"* was removed, and nothing replaced it.

## How it was caught

The e2e probe went from **7/8 to 6/8** after the deploy. The check that had been passing via `project` started failing — the regression naming itself, which is exactly what that script exists for.

## Two corrections, one root cause

- **`SessionView.project`** now carries `emdash_project` — the project, or the agent's slug when an agent owns the row. That value never moved, and it is the same half of the identity a runner resolves a transcript by.
- **`SessionView.agent` exists at all.** Its absence read as `agent: null` to every consumer doing `.get("agent")` — indistinguishable from *"known to belong to nobody"*. I made exactly that misreading myself, and described a missing key as a null value in #694's own commit message.

`select_related("session__agent")` so naming the owner costs no extra query per row on a feed polled every few seconds.

**Verified:** 2360 tests pass; the new assertions fail against the pre-fix projection. Frontend types regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fa4YkvrDpVGJnhn5Bn4bF
