### PR TITLE
Only accept a COMPLETE authorize URL — the first live sign-in stored 80 chars

### DIFF
--- a/runner/ec2/cloud_runner.py
+++ b/runner/ec2/cloud_runner.py
@@ -57,15 +57,18 @@ from __future__ import annotations
 
 import json
 import os
+import fcntl
 import pathlib
 import pty
 import re
 import select
 import signal
+import struct
 import socket
 import shutil
 import subprocess
 import sys
+import termios
 import threading
 import time
 import urllib.error
@@ -1767,14 +1770,34 @@ def strip_terminal(raw: bytes) -> str:
     return text.decode("utf-8", "replace").replace("\r", "\n")
 
 
+#: Every parameter the authorize request needs to be usable. Acceptance is
+#: SEMANTIC rather than "does it look like a URL", because the failure this
+#: prevents parses perfectly as one: the first live run stored 80 characters —
+#: exactly the terminal width — because `_pump` answers on the first match and
+#: the visible copy's first WRAPPED line reaches the buffer before the OSC-8
+#: payload carrying the whole URL. The human got "Invalid OAuth Request /
+#: Missing redirect_uri parameter". A fixture of the finished output cannot
+#: catch that; a stream is not a buffer.
+_REQUIRED_AUTHORIZE_PARAMS = (
+    "client_id=", "response_type=", "redirect_uri=",
+    "code_challenge=", "code_challenge_method=", "state=",
+)
+
+
 def extract_authorize_url(raw: bytes) -> str | None:
-    """The URL to put in front of a human, or None if it has not rendered yet."""
-    # The TUI prints the URL twice — once inside the hyperlink escape and once as
-    # visible text that it WRAPS at the terminal width. Longest wins: the wrapped
-    # copy is truncated, and a truncated authorize URL fails on an invalid-request
-    # page rather than anything that looks like our bug.
-    found = _AUTHORIZE.findall(strip_terminal(raw))
-    return max(found, key=len) if found else None
+    """A COMPLETE URL to put in front of a human, or None if it is not all here.
+
+    None means "not yet", and the caller keeps reading — so a partial render can
+    only ever delay the answer, never corrupt it.
+    """
+    # The TUI prints the URL twice — inside the hyperlink escape, and as visible
+    # text it wraps at the terminal width. Longest first, then completeness: the
+    # wrapped copy is a truncation, and a truncated authorize URL fails on an
+    # invalid-request page rather than on anything that looks like our bug.
+    for url in sorted(_AUTHORIZE.findall(strip_terminal(raw)), key=len, reverse=True):
+        if all(p in url for p in _REQUIRED_AUTHORIZE_PARAMS):
+            return url
+    return None
 
 
 def extract_token(raw: bytes) -> str | None:
@@ -1814,6 +1837,16 @@ class MintSession:
         # printed either way, so the launch is simply neutralised.
         env["BROWSER"] = "/usr/bin/true"
         pid, fd = pty.fork()
+        if pid != 0:
+            # A pty defaults to 80 columns, which is what made the TUI wrap the
+            # authorize URL and hand us an 80-char prefix. Belt to the parser's
+            # braces: a wide terminal means the visible copy is not chopped at
+            # all, so the two defences fail independently rather than together.
+            try:
+                fcntl.ioctl(fd, termios.TIOCSWINSZ,
+                            struct.pack("HHHH", 50, 400, 0, 0))
+            except OSError:
+                pass  # a narrower terminal still works — the parser gates it
         if pid == 0:  # pragma: no cover — the child never returns
             os.execvpe(self._argv[0], list(self._argv), env)
             os._exit(1)

--- a/runner/ec2/tests/test_claude_mint.py
+++ b/runner/ec2/tests/test_claude_mint.py
@@ -88,3 +88,49 @@ def test_an_api_key_is_not_a_setup_token(cm):
 def test_no_token_while_the_flow_is_still_running(cm, raw):
     """The authorize-URL screen must not read as a completed mint."""
     assert cm.extract_token(raw) is None
