### PR TITLE
An alarm's creation has two spellings; #688 only knew one

### DIFF
--- a/runner/canopy_runner/canopy_runner/inbox.py
+++ b/runner/canopy_runner/canopy_runner/inbox.py
@@ -28,20 +28,39 @@ DEFAULT_QUERY = "in:inbox is:unread newer_than:14d"
 #: matching `OK: "<name>" in <region>`. The quoted alarm name is what pairs the two.
 _ALARM_SUBJECT = re.compile(r'^\s*(ALARM|OK):\s*"([^"]+)"')
 
-#: An alarm announcing its OWN CREATION, in the body of an otherwise ordinary `OK:`.
+#: The prior state named by an `OK:` notification's body — the `X` in `X -> OK`.
 #:
 #: CloudWatch emails every alarm carrying `OKActions` the moment it is created, and the
 #: subject is indistinguishable from a real recovery — same `OK: "<name>" in <region>`
-#: shape, same SNS sender. Only the body separates them, and it is unambiguous: a real
-#: recovery always names a concrete prior state (`ALARM -> OK`, `INSUFFICIENT_DATA -> OK`),
-#: while a creation has no prior state at all.
+#: shape, same SNS sender. Only the body separates them.
 #:
 #: So every monitoring PR that adds an alerting alarm used to dispatch a full agent
 #: session on a non-event. Measured on hal twice in two days —
 #: `labs-jj-web-cpu-high-actionable` (2026-09-06, connect-labs#1463) and
 #: `labs-jj-web-worker-kill-rate-actionable` (2026-09-07, connect-labs#1537, emailed
 #: 8 minutes after that PR merged). See #688.
