### PR TITLE
Runner knows the difference between capped and signed-out

### DIFF
--- a/runner/ec2/cloud_runner.py
+++ b/runner/ec2/cloud_runner.py
@@ -58,6 +58,7 @@ from __future__ import annotations
 import json
 import os
 import pathlib
+import re
 import signal
 import socket
 import shutil
@@ -849,14 +850,24 @@ def execute_prompt(prompt: str, turn_id: str, emit, cwd=None, agent_slug=None,
     an ordinary bug and spend real money doing it).
     """
     attempted: list[str] = []
+    saw_dead_credential = False
     while True:
         ok, text, session_id = _execute_once(
             prompt, turn_id, emit, cwd=cwd, agent_slug=agent_slug,
             resume_session_id=resume_session_id)
         attempted.append(_claude_cred_label())
-        if ok or not _is_usage_cap(text):
+        capped, dead = _is_usage_cap(text), _is_auth_required(text)
+        if ok or not (capped or dead):
             return ok, text, session_id
-        _log(f"turn {turn_id[:8]}: {_claude_cred_label()} is at its usage cap")
+        if dead:
+            # An unusable credential either way, so it advances the same as a cap
+            # — but the REASON is carried to the terminal message below, because
+            # "wait for the reset" is wrong advice for a token that has none.
+            saw_dead_credential = True
+            _log(f"turn {turn_id[:8]}: {_claude_cred_label()} is not signed in")
+            _notify_auth_required(_claude_cred_label(), turn_id)
+        else:
+            _log(f"turn {turn_id[:8]}: {_claude_cred_label()} is at its usage cap")
         if not _advance_claude_credential(turn_id=turn_id):
             # Before giving up: re-read the bundle. An operator who just ran
             # `canopy runner credential` to rescue a stuck box should not also
@@ -871,10 +882,20 @@ def execute_prompt(prompt: str, turn_id: str, emit, cwd=None, agent_slug=None,
             # bare cap message names a reset time but never says the fleet has
             # run out of credentials entirely, which is the thing a human has to
             # act on.
-            return ok, (f"{text}\n\n[runner] every Claude credential on this box is "
-                        f"exhausted (tried: {', '.join(attempted)}). Turns will keep "
-                        f"failing until a cap resets or a new credential is set "
-                        f"(`canopy runner credential`)."), session_id
+            if saw_dead_credential:
+                # Deliberately does NOT mention waiting: this is the state that
+                # never clears on its own, and telling an operator a cap will
+                # reset is how a box sits dead for a day.
+                note = (f"[runner] this box is not signed in to Claude (tried: "
+                        f"{', '.join(attempted)}). This will NOT clear on its own — "
+                        f"someone has to re-authenticate the subscription and set the "
+                        f"token (`canopy runner credential`).")
+            else:
+                note = (f"[runner] every Claude credential on this box is exhausted "
+                        f"(tried: {', '.join(attempted)}). Turns will keep failing "
+                        f"until a cap resets or a new credential is set "
+                        f"(`canopy runner credential`).")
+            return ok, f"{text}\n\n{note}", session_id
         # `--resume` is deliberately dropped on the retry: the failed attempt may
         # have written a partial session, and resuming it under a different
         # credential is not a state we want to debug at 2am.
@@ -1458,22 +1479,60 @@ _CLAUDE_CRED_I = 0
 _CLAUDE_CRED_RUNNER_ID = ""   # set at staging; lets an exhausted cascade re-read
 _CLAUDE_AUTH_VARS = ("CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_API_KEY")
 
-#: Substrings that mean "this credential is capped", not "this turn failed".
-#: Matched case-insensitively against the turn's final text.
+#: A usage cap, matched by SHAPE rather than by phrase.
+#:
+#: Anthropic ships session (5-hour), daily and weekly caps and words each one a
+#: little differently — "hit your session limit", "reached your weekly usage
+#: limit" — and adds to the set over time. The original list enumerated the
+#: phrasings it knew, which is precisely how the session cap went unmatched
+#: until 2026-09-08: a turn on cloud-ec2-1 re-queued three times against the
+#: same capped credential and reported a bare failure. So match the shape a cap
+#: message always has — a hit/reached verb, then "limit" close behind — and keep
+#: an explicit list only for the phrasings that never say "limit".
+_USAGE_CAP_RE = re.compile(
+    r"\b(?:hit|reached)\b[^.\n]{0,40}?\blimits?\b"
+    r"|\blimits?\s+reached\b",
+    re.IGNORECASE,
+)
+
 _USAGE_CAP_MARKERS = (
-    "hit your weekly limit",
-    "hit your usage limit",
-    "usage limit reached",
     "out of usage",
     "rate limit exceeded",
     "insufficient credit",
     "credit balance is too low",
 )
 
+#: Substrings that mean "this credential is DEAD and a human must sign in".
+#:
+#: A cap and an expired token both stop the box, and the runner used to have a
+#: name for only one of them. The difference is the whole point: a cap fixes
+#: itself when the clock runs out, a subscription token never does. Read out of
+#: the shipped `claude` binary; deliberately narrow, because turn text is AGENT
+#: output and an agent that merely writes about `/login` must not mark the fleet
+#: dead. Unlike the caps there is no shape to match here — these are fixed
+#: sentences, not a family that grows a new adjective each release.
+_AUTH_REQUIRED_MARKERS = (
+    "not logged in",
+    "please run /login",
+    "auth token expired or invalid",
+    "refresh token expired",
+    "invalid api key",
+)
+
 
 def _is_usage_cap(text: str) -> bool:
     low = (text or "").lower()
-    return any(m in low for m in _USAGE_CAP_MARKERS)
+    return bool(_USAGE_CAP_RE.search(low)) or any(m in low for m in _USAGE_CAP_MARKERS)
+
+
+def _is_auth_required(text: str) -> bool:
+    """True when the credential needs a human to sign in again.
+
+    Checked ALONGSIDE `_is_usage_cap`, never instead of it — the two states are
+    disjoint and want opposite responses (wait vs. fetch a person).
+    """
+    low = (text or "").lower()
+    return any(m in low for m in _AUTH_REQUIRED_MARKERS)
 
 
 def _claude_cred_label() -> str:
@@ -1537,6 +1596,39 @@ def _notify_api_key_fallback(label: str, turn_id: str) -> None:
     except Exception as exc:  # noqa: BLE001 — notifying must never break the turn
         _log(f"warn: could not notify about API-key fallback ({exc}) — metered billing "
              "has started and nobody has been told")
+
+
+def _notify_auth_required(label: str, turn_id: str) -> None:
+    """Tell canopy-web that a credential needs a human to sign in again.
+
+    The sibling of `_notify_api_key_fallback`, and the more urgent of the two:
+    a fallback means money is being spent, this means nothing is running at all
+    and no amount of waiting will change that. Best-effort like its sibling, and
+    logged when it fails for the same reason — the entire point is that a person
+    finds out.
+    """
+    body = {
+        "items": [{
+            "source": "runner.credential",
+            "kind": "claude_auth_required",
+            "level": "error",
+            "summary": (f"The Claude credential ({label}) on "
+                        f"{RUNNER_NAME or 'this runner'} is no longer signed in. "
+                        f"Turns will keep failing until someone re-authenticates it "
+                        f"— this does NOT reset on its own like a usage cap."),
+            # One row per runner per day: a dead token is a STATE a human acts on
+            # once, not a stream of one row per failed turn.
+            "key": f"auth-required:{RUNNER_NAME}",
+        }],
+    }
+    try:
+        status, _ = _api("POST", "/", body, prefix="/api/events")
+        if status not in (200, 201):
+            _log(f"warn: auth-required notify returned {status} — a human may not know "
+                 "that this box needs to be signed in again")
+    except Exception as exc:  # noqa: BLE001 — notifying must never break the turn
+        _log(f"warn: could not notify about the dead credential ({exc}) — the box is "
+             "unauthenticated and nobody has been told")
 
 
 def _reload_claude_credentials() -> bool:

--- a/runner/ec2/tests/test_auth_required.py
+++ b/runner/ec2/tests/test_auth_required.py
@@ -1,0 +1,96 @@
+"""A dead subscription token is not a capped one, and neither is a plain bug.
+
+The runner already knew about usage caps. It did not know about the state a
+subscription actually spends most of its downtime in: the token has expired and
+a human must sign in again. With no such concept, `claude`'s "Please run /login"
+read as an ordinary turn failure — so the harness re-queued the turn, the same
+dead token failed it again, and nothing anywhere said the box needed a person.
+
+Every string asserted below was read out of the shipped `claude` binary
+(2.1.263) rather than guessed, because a hand-transcribed copy of another
+product's user-facing copy is exactly how the session cap went unnoticed.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture()
+def cr(cloud_runner, monkeypatch):
+    monkeypatch.setenv("RUNNER_NAME", "cloud-ec2-1")
+    return cloud_runner
+
+
+# ── the cap the fleet actually hit, and kept hitting ────────────────────────
+
+def test_the_session_cap_is_a_usage_cap(cr):
+    """The 5-hour cap — by far the most frequently hit, and the one the original
+    marker list missed. Observed on cloud-ec2-1 on 2026-09-08, where it re-queued
+    a turn three times against the same capped credential."""
+    assert cr._is_usage_cap("You've hit your session limit · resets 4:20pm (UTC)")
+
+
+@pytest.mark.parametrize("text", [
+    "You've hit your session limit · resets 4:20pm (UTC)",
+    "You've hit your weekly limit · resets Aug 3, 11pm (UTC)",
+    "You've hit your daily limit · resets midnight (UTC)",
+    "you have reached your weekly usage limit",
+    "you have reached your daily usage limit",
+    "Error: usage limit reached",
+])
+def test_every_cap_wording_matches_by_shape(cr, text):
+    """Session, daily and weekly caps are each worded differently and the set
+    grows. Enumerating phrasings is what missed the session cap, so the match is
+    on the shape every cap message shares: a hit/reached verb, then "limit"."""
+    assert cr._is_usage_cap(text)
+
+
+def test_the_capless_phrasings_still_match(cr):
+    """The few that never say "limit" — the shape rule cannot see these."""
+    assert cr._is_usage_cap("your credit balance is too low")
+    assert cr._is_usage_cap("rate limit exceeded")
+
+
+# ── the state that had no name ──────────────────────────────────────────────
+
+@pytest.mark.parametrize("text", [
+    "Not logged in",
+    "Please run /login",
+    "Please run /login and sign in with your Claude.ai account (not Console).",
+    "API Error: 401 Invalid API key · Please run /login",
+    "Auth token expired or invalid",
+    "Refresh token expired",
+])
+def test_a_dead_token_is_auth_required(cr, text):
+    assert cr._is_auth_required(text)
+
+
+def test_a_cap_is_not_auth_required(cr):
+    """The distinction that earns this its own state: a cap fixes itself when the
+    clock runs out, a dead token never does. Confusing them means either waiting
+    forever for a reset that is not coming, or paging a human about a cap."""
+    assert not cr._is_auth_required("You've hit your session limit · resets 4:20pm (UTC)")
+    assert not cr._is_auth_required("You've hit your weekly limit · resets Aug 3, 11pm (UTC)")
+
+
+def test_an_ordinary_failure_is_neither(cr):
+    """The expensive false positive, in both directions."""
+    assert not cr._is_auth_required("TypeError: 'NoneType' object is not subscriptable")
+    assert not cr._is_auth_required("")
+    assert not cr._is_usage_cap("TypeError: 'NoneType' object is not subscriptable")
+
+
+def test_a_login_mention_in_prose_is_not_a_dead_token(cr):
+    """An agent that merely WRITES about logging in must not mark the box dead —
+    turn text is agent output, so the markers have to be the CLI's own wording."""
+    assert not cr._is_auth_required(
+        "I updated the docs to explain how a new operator runs /login on their laptop."
+    )
+
+
+def test_a_limit_mentioned_in_passing_is_not_a_cap(cr):
+    """The cost of matching by shape. Both of these appear in ordinary agent
+    prose, and neither is Anthropic telling us to stop — "limit" alone must not
+    be enough, which is why the verb has to be near it."""
+    assert not cr._is_usage_cap("The slug is truncated at Connect's 50-char limit.")
+    assert not cr._is_usage_cap("I raised the limit in the config and re-ran it.")


