### PR TITLE
Report what setup-token actually said when a sign-in fails

### DIFF
--- a/runner/ec2/cloud_runner.py
+++ b/runner/ec2/cloud_runner.py
@@ -1806,6 +1806,36 @@ def extract_token(raw: bytes) -> str | None:
     return m.group(0) if m else None
 
 
+#: Anything token-shaped is stripped before the CLI's own words are reported.
+#: The transcript is diagnostic, not a place to spill a credential.
+_TOKENISH = re.compile(r"sk-ant-[A-Za-z0-9_\-]+")
+
+
+def _diagnostic_tail(raw: bytes, limit: int = 600) -> str:
+    """The last thing `setup-token` actually said, fit to be shown to a human.
+
+    This exists because the first two live failures were debugged by GUESSING.
+    The runner knew exactly what the CLI printed — "invalid code", "expired", a
+    prompt still waiting — and threw it away, reporting only that no token had
+    appeared. Two wrong theories and two wasted sign-in attempts later: report
+    what it said.
+    """
+    text = strip_terminal(raw)
+    text = _TOKENISH.sub("<redacted>", text)
+    # Collapse the TUI's redraw frames — spinner rows carry no information and
+    # would otherwise be the entire tail.
+    lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
+    seen, keep = set(), []
+    for ln in reversed(lines):
+        if ln in seen:
+            continue
+        seen.add(ln)
+        keep.append(ln)
+        if sum(len(k) for k in keep) > limit:
+            break
+    return " | ".join(reversed(keep))[:limit]
+
+
 class MintTimeout(RuntimeError):
     """The CLI never reached the expected step. Always fatal to the attempt:
     a half-driven TUI is not a state worth resuming."""
@@ -1863,10 +1893,11 @@ class MintSession:
             raise MintTimeout("this mint session is not running")
         os.write(self._fd, code.strip().encode() + b"\r")
         token = self._pump(timeout, extract_token)
+        tail = _diagnostic_tail(self._buf)
         self.close()
         if token is None:
-            raise MintTimeout("setup-token never printed a token — the code may "
-                              "have been wrong, expired, or already used")
+            raise MintTimeout(
+                "setup-token never printed a token. What it said: " + (tail or "(nothing)"))
         return token
 
     def close(self) -> None:
@@ -1977,7 +2008,9 @@ def _drain_mint(runner_id: str) -> None:
             try:
                 token = _MINT_SESSION.submit_code(code)
             except Exception as exc:  # noqa: BLE001
-                _api("POST", f"/runners/{runner_id}/mint/result", {"detail": str(exc)})
+                # str(exc) now carries the CLI's own words — that is the point.
+                _api("POST", f"/runners/{runner_id}/mint/result",
+                     {"detail": str(exc)[:900]})
             else:
                 # The token goes straight to canopy-web, which writes it into the
                 # encrypted bundle — it never touches the browser, so the only

--- a/runner/ec2/tests/test_claude_mint.py
+++ b/runner/ec2/tests/test_claude_mint.py
@@ -134,3 +134,38 @@ def test_the_url_is_recovered_progressively_not_just_from_a_finished_buffer(cm, 
             for param in ("redirect_uri", "code_challenge_method", "state"):
                 assert f"{param}=" in got, f"answered a URL missing {param}"
     assert seen == cm.extract_authorize_url(raw)
+
+
+# ── reporting what the CLI actually said ───────────────────────────────────
+#
+# The first two live failures were debugged by GUESSING — staleness, then a
+# mismatched session — and both theories were wrong. The runner knew exactly
+# what `setup-token` had printed and discarded it, reporting only that no token
+# appeared. These pin the fix: say what it said.
+
+def test_the_failure_reports_the_clis_own_words(cm):
+    out = b"\x1b[2mPasting code\x1b[0m\r\nInvalid authorization code. Please try again.\r\n"
+    assert "Invalid authorization code" in cm._diagnostic_tail(out)
+
+
+def test_the_tail_never_carries_a_token(cm):
+    """Diagnostic output is shown to a human on a web page — it is not a place
+    to spill the credential we just minted."""
+    out = b"Success! Your token:\r\nsk-ant-oat01-SECRETVALUE\r\ndone\r\n"
+    tail = cm._diagnostic_tail(out)
+    assert "sk-ant-oat01-SECRETVALUE" not in tail
+    assert "<redacted>" in tail
+
+
+def test_spinner_frames_do_not_crowd_out_the_message(cm):
+    """A TUI redraws constantly; without de-duplication the tail is all spinner
+    and none of the sentence that matters."""
+    noise = b"".join(b"\r\n" + f.encode() for f in "✦✳✶✻✽" * 40)
+    out = noise + b"\r\nCode expired. Start a new sign-in.\r\n"
+    tail = cm._diagnostic_tail(out)
+    assert "Code expired" in tail
+
+
+def test_the_tail_is_bounded(cm, raw):
+    """It rides in a failure detail that a human reads, not a log."""
+    assert len(cm._diagnostic_tail(raw)) <= 600


### PR DESCRIPTION
Two live failures, two wrong theories, two wasted sign-in attempts.

The first was blamed on a stale link — the mint was 68 minutes old, which was true but wasn't the cause. The second used a link generated **four minutes** earlier, whose `state` matched the issued URL exactly, and failed identically:

> `setup-token never printed a token — the code may have been wrong, expired, or already used`

Three guesses in a trench coat, with no way to tell which.

Both were debugged by guessing, and neither needed to be. The runner had the pty buffer in hand — whatever `setup-token` actually printed when it rejected the code — and discarded it.

## The change

The failure detail now carries the CLI's own words. `_diagnostic_tail`:

- **de-duplicates the TUI's redraw frames** — a spinner would otherwise *be* the entire tail
- **redacts anything token-shaped** — this string renders on a web page, not into a log
- **is bounded at 600 chars**, because a human reads it in a UI

## What this is not

It does not fix the sign-in. It makes the next failure **say why**, which is the prerequisite for fixing it — and is what should have shipped with the flow in the first place.

4 new tests: the CLI's message survives, a token never does, spinner noise doesn't crowd out the sentence that matters, and the tail stays bounded. Runner suite: **204 passed, 33 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZoTH3niSknEU47NdZ42HJ