-_ALARM_CREATION = re.compile(r"^\s*-?\s*State Change:\s*N/A\s*->\s*OK\s*$",
+#:
+#: #688 keyed on `N/A -> OK` and recorded the reason: "a real recovery always names a
+#: concrete prior state (`ALARM -> OK`, `INSUFFICIENT_DATA -> OK`), while a creation has
+#: no prior state at all." The second half of that is false, and #712 is the counterexample:
+#: creation has TWO spellings, and which one you get is a timing accident. An alarm created
+#: while its evaluation window already has datapoints evaluates immediately and says
+#: `N/A -> OK`; one created a few minutes ahead of its data lands in `INSUFFICIENT_DATA`
+#: first and says `INSUFFICIENT_DATA -> OK` for the very same non-event.
+#: (`labs-jj-rds-free-storage-low`, created 2026-09-09 00:15:09Z by a CloudFormation change
+#: set, emailed `INSUFFICIENT_DATA -> OK` at 00:27:33Z with 83.7 GB free against a 20 GB
+#: threshold. It had never been in ALARM. A full hal turn was dispatched on it.)
+#:
+#: Nothing in the body distinguishes that from a genuine metric-went-dark-and-came-back —
+#: both carry a threshold-crossed reason. So do not try to detect *creation*. Detect what
+#: this check is actually for, which is strictly checkable and cannot swallow a real
+#: recovery: **an `OK:` is only work when it recovers from `ALARM`.**
+#:
+#: The apparent counterexample — ALARM -> INSUFFICIENT_DATA -> OK, where a real incident's
+#: recovery reports `INSUFFICIENT_DATA -> OK` — never reaches this check: `_alarm_incident_is_owned`
+#: (#670) coalesces that `OK:` into its `ALARM:` turn first. And if a runner restart lost that
+#: memory, the `ALARM:` thread is still unread and enqueues on its own, which is the right owner.
+_OK_PRIOR_STATE = re.compile(r"^\s*-?\s*State Change:\s*(\S+)\s*->\s*OK\s*$",
                              re.MULTILINE)
 
 
@@ -111,15 +130,17 @@ def search_threads(mailbox: str, gog_client: str, query: str = DEFAULT_QUERY,
 class ThreadFacts(NamedTuple):
     """What one `gog gmail thread get` tells us about a thread's NEWEST message.
 
-    Both fields fail OPEN — `newest_from=None` and `is_alarm_creation=False` are the
+    Both fields fail OPEN — `newest_from=None` and `recovers_from_alarm=None` are the
     "we don't know" values, and every caller treats them as "enqueue normally".
     """
 
     #: The newest message's `From`, lowercased, or None if undeterminable.
     newest_from: str | None = None
-    #: True only when the body positively identifies an alarm announcing its own
-    #: creation (see `_ALARM_CREATION`). Never a guess.
-    is_alarm_creation: bool = False
+    #: For an `OK:` body carrying a parseable `X -> OK` state change: whether `X` is
+    #: `ALARM`, i.e. whether this is a real recovery. `None` means the body named no
+    #: prior state we could read — the fail-open value (see `_OK_PRIOR_STATE`).
+    #: Never a guess.
+    recovers_from_alarm: bool | None = None
 
 
 def _decoded_body(msg: dict) -> str:
@@ -179,8 +200,9 @@ def thread_facts(mailbox: str, gog_client: str, thread_id: str, *,
         if h.get("name", "").lower() == "from":
             sender = (h.get("value") or "").lower()
             break
+    m = _OK_PRIOR_STATE.search(_decoded_body(newest))
     return ThreadFacts(newest_from=sender,
-                       is_alarm_creation=bool(_ALARM_CREATION.search(_decoded_body(newest))))
+                       recovers_from_alarm=(m.group(1).upper() == "ALARM") if m else None)
 
 
 def newest_sender(mailbox: str, gog_client: str, thread_id: str, *,
@@ -254,8 +276,9 @@ def check_inbox(client, agent: str, *, mailbox: str, gog_client: str,
     "skipped": [ids whose newest message is the agent's own reply],
     "coalesced": [SNS alarm ids folded into an existing incident's turn — an `OK:`
     recovery, or an `ALARM:` re-firing inside ALARM_REPEAT_WINDOW_S],
-    "created": [SNS `OK:` ids that are an alarm announcing its OWN creation — a
-    non-event, in its own bucket because there is no incident to fold it into]}
+    "ok_without_alarm": [SNS `OK:` ids whose body recovers from something other than
+    `ALARM` — an alarm announcing its own creation, or a merely-dark metric. A non-event,
+    in its own bucket because there is no incident to fold it into]}
     — the split matters
     for logging: re-polling the same unread mail is idempotent server-side, so it must
     read as "nothing new", not as fresh work.
@@ -284,7 +307,7 @@ def check_inbox(client, agent: str, *, mailbox: str, gog_client: str,
     seen: list[str] = []
     skipped: list[str] = []
     coalesced: list[str] = []
-    created: list[str] = []
+    ok_without_alarm: list[str] = []
     box = mailbox.lower()
     # ONE INCIDENT, ONE TURN. CloudWatch emits `ALARM:` and `OK:` as two Gmail threads
     # (the subjects differ), so one alarm transition used to enqueue two turns — and the
@@ -334,14 +357,16 @@ def check_inbox(client, agent: str, *, mailbox: str, gog_client: str,
             _seen_state[(box, tid)] = count
             continue
         facts = facts_of(tid)
-        # An alarm announcing its OWN creation. This is the one check that needs the
-        # body, and it is deliberately placed AFTER the two cheap guards above and on
+        # An `OK:` that recovers from something other than `ALARM` — an alarm announcing
+        # its own creation (`N/A -> OK`, or `INSUFFICIENT_DATA -> OK` when it was created
+        # ahead of its data), or a metric that was merely dark. None of those is an
+        # incident: there was no ALARM to recover from. This is the one check that needs
+        # the body, and it is deliberately placed AFTER the two cheap guards above and on
         # the SAME fetch as the sender — so it costs no subprocess this path was not
-        # already paying for (see `thread_facts`). Narrow on purpose: only an `OK:`
-        # from SNS (`alarm_key`) whose body says `N/A -> OK`. A real recovery names a
-        # concrete prior state and still fires. #688.
-        if key and key[0] == "OK" and facts.is_alarm_creation:
-            created.append(tid)
+        # already paying for (see `thread_facts`). A real recovery says `ALARM -> OK` and
+        # still fires; an unreadable body says None and still fires. #688, #712.
+        if key and key[0] == "OK" and facts.recovers_from_alarm is False:
+            ok_without_alarm.append(tid)
             _seen_state[(box, tid)] = count
             continue
         latest = facts.newest_from
@@ -374,4 +399,4 @@ def check_inbox(client, agent: str, *, mailbox: str, gog_client: str,
             _alarm_enqueued[(box, key[1])] = clock()
         (new if (res or {}).get("_created") else seen).append(tid)
     return {"new": new, "seen": seen, "skipped": skipped, "coalesced": coalesced,
-            "created": created}
+            "ok_without_alarm": ok_without_alarm}

--- a/runner/canopy_runner/canopy_runner/main.py
+++ b/runner/canopy_runner/canopy_runner/main.py
@@ -215,7 +215,7 @@ def _maybe_check_inboxes(cfg: Config, client: Client, now_fn=time.time,
             n_new, n_seen = len(res["new"]), len(res["seen"])
             n_skip = len(res.get("skipped", []))
             n_coal = len(res.get("coalesced", []))
-            n_created = len(res.get("created", []))
+            n_no_alarm = len(res.get("ok_without_alarm", []))
             # Log EVERY poll, not just ones that enqueue — otherwise a healthy poll that
             # finds nothing new is silent and you can't tell polling is happening at all.
             # `skipped` = unread threads whose newest message is the agent's own reply
@@ -224,14 +224,18 @@ def _maybe_check_inboxes(cfg: Config, client: Client, now_fn=time.time,
             # `coalesced` = a CloudWatch `OK:` folded into its `ALARM:` turn (one incident,
             # one session). Logged rather than silent: suppressing a turn is exactly the
             # kind of behaviour that must be visible when someone asks why no turn fired.
-            # `created` = an alarm announcing its own creation — no incident to fold into,
-            # so it gets its own count for the same visibility reason.
+            # `ok_without_alarm` = an `OK:` that recovers from something other than ALARM
+            # (an alarm announcing its own creation, or a merely-dark metric) — there was
+            # no incident to fold into, so it gets its own count for the same visibility
+            # reason. Named for what it MEASURES, not for the one cause we first saw it
+            # from: keying on `N/A -> OK` alone missed the `INSUFFICIENT_DATA -> OK`
+            # spelling and burned a hal turn (#712).
             logger.info("inbox[%s]: %s — %d unread (%d NEW -> session, %d already tracked, "
                         "%d skipped: agent's own reply, %d coalesced: alarm OK: into its "
-                        "ALARM:, %d alarm self-creation notices)",
+                        "ALARM:, %d OK: with no ALARM to recover from)",
                         agent, "RUNG" if agent in rung_slugs else "polled",
-                        n_new + n_seen + n_skip + n_coal + n_created,
-                        n_new, n_seen, n_skip, n_coal, n_created)
+                        n_new + n_seen + n_skip + n_coal + n_no_alarm,
+                        n_new, n_seen, n_skip, n_coal, n_no_alarm)
         except Exception as exc:  # noqa: BLE001 — one bad inbox never kills the loop
             logger.warning("inbox check for %s failed: %s", agent, exc)
         finally:

--- a/runner/canopy_runner/tests/test_inbox.py
+++ b/runner/canopy_runner/tests/test_inbox.py
@@ -49,7 +49,7 @@ def test_idempotency_key_includes_message_count():
 
 def test_empty_inbox_enqueues_nothing():
     client = FakeClient()
-    assert inbox.check_inbox(client, "hal", mailbox="m", gog_client="c", runner=_runner([])) == {"new": [], "seen": [], "skipped": [], "coalesced": [], "created": []}
+    assert inbox.check_inbox(client, "hal", mailbox="m", gog_client="c", runner=_runner([])) == {"new": [], "seen": [], "skipped": [], "coalesced": [], "ok_without_alarm": []}
     assert client.enqueued == []
 
 
@@ -361,12 +361,18 @@ def test_a_human_subject_that_looks_like_a_refire_is_never_suppressed():
     assert res["new"] == ["thr-human"]
 
 
-# --- An alarm announcing its OWN CREATION is not an incident (#688) ----------------
+# --- An `OK:` with no ALARM to recover from is not an incident (#688, #712) ---------
 #
 # CloudWatch emails every alarm carrying `OKActions` the moment it is created, under a
 # subject indistinguishable from a real recovery. Only the body separates them. Bodies
 # below are the real 2026-09-07 `labs-jj-web-worker-kill-rate-actionable` notice, which
 # burned a full hal session, and its real-recovery counterpart.
+#
+# #688 keyed on `N/A -> OK`. #712 is why that was too narrow: the SAME non-event spells
+# itself `INSUFFICIENT_DATA -> OK` when the alarm is created a few minutes ahead of its
+# data, and that spelling burned another full hal session. The rule is now "an `OK:` is
+# only work when it recovers from ALARM", which covers both spellings and cannot swallow
+# a real recovery.
 
 _CREATION_OK = 'OK: "labs-jj-web-worker-kill-rate-actionable" in US East (N. Virginia)'
 
@@ -387,6 +393,25 @@ _RECOVERY_BODY = (
     '"labs-jj-web-cpu-high" ... has transitioned to OK state.\r\n\r\nAlarm Details:\r\n'
     "- Name:                       labs-jj-web-cpu-high\r\n"
     "- State Change:               ALARM -> OK\r\n"
+)
+
+_INSUFFICIENT_OK = 'OK: "labs-jj-rds-free-storage-low" in US East (N. Virginia)'
+
+#: The real 2026-09-09 notice (#712). `labs-jj-rds-free-storage-low` was created by a
+#: CloudFormation change set at 00:15:09Z and emailed this at 00:27:33Z — 83.7 GB free
+#: against a 20 GB threshold, having never been in ALARM. Note there is NO "was created"
+#: marker in the reason and NO `N/A`: the ONLY thing separating it from a real recovery
+#: is that the prior state is not `ALARM`.
+_INSUFFICIENT_CREATION_BODY = (
+    "You are receiving this email because your Amazon CloudWatch Alarm "
+    '"labs-jj-rds-free-storage-low" in the US East (N. Virginia) region has entered the '
+    'OK state, because "Threshold Crossed: 3 out of the last 3 datapoints '
+    "[8.3714617344E10 (09/09/26 00:22:00), 8.3835891712E10 (09/09/26 00:17:00), "
+    '8.3510099968E10 (09/09/26 00:12:00)] were not less than the threshold '
+    '(2.147483648E10)".\r\n\r\nAlarm Details:\r\n'
+    "- Name:                       labs-jj-rds-free-storage-low\r\n"
+    "- State Change:               INSUFFICIENT_DATA -> OK\r\n"
+    "- Timestamp:                  Wednesday 09 September, 2026 00:27:33 UTC\r\n"
 )
 
 
@@ -429,7 +454,7 @@ def test_alarm_creation_notice_does_not_fire_a_turn():
                 "messageCount": 1}]
     res = inbox.check_inbox(client, "hal", mailbox="hal@dimagi-ai.com", gog_client="canopy",
                             runner=_dual_runner(threads, _CREATION_BODY))
-    assert res["created"] == ["thr-created"]
+    assert res["ok_without_alarm"] == ["thr-created"]
     assert res["new"] == []
     assert client.enqueued == []
 
@@ -440,7 +465,29 @@ def test_creation_notice_is_detected_inside_a_multipart_body():
                 "messageCount": 1}]
     res = inbox.check_inbox(client, "hal", mailbox="hal@dimagi-ai.com", gog_client="canopy",
                             runner=_dual_runner(threads, _CREATION_BODY, parts=True))
-    assert res["created"] == ["thr-created"]
+    assert res["ok_without_alarm"] == ["thr-created"]
+
+
+def test_an_INSUFFICIENT_DATA_creation_does_not_fire_a_turn():
+    """#712: the second spelling of a creation. `labs-jj-rds-free-storage-low` was created
+    at 00:15:09Z, had never been in ALARM, and emailed `INSUFFICIENT_DATA -> OK` at
+    00:27:33Z with 83.7 GB free against a 20 GB threshold. #688's `N/A -> OK` key did not
+    match it and it dispatched a full hal turn."""
+    client = FakeClient()
+    threads = [{"id": "thr-insuff", "from": SNS, "subject": _INSUFFICIENT_OK,
+                "messageCount": 1}]
+    res = inbox.check_inbox(client, "hal", mailbox="hal@dimagi-ai.com", gog_client="canopy",
+                            runner=_dual_runner(threads, _INSUFFICIENT_CREATION_BODY))
+    assert res["ok_without_alarm"] == ["thr-insuff"]
+    assert res["new"] == []
+    assert client.enqueued == []
+
+
+def test_thread_facts_reads_INSUFFICIENT_DATA_as_not_a_recovery():
+    facts = inbox.thread_facts(
+        "hal@dimagi-ai.com", "canopy", "thr-insuff",
+        runner=_dual_runner([], _INSUFFICIENT_CREATION_BODY))
+    assert facts.recovers_from_alarm is False
 
 
 def test_a_real_recovery_still_fires():
@@ -451,7 +498,7 @@ def test_a_real_recovery_still_fires():
     res = inbox.check_inbox(client, "hal", mailbox="hal@dimagi-ai.com", gog_client="canopy",
                             runner=_dual_runner(threads, _RECOVERY_BODY))
     assert res["new"] == ["thr-ok"]
-    assert res["created"] == []
+    assert res["ok_without_alarm"] == []
 
 
 def test_creation_body_on_a_non_sns_sender_is_never_suppressed():
@@ -463,7 +510,7 @@ def test_creation_body_on_a_non_sns_sender_is_never_suppressed():
     res = inbox.check_inbox(client, "hal", mailbox="hal@dimagi-ai.com", gog_client="canopy",
                             runner=_dual_runner(threads, _CREATION_BODY, frm=human))
     assert res["new"] == ["thr-human"]
-    assert res["created"] == []
+    assert res["ok_without_alarm"] == []
 
 
 def test_creation_marker_in_an_ALARM_subject_is_not_suppressed():
@@ -473,7 +520,7 @@ def test_creation_marker_in_an_ALARM_subject_is_not_suppressed():
     res = inbox.check_inbox(client, "hal", mailbox="hal@dimagi-ai.com", gog_client="canopy",
                             runner=_dual_runner(threads, _CREATION_BODY))
     assert res["new"] == ["thr-alarm"]
-    assert res["created"] == []
+    assert res["ok_without_alarm"] == []
 
 
 def test_thread_facts_returns_sender_and_creation_flag_from_one_fetch():
@@ -481,11 +528,12 @@ def test_thread_facts_returns_sender_and_creation_flag_from_one_fetch():
         "hal@dimagi-ai.com", "canopy", "thr-created",
         runner=_dual_runner([], _CREATION_BODY))
     assert facts.newest_from == SNS.lower()
-    assert facts.is_alarm_creation is True
+    assert facts.recovers_from_alarm is False
 
 
 def test_thread_facts_fails_open_on_an_undecodable_body():
-    """Unknown must read as 'not a creation notice' — i.e. enqueue."""
+    """Unknown must read as None — 'we could not tell' — i.e. enqueue. Only a POSITIVE
+    read of a non-ALARM prior state suppresses; `None` never does."""
     def run(cmd, capture_output, text, timeout):
         payload = json.dumps({"messages": [{"payload": {
             "mimeType": "text/plain",
@@ -494,7 +542,7 @@ def test_thread_facts_fails_open_on_an_undecodable_body():
         return SimpleNamespace(returncode=0, stdout=payload, stderr="")
     facts = inbox.thread_facts("hal@dimagi-ai.com", "canopy", "t", runner=run)
     assert facts.newest_from == SNS.lower()
-    assert facts.is_alarm_creation is False
+    assert facts.recovers_from_alarm is None
 
 
 def test_sender_of_injection_opts_out_of_body_facts():
@@ -506,4 +554,4 @@ def test_sender_of_injection_opts_out_of_body_facts():
     res = inbox.check_inbox(client, "hal", mailbox="hal@dimagi-ai.com", gog_client="canopy",
                             runner=_runner(threads), sender_of=lambda tid: SNS.lower())
     assert res["new"] == ["thr-created"]
-    assert res["created"] == []
+    assert res["ok_without_alarm"] == []


### PR DESCRIPTION
## What happened

`labs-jj-rds-free-storage-low` was created by a CloudFormation change set in a live hal
session at **00:15:09Z** today. At **00:27:33Z** CloudWatch emailed:

```
- Name:          labs-jj-rds-free-storage-low
- State Change:  INSUFFICIENT_DATA -> OK
- Reason:        Threshold Crossed: 3 out of the last 3 datapoints
                 [8.37e10 (00:22), 8.38e10 (00:17), 8.35e10 (00:12)]
                 were not less than the threshold (2.147e10)
```

83.7 GB free against a 20 GB threshold, twelve minutes after the alarm first existed,
never having been in `ALARM`. It dispatched a full hal turn — the exact thing #688 exists
to prevent.

## Why #688 missed it

`_ALARM_CREATION` keyed on `N/A -> OK`, and the comment at the site recorded the reason:

> a real recovery always names a concrete prior state (`ALARM -> OK`,
> `INSUFFICIENT_DATA -> OK`), while a creation has no prior state at all.

The second half is false. Creation has **two** spellings and which one you get is a timing
accident: an alarm created while its evaluation window already has datapoints evaluates
immediately (`N/A -> OK`); one created a few minutes ahead of its data sits in
`INSUFFICIENT_DATA` first and reports `INSUFFICIENT_DATA -> OK` for the identical
non-event. The two alarms measured in #688 were both the former.

## The fix

Nothing in the body separates that from a genuine metric-went-dark-and-came-back — both
carry a threshold-crossed reason, and neither carries a `was created` marker. So this
stops trying to detect *creation* and detects what the check is actually for:

**An `OK:` is only work when it recovers from `ALARM`.**

- `_OK_PRIOR_STATE` reads the `X` out of `X -> OK`.
- `ThreadFacts.recovers_from_alarm` is a **tri-state**: `True` (real recovery, fires),
  `False` (no ALARM to recover from, suppressed), `None` (no parseable state change —
  the fail-open value, fires). Only a *positive* read of a non-ALARM prior state suppresses.

This cannot swallow a real recovery, because a recovery is `ALARM -> OK` by definition.

**The apparent counterexample** — `ALARM` → `INSUFFICIENT_DATA` → `OK`, where a real
incident's recovery reports `INSUFFICIENT_DATA -> OK` — never reaches this check:
`_alarm_incident_is_owned` (#670) coalesces that `OK:` into its `ALARM:` turn ~35 lines
earlier. And if a runner restart lost that memory, the `ALARM:` thread is still unread and
enqueues on its own, which is the correct owner anyway.

Also renames the result bucket `created` → `ok_without_alarm` and its log text, so the
counter is named for what it measures rather than for the one cause we first saw it from.
That naming is a large part of why the gap was easy to miss — the log line read
`N alarm self-creation notices` for a bucket that was really "OK: with nothing to fold into".

## Verification

- `uv run --with pytest pytest` in `runner/canopy_runner` (the exact CI step): **618 passed**.
- `ruff check --select F --ignore F403,F405` on the three changed files: **All checks passed**.
- `bin/hal-ci-gates`: one gate fires on this diff (`CI [ci.yml]`); `regen-openapi.yml` is
  excluded by its paths filter, the other three have no push/PR trigger.
- **The new tests were watched failing.** Reverting `inbox.py` alone fails them on
  `KeyError`/`AttributeError` — a rename artefact that proves nothing — so the falsifier was
  run properly: with the new code in place but the prior-state test narrowed back to `N/A`
  only, the two new tests fail on their **assertions** (`Right contains one more item:
  'thr-insuff'`, `assert None is False`) while the other 34 stay green.

Refs #712