+
+
+# ── the truncation that shipped, and why the fixture missed it ─────────────
+#
+# The first live run stored an 80-character URL — exactly the terminal width.
+# `_pump` returns on the FIRST match, and on a real box the visible copy's first
+# WRAPPED line lands in the buffer before the OSC-8 payload carrying the whole
+# URL does. The human got "Invalid OAuth Request / Missing redirect_uri".
+#
+# The fixture could not catch it: it holds the COMPLETE output, and the parser
+# was only ever asked about a finished buffer. A stream is not a buffer.
+
+_TRUNCATED = (
+    b"https://claude.com/cai/oauth/authorize?code=true&client_id=9d1c250a-e61b-44d9-88"
+)
+
+
+def test_a_wrapped_first_line_is_not_an_answer(cm):
+    """80 chars, cut mid-client_id. It parses as a URL and is useless as one."""
+    assert cm.extract_authorize_url(_TRUNCATED) is None
+
+
+def test_a_url_missing_any_required_parameter_is_rejected(cm, raw):
+    """Acceptance is semantic, not "does it look like a URL" — the flow needs
+    every one of these, and a partial read can drop any of them."""
+    full = cm.extract_authorize_url(raw)
+    assert full is not None
+    for param in ("client_id", "response_type", "redirect_uri",
+                  "code_challenge", "code_challenge_method", "state"):
+        assert f"{param}=" in full
+        # Chop the URL just before this parameter and it must stop being valid.
+        assert cm.extract_authorize_url(full[:full.index(f"{param}=")].encode()) is None
+
+
+def test_the_url_is_recovered_progressively_not_just_from_a_finished_buffer(cm, raw):
+    """Feed the capture one chunk at a time, as a pty actually delivers it. The
+    parser must answer None until the whole URL is present, then the full one —
+    never a prefix of it."""
+    seen = None
+    for end in range(0, len(raw) + 1, 64):
+        got = cm.extract_authorize_url(raw[:end])
+        if got is not None:
+            seen = got
+            for param in ("redirect_uri", "code_challenge_method", "state"):
+                assert f"{param}=" in got, f"answered a URL missing {param}"
+    assert seen == cm.extract_authorize_url(raw)


### PR DESCRIPTION
The first real use of #701 failed in the browser:

> **Invalid OAuth Request** — Missing redirect_uri parameter

The runner had stored an **80-character** URL — exactly the terminal width — cut mid-`client_id`:

```
https://claude.com/cai/oauth/authorize?code=true&client_id=9d1c250a-e61b-44d9-88
```

## Why

`_pump` answers on the **first** match. On a real box the visible copy's first *wrapped* line reaches the buffer before the OSC-8 payload carrying the whole URL does, so the parser was handed a prefix and — correctly, by its own rules — returned the longest thing it could see. `max(found, key=len)` only ever helped when every candidate was already in the buffer.

## Why the fixture missed it, precisely

The fixture holds the **complete output of a finished run**, and the parser was only ever asked about a finished buffer. **A stream is not a buffer.** The regression test added here feeds that same capture 64 bytes at a time, the way a pty actually delivers it, and asserts the parser never answers with a URL missing a required parameter.

That is the real lesson: #700's fixture caught a genuine bug (the glued-together copies) and I took it as evidence the parsing was covered. It covered the shape of the bytes, not the timing of their arrival.

## Two independent defences

Neither is load-bearing alone:

1. **Acceptance is semantic.** A URL is returned only when it carries every parameter the flow needs — `client_id`, `response_type`, `redirect_uri`, `code_challenge`, `code_challenge_method`, `state`. `None` means "not yet" and the caller keeps reading, so a partial render can *delay* the answer but never corrupt it. This is what makes the failure impossible rather than unlikely: the broken URL parsed perfectly as a URL, so nothing short of checking what it *contains* could have rejected it.
2. **The pty opens at 400 columns** instead of the default 80, so the TUI does not wrap the URL at all.

## Verified live, not just against the fixture

Driving `MintSession.start()` end to end against the real CLI returns a complete **346-char** URL with every parameter present:

```
https://claude.com/cai/oauth/authorize?code=true&client_id=9d1c250a-…
  &response_type=code&redirect_uri=https%3A%2F%2Fplatform.claude.com%2Foauth%2Fcode%2Fcallback
  &scope=user%3Ainference&code_challenge=…&code_challenge_method=S256&state=…
missing params: NONE
```

Killed before any code was entered, so nothing was minted. Given a fixture already missed this once, the live check is the one that counts.

Runner suite: **200 passed, 33 skipped.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZoTH3niSknEU47NdZ42HJ
