### PR TITLE
Never swap the service worker underneath a page someone is looking at

### DIFF
--- a/frontend/src/pwa/registerPwa.ts
+++ b/frontend/src/pwa/registerPwa.ts
@@ -1,23 +1,55 @@
 import { registerSW } from 'virtual:pwa-register'
 
-// Always auto-update.
+// Adopt new service workers — but never underneath a page someone is looking at.
 //
-// `registerType: 'autoUpdate'` (vite.config.ts) makes the app adopt a new service
-// worker + reload — but ONLY checks for one on page load. A long-lived open client
-// (the installed PWA, the menubar WKWebView, a tab left open for days) therefore
-// never notices a new deploy and serves a stale bundle forever. That is exactly how
-// the Sessions surface got stuck on a pre-feature bundle.
+// The old arrangement was `registerType: 'autoUpdate'` plus a 60s poll calling
+// registration.update(). autoUpdate forces skipWaiting + clientsClaim, so any of
+// those ticks could activate a new SW MID-LOAD or mid-use. On activation
+// cleanupOutdatedCaches() deletes the previous precache, and the live page — which
+// was served the OLD index.html by navigateFallback — then asks for asset hashes
+// that are gone from the cache and 404 on the server, because every deploy rehashes
+// them. The modules fail and the app paints a WHITE PAGE. A manual reload fixes it,
+// since by then the new SW serves the new shell.
 //
-// So we poll: check for a new SW on an interval AND whenever the app regains focus
-// (menubar reopened, tab refocused). When update() finds one, autoUpdate skips
-// waiting and reloads on its own — no prompt, no manual hard-refresh.
+// That is the reported bug: white on first load, fine after a refresh, and constant
+// on a day with six deploys — the 60s poll turned a per-load race into a per-minute
+// one.
+//
+// So: 'prompt' in vite.config.ts leaves the new SW WAITING, and we choose the
+// moment. The polling below is kept — a long-lived client (installed PWA, menubar
+// WKWebView, a tab open for days) otherwise never discovers a deploy at all, which
+// is how the Sessions surface once got stuck on a pre-feature bundle.
 const UPDATE_INTERVAL_MS = 60_000
