### PR TITLE
Show the current state and a way in — not a verdict on someone else's attempt

### DIFF
--- a/frontend/src/components/supervisor/RunnerReauth.test.tsx
+++ b/frontend/src/components/supervisor/RunnerReauth.test.tsx
@@ -24,7 +24,7 @@ const URL_ = 'https://claude.com/cai/oauth/authorize?code=true&client_id=x&state
 function mint(over: Partial<RunnerMint> = {}): RunnerMint {
   return {
     id: 'm1', status: 'requested', authorize_url: '', detail: '',
-    created_at: '2026-09-08T00:00:00Z', updated_at: '2026-09-08T00:00:00Z',
+    created_at: new Date().toISOString(), updated_at: new Date().toISOString(),
     ...over,
   } as RunnerMint
 }
@@ -34,6 +34,18 @@ beforeEach(() => {
   api.getRunnerMint.mockResolvedValue(null)
 })
 afterEach(cleanup)
+
+/** Establish PRESENCE: an outcome is only shown to an operator who started the
+ *  sign-in in this visit, so every test that asserts on one has to click first.
+ *  That is the rule under test, not incidental setup. */
+async function startHere() {
+  api.startRunnerMint.mockResolvedValue(mint({ status: 'requested' }))
+  // Flush the initial load by draining microtasks rather than waitFor: one of
+  // these tests runs under fake timers, where waitFor can never advance and
+  // would hang the whole file.
+  await act(async () => { await Promise.resolve() })
+  await act(async () => { fireEvent.click(screen.getByTestId('reauth-start')) })
+}
 
 describe('RunnerReauth', () => {
   it('offers a single button when nothing is in flight', async () => {
@@ -98,9 +110,10 @@ describe('RunnerReauth', () => {
     // said `failed` the whole time. Reported 2026-09-08.
     vi.useFakeTimers()
     try {
-      api.getRunnerMint.mockResolvedValue(mint({ status: 'completing' }))
+      api.getRunnerMint.mockResolvedValue(mint({ status: 'requested' }))
       render(<RunnerReauth runnerId="r1" />)
-      await act(async () => { await Promise.resolve() })
+      await startHere()
+      api.getRunnerMint.mockResolvedValue(mint({ status: 'completing' }))
 
       await act(async () => { vi.advanceTimersByTime(95_000) })
       const callsAfterLimit = api.getRunnerMint.mock.calls.length
@@ -117,19 +130,55 @@ describe('RunnerReauth', () => {
   })
 
   it('reports a failed sign-in with the runner’s reason', async () => {
+    api.getRunnerMint.mockResolvedValue(mint({ status: 'requested' }))
+    render(<RunnerReauth runnerId="r1" />)
+    await startHere()
     api.getRunnerMint.mockResolvedValue(
       mint({ status: 'failed', detail: 'the code had expired' }))
-    render(<RunnerReauth runnerId="r1" />)
+    // Arrives on the poll tick (POLL_MS = 3s), not synchronously.
     await waitFor(() => expect(screen.getByTestId('reauth-failed').textContent)
-      .toContain('the code had expired'))
+      .toContain('the code had expired'), { timeout: 4000 })
     // and offers a retry rather than a dead end
     expect(screen.getByTestId('reauth-start')).toBeTruthy()
   })
 
+  it('does not greet you with the outcome of an attempt nobody remembers', async () => {
+    // Observed 2026-09-08: a mint abandoned at 14:39 was still showing "This
+    // sign-in expired before it was finished" in red, on a fresh page load an
+    // hour later, above a perfectly healthy box. Opening the page cold should
+    // show the CURRENT state and a way in — not a verdict on someone else's
+    // attempt. Age is irrelevant; presence is the test.
+    api.getRunnerMint.mockResolvedValue(mint({
+      status: 'failed',
+      detail: 'This sign-in expired before it was finished',
+    }))
+    render(<RunnerReauth runnerId="r1" />)
+    await waitFor(() => expect(screen.getByTestId('reauth-start')).toBeTruthy())
+    expect(screen.queryByTestId('reauth-failed')).toBeNull()
+    // …and it offers a plain start, not "again" for something they never did.
+    expect(screen.getByTestId('reauth-start').textContent).toContain('Start sign-in')
+  })
+
+  it('still shows an outcome you were actually present for', async () => {
+    // The diagnostic path: you clicked, it failed, you get to read why. This is
+    // what the whole runner-side error reporting exists to deliver, so the
+    // suppression above must not swallow it.
+    api.getRunnerMint.mockResolvedValue(mint({ status: 'requested' }))
+    render(<RunnerReauth runnerId="r1" />)
+    await startHere()
+    api.getRunnerMint.mockResolvedValue(
+      mint({ status: 'failed', detail: 'the code was rejected' }))
+    await waitFor(() => expect(screen.getByTestId('reauth-failed').textContent)
+      .toContain('the code was rejected'), { timeout: 4000 })
+  })
+
   it('never renders a token', async () => {
-    api.getRunnerMint.mockResolvedValue(mint({ status: 'done', detail: 'signed in' }))
+    api.getRunnerMint.mockResolvedValue(mint({ status: 'requested' }))
     const { container } = render(<RunnerReauth runnerId="r1" />)
-    await waitFor(() => expect(screen.getByTestId('reauth-done')).toBeTruthy())
+    await startHere()
+    api.getRunnerMint.mockResolvedValue(mint({ status: 'done', detail: 'signed in' }))
+    await waitFor(() => expect(screen.getByTestId('reauth-done')).toBeTruthy(),
+      { timeout: 4000 })
     expect(container.textContent).not.toContain('sk-ant-')
   })
 })

--- a/frontend/src/components/supervisor/RunnerReauth.tsx
+++ b/frontend/src/components/supervisor/RunnerReauth.tsx
@@ -30,6 +30,16 @@ import {
 const WAIT_LIMIT_MS = 90_000
 const POLL_MS = 3_000
 
+/* Outcomes are NOT persisted across visits.
+ *
+ * The newest mint is kept forever, so rendering its outcome unconditionally
+ * turned a sign-in abandoned at 14:39 into a red error greeting the next
+ * visitor an hour later, above a perfectly healthy box. A time window was the
+ * first fix and it was still too clever: what an operator wants here is the
+ * CURRENT state and a way in — not a verdict on an attempt they have no memory
+ * of. So an outcome shows only when it happened in front of you, in this visit.
+ */
+
 export function RunnerReauth({ runnerId, onSignedIn }: {
   runnerId: string
   /** Lets the parent refresh its masked credential status once a token lands. */
@@ -41,6 +51,9 @@ export function RunnerReauth({ runnerId, onSignedIn }: {
   const [error, setError] = useState<string | null>(null)
   const [waitedOut, setWaitedOut] = useState(false)
   const startedWaiting = useRef<number | null>(null)
+  /** Set when the operator starts or submits here — never by a poll. It is what
+   *  separates "this failed in front of me" from "this row is old". */
+  const actedThisVisit = useRef(false)
   const status = mint?.status
 
   const refresh = useCallback(async () => {
@@ -104,6 +117,7 @@ export function RunnerReauth({ runnerId, onSignedIn }: {
   }
 
   const start = () => run(async () => {
+    actedThisVisit.current = true
     setCode('')
     setWaitedOut(false)
     startedWaiting.current = null
@@ -111,6 +125,7 @@ export function RunnerReauth({ runnerId, onSignedIn }: {
   })
 
   const submit = () => run(async () => {
+    actedThisVisit.current = true
     const m = await submitRunnerMintCode(runnerId, code)
     setCode('')
     onSignedIn?.()
@@ -120,7 +135,11 @@ export function RunnerReauth({ runnerId, onSignedIn }: {
   // Narrowed through `mint` itself rather than a hoisted `mint?.status`: the
   // optional chain reads fine but does not narrow, so every `mint.` below then
   // needs a non-null assertion. `tsc -b` catches that; `tsc --noEmit` does not.
-  const idle = !mint || status === 'done' || status === 'failed'
+  const settled = status === 'done' || status === 'failed'
+  // Did this outcome happen while the operator was watching? Only then is it
+  // theirs to read. A page opened cold shows the live state and a button.
+  const outcomeIsFresh = settled && actedThisVisit.current
+  const idle = !mint || settled
 
   return (
     <section className="rounded-md border border-border p-3" data-testid="runner-reauth">
@@ -137,7 +156,7 @@ export function RunnerReauth({ runnerId, onSignedIn }: {
           data-testid="reauth-start"
           className="rounded-md border border-border px-2 py-1 text-xs hover:bg-muted disabled:opacity-50"
         >
-          {idle ? (status ? 'Sign in again' : 'Start sign-in') : 'Start again'}
+          {!idle ? 'Start again' : outcomeIsFresh ? 'Sign in again' : 'Start sign-in'}
         </button>
       </div>
 
@@ -208,13 +227,13 @@ export function RunnerReauth({ runnerId, onSignedIn }: {
         </p>
       )}
 
-      {status === 'done' && (
+      {status === 'done' && outcomeIsFresh && (
         <p className="mt-2 text-sm text-emerald-600" data-testid="reauth-done">
           Signed in. The runner is using the new token.
         </p>
       )}
 
-      {mint !== null && mint.status === 'failed' && (
+      {mint !== null && mint.status === 'failed' && outcomeIsFresh && (
         <p className="mt-2 text-sm text-destructive" data-testid="reauth-failed">
           {mint.detail || 'The sign-in did not complete.'}
         </p>


### PR DESCRIPTION
Reported: *"I just opened the url and I still see this red!"* — then, on the first attempt at a fix: *"I don't care about the state of the last attempt at all, just the current state and the ability to log in."*

The newest mint is kept forever, and the section rendered its outcome unconditionally. So a sign-in abandoned at 14:39 was still showing

> This sign-in expired before it was finished — the link is only good for a few minutes. Start another one.

in red, on a **fresh page load an hour later**, above a perfectly healthy box.

## Presence, not age

My first fix bounded the outcome by age (10 minutes). That was still too clever — age was never the question. An outcome now shows only when the operator **started or submitted the sign-in in this visit**. A page opened cold shows the live state and a button, nothing else. The button label drops "again" in that case too: it was offering to repeat something the reader never did.

A failure you **are** present for still surfaces immediately. That path is the entire point of the runner-side error reporting, so it has its own test sitting right next to the suppression to keep it from being swallowed.

## The tests moved the same way

Every case that asserts on an outcome now clicks first, via a `startHere` helper — establishing presence **is** the rule under test, not incidental setup. Two details worth keeping:

- The helper drains microtasks rather than using `waitFor`: one case runs under fake timers, where `waitFor` can never advance, and it hung the entire file until I spotted the cascade.
- The outcome arrives on the 3s poll, so those assertions carry an explicit timeout rather than relying on the 1s default — they exercise the real path instead of a synthetic seam.

Frontend suite: **710 passed**, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZoTH3niSknEU47NdZ42HJ
