### PR TITLE
A sign-in link expires, and can always be restarted

### DIFF
--- a/apps/harness/services.py
+++ b/apps/harness/services.py
@@ -2282,6 +2282,40 @@ def list_runner_admins(runner):
 
 
 # ---- Browser-driven re-authentication (RunnerMint) ------------------------
+#: How long a sign-in may sit unfinished before it is treated as dead.
+#:
+#: An authorize URL is not durable. Its PKCE `state` and challenge expire, and
+#: the `claude setup-token` process waiting on the box expires with them — so a
+#: link that LOOKS fine can be unusable. Measured 2026-09-08: a mint started at
+#: 17:56 and completed at 19:04 failed with "setup-token never printed a token",
+#: and the only clue that anything was wrong was the clock. Ten minutes is
+#: comfortably longer than the flow takes and comfortably shorter than the point
+#: at which it silently stops working.
+MINT_TTL_SECONDS = 600
+
+
+def _expire_if_stale(mint):
+    """Fail a mint that has aged out, so a dead link stops being offered as live.
+
+    Returns the mint either way — callers want the row, not a decision about
+    whether to look at it.
+    """
+    from django.utils import timezone
+
+    from .models import RunnerMint
+
+    if mint is None or mint.status in RunnerMint.FINISHED:
+        return mint
+    if (timezone.now() - mint.updated_at).total_seconds() <= MINT_TTL_SECONDS:
+        return mint
+    mint.status = RunnerMint.FAILED
+    mint.detail = ("This sign-in expired before it was finished — the link is only "
+                   "good for a few minutes. Start another one.")
+    mint.code = ""
+    mint.save(update_fields=["status", "detail", "code", "updated_at"])
+    return mint
+
+
 def start_runner_mint(runner, *, requested_by=None):
     """Ask a runner to begin a browser sign-in, superseding any unfinished one.
 
@@ -2306,7 +2340,8 @@ def current_runner_mint(runner):
     """
     from .models import RunnerMint
 
-    return RunnerMint.objects.filter(runner=runner).order_by("-created_at").first()
+    return _expire_if_stale(
+        RunnerMint.objects.filter(runner=runner).order_by("-created_at").first())
 
 
 def claim_runner_mint(runner):