### PR DESCRIPTION
The cascade could name exactly one reason a credential stops working — a usage cap — matched against a hand-transcribed list of Anthropic's phrasings. That list had two holes.

## 1. The cap list missed the session cap

Measured on `cloud-ec2-1`, 2026-09-08. A probe turn claimed, failed, re-queued, and did that three times against the same capped credential:

```
1  status    {"runner": "cloud-ec2-1", "status": "claimed"}
2  status    {"status": "running"}
3  assistant {"text": "You've hit your session limit · resets 4:20pm (UTC)"}
4  status    {"status": "queued", "attempt": 1, ...}
   … ×3 → failed
```

`"hit your session limit"` matched none of the seven markers, so `_is_usage_cap()` returned `False` and `execute_prompt` took the ordinary-failure branch. Those retries are the harness re-queueing; the cascade was never entered, and the operator-facing "every credential is exhausted" text never fired.

Enumerating phrasings is the root cause, not the missing entry — daily caps are worded differently again, and the set grows. So caps now match by **shape**: a hit/reached verb with `limit` close behind, with an explicit list kept only for the phrasings that never say "limit" (`credit balance is too low`, `rate limit exceeded`). The verb has to be *near* it — `"Connect's 50-char limit"` is ordinary agent prose, not Anthropic telling us to stop, and there's a test for exactly that.