+
+/** Apply a waiting update only when the page is HIDDEN.
+ *
+ *  Reloading a visible page is its own bug here: this app's sign-in flow has a
+ *  box you paste a single-use code into, and a surprise reload would throw it
+ *  away. Hidden means the operator has looked elsewhere, so the reload costs
+ *  them nothing and they come back to a current bundle. */
+function applyWhenHidden(apply: () => void): void {
+  if (document.visibilityState === 'hidden') {
+    apply()
+    return
+  }
+  const onHide = (): void => {
+    if (document.visibilityState !== 'hidden') return
+    document.removeEventListener('visibilitychange', onHide)
+    apply()
+  }
+  document.addEventListener('visibilitychange', onHide)
+}
 
 export function registerPwa(): void {
   if (typeof window === 'undefined' || !('serviceWorker' in navigator)) return
 
-  registerSW({
+  const updateSW = registerSW({
     immediate: true,
+    // Fired once a new SW is installed and waiting. Nothing has been swapped
+    // yet — the running page keeps the precache it was built against.
+    onNeedRefresh() {
+      applyWhenHidden(() => void updateSW(true))
+    },
     onRegisteredSW(swUrl, registration) {
       if (!registration) return
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -30,7 +30,12 @@ export default defineConfig({
     react(),
     tailwindcss(),
     VitePWA({
-      registerType: 'autoUpdate',
+      // NOT 'autoUpdate'. That preset forces skipWaiting + clientsClaim and
+      // overrides the workbox options below, which is the race documented there:
+      // a new SW activating underneath a page that was already served the old
+      // shell, then deleting the precache out from under it. 'prompt' leaves the
+      // new SW waiting; src/pwa/register.ts applies it at a safe moment.
+      registerType: 'prompt',
       // The deployment is path-prefixed (/canopy/ on labs). scope and start_url
       // MUST follow it — a manifest scoped to "/" installs an app that opens the
       // wrong site. `base` is this file's own base option, computed above.
@@ -56,6 +61,28 @@ export default defineConfig({
         // Cache the shell so the app opens instantly and survives a labs outage
         // (this is also what makes the menubar's WKWebView resilient in Phase 5).
         globPatterns: ['**/*.{js,css,html,svg,png,woff2}'],
+        // A new SW must NOT take over a page that has already been served the
+        // old shell. registerType 'autoUpdate' turns both of these on, and the
+        // three defaults together are a race:
+        //
+        //   1. navigation is served the OLD precached index.html
+        //      (navigateFallback -> createHandlerBoundToURL('index.html'))
+        //   2. the new SW installs and, under skipWaiting, activates MID-LOAD
+        //   3. cleanupOutdatedCaches() deletes the old precache
+        //   4. clientsClaim() takes over the page
+        //   5. that page now asks for the OLD asset hashes — gone from the cache
+        //      and 404 on the server, because every deploy rehashes them
+        //   6. the modules fail and the app paints a WHITE PAGE; a reload fixes
+        //      it, because by then the new SW serves the new index.html
+        //
+        // Which is exactly the report: white on first load, fine after a manual
+        // refresh, and it went from rare to constant on a day with six deploys.
+        //
+        // With both false the new SW waits. The loading page keeps the precache
+        // it was built against and renders; the update applies on the next
+        // navigation. Still automatic — just never underneath a live page.
+        skipWaiting: false,
+        clientsClaim: false,
         // vite-plugin-pwa's generated SW only caches — it has no push listener.
         // Without this, a push payload arrives and nothing happens (no error,
         // no notification). importScripts (not injectManifest) keeps the


### PR DESCRIPTION
Reported repeatedly: the supervisor page loads **all white**, and only a manual refresh fixes it. Reproduced by driving a browser at the live site and reading the deployed `sw.js`, rather than reasoning about it — my three previous theories were all wrong.

## The race

The live SW carried all four ingredients:

```
self.skipWaiting()   clientsClaim()   cleanupOutdatedCaches()
createHandlerBoundToURL("index.html")   // navigations served from cache
```

1. A navigation is served the **old** precached `index.html`
2. The new SW installs and, under `skipWaiting`, activates **mid-load**
3. `cleanupOutdatedCaches()` deletes the old precache
4. `clientsClaim()` takes the live page over
5. That page asks for the **old** asset hashes — gone from the cache, and **404** from the server, because every deploy rehashes them
6. Modules fail; the app paints white. A reload works, because by then the new SW serves the new shell.

**`registerPwa.ts` made it far worse than once-per-load:** it polls every 60s and calls `registration.update()`, so the swap could land at any moment, including mid-task. A day with six deploys turned a rare race into a constant one.

## The fix

`registerType: 'autoUpdate'` is the source — that preset forces `skipWaiting` + `clientsClaim` and **overrides the workbox options**, so setting them to `false` under `workbox` did nothing. I checked the built `sw.js` and it still emitted both; `'prompt'` is what actually removes them.

With `'prompt'` the new SW waits, and we choose the moment: **only when the document is hidden.**

A surprise reload of a *visible* page is its own bug here — the sign-in flow has a box you paste a single-use code into, and a reload would discard it. Hidden means the operator has looked away, so the reload costs nothing and they come back to a current bundle.

The 60s polling is **kept**. A long-lived client (installed PWA, menubar WKWebView, a tab open for days) otherwise never discovers a deploy at all — that's how the Sessions surface once got stuck on a pre-feature bundle. Discovery was never the problem; adoption *timing* was.

## Known residual

Existing browsers are still running the **old** `autoUpdate` SW, so their *next* update is applied by it and can still land badly once. From the version after this one, the waiting behaviour is in charge. Worth knowing before concluding the fix didn't work.

Frontend suite: **724 passed**, build clean, and the generated `sw.js` verified to contain no `clientsClaim()` and to call `skipWaiting()` only on an explicit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZoTH3niSknEU47NdZ42HJ
