### PR TITLE
Keep polling after the wait limit, so a late failure reaches the screen

### DIFF
--- a/frontend/src/components/supervisor/RunnerReauth.test.tsx
+++ b/frontend/src/components/supervisor/RunnerReauth.test.tsx
@@ -90,6 +90,32 @@ describe('RunnerReauth', () => {
     }
   })
 
+  it('keeps polling after the wait limit, so a late failure still lands', async () => {
+    // The bug this pins: the poll callback hit `return` before refresh() once the
+    // wait limit passed, so after 90s the page stopped looking. A mint that
+    // failed four minutes in was never fetched, and the screen sat on
+    // "Finishing the sign-in on the runner…" indefinitely while the server had
+    // said `failed` the whole time. Reported 2026-09-08.
+    vi.useFakeTimers()
+    try {
+      api.getRunnerMint.mockResolvedValue(mint({ status: 'completing' }))
+      render(<RunnerReauth runnerId="r1" />)
+      await act(async () => { await Promise.resolve() })
+
+      await act(async () => { vi.advanceTimersByTime(95_000) })
+      const callsAfterLimit = api.getRunnerMint.mock.calls.length
+
+      api.getRunnerMint.mockResolvedValue(
+        mint({ status: 'failed', detail: 'the code was rejected' }))
+      await act(async () => { vi.advanceTimersByTime(30_000) })
+
+      expect(api.getRunnerMint.mock.calls.length).toBeGreaterThan(callsAfterLimit)
+      expect(screen.getByTestId('reauth-failed').textContent).toContain('the code was rejected')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('reports a failed sign-in with the runner’s reason', async () => {
     api.getRunnerMint.mockResolvedValue(
       mint({ status: 'failed', detail: 'the code had expired' }))

--- a/frontend/src/components/supervisor/RunnerReauth.tsx
+++ b/frontend/src/components/supervisor/RunnerReauth.tsx
@@ -41,6 +41,7 @@ export function RunnerReauth({ runnerId, onSignedIn }: {
   const [error, setError] = useState<string | null>(null)
   const [waitedOut, setWaitedOut] = useState(false)
   const startedWaiting = useRef<number | null>(null)
+  const status = mint?.status
 
   const refresh = useCallback(async () => {
     try {
@@ -62,17 +63,33 @@ export function RunnerReauth({ runnerId, onSignedIn }: {
       setWaitedOut(false)
       return
     }
-    startedWaiting.current ??= Date.now()
+    // Each PHASE gets its own budget: "the runner has not started" and "the
+    // runner is finishing" are different waits, and sharing one clock made the
+    // second inherit however long the first took.
+    startedWaiting.current = Date.now()
+  }, [waitingOnRunner, status])
+
+  useEffect(() => {
+    if (!waitingOnRunner) return
     const t = window.setInterval(() => {
+      // waitedOut is a thing we SAY, never a reason to stop looking. It used to
+      // `return` before the refresh, so after 90s the page stopped polling for
+      // good — and a mint that failed four minutes in was never fetched. The
+      // screen sat on "Finishing the sign-in on the runner…" forever while the
+      // server had said `failed` the whole time. Reported 2026-09-08.
       if (Date.now() - (startedWaiting.current ?? 0) > WAIT_LIMIT_MS) {
         setWaitedOut(true)
-        return
       }
       void refresh()
-      if (mint?.status === 'completing') onSignedIn?.()
     }, POLL_MS)
     return () => window.clearInterval(t)
-  }, [waitingOnRunner, refresh, mint?.status, onSignedIn])
+  }, [waitingOnRunner, refresh])
+
+  useEffect(() => {
+    // Once, on the transition — not on every tick of `completing`, which had the
+    // parent refetching its credential view every few seconds for nothing.
+    if (status === 'done') onSignedIn?.()
+  }, [status, onSignedIn])
 
   const run = async (fn: () => Promise<RunnerMint>) => {
     setBusy(true)
@@ -103,7 +120,6 @@ export function RunnerReauth({ runnerId, onSignedIn }: {
   // Narrowed through `mint` itself rather than a hoisted `mint?.status`: the
   // optional chain reads fine but does not narrow, so every `mint.` below then
   // needs a non-null assertion. `tsc -b` catches that; `tsc --noEmit` does not.
-  const status = mint?.status
   const idle = !mint || status === 'done' || status === 'failed'
 
   return (


### PR DESCRIPTION
Reported: *"the UI doesn't even reflect a failure, it doesn't reflect anything."*

The poll callback hit `return` **before** `refresh()` once the wait limit passed:

```js
if (Date.now() - startedWaiting > WAIT_LIMIT_MS) {
  setWaitedOut(true)
  return          // ← stops refreshing, permanently
}
void refresh()
```

So after 90 seconds the page stopped looking. The sign-in failed about **four minutes** in, and that state was never fetched — the screen sat on *"Finishing the sign-in on the runner…"* indefinitely while the server had said `failed` the whole time.

That's worse than a missing error message: it presented a **finished** attempt as one still in progress, which is why the same dead link got tried twice.

`waitedOut` is now something the screen **says**, never a reason to stop looking.

## Two smaller things in the same effect

- **Each phase gets its own wait budget.** "The runner hasn't started" and "the runner is finishing" are different waits; sharing one clock made the second inherit however long the first had taken.
- **The parent is told once**, on the transition to `done`, rather than on every tick of `completing` — which had it refetching its credential view every few seconds for nothing.

## Testing

The regression test drives fake timers past the limit, changes the server's answer to `failed`, then asserts both that polling continued *and* that the reason reached the screen. **Verified failing against the old component** before the fix — it reproduces the exact symptom. Frontend suite: **708 passed**, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZoTH3niSknEU47NdZ42HJ
