### PR TITLE
Make the UI usable on a phone, and fix what the audit found

### DIFF
--- a/frontend/packages/canopy-ui/src/shell/WorkbenchNavItem.tsx
+++ b/frontend/packages/canopy-ui/src/shell/WorkbenchNavItem.tsx
@@ -12,8 +12,10 @@ export function workbenchNavItemClass({
     variant === 'neutral'
       ? 'bg-accent border-transparent text-foreground font-medium'
       : 'bg-primary/10 border-primary/30 text-primary font-medium'
+  // `min-h-11` below `sm` is the 44px touch minimum; from `sm` up the rail keeps
+  // its original density, where the pointer is precise and vertical space is dear.
   return cn(
-    'flex items-center justify-between gap-2 rounded-md border px-3 py-1.5 text-sm transition-colors',
+    'flex min-h-11 items-center justify-between gap-2 rounded-md border px-3 py-1.5 text-sm transition-colors sm:min-h-0',
     active
       ? activeClass
       : 'border-transparent text-muted-foreground hover:bg-accent hover:text-foreground',

--- a/frontend/packages/canopy-ui/src/ui/button.tsx
+++ b/frontend/packages/canopy-ui/src/ui/button.tsx
@@ -4,6 +4,11 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "../lib/cn"
 
 const buttonVariants = cva(
+  // Every size variant sets a fixed height (default h-8, sm h-7, xs h-6), all of
+  // them below the 44px touch minimum. Rather than teach each variant about
+  // touch, the floor lives here once and lifts off at `sm`, where a pointer is
+  // precise and the density is the point.
+  "min-h-11 min-w-11 sm:min-h-0 sm:min-w-0 " +
   "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {

--- a/frontend/packages/canopy-ui/src/ui/input.tsx
+++ b/frontend/packages/canopy-ui/src/ui/input.tsx
@@ -9,7 +9,9 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        // Touch floor, matching Button: `h-8` is 32px, under the 44px minimum. Lifts
+        // off at `sm` so desktop density is unchanged.
+        "min-h-11 sm:min-h-0 sm:h-8 h-11 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
         className
       )}
       {...props}

--- a/frontend/packages/canopy-ui/src/ui/tabs.tsx
+++ b/frontend/packages/canopy-ui/src/ui/tabs.tsx
@@ -23,8 +23,17 @@ function Tabs({
   )
 }
 
+// Touch first, then shrink to the desktop density at `sm`.
+//
+// `w-fit` + a fixed `h-8` was two bugs at once on a phone: the list sized itself
+// to its content, so a fourth tab ran off the viewport with no scroll and no
+// wrap (measured on /supervisor at 375px: scrollWidth 302 vs clientWidth 293,
+// clipping "Runners"), and the height capped every trigger at 23px — roughly
+// half the 44px touch minimum, on the surface that ships as the phone PWA.
+// Below `sm` the list is now full-width and wraps; from `sm` up it is exactly
+// what it was.
 const tabsListVariants = cva(
-  "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-horizontal/tabs:h-8 group-data-vertical/tabs:h-fit group-data-vertical/tabs:flex-col data-[variant=line]:rounded-none",
+  "group/tabs-list grid w-full max-w-full grid-cols-2 items-center justify-center rounded-lg p-[3px] text-muted-foreground sm:inline-flex sm:w-fit sm:grid-cols-none group-data-horizontal/tabs:h-auto sm:group-data-horizontal/tabs:h-8 group-data-vertical/tabs:h-fit group-data-vertical/tabs:flex-col data-[variant=line]:rounded-none",
   {
     variants: {
       variant: {
@@ -58,7 +67,7 @@ function TabsTrigger({ className, ...props }: TabsPrimitive.Tab.Props) {
     <TabsPrimitive.Tab
       data-slot="tabs-trigger"
       className={cn(
-        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2.5 py-0.5 text-sm font-medium whitespace-nowrap text-muted-foreground transition-all group-data-vertical/tabs:w-full group-data-vertical/tabs:justify-start hover:text-foreground-secondary focus-visible:border-primary/50 focus-visible:ring-2 focus-visible:ring-primary/20 focus-visible:outline-1 focus-visible:outline-primary/40 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 group-data-[variant=default]/tabs-list:data-active:shadow-sm group-data-[variant=line]/tabs-list:data-active:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "relative inline-flex min-h-11 flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-0.5 text-sm font-medium whitespace-nowrap text-muted-foreground transition-all sm:h-[calc(100%-1px)] sm:min-h-0 sm:px-2.5 group-data-vertical/tabs:w-full group-data-vertical/tabs:justify-start hover:text-foreground-secondary focus-visible:border-primary/50 focus-visible:ring-2 focus-visible:ring-primary/20 focus-visible:outline-1 focus-visible:outline-primary/40 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 group-data-[variant=default]/tabs-list:data-active:shadow-sm group-data-[variant=line]/tabs-list:data-active:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent group-data-[variant=line]/tabs-list:data-active:border-transparent",
         "data-active:bg-background data-active:text-foreground data-active:border-border",
         "after:absolute after:bg-primary after:opacity-0 after:transition-opacity group-data-horizontal/tabs:after:inset-x-0 group-data-horizontal/tabs:after:bottom-[-5px] group-data-horizontal/tabs:after:h-0.5 group-data-vertical/tabs:after:inset-y-0 group-data-vertical/tabs:after:-right-1 group-data-vertical/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",

--- a/frontend/src/components/AppLayout/AppLayout.tsx
+++ b/frontend/src/components/AppLayout/AppLayout.tsx
@@ -89,7 +89,7 @@ function UserMenu() {
         type="button"
         onClick={() => setOpen(!open)}
         aria-label="Account menu"
-        className="flex items-center gap-2 rounded-full border border-border bg-card pl-1 pr-3 py-1 hover:bg-muted"
+        className="flex min-h-11 items-center gap-2 rounded-full border border-border bg-card py-1 pl-1 pr-3 hover:bg-muted sm:min-h-0"
       >
         {auth.user.avatar_url ? (
           <img src={auth.user.avatar_url} alt="" className="h-6 w-6 rounded-full" />
@@ -189,7 +189,7 @@ function WorkspaceSwitcher() {
   return (
     <select
       aria-label="Workspace"
-      className="bg-input border border-input text-foreground text-[13px] rounded px-2 py-1"
+      className="min-h-11 rounded border border-input bg-input px-2 py-1 text-[13px] text-foreground sm:min-h-0"
       value={active ?? ''}
       onChange={(e) => navigate(`/w/${e.target.value}/agents`)}
     >
@@ -271,7 +271,7 @@ function AppShell() {
       <header className="border-b border-border bg-background relative">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 py-3 flex items-center justify-between gap-3">
           {isAuthed ? (
-            <Link to="/" className="text-lg font-semibold text-foreground shrink-0">Canopy<span className="text-primary">.</span></Link>
+            <Link to="/" className="flex min-h-11 shrink-0 items-center text-lg font-semibold text-foreground sm:min-h-0">Canopy<span className="text-primary">.</span></Link>
           ) : (
             <span className="text-lg font-semibold text-foreground shrink-0">Canopy<span className="text-primary">.</span></span>
           )}
@@ -325,7 +325,7 @@ function AppShell() {
               onClick={() => setMobileOpen((o) => !o)}
               aria-label="Toggle navigation menu"
               aria-expanded={mobileOpen}
-              className="md:hidden -mr-1 p-2 rounded text-foreground-secondary hover:text-foreground-secondary hover:bg-card"
+              className="-mr-1 flex min-h-11 min-w-11 items-center justify-center rounded text-foreground-secondary hover:bg-card hover:text-foreground-secondary md:hidden"
             >
               <svg className="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
                 {mobileOpen ? (
@@ -393,7 +393,11 @@ function AppShell() {
         // persistent left rail + wide main. The page owns its own scroll.
         <main className="h-[calc(100vh-53px)]"><Outlet /></main>
       ) : (
-        <main className="mx-auto max-w-7xl px-6 py-8"><Outlet /></main>
+        // `px-6` unconditionally, on top of the `p-6` several pages set for
+        // themselves, spent 96px of a 375px screen on padding — a quarter of the
+        // width, before any content. The gutter now scales with the viewport;
+        // the header above already did this.
+        <main className="mx-auto max-w-7xl px-4 py-6 sm:px-6 sm:py-8"><Outlet /></main>
       )}
     </div>
   )

--- a/frontend/src/components/agents/AgentLeftNav.tsx
+++ b/frontend/src/components/agents/AgentLeftNav.tsx
@@ -20,26 +20,38 @@ export function AgentLeftNav({ agent }: { agent: AgentDetailOut }) {
     }
   }, [agent.slug])
 
+  // ONE badge, and it means "waiting on you".
+  //
+  // Six of these carried a size (Tasks 9, Turns 115, Skills 129) and four did
+  // not, which made a blank badge unreadable: `Inbox 0` and `Syncs 0` render an
+  // explicit zero, so blank could not mean "none" — it had to mean "unknown".
+  // Credentials was the proof, blank in the rail while its own page header read
+  // "Credentials 45" (a number the rail cannot reach without a fetch per render).
+  //
+  // Adding the missing counts would have made the rail consistent and still
+  // useless: knowing there are 115 turns changes nothing about whether you click
+  // Turns, and every section page already prints its own count in its header. So
+  // the sizes go, blank becomes unambiguous everywhere, and the one number that
+  // does change a decision keeps its badge. It also shortens every pill, which
+  // is real estate the phone strip needs.
   const items: NavItem[] = [
-    // Inbox = OPEN items, decidable in place (the count). Items = the full ledger
-    // incl. decided/dismissed + batch sittings (?batch=) — browse/history, no badge.
+    // Inbox = OPEN items, decidable in place. Items = the full ledger incl.
+    // decided/dismissed + batch sittings (?batch=) — browse/history, no badge.
     { to: 'inbox', label: 'Inbox', count: waiting },
     { to: 'overview', label: 'Overview' },
-    { to: 'tasks', label: 'Tasks', count: agent.task_count },
+    { to: 'tasks', label: 'Tasks' },
     { to: 'items', label: 'Items' },
-    { to: 'turns', label: 'Turns', count: agent.turn_count },
-    // No count: the agent detail carries no schedule_count, and a badge that
-    // needs its own fetch to say "3" isn't worth a request on every rail render.
+    { to: 'turns', label: 'Turns' },
     { to: 'schedules', label: 'Schedules' },
-    { to: 'syncs', label: 'Syncs', count: agent.sync_count },
+    { to: 'syncs', label: 'Syncs' },
     { to: 'credentials', label: 'Credentials' },
-    { to: 'work-products', label: 'Work products', count: agent.work_product_count },
-    { to: 'skills', label: 'Skills', count: agent.skill_count },
+    { to: 'work-products', label: 'Work products' },
+    { to: 'skills', label: 'Skills' },
   ]
 
   const header = (
     <div className="px-4 py-4">
-      <Link to="/agents" className="text-[12px] text-muted-foreground hover:text-primary transition-colors">
+      <Link to="/agents" className="inline-flex min-h-11 items-center text-[12px] text-muted-foreground transition-colors hover:text-primary sm:min-h-0">
         ← Agents
       </Link>
       <div className="mt-3 flex items-start gap-3">
@@ -76,10 +88,22 @@ export function AgentLeftNav({ agent }: { agent: AgentDetailOut }) {
           identity header above it that pushed the actual content to 55% down the
           first screen: you scrolled past the navigation to reach what you opened.
           Desktop is unchanged from md up. */}
-      <nav className="px-2 py-3">
-        <div className="flex gap-0.5 overflow-x-auto md:flex-col md:overflow-x-visible">
+      {/* The strip scrolls, so it has to LOOK like it scrolls. Ten sections at
+          375px means 588 of 899px sit off-screen (measured), and macOS hides
+          overlay scrollbars — so Credentials, Skills, Turns, Schedules, Syncs and
+          Work products were not merely off-screen but undiscoverable: a strip
+          with no visible edge reads as "that is all of them". The right-edge
+          fade is the affordance, and it is masked out from `md` up where the
+          rail is vertical and everything is already visible. */}
+      <nav className="relative px-2 py-3 after:pointer-events-none after:absolute after:inset-y-3 after:right-0 after:w-10 after:bg-gradient-to-l after:from-background after:via-background/80 after:to-transparent md:after:hidden">
+        <div className="flex snap-x gap-0.5 overflow-x-auto md:flex-col md:overflow-x-visible">
           {items.map((item) => (
-            <NavLink key={item.to} to={item.to} end={item.to === 'overview'} className="shrink-0 md:shrink">
+            <NavLink
+              key={item.to}
+              to={item.to}
+              end={item.to === 'overview'}
+              className="shrink-0 snap-start md:shrink md:snap-align-none"
+            >
               {({ isActive }) => (
                 <WorkbenchNavItem active={isActive} count={item.count}>
                   {item.label}

--- a/frontend/src/components/chat/ChatSessionsPanel.test.tsx
+++ b/frontend/src/components/chat/ChatSessionsPanel.test.tsx
@@ -318,7 +318,12 @@ describe('ChatSessionsPanel — sessions on a parked runner', () => {
 
     expect(await screen.findByText('Live one')).toBeTruthy()
     expect(screen.queryByText('Parked one')).toBeNull()
-    expect(screen.getByTestId('parked-summary').textContent).toBe('1 hidden — runner paused')
+    const summary = screen.getByTestId('parked-summary')
+    expect(summary.textContent).toContain('1 hidden — runner paused')
+    // …and it has to LOOK like the control it always was. Set as dim caption
+    // text it read as an explanation of an absence rather than the way to undo
+    // it, while withholding most of the list.
+    expect(summary.textContent).toContain('Show them')
   })
 
   it('reveals them dimmed, with the reason on the row, when Show offline is on', async () => {

--- a/frontend/src/components/chat/ChatSessionsPanel.tsx
+++ b/frontend/src/components/chat/ChatSessionsPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { Plus } from 'lucide-react'
 import {
@@ -16,6 +16,7 @@ import { listRunners, type RunnerOut } from '@/api/harness'
 import { projectsApi, type ProjectSlug } from '@/api/projects'
 import { relativeTime } from '@/components/activity/turnLog'
 import { sessionTargetLabel } from './sessionTargetLabel'
+import { sessionDisplayTitle } from './sessionDisplayTitle'
 import { projectHeader, sortSessions, type SessionSort } from './sessionSort'
 import { closeIntent, closeResultMessage } from './closeAction'
 import {
@@ -30,6 +31,37 @@ import {
 type PendingTarget =
   | { kind: 'agent'; agent: AgentOut }
   | { kind: 'project'; project: ProjectSlug }
+
+/** An independent on/off filter — deliberately shaped unlike the sort segments
+ *  beside it, so the row does not read as four options where you pick one. */
+function FilterToggle({
+  checked,
+  onChange,
+  testId,
+  children,
+}: {
+  checked: boolean
+  onChange: () => void
+  testId?: string
+  children: ReactNode
+}) {
+  return (
+    <label
+      className={`inline-flex min-h-11 cursor-pointer items-center gap-1.5 sm:min-h-0 ${
+        checked ? 'text-foreground' : 'text-muted-foreground hover:text-foreground-secondary'
+      }`}
+    >
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={onChange}
+        data-testid={testId}
+        className="h-3.5 w-3.5 shrink-0 accent-primary"
+      />
+      {children}
+    </label>
+  )
+}
 
 /**
  * Reusable, CROSS-WORKSPACE chat session surface: a findable list of your chat
@@ -357,50 +389,46 @@ export function ChatSessionsPanel({
           held back, the sort row would never render and its own reveal toggle
           would be unreachable — a chat you cannot get back to. */}
       {(sessions.length > 1 || showArchived || parked.length > 0 || showOffline) && (
-        <div className="flex items-center gap-1 pb-2 text-xs">
-          <span className="mr-1 text-muted-foreground">Sort</span>
-          {(['time', 'project'] as const).map((m) => (
-            <button
-              key={m}
-              type="button"
-              onClick={() => setSort(m)}
-              aria-pressed={sort === m}
-              className={
-                sort === m
-                  ? 'rounded-md border border-primary/40 bg-primary/10 px-2 py-0.5 font-medium text-primary'
-                  : 'rounded-md border border-border px-2 py-0.5 text-muted-foreground hover:bg-muted'
-              }
-            >
-              {m === 'time' ? 'Recent' : 'Project'}
-            </button>
-          ))}
-          <button
-            type="button"
-            onClick={() => setShowArchived((v) => !v)}
-            aria-pressed={showArchived}
-            className={
-              showArchived
-                ? 'ml-2 rounded-md border border-primary/40 bg-primary/10 px-2 py-0.5 font-medium text-primary'
-                : 'ml-2 rounded-md border border-border px-2 py-0.5 text-muted-foreground hover:bg-muted'
-            }
-          >
-            Show archived
-          </button>
-          {(parked.length > 0 || showOffline) && (
-            <button
-              type="button"
-              onClick={() => setShowOffline((v) => !v)}
-              aria-pressed={showOffline}
-              data-testid="toggle-offline"
-              className={
-                showOffline
-                  ? 'rounded-md border border-primary/40 bg-primary/10 px-2 py-0.5 font-medium text-primary'
-                  : 'rounded-md border border-border px-2 py-0.5 text-muted-foreground hover:bg-muted'
-              }
-            >
-              Show offline
-            </button>
-          )}
+        // Four identical pills in a row, but the first two are a choose-ONE sort
+        // and the last two are independent switches — a difference carried only
+        // by the word "Sort" at the far left, which governs half the row. The
+        // sort is now one segmented control with a shared border (visibly one
+        // widget, one choice); the filters are checkboxes that say on or off.
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-2 pb-2 text-xs">
+          <div className="flex items-center gap-1.5">
+            <span className="text-muted-foreground">Sort</span>
+            <div className="inline-flex overflow-hidden rounded-md border border-border" role="group">
+              {(['time', 'project'] as const).map((m) => (
+                <button
+                  key={m}
+                  type="button"
+                  onClick={() => setSort(m)}
+                  aria-pressed={sort === m}
+                  className={`min-h-11 px-2.5 py-0.5 sm:min-h-0 ${
+                    sort === m
+                      ? 'bg-primary/10 font-medium text-primary'
+                      : 'text-muted-foreground hover:bg-muted'
+                  }`}
+                >
+                  {m === 'time' ? 'Recent' : 'Project'}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+            <FilterToggle checked={showArchived} onChange={() => setShowArchived((v) => !v)}>
+              Show archived
+            </FilterToggle>
+            {(parked.length > 0 || showOffline) && (
+              <FilterToggle
+                checked={showOffline}
+                onChange={() => setShowOffline((v) => !v)}
+                testId="toggle-offline"
+              >
+                Show offline
+              </FilterToggle>
+            )}
+          </div>
         </div>
       )}
 
@@ -442,8 +470,11 @@ export function ChatSessionsPanel({
                     }`}
                   >
                     <div className="min-w-0">
-                      <div className="truncate text-sm font-medium text-foreground">
-                        {s.title?.trim() || 'Untitled chat'}
+                      <div
+                        className="truncate text-sm font-medium text-foreground"
+                        title={s.title?.trim() || undefined}
+                      >
+                        {sessionDisplayTitle(s.title) || 'Untitled chat'}
                       </div>
                       <div className="truncate text-xs text-muted-foreground">
                         {label} · {s.workspace}
@@ -474,8 +505,17 @@ export function ChatSessionsPanel({
                           running
                         </span>
                       ) : (
-                        <span className="text-muted-foreground">{relativeTime(s.last_activity_at, now)}</span>
+                        <span className="flex items-center gap-1 text-muted-foreground">
+                          <span className="inline-block h-1.5 w-1.5 rounded-full bg-muted-foreground" />
+                          idle
+                        </span>
                       )}
+                      {/* The age used to REPLACE the status, so one slot held two
+                          different kinds of fact — five rows read "running" and
+                          the sixth read "6h ago", and the column could not be
+                          scanned without reading each value to learn which
+                          question it was answering. Status always; age alongside. */}
+                      <span className="text-muted-foreground">{relativeTime(s.last_activity_at, now)}</span>
                       {s.runner_name && (
                         <span className="text-muted-foreground">
                           {s.runner_name}
@@ -512,9 +552,13 @@ export function ChatSessionsPanel({
           type="button"
           onClick={() => setShowOffline(true)}
           data-testid="parked-summary"
-          className="self-start py-1.5 text-[11px] text-muted-foreground hover:text-foreground"
+          // It always revealed them on click; it just did not look like it could.
+          // Set smaller and dimmer than the rows it withholds, with no border or
+          // underline, it read as a caption explaining an absence rather than a
+          // control that undoes it — while hiding 10 of 16 chats.
+          className="mt-1 min-h-11 self-start rounded-md border border-dashed border-border px-2 py-1.5 text-xs text-foreground-secondary transition-colors hover:border-input hover:bg-muted hover:text-foreground sm:min-h-0"
         >
-          {parkedSummary(parked)}
+          {parkedSummary(parked)} <span className="text-primary">· Show them</span>
         </button>
       )}
     </div>

--- a/frontend/src/components/chat/sessionDisplayTitle.test.ts
+++ b/frontend/src/components/chat/sessionDisplayTitle.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { sessionDisplayTitle } from './sessionDisplayTitle'
+
+describe('sessionDisplayTitle', () => {
+  it('collapses the doubled resume marker seen in the live list', () => {
+    expect(sessionDisplayTitle('c-resume-c-resume-ace-kmc-metrics-e999')).toBe(
+      'c-resume-ace-kmc-metrics-e999',
+    )
+    expect(sessionDisplayTitle('c-resume-c-resume-feat-runtime-yaml-1f1e')).toBe(
+      'c-resume-feat-runtime-yaml-1f1e',
+    )
+  })
+
+  it('collapses a deeper nest to a single marker', () => {
+    expect(sessionDisplayTitle('c-resume-c-resume-c-resume-spark-ec06')).toBe('c-resume-spark-ec06')
+  })
+
+  it('leaves a single resume alone', () => {
+    expect(sessionDisplayTitle('c-resume-spark-ec06')).toBe('c-resume-spark-ec06')
+  })
+
+  it('leaves every other canopy name untouched', () => {
+    for (const name of [
+      'c-meet-our-speakers-aif-s-annual-65ba',
+      'c-issue-triage-4a4e',
+      'c-turn-0001',
+    ]) {
+      expect(sessionDisplayTitle(name)).toBe(name)
+    }
+  })
+
+  it('does not rewrite a human-typed emdash task', () => {
+    // No `c-` marker means a person named it; it is not ours to tidy.
+    expect(sessionDisplayTitle('bednet')).toBe('bednet')
+    expect(sessionDisplayTitle('userswitch')).toBe('userswitch')
+    expect(sessionDisplayTitle('resume-resume-by-hand')).toBe('resume-resume-by-hand')
+  })
+
+  it('does not collapse a word that merely recurs later in the subject', () => {
+    // Only an immediately repeated marker is a stack; "resume" appearing again
+    // further along is part of the subject someone wrote.
+    expect(sessionDisplayTitle('c-resume-plan-then-resume-later-ab12')).toBe(
+      'c-resume-plan-then-resume-later-ab12',
+    )
+  })
+
+  it('handles empty and missing input', () => {
+    expect(sessionDisplayTitle('')).toBe('')
+    expect(sessionDisplayTitle(null)).toBe('')
+    expect(sessionDisplayTitle(undefined)).toBe('')
+  })
+})

--- a/frontend/src/components/chat/sessionDisplayTitle.ts
+++ b/frontend/src/components/chat/sessionDisplayTitle.ts
@@ -1,0 +1,49 @@
+/**
+ * What to SHOW for an emdash-discovered session name.
+ *
+ * The names arrive already built (`c-<subject>-<disc>`, see the runner's
+ * `session_naming.py`) and canopy-web only reads them. Two of six rows in the
+ * live list read `c-resume-c-resume-…`, because resuming a session derives the
+ * new subject from the old session's NAME, and the old name already began with
+ * `c-resume-`. Each resume nests another copy.
+ *
+ * The real fix belongs wherever that resume subject is built — it should strip
+ * an existing task-name shape before prefixing, not stack onto it. This is the
+ * display-side mitigation so the list is readable in the meantime, and it is
+ * deliberately narrow: it collapses a RUN OF THE SAME repeated marker and
+ * nothing else, so it cannot mangle a name that merely happens to repeat a word.
+ * The untouched name stays available for the row's `title`.
+ */
+
+/** Markers a resume-style flow is known to stack. Lower-case, no delimiters. */
+const STACKABLE = ['resume']
+
+export function sessionDisplayTitle(raw: string | null | undefined): string {
+  const name = (raw ?? '').trim()
+  if (!name) return ''
+
+  // Only the canopy shape is in scope — a human-typed emdash task ("bednet")
+  // is theirs, and we do not rewrite it.
+  const prefix = name.startsWith('c-') ? 'c-' : ''
+  if (!prefix) return name
+
+  const segments = name.slice(prefix.length).split('-')
+  const out: string[] = []
+  for (let i = 0; i < segments.length; i += 1) {
+    const seg = segments[i]
+    // `c-resume-c-resume-x`: after the leading `c-` is stripped the repetition
+    // reads as `resume, c, resume, x`. Drop a marker that is about to be
+    // restated, along with the `c` that separates the two copies.
+    if (STACKABLE.includes(seg.toLowerCase())) {
+      const next = segments[i + 1]
+      const after = segments[i + 2]
+      if (next === 'c' && after && after.toLowerCase() === seg.toLowerCase()) {
+        i += 1 // skip the interleaved 'c'; the loop re-reads the second marker
+        continue
+      }
+      if (next && next.toLowerCase() === seg.toLowerCase()) continue
+    }
+    out.push(seg)
+  }
+  return prefix + out.join('-')
+}

--- a/frontend/src/components/items/ItemCard.tsx
+++ b/frontend/src/components/items/ItemCard.tsx
@@ -84,7 +84,12 @@ export function ItemCard({
             disabled={busy}
             placeholder="Type an answer…"
             onChange={(e) => setAnswer(e.target.value)}
-            className="min-w-0 flex-1 min-h-11 sm:min-h-0 rounded-md border border-input bg-input px-2 py-1 text-[12px] text-foreground placeholder:text-muted-foreground dark:placeholder:text-foreground-secondary disabled:opacity-50"
+            // `flex-1` alone let the two buttons take the row and squeeze the
+            // field to 87px at 375 — about six visible characters, on the
+            // control that takes the actual answer. `basis-full` gives it the
+            // whole row on a phone and pushes the buttons below; from `sm` up
+            // the three share a line as before.
+            className="min-h-11 w-full min-w-0 basis-full rounded-md border border-input bg-input px-2 py-1 text-[12px] text-foreground placeholder:text-muted-foreground disabled:opacity-50 sm:min-h-0 sm:w-auto sm:flex-1 sm:basis-auto dark:placeholder:text-foreground-secondary"
             data-testid={`item-answer-${item.id}`}
           />
           <button

--- a/frontend/src/components/schedules/ScheduleCalendar.tsx
+++ b/frontend/src/components/schedules/ScheduleCalendar.tsx
@@ -73,11 +73,11 @@ export function ScheduleCalendar({ showWorkspaceFilter }: { showWorkspaceFilter:
         </div>
         <div className="flex items-center gap-1">
           <button type="button" onClick={() => shiftWeek(-7)}
-            className="rounded border border-border px-2 py-1 text-sm text-foreground hover:bg-muted">←</button>
+            className="min-h-11 min-w-11 rounded border border-border px-2 py-1 text-sm text-foreground hover:bg-muted sm:min-h-0 sm:min-w-0">←</button>
           <button type="button" onClick={() => setWeekStart(mondayOf(new Date()))}
-            className="rounded border border-border px-2 py-1 text-sm text-foreground hover:bg-muted">This week</button>
+            className="min-h-11 min-w-11 rounded border border-border px-2 py-1 text-sm text-foreground hover:bg-muted sm:min-h-0 sm:min-w-0">This week</button>
           <button type="button" onClick={() => shiftWeek(7)}
-            className="rounded border border-border px-2 py-1 text-sm text-foreground hover:bg-muted">→</button>
+            className="min-h-11 min-w-11 rounded border border-border px-2 py-1 text-sm text-foreground hover:bg-muted sm:min-h-0 sm:min-w-0">→</button>
         </div>
       </header>
 
@@ -105,9 +105,9 @@ export function ScheduleCalendar({ showWorkspaceFilter }: { showWorkspaceFilter:
                   <li key={i}>
                     <button type="button"
                       onClick={() => setEditing({ agentSlug: f.item.schedule.agent_slug, schedule: f.item.schedule })}
-                      className="w-full rounded bg-muted px-1.5 py-1 text-left text-xs hover:bg-primary/10">
+                      className="min-h-11 w-full rounded bg-muted px-1.5 py-1 text-left text-xs hover:bg-primary/10 sm:min-h-0">
                       <span className="font-medium text-foreground">{timeLabel(f.when)}</span>{" "}
-                      <span className="text-muted-foreground">{f.item.schedule.agent_slug}</span>
+                      <span className="text-foreground-secondary">{f.item.schedule.agent_slug}</span>
                       <div className="truncate text-foreground-secondary">{f.item.schedule.name}</div>
                     </button>
                   </li>
@@ -139,12 +139,12 @@ function FilterRow({ label, value, options, onChange }: {
     <div className="flex flex-wrap items-center gap-1">
       <span className="text-muted-foreground">{label}:</span>
       <button type="button" onClick={() => onChange(null)}
-        className={`rounded border px-1.5 py-0.5 ${value === null ? "border-primary text-primary" : "border-border text-foreground-secondary hover:bg-muted"}`}>
+        className={`min-h-11 rounded border px-2 py-0.5 sm:min-h-0 ${value === null ? "border-primary text-primary" : "border-border text-foreground-secondary hover:bg-muted"}`}>
         All
       </button>
       {options.map((o) => (
         <button key={o} type="button" onClick={() => onChange(o)}
-          className={`rounded border px-1.5 py-0.5 ${value === o ? "border-primary text-primary" : "border-border text-foreground-secondary hover:bg-muted"}`}>
+          className={`min-h-11 rounded border px-2 py-0.5 sm:min-h-0 ${value === o ? "border-primary text-primary" : "border-border text-foreground-secondary hover:bg-muted"}`}>
           {o}
         </button>
       ))}

--- a/frontend/src/components/supervisor/RunnerStatus.tsx
+++ b/frontend/src/components/supervisor/RunnerStatus.tsx
@@ -1,6 +1,7 @@
 import type { JSX } from 'react'
 import type { RunnerOut } from '@/api/harness'
 import type { components } from '@/api/generated'
+import { relativeAge } from '@/lib/relativeAge'
 
 type DrillRollup = components['schemas']['DrillRollup']
 
@@ -18,13 +19,9 @@ const DOT: Record<string, string> = {
   paused: 'bg-info',
 }
 
-function relative(iso: string | null): string {
-  if (!iso) return 'never'
-  const secs = Math.round((Date.now() - new Date(iso).getTime()) / 1000)
-  if (secs < 60) return `${secs}s ago`
-  if (secs < 3600) return `${Math.round(secs / 60)}m ago`
-  return `${Math.round(secs / 3600)}h ago`
-}
+// Ladder lives in `relativeAge` (and is unit-tested there) so it cannot stop at
+// hours again — that is what produced "drilled 1087h ago" on this very row.
+const relative = (iso: string | null): string => relativeAge(iso)
 
 // Worst-signal-wins: a single failed drill outranks any number of pending
 // ones for the at-a-glance color, which in turn outranks an all-clear.
@@ -55,9 +52,10 @@ export function RunnerStatus({
           key={r.id}
           type="button"
           onClick={() => onSelect?.(r)}
-          className="flex w-full items-center gap-2.5 rounded-lg border border-border bg-card px-3 py-2 text-left"
+          className="flex min-h-11 w-full flex-col gap-1 rounded-lg border border-border bg-card px-3 py-2 text-left sm:min-h-0"
           data-testid={`runner-${r.name}`}
         >
+          <span className="flex w-full items-center gap-2.5">
           <span className={`h-2 w-2 shrink-0 rounded-full ${DOT[r.status] ?? 'bg-muted-foreground'}`} />
           <span className="min-w-0 flex-1 truncate text-[13px] font-medium text-foreground">{r.name}</span>
           {/* `paused` outranks `not ready` here for the same reason it outranks a
@@ -76,17 +74,40 @@ export function RunnerStatus({
               not ready
             </span>
           ) : null}
-          {r.host && <span className="hidden truncate text-[11px] text-foreground-subtle sm:inline">{r.host}</span>}
+          {/* The host was `text-foreground-subtle` at 11px — 1.7:1 against this
+              row, where AA asks 4.5:1 — AND `hidden sm:inline`, so on a phone it
+              was not dim but absent. Which box a runner is on is the field that
+              tells two near-identical rows apart, so it is the last thing that
+              should be decoration: it moves up the emphasis ladder, up to 12px,
+              and onto the second line rather than off the screen. */}
+          {r.host && (
+            <span className="hidden min-w-0 truncate text-xs text-muted-foreground sm:inline">{r.host}</span>
+          )}
           {r.drill_rollup && (
             <span
               data-testid={`runner-drill-badge-${r.name}`}
-              className={`hidden shrink-0 text-[11px] sm:inline ${drillBadgeClass(r.drill_rollup)}`}
+              className={`hidden shrink-0 text-xs sm:inline ${drillBadgeClass(r.drill_rollup)}`}
             >
               drilled {relative(r.drill_rollup.last_finished_at)} —{' '}
               {r.drill_rollup.passed}/{r.drill_rollup.passed + r.drill_rollup.failed + r.drill_rollup.pending}
             </span>
           )}
-          <span className="shrink-0 text-[11px] text-muted-foreground">{relative(r.last_heartbeat_at)}</span>
+          <span className="shrink-0 text-xs text-muted-foreground">{relative(r.last_heartbeat_at)}</span>
+          </span>
+
+          {/* Phone: the two facts the wide row shows inline, on their own line
+              instead of hidden. A runner you cannot identify is the failure this
+              list exists to prevent. */}
+          {(r.host || r.drill_rollup) && (
+            <span className="flex items-baseline gap-2 pl-[18px] text-xs sm:hidden">
+              {r.host && <span className="min-w-0 truncate text-muted-foreground">{r.host}</span>}
+              {r.drill_rollup && (
+                <span className={`shrink-0 ${drillBadgeClass(r.drill_rollup)}`}>
+                  drilled {relative(r.drill_rollup.last_finished_at)}
+                </span>
+              )}
+            </span>
+          )}
         </button>
       ))}
     </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -88,13 +88,26 @@
     --secondary: oklch(0.268 0.007 34.3);        /* ~stone-800 */
     --secondary-foreground: oklch(0.923 0.003 48.72);
     --muted: oklch(0.268 0.007 34.3);            /* ~stone-800 */
-    --muted-foreground: oklch(0.553 0.013 58.07);/* ~stone-500 */
+    /* Raised from 0.553 (~stone-500), which measured 3.65:1 on --card in the
+       default dark theme — under the 4.5:1 AA asks for body text, and this is
+       the token every timestamp, caption and inactive tab label uses. Only the
+       DARK value moves: in light mode this is dark text on white and already
+       clears AA, where raising it would REDUCE contrast. The rung below
+       (--foreground-subtle, 0.374) is unchanged, so the ladder keeps its steps. */
+    --muted-foreground: oklch(0.62 0.013 58.07); /* ~stone-450 */
     --foreground-secondary: oklch(0.809 0.005 56.0); /* ~stone-300 — secondary text */
     /* NOTE: identical to --input below. Faint text placed ON an input is therefore
        INVISIBLE in dark mode (contrast 1.00) — use --muted-foreground for anything
        sitting on an input surface, e.g. placeholders. Guarded by the
        'no invisible placeholders' e2e test. */
-    --foreground-subtle: oklch(0.374 0.01 67.56);    /* ~stone-700 — faint text */
+    /* Raised from 0.374 (~stone-700), which measured 1.70:1 on --card — not
+       "faint" but effectively unreadable, and it is carrying real content in
+       ~20 places (a runner's host name, "set"/"not set", inbox counts). It was
+       also EXACTLY --input below, which is the documented reason faint text on
+       an input surface rendered at contrast 1.00, i.e. invisible; they are now
+       distinct, so that whole hazard class is gone. Still clearly the faintest
+       rung — a step below --muted-foreground, not level with it. */
+    --foreground-subtle: oklch(0.52 0.01 67.56);     /* ~stone-550 — faint text */
     --accent: oklch(0.268 0.007 34.3);
     --accent-foreground: oklch(0.923 0.003 48.72);
     --destructive: oklch(0.704 0.191 22.216);    /* ~red-500 — errors / destructive */

--- a/frontend/src/lib/relativeAge.test.ts
+++ b/frontend/src/lib/relativeAge.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { relativeAge } from './relativeAge'
+
+const NOW = new Date('2026-09-08T12:00:00Z')
+const ago = (secs: number) => new Date(NOW.getTime() - secs * 1000).toISOString()
+
+const H = 3600
+const D = 24 * H
+
+describe('relativeAge', () => {
+  it('keeps second granularity, because a heartbeat is meant to be seconds fresh', () => {
+    // turnLog's relativeTime floors this whole range to "just now", which cannot
+    // tell a runner that reported 2s ago from one that reported 59s ago.
+    expect(relativeAge(ago(2), NOW)).toBe('2s ago')
+    expect(relativeAge(ago(59), NOW)).toBe('59s ago')
+  })
+
+  it('climbs to minutes and hours', () => {
+    expect(relativeAge(ago(90), NOW)).toBe('2m ago')
+    expect(relativeAge(ago(2 * H), NOW)).toBe('2h ago')
+    expect(relativeAge(ago(23 * H), NOW)).toBe('23h ago')
+  })
+
+  it('does not report a month and a half as 1087 hours', () => {
+    // The regression this exists for: the Runners tab read "drilled 1087h ago".
+    // 1087h is 45 days, which is far enough back that months is the unit a
+    // reader wants — the point is only that the number is never 1087.
+    expect(relativeAge(ago(1087 * H), NOW)).toBe('2mo ago')
+    expect(relativeAge(ago(80 * H), NOW)).toBe('3d ago')
+  })
+
+  it('climbs past days into weeks, months and years', () => {
+    expect(relativeAge(ago(10 * D), NOW)).toBe('1w ago')
+    expect(relativeAge(ago(21 * D), NOW)).toBe('3w ago')
+    expect(relativeAge(ago(60 * D), NOW)).toBe('2mo ago')
+    expect(relativeAge(ago(400 * D), NOW)).toBe('1y ago')
+  })
+
+  it('never emits a unit a reader has to convert', () => {
+    // Every step of the ladder, sampled: the number stays small enough to read.
+    for (const secs of [0, 30, 61, 600, 5 * H, 30 * H, 6 * D, 20 * D, 90 * D, 800 * D]) {
+      const out = relativeAge(ago(secs), NOW)
+      const n = Number(out.match(/^\d+/)?.[0] ?? 0)
+      expect(n, `${secs}s → ${out}`).toBeLessThan(60)
+    }
+  })
+
+  it('reads a missing or unparseable timestamp as never', () => {
+    expect(relativeAge(null, NOW)).toBe('never')
+    expect(relativeAge('not a date', NOW)).toBe('never')
+  })
+
+  it('treats a slightly fast clock as fresh rather than negative', () => {
+    expect(relativeAge(ago(-5), NOW)).toBe('0s ago')
+    expect(relativeAge(ago(-3600), NOW)).toBe('in the future')
+  })
+})

--- a/frontend/src/lib/relativeAge.ts
+++ b/frontend/src/lib/relativeAge.ts
@@ -1,0 +1,42 @@
+/**
+ * "How long ago", for the runner list.
+ *
+ * Deliberately NOT `activity/turnLog`'s `relativeTime`, which floors anything
+ * under a minute to "just now": a heartbeat's whole job is to be seconds fresh,
+ * and "just now" cannot distinguish a runner that reported 2s ago from one that
+ * reported 59s ago.
+ *
+ * It stopped at hours, which is how the Runners tab came to report a readiness
+ * drill as `drilled 1087h ago`. Nobody converts 1087 hours; it is 45 days. The
+ * ladder now runs all the way up, so the unit is always one a person reads at a
+ * glance.
+ */
+export function relativeAge(iso: string | null, now: Date = new Date()): string {
+  if (!iso) return 'never'
+  const ms = new Date(iso).getTime()
+  if (Number.isNaN(ms)) return 'never'
+
+  const secs = Math.round((now.getTime() - ms) / 1000)
+  // A clock skewed a little ahead of the server should read as fresh, not as a
+  // negative age. Anything beyond a minute in the future is a real anomaly and
+  // says so rather than pretending.
+  if (secs < -60) return 'in the future'
+  if (secs < 60) return `${Math.max(secs, 0)}s ago`
+
+  const mins = Math.round(secs / 60)
+  if (mins < 60) return `${mins}m ago`
+
+  const hours = Math.round(mins / 60)
+  if (hours < 24) return `${hours}h ago`
+
+  const days = Math.round(hours / 24)
+  if (days < 7) return `${days}d ago`
+
+  const weeks = Math.round(days / 7)
+  if (weeks < 5) return `${weeks}w ago`
+
+  const months = Math.round(days / 30)
+  if (months < 12) return `${months}mo ago`
+
+  return `${Math.round(days / 365)}y ago`
+}

--- a/frontend/src/pages/ActivityPage.tsx
+++ b/frontend/src/pages/ActivityPage.tsx
@@ -181,7 +181,7 @@ function FilterRow({ label, value, options, onChange }: {
     <label className="flex items-center gap-1">
       <span className="text-muted-foreground">{label}</span>
       <select
-        className="rounded border border-input bg-input px-1.5 py-1 text-foreground"
+        className="min-h-11 rounded border border-input bg-input px-1.5 py-1 text-foreground sm:min-h-0"
         value={value ?? ""}
         onChange={(e) => onChange(e.target.value || null)}
       >

--- a/frontend/src/pages/InboundPushPage.tsx
+++ b/frontend/src/pages/InboundPushPage.tsx
@@ -38,7 +38,14 @@ function CopyField({ label, value }: { label: string; value: string }): JSX.Elem
     <div className="space-y-1">
       <div className="text-xs text-muted-foreground">{label}</div>
       <div className="flex gap-2">
-        <code className="flex-1 overflow-x-auto rounded border border-border bg-muted px-2 py-1 text-xs">
+        {/* `whitespace-pre` is load-bearing, not cosmetic. The gcloud block is
+            five numbered steps separated by blank lines — 27 newlines in all —
+            and the browser's default `white-space: normal` collapsed every one
+            of them, rendering the page's most important element (the thing you
+            paste into a terminal) as a single unbroken run-on. `min-w-0` is what
+            lets this flex child shrink so `overflow-x-auto` actually engages
+            instead of the row pushing the page wide on a phone. */}
+        <code className="min-w-0 flex-1 overflow-x-auto whitespace-pre rounded border border-border bg-muted px-2 py-1 text-xs">
           {value}
         </code>
         <Button
@@ -200,7 +207,7 @@ export function InboundPushPage(): JSX.Element | null {
         <CopyField label="Run these" value={commands} />
         <div className="flex flex-wrap gap-3 text-xs">
           {consoleLinks(project).map((l) => (
-            <a key={l.url} className="text-primary underline" href={l.url} target="_blank" rel="noreferrer">
+            <a key={l.url} className="inline-flex min-h-11 items-center text-primary underline sm:min-h-0" href={l.url} target="_blank" rel="noreferrer">
               {l.label}
             </a>
           ))}

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { Link, useSearchParams } from 'react-router-dom'
 import { AnimatePresence, LayoutGroup, motion } from 'framer-motion'
 import { type Project, projectsApi } from '@/api/projects'
+import { relativeAge } from '@/lib/relativeAge'
 import {
   type Insight,
   insightsApi,
@@ -26,16 +27,13 @@ const HYGIENE_ACTIONS: Array<{ key: string; label: string }> = [
   { key: 'canopy:pm-scout', label: 'pm-scout' },
 ]
 
-function relativeTime(iso: string): string {
-  const diff = Date.now() - new Date(iso).getTime()
-  const minutes = Math.floor(diff / 60000)
-  if (minutes < 60) return `${minutes}m ago`
-  const hours = Math.floor(minutes / 60)
-  if (hours < 24) return `${hours}h ago`
-  const days = Math.floor(hours / 24)
-  if (days < 7) return `${days}d ago`
-  return new Date(iso).toLocaleDateString()
-}
+// This page had its own third copy of "how long ago", and it was the one that
+// fell back to `toLocaleDateString()` past a week — which is how the freshness
+// line read "Refreshed 5/30/2026": an ambiguous absolute date, in a US format,
+// sitting among relative times everywhere else, hiding the fact that it was 101
+// days old. `relativeAge` keeps climbing (d → w → mo → y) so the age stays
+// legible instead of turning into a date the reader has to subtract.
+const relativeTime = (iso: string): string => relativeAge(iso)
 
 // A project is considered stale (and dropped behind the "Show stale" toggle)
 // if its DB status is `stale` or `archived`, OR if its most recent summary is
@@ -162,9 +160,14 @@ function PrivateBadge() {
 function TopThreeHero({
   insights,
   onActivate,
+  knownSlugs,
 }: {
   insights: Insight[]
   onActivate: (slug: string) => void
+  /** Slugs the CURRENT workspace actually has a project for. Insights are
+   *  user-scoped by design (cross-portfolio) while projects are tenant-scoped,
+   *  so a row here can name a project this workspace cannot open. */
+  knownSlugs: ReadonlySet<string>
 }) {
   const top = rankInsights(insights, 3)
   const newest = newestInsightTimestamp(insights)
@@ -215,21 +218,49 @@ function TopThreeHero({
         {top.map((insight) => {
           const category = parseInsightCategory(insight.content)
           const body = parseInsightBody(insight.content)
-          return (
+          // `onActivate` expands a tile in THIS page's grid, so it can only do
+          // anything for a project this workspace has. Standing in a workspace
+          // with no projects, every row still rendered a hover state and an
+          // "Open →" that silently did nothing. A row we cannot open says so
+          // instead of pretending.
+          const openable = knownSlugs.has(insight.project_slug)
+          const inner = (
+            <>
+              <CategoryBadge category={category} />
+              <span className="text-[11px] text-muted-foreground shrink-0 sm:w-32 sm:truncate">
+                {insight.project_name}
+              </span>
+              {/* Two lines, not one: this is the day's top item and the single
+                  clamped line cut mid-sentence, usually inside the clause that
+                  says what to do. */}
+              <span className="text-xs text-foreground-secondary line-clamp-2 flex-1 min-w-0">{body}</span>
+              <span
+                className={`text-[11px] shrink-0 ${
+                  openable ? 'text-muted-foreground group-hover:text-primary transition-colors' : 'text-muted-foreground'
+                }`}
+              >
+                {openable ? 'Open →' : 'other workspace'}
+              </span>
+            </>
+          )
+          const shared =
+            'w-full flex flex-wrap sm:flex-nowrap items-center gap-x-3 gap-y-1 text-left border rounded-lg px-3 py-2'
+          return openable ? (
             <button
               key={insight.id}
               onClick={() => onActivate(insight.project_slug)}
-              className="w-full flex items-center gap-3 text-left bg-background/40 hover:bg-background/70 border border-border hover:border-input rounded-lg px-3 py-2 transition-colors group"
+              className={`${shared} min-h-11 sm:min-h-0 bg-background/40 hover:bg-background/70 border-border hover:border-input transition-colors group`}
             >
-              <CategoryBadge category={category} />
-              <span className="text-[11px] text-muted-foreground shrink-0 w-32 truncate">
-                {insight.project_name}
-              </span>
-              <span className="text-xs text-foreground-secondary truncate flex-1">{body}</span>
-              <span className="text-[11px] text-muted-foreground group-hover:text-primary transition-colors shrink-0">
-                Open →
-              </span>
+              {inner}
             </button>
+          ) : (
+            <div
+              key={insight.id}
+              title={`${insight.project_name} is not in this workspace — open it from the workspace that has it, or from /insights.`}
+              className={`${shared} bg-background/20 border-border/60`}
+            >
+              {inner}
+            </div>
           )
         })}
       </div>
@@ -658,7 +689,28 @@ export function ProjectsPage() {
         </span>
       </div>
 
-      <TopThreeHero insights={allInsights} onActivate={expand} />
+      <TopThreeHero
+        insights={allInsights}
+        onActivate={expand}
+        knownSlugs={new Set(projects.map((p) => p.slug))}
+      />
+
+      {/* The landing page had no empty state, so a workspace with no projects
+          rendered "0 projects" as a badge directly above a hero full of project
+          rows — the front door contradicting itself, with nothing saying why.
+          Insights are user-scoped on purpose (they span the portfolio); projects
+          are tenant-scoped. That is the sentence the reader needed. */}
+      {!loading && projects.length === 0 && (
+        <div className="mb-6 rounded-xl border border-border bg-card px-5 py-6">
+          <h2 className="text-sm font-semibold text-foreground">No projects in this workspace</h2>
+          <p className="mt-1 max-w-prose text-xs leading-relaxed text-muted-foreground">
+            Projects belong to a workspace; insights are yours and span all of them, which is why
+            the list above can name work that lives elsewhere. Switch workspace in the header to
+            reach those, or run <code className="rounded bg-muted px-1 py-0.5 text-foreground-secondary">canopy:portfolio-review</code>{' '}
+            to seed this one.
+          </p>
+        </div>
+      )}
 
       <LayoutGroup>
         {/* Stack of expanded cards at the top */}

--- a/frontend/src/pages/SupervisorPage.tsx
+++ b/frontend/src/pages/SupervisorPage.tsx
@@ -161,7 +161,16 @@ export default function SupervisorPage(): JSX.Element {
     setSearchParams(value === 'inbox' ? {} : { tab: value })
 
   return (
-    <div className="mx-auto flex max-w-2xl flex-col gap-4 p-4" data-testid="supervisor-page">
+    // `max-w-2xl` (672px) is the right measure for the Inbox, whose cards are
+    // prose you read. It was applied to the whole page, so on a 1440 laptop —
+    // one of this surface's three declared consumers, alongside the phone PWA
+    // and the menubar — the runner and session tables also sat in a 672px column
+    // with the right half of the window empty. Prose keeps its measure; the
+    // tables get the room from `lg` up.
+    <div
+      className={`mx-auto flex w-full flex-col gap-4 p-4 ${tab === 'inbox' ? 'max-w-2xl' : 'max-w-2xl lg:max-w-5xl'}`}
+      data-testid="supervisor-page"
+    >
       <header>
         <h1 className="text-lg font-semibold text-foreground">Supervisor</h1>
         <p className="mt-0.5 text-[12px] text-muted-foreground">Your fleet, and what it needs from you.</p>

--- a/frontend/src/pages/agents/AgentCredentialsSection.tsx
+++ b/frontend/src/pages/agents/AgentCredentialsSection.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/api/agents'
 import type { AgentOutletContext } from '@/pages/AgentWorkspacePage'
 import { headline, sections } from '@/pages/agents/agentCredentials'
+import { relativeAge } from '@/lib/relativeAge'
 import { declaresMailbox, mintOutcome } from '@/pages/agents/googleMint'
 import { AgentVaultSection } from '@/pages/agents/AgentVaultSection'
 import { WorkbenchSubHeader, WorkbenchSkeleton } from 'canopy-ui'
@@ -122,9 +123,9 @@ export function AgentCredentialsSection() {
         </span>
       )}
       {r.set && (
-        <span className="text-[11px] text-foreground-subtle">
+        <span className="text-[11px] text-muted-foreground">
           {r.source}
-          {r.updated_at ? ` · ${new Date(r.updated_at).toLocaleDateString()}` : ''}
+          {r.updated_at ? ` · ${relativeAge(r.updated_at)}` : ''}
           {r.updated_by_email ? ` · ${r.updated_by_email}` : ''}
         </span>
       )}
@@ -136,23 +137,33 @@ export function AgentCredentialsSection() {
         onChange={(e) => setDraft((d) => ({ ...d, [r.name]: e.target.value }))}
         placeholder={r.set ? 'rotate…' : 'store here instead'}
         aria-label={`Value for ${r.name}`}
-        className="ml-auto w-56 rounded-md border border-input bg-input px-2 py-1 font-mono text-[12px] text-foreground placeholder:text-muted-foreground"
+        className="ml-auto min-h-11 w-full rounded-md border border-input bg-input px-2 py-1 font-mono text-[12px] text-foreground placeholder:text-muted-foreground sm:min-h-0 sm:w-56"
       />
       <button
         type="button"
         onClick={() => void save(r.name)}
         disabled={busy || !(draft[r.name] ?? '').trim()}
-        className="rounded-md bg-primary px-2 py-1 text-[12px] font-medium text-primary-foreground disabled:opacity-40"
+        className="min-h-11 rounded-md bg-primary px-3 py-1 text-[12px] font-medium text-primary-foreground disabled:opacity-40 sm:min-h-0"
       >
         Save
       </button>
       {r.set && (
+        // Destroys a secret nothing else holds — canopy-web is the store, so
+        // there is no undo and no second copy to restore from. It was a 20×24
+        // target whose only description was the glyph: `title` now names the
+        // consequence the way the chat list's close button does, the hit area
+        // clears 44px on touch, and it asks first.
         <button
           type="button"
-          onClick={() => void remove(r.name)}
+          onClick={() => {
+            if (window.confirm(`Delete the stored value for "${r.name}"? This cannot be undone.`)) {
+              void remove(r.name)
+            }
+          }}
           disabled={busy}
-          aria-label={`Remove ${r.name}`}
-          className="px-1 text-muted-foreground hover:text-destructive disabled:opacity-40"
+          aria-label={`Delete the stored value for ${r.name}`}
+          title={`Delete the stored value for "${r.name}" (cannot be undone)`}
+          className="flex min-h-11 w-11 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive disabled:opacity-40 sm:min-h-0 sm:h-7 sm:w-7"
         >
           ✕
         </button>
@@ -207,7 +218,7 @@ export function AgentCredentialsSection() {
                   type="button"
                   onClick={() => void connectMailbox()}
                   disabled={busy}
-                  className="ml-auto rounded-md bg-primary px-2 py-1 text-[12px] font-medium text-primary-foreground disabled:opacity-40"
+                  className="ml-auto min-h-11 rounded-md bg-primary px-3 py-1 text-[12px] font-medium text-primary-foreground disabled:opacity-40 sm:min-h-0"
                 >
                   Connect Google mailbox
                 </button>
@@ -241,7 +252,7 @@ export function AgentCredentialsSection() {
               <button
                 type="button"
                 onClick={() => setShowVault((v) => !v)}
-                className="text-[12px] text-muted-foreground underline-offset-2 hover:underline"
+                className="inline-flex min-h-11 items-center text-[12px] text-muted-foreground underline-offset-2 hover:underline sm:min-h-0"
                 data-testid="toggle-vault-refs"
                 aria-expanded={showVault}
               >
@@ -269,7 +280,7 @@ export function AgentCredentialsSection() {
         </p>
       )}
 
-      <p className="mt-4 text-[11px] text-foreground-subtle">
+      <p className="mt-4 text-[11px] text-muted-foreground">
         Values are write-only: encrypted at rest, and readable only by a runner this agent routes to.
         This page can show whether a secret is set, never what is in it.
       </p>

--- a/frontend/src/pages/agents/AgentVaultSection.tsx
+++ b/frontend/src/pages/agents/AgentVaultSection.tsx
@@ -79,7 +79,7 @@ export function AgentVaultSection({ slug }: { slug: string }) {
             value={vault}
             onChange={(e) => setVault(e.target.value)}
             placeholder="Agent-Ace"
-            className="w-44 rounded-md border border-input bg-input px-2 py-1 font-mono text-[12px] text-foreground"
+            className="min-h-11 w-full sm:min-h-0 sm:w-44 rounded-md border border-input bg-input px-2 py-1 font-mono text-[12px] text-foreground"
           />
           <label className="text-[12px] text-muted-foreground" htmlFor="vault-key">
             Service key
@@ -91,19 +91,19 @@ export function AgentVaultSection({ slug }: { slug: string }) {
             value={key}
             onChange={(e) => setKey(e.target.value)}
             placeholder={keySet ? 'set — paste to rotate' : 'paste to set'}
-            className="w-52 rounded-md border border-input bg-input px-2 py-1 font-mono text-[12px] text-foreground"
+            className="min-h-11 w-full rounded-md border border-input bg-input px-2 py-1 font-mono text-[12px] text-foreground sm:min-h-0 sm:w-52"
           />
           <button
             type="button"
             onClick={() => void save()}
             disabled={busy}
-            className="ml-auto rounded-md bg-primary px-2 py-1 text-[12px] font-medium text-primary-foreground disabled:opacity-40"
+            className="ml-auto min-h-11 rounded-md bg-primary px-3 py-1 text-[12px] font-medium text-primary-foreground disabled:opacity-40 sm:min-h-0"
           >
             Save
           </button>
         </div>
 
-        <p className="mt-2 text-[11px] text-foreground-subtle">
+        <p className="mt-2 text-[11px] text-muted-foreground">
           A service account scoped to this one vault. <strong>The runner uses it</strong> — canopy-web
           holds it and hands it to a runner this agent routes to, and never resolves secrets itself.
           Encrypted at rest, never returned to a browser.

--- a/frontend/src/pages/agents/ItemsSection.tsx
+++ b/frontend/src/pages/agents/ItemsSection.tsx
@@ -173,9 +173,18 @@ export function ItemsSection(): JSX.Element {
         </p>
       </header>
       {primary.length === 0 ? (
-        <p className="rounded-lg border border-border bg-card p-3 text-[13px] text-muted-foreground">
-          {showAll || settled.length === 0 ? 'Nothing here.' : 'Nothing waiting on you.'}
-        </p>
+        <div className="rounded-lg border border-border bg-card p-4">
+          <p className="text-[13px] text-foreground">
+            {showAll || settled.length === 0 ? 'No items yet' : 'Nothing waiting on you'}
+          </p>
+          {/* "Nothing here." is accurate but tells a first-time reader nothing
+              about what would be here, or what puts it there. */}
+          <p className="mt-1 text-[12px] leading-snug text-muted-foreground">
+            {showAll || settled.length === 0
+              ? `Items are the questions and reviews ${agent.name} raises for a human. They appear here as it works.`
+              : 'Everything raised so far has been decided. Settled items are below.'}
+          </p>
+        </div>
       ) : (
         primary.map(renderCard)
       )}


### PR DESCRIPTION
A page-by-page UI/UX audit of canopy-web produced 20 findings ([report](https://claude.ai/code/artifact/53276da0-4e12-4e95-b9fe-ed9c754df8c6)). This fixes them, plus what a second pass found once the first round was in. Every claim was measured off the rendered page.

## The leveraged fixes are in `canopy-ui`

- **`TabsList`** was `w-fit` with a fixed `h-8` — two bugs at once. The list sized to its content, so a fourth tab ran off a 375px viewport with no scroll and no wrap (measured on `/supervisor`: `scrollWidth 302` vs `clientWidth 293`, clipping "Runners"), and the height capped every trigger at **23px**, on the surface that ships as the phone PWA. Below `sm` it is now a 2-column grid at 44px; from `sm` up it is byte-identical to before.
- **`Button`** and **`Input`** set fixed heights (`h-8`/`h-7`/`h-6`), all under 44px. The touch floor now lives once in each base class and lifts at `sm`, rather than being taught to every size variant.
- **`WorkbenchNavItem`** likewise.

## Contrast was one token, not twenty call sites

In dark mode `--foreground-subtle` was `0.374` — **1.70:1** on a card, and *exactly* `--input`, which is the documented reason faint text on an input surface rendered at contrast 1.00. That and `--muted-foreground` (3.65:1) are raised. Only the dark values move: in light mode these are dark-on-white and already clear AA, where raising them would reduce contrast.

**Result: zero sub-AA text on any audited page, at 375 and 1440.**

## Individually

| | |
|---|---|
| **Workbench** | Said "0 projects" above three project rows. Insights are user-scoped by design, projects are tenant-scoped, `connect` has 0 while `dimagi` has 19 — so the hero listed work the page couldn't open and "Open →" silently did nothing. Rows now name the other workspace; an empty workspace explains itself. |
| **Inbound** | The gcloud block held 27 real newlines under `white-space: normal`, rendering five numbered steps as one run-on. One `whitespace-pre`. |
| **Agent rail** | Hid 6 of 10 sections behind a silent horizontal scroll (588px off-screen; macOS hides overlay scrollbars). Gets an edge fade. |
| **Rail badges** | Six sections showed a size, four didn't — and `Inbox 0` made blank ambiguous with zero. Sizes removed (every section page prints its own count); Inbox keeps the one number that means "needs you". |
| **Runners** | `relative()` stopped at hours → "drilled 1087h ago". Now a shared, tested `relativeAge` (d → w → mo → y), which also replaces ProjectsPage's *third* copy — the one that fell back to "5/30/2026". |
| **Chat list** | Status and age no longer share a column; sort is visibly a segmented control and filters are checkboxes; the "10 hidden" footnote looks like the button it always was; doubled `c-resume-c-resume-` titles collapse for display. |
| **Supervisor** | Runner/session tables get the window from `lg`; the Inbox keeps its 672px measure, because prose wants one. |
| **Credentials** | Delete now asks before destroying a secret nothing else holds. |
| **Layout** | `main` had `px-6` on top of pages' own `p-6` — 96px of a 375px screen. |

## Corrected from the first pass

Measuring properly overturned five findings, and they're recorded rather than quietly dropped: the chat close button and credential delete **already had** `aria-label`s; the "10 hidden" footnote **was already** a button; `ItemCard` **already had** touch targets (I'd measured at 1440, where `sm:min-h-0` correctly applies); the Items ledger **was truthful** (`ace` genuinely has 0 items, and the settled disclosure does render when there's anything to disclose); and red on a *failed* drill is correct, not alarmism.

## Verification

- `npx vitest run` — **722 passed**, 71 files, incl. new units for `relativeAge` and `sessionDisplayTitle`.
- `npm run build` — clean.
- Live pass against labs data at 375 and 1440 across `/supervisor`, `/w/:ws`, `/chat`, `/agents/:slug/credentials`, `/inbound`, `/activity`, `/schedules`: **no horizontal overflow, zero sub-AA text, no undersized touch targets on mobile** anywhere.

The one thing not fixed here: the `c-resume-c-resume-` doubling is mitigated for display only. The real fix belongs to whatever builds a resume turn's subject — it should strip an existing task-name shape before prefixing, not stack onto it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KgHtGGXSGucSVAWWSswkXn