--- a/frontend/src/components/supervisor/RunnerReauth.tsx
+++ b/frontend/src/components/supervisor/RunnerReauth.tsx
@@ -110,17 +110,19 @@ export function RunnerReauth({ runnerId, onSignedIn }: {
     <section className="rounded-md border border-border p-3" data-testid="runner-reauth">
       <div className="flex items-baseline justify-between gap-3">
         <h4 className="text-sm font-semibold">Sign in to Claude</h4>
-        {idle && (
-          <button
-            type="button"
-            onClick={start}
-            disabled={busy}
-            data-testid="reauth-start"
-            className="rounded-md border border-border px-2 py-1 text-xs hover:bg-muted disabled:opacity-50"
-          >
-            {status === 'done' || status === 'failed' ? 'Sign in again' : 'Start sign-in'}
-          </button>
-        )}
+        {/* ALWAYS offered, not only when idle. A link is good for minutes, so a
+            sign-in left half-done is the ordinary case — and with the button
+            hidden mid-flight, a stale link was a dead end with nothing to click.
+            That is exactly how a 68-minute-old link got used on 2026-09-08. */}
+        <button
+          type="button"
+          onClick={start}
+          disabled={busy}
+          data-testid="reauth-start"
+          className="rounded-md border border-border px-2 py-1 text-xs hover:bg-muted disabled:opacity-50"
+        >
+          {idle ? (status ? 'Sign in again' : 'Start sign-in') : 'Start again'}
+        </button>
       </div>
 
       <p className="mt-1 text-xs text-muted-foreground">
@@ -139,10 +141,11 @@ export function RunnerReauth({ runnerId, onSignedIn }: {
       {/* A runner that never picks the request up is the common real failure —
           it is, after all, a box we already suspect is unhealthy. Say that,
           rather than spinning: the operator's next move is a different one. */}
-      {status === 'requested' && waitedOut && (
+      {waitingOnRunner && waitedOut && (
         <p className="mt-2 text-sm text-destructive" data-testid="reauth-stalled">
-          The runner hasn&rsquo;t picked this up. It may be offline &mdash; check it is
-          running, then start again.
+          {status === 'requested'
+            ? 'The runner hasn\u2019t picked this up. It may be offline \u2014 check it is running, then start again.'
+            : 'The runner is taking longer than expected to finish. If it does not resolve, start again.'}
         </p>
       )}
 
@@ -159,7 +162,8 @@ export function RunnerReauth({ runnerId, onSignedIn }: {
           </a>
           <p className="text-xs text-muted-foreground">
             Sign in as the account whose subscription this runner uses, then copy the
-            code it shows you and paste it here.
+            code it shows you and paste it here. <strong>Do it now</strong> &mdash; the
+            link is only good for a few minutes.
           </p>
           <div className="flex gap-2">
             <input

--- a/tests/test_runner_mint.py
+++ b/tests/test_runner_mint.py
@@ -11,6 +11,7 @@ operator-facing shape ever carries a secret.
 """
 from __future__ import annotations
 
+import datetime as dt
 import json
 
 import pytest
@@ -170,3 +171,50 @@ def test_a_stranger_cannot_drive_someone_elses_runner(client, runner):
     stranger = Client()
     stranger.force_login(other)
     assert _post(stranger, _base(runner)).status_code == 404
+
+
+# ── expiry: a dead link must stop being offered as live ────────────────────
+
+def test_a_sign_in_left_open_too_long_expires(client, runner, monkeypatch):
+    """The failure this prevents, measured 2026-09-08: a mint started at 17:56
+    was completed at 19:04 and failed with "setup-token never printed a token".
+    The authorize URL's PKCE state and the CLI process waiting on the box had
+    both expired an hour earlier; nothing said so, and the only clue was the
+    clock. An aged-out mint now says what happened."""
+    from django.utils import timezone
+
+    from apps.harness import services
+    from apps.harness.models import RunnerMint
+
+    _post(client, _base(runner))
+    _post(client, f"{_base(runner)}/url", {"url": "https://claude.com/cai/oauth/authorize?x=1"})
+
+    stale = timezone.now() + dt.timedelta(seconds=services.MINT_TTL_SECONDS + 60)
+    monkeypatch.setattr(timezone, "now", lambda: stale)
+
+    body = client.get(_base(runner)).json()
+    assert body["status"] == RunnerMint.FAILED
+    assert "expired" in body["detail"].lower()
+
+
+def test_an_expired_mint_is_not_handed_to_the_runner(client, runner, monkeypatch):
+    """Belt and braces: the runner must not pick up a code for a flow whose
+    verifier is already dead — it can only fail, slowly."""
+    from django.utils import timezone
+
+    from apps.harness import services
+
+    _post(client, _base(runner))
+    _post(client, f"{_base(runner)}/url", {"url": "https://claude.com/cai/oauth/authorize?x=1"})
+    _post(client, f"{_base(runner)}/code", {"code": "the-code"})
+
+    stale = timezone.now() + dt.timedelta(seconds=services.MINT_TTL_SECONDS + 60)
+    monkeypatch.setattr(timezone, "now", lambda: stale)
+    assert client.get(f"{_base(runner)}/claim").json()["mint"] is None
+
+
+def test_a_fresh_sign_in_is_not_expired(client, runner):
+    """The guard must not fire on the ordinary case."""
+    _post(client, _base(runner))
+    _post(client, f"{_base(runner)}/url", {"url": "https://claude.com/cai/oauth/authorize?x=1"})
+    assert client.get(_base(runner)).json()["status"] == "awaiting_code"


### PR DESCRIPTION
Measured today, on the first real use of this flow: a mint started at **17:56** was completed at **19:04** and failed with

> `setup-token never printed a token — the code may have been wrong, expired, or already used`

Nothing was wrong with the code. The authorize URL's PKCE `state` and the `claude setup-token` process waiting on the box had both expired an hour earlier. **The only clue that anything was stale was the clock**, and the failure only surfaced after someone had gone to the trouble of signing in.

`start()` was bounded at 60s and `submit_code()` at 90s, but nothing bounded how long a mint could **sit** in `awaiting_code` — so a dead link was presented as a live one, indefinitely.

## Two changes, because either alone still traps someone

**1. Links expire.** A mint older than `MINT_TTL_SECONDS` (10 minutes) is failed on read, with a detail that says so and tells you to start another. Ten minutes is comfortably longer than the flow takes and comfortably shorter than the point where it silently stops working. `claim_runner_mint` reads through the same helper, so the **runner** also stops being handed a code for a flow whose verifier is already dead — that can only fail, slowly.

**2. Restart is always available.** The button was hidden while a mint was in flight, so a stale link was a dead end with nothing to click — which is how a 68-minute-old link came to be used at all. It now reads "Start again" mid-flight. The stall message covers `completing` as well as `requested` (that state could previously spin forever with nothing said), and the awaiting-code copy states outright that the link is good for a few minutes.

## Testing

3 new backend tests — an aged mint expires with a legible reason, an expired mint is not handed to the runner, and a fresh one is untouched (the guard must not fire on the ordinary case). Suites: **1749 backend, 707 frontend**, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZoTH3niSknEU47NdZ42HJ
