### PR TITLE
A missing bundle 404s instead of painting a white page; drop the fallback nag

### DIFF
--- a/apps/common/middleware.py
+++ b/apps/common/middleware.py
@@ -18,6 +18,13 @@ PUBLIC_PATH_PREFIXES = (
     "/admin/",               # Django admin has its own auth
     "/health/",              # health check for Cloud Run
     "/static/",              # static assets
+    # The built SPA's content-hashed bundles — the same class of thing as
+    # /static/, and already referenced by the login page's own HTML, so gating
+    # them protects nothing. Gating them DID break things: an expired session
+    # turned every <script> request into a 302 to Google, so the browser was
+    # handed a sign-in page where it expected a module and rendered a white
+    # page. Reproduced 2026-09-08.
+    "/assets/",              # built SPA bundles
     "/api/csrf/",            # bootstraps CSRF cookie before login
     "/api/openapi.json",      # openapi-typescript fetches the schema
     "/api/docs/",             # Scalar HTML

--- a/config/urls.py
+++ b/config/urls.py
@@ -33,5 +33,21 @@ urlpatterns = [
     path("api/docs/", scalar_docs, name="api_docs_scalar"),
     path("api/redoc/", redoc_docs, name="api_docs_redoc"),
     # Catch-all: serve the SPA for any non-API route (last).
-    re_path(r"^(?!api/|admin/|accounts/|health/|static/|auth/).*$", spa_view, name="spa"),
+    #
+    # `assets/` is excluded, and that exclusion is load-bearing. Those paths are
+    # content-hashed bundles, and every deploy rehashes them — so a browser
+    # holding a cached index.html (the service worker precaches it) asks for a
+    # filename that no longer exists on the server. WhiteNoise passes the miss
+    # through, and without this the catch-all answered a `.js` request with
+    # index.html at `200 text/html`. The browser cannot parse HTML as a module,
+    # so the app rendered a WHITE PAGE until a force-refresh, with no error a
+    # user could act on. Reported and reproduced 2026-09-08.
+    #
+    # A 404 is the honest answer to "that bundle is gone", and it is one the
+    # client can handle: the request fails visibly rather than half-succeeding.
+    re_path(
+        r"^(?!api/|admin/|accounts/|health/|static/|auth/|assets/).*$",
+        spa_view,
+        name="spa",
+    ),
 ]

--- a/frontend/src/components/supervisor/RunnerCredentials.test.tsx
+++ b/frontend/src/components/supervisor/RunnerCredentials.test.tsx
@@ -71,7 +71,8 @@ describe('credentialSummary', () => {
   it('warns when the only Claude credential is the primary', () => {
     const s = credentialSummary(ONE_CLAUDE)
     expect(s.claudeFallback).toBe('none')
-    expect(s.warning).toMatch(/cap/i)
+    // A single credential is a CHOICE, not a fault — no banner for it.
+    expect(s.warning).toBeNull()
   })
 
   it('clears once a secondary subscription is set', () => {
@@ -85,7 +86,8 @@ describe('credentialSummary', () => {
     // notifies a human rather than quietly spending money.
     const s = credentialSummary({ ...ONE_CLAUDE, has_claude_api_key: true })
     expect(s.claudeFallback).toBe('api_key')
-    expect(s.warning).toMatch(/metered|billed|spend/i)
+    // Likewise a metered-only fallback: worth knowing, not worth a standing banner.
+    expect(s.warning).toBeNull()
   })
 
   it('says nothing is set at all rather than warning about a fallback', () => {

--- a/frontend/src/components/supervisor/RunnerCredentials.tsx
+++ b/frontend/src/components/supervisor/RunnerCredentials.tsx
@@ -100,18 +100,18 @@ export function credentialSummary(s: CredentialStatus): Summary {
       ? 'api_key'
       : 'none'
 
-  let warning: string | null = null
-  if (!s.has_claude_token) {
-    // A missing PRIMARY is a different failure from a missing fallback, and
-    // "add a fallback" would be the wrong instruction for it.
-    warning = 'No Claude credential at all — this runner cannot execute any turn.'
-  } else if (fallback === 'none') {
-    warning =
-      'Only one Claude credential is set. A usage cap will stop every agent on this box with nothing to fail over to.'
-  } else if (fallback === 'api_key') {
-    warning =
-      'The only fallback is the API key, which is metered — a cap on the primary starts billing rather than switching subscription.'
-  }
+  // ONLY the state that means this box cannot run anything. The two
+  // fallback warnings that used to live here — "only one credential is set",
+  // "the only fallback is metered" — were removed 2026-09-08: a standing banner
+  // about a deliberate configuration is a nag, and it sat above the controls
+  // every single visit, training the eye to skip the whole block. Which is
+  // exactly where the one alarm that matters has to be seen.
+  //
+  // `claudeFallback` is still computed; a caller that wants to say something
+  // about fallbacks can, at a moment when it is actually the subject.
+  const warning: string | null = s.has_claude_token
+    ? null
+    : 'No Claude credential at all — this runner cannot execute any turn.'
   return { claudeFallback: fallback, warning, unset }
 }
 

--- a/tests/test_asset_404.py
+++ b/tests/test_asset_404.py
@@ -1,0 +1,49 @@
+"""A missing hashed bundle must 404, not be answered with the SPA shell.
+
+Reported and reproduced 2026-09-08. Asset filenames are content-hashed and every
+deploy rehashes them, so a browser holding a cached index.html — the service
+worker precaches it — asks for a bundle the server no longer has. WhiteNoise
+passes the miss through, and the SPA catch-all used to answer that `.js` request
+with index.html at `200 text/html`.
+
+The browser cannot parse HTML as a module, so the app rendered a WHITE PAGE until
+a force-refresh, with no error anyone could act on. Six deploys in a day is what
+made it routine.
+"""
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.mark.parametrize("path", [
+    "/assets/index-DEADBEEF.js",
+    "/assets/ui-GONE.css",
+    "/assets/nested/thing-OLD.js",
+])
+def test_a_missing_bundle_404s(client, settings, path):
+    settings.REQUIRE_AUTH = False
+    r = client.get(path)
+    assert r.status_code == 404, (
+        f"{path} returned {r.status_code} — a JS/CSS request answered with the "
+        "SPA shell is what produced the white page"
+    )
+    assert "text/html" not in (r.headers.get("Content-Type") or "").lower() or r.status_code == 404
+
+
+def test_the_spa_still_serves_app_routes(client, settings):
+    """The catch-all must keep doing its job — deep links into the SPA are the
+    reason it exists."""
+    settings.REQUIRE_AUTH = False
+    r = client.get("/supervisor")
+    assert r.status_code in (200, 503)  # 503 only when no build output is present
+
+
+def test_an_unauthenticated_asset_miss_does_not_redirect_to_login(client, settings):
+    """The other half of the same bug: before, a miss fell through to the SPA
+    route and the auth middleware bounced it to Google — so a script tag was
+    answered with a sign-in page. A 404 has nothing to redirect."""
+    settings.REQUIRE_AUTH = True
+    r = client.get("/assets/index-DEADBEEF.js")
+    assert r.status_code == 404


### PR DESCRIPTION
Two supervisor-page complaints, both reproduced.

## White page on first load

Asset filenames are content-hashed and every deploy rehashes them, so a browser holding a cached `index.html` — the service worker precaches it — asks for a bundle the server no longer has. WhiteNoise passed the miss through, and the SPA catch-all answered that `.js` request with `index.html` at **`200 text/html`**.

A browser cannot parse HTML as a module, so the app rendered a **white page** until a force-refresh, with no error anyone could act on. Six deploys in one day is what made it routine.

Verified on the live host, authenticated:

```
GET /canopy/assets/index-D4vRniqN.js  →  200 text/html   "<!doctype html>…"
```

**Two changes, because the two auth states failed differently** — and I only saw the second one first (my initial repro used curl with no cookies, which is why I reported a login redirect):

- `assets/` is excluded from the SPA catch-all, so a miss **404s**. That's the honest answer to "that bundle is gone", and one a client can act on.
- `/assets/` joins `/static/` in `PUBLIC_PATH_PREFIXES`. Unauthenticated, the miss never reached the catch-all at all — `LoginRequiredMiddleware` runs before URL resolution and bounced it to Google, so an expired session turned every `<script>` tag into a sign-in page. These bundles are already referenced by the login page's own HTML; gating them protected nothing.

## The standing yellow banner

*"Only one Claude credential is set"* and *"the only fallback is metered"* described a **deliberate** configuration, sat above the controls on every visit, and trained the eye to skip the whole block — which is precisely where the one alarm that matters has to be seen.

That alarm is kept: **no Claude credential at all** still says so, because it means the box cannot run anything. `claudeFallback` is still computed, for a caller that wants to raise it at a moment when it's actually the subject.

## Testing

5 new backend tests — a missing bundle 404s at several shapes, the SPA still serves app routes, and an unauthenticated miss no longer redirects. Suites: **1754 backend, 708 frontend**, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZoTH3niSknEU47NdZ42HJ