## 2. A signed-out box had no name at all

This is the more expensive hole. An **expired** subscription token is not a cap: a cap clears when the clock runs out, a dead token never does. With no such concept, `Please run /login` read as a plain turn failure — re-queued, failed again on the same dead token, forever, with nothing anywhere saying the box needed a person. Subscription tokens expire often enough that this is the state a box spends most of its downtime in.

`_is_auth_required` is now checked alongside `_is_usage_cap`. A dead credential still advances the cascade (unusable either way), but the reason is carried to the terminal message, which deliberately **does not mention waiting** — telling an operator a cap will reset is how a box sits dead for a day. It also posts a `claude_auth_required` event, coalesced one-per-runner-per-day exactly like its `claude_api_key_fallback` sibling, because a dead token is a state someone acts on once, not a stream of failed turns.

## On the strings

Every string asserted in the tests was read out of the shipped `claude` binary (2.1.263), not recalled. The false-positive guards matter as much as the matches: turn text is **agent output**, so an agent that writes about `/login`, or mentions a character limit, must not mark the fleet dead.

## Testing

`runner/ec2/tests/test_auth_required.py`, 18 cases — each cap wording (session / daily / weekly / `usage limit reached`), each auth wording, both false-positive guards, and the cap-is-not-auth / auth-is-not-cap disjointness. Written failing first against the old code. Full runner suite: **189 passed, 33 skipped**.

## Scoped out, deliberately

- **Where this state surfaces in the UI.** The event is posted; whether it becomes a badge on the Runners tab, a row on agent setup, or a notification is a product call, not this PR's.
- **Fallback credentials.** Explicitly out of scope per Jonathan — primary only for now. The cascade behaviour is unchanged apart from carrying the reason.
- **Web-driven re-authentication.** The thing that would actually let someone fix a signed-out box from a browser. Findings on feasibility are written up separately; this PR only makes the state *detectable*, which is its precondition.

Closes #698

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZoTH3niSknEU47NdZ42HJ
