### PR TITLE
runner: persist alarm incident ownership across a restart

### DIFF
--- a/runner/canopy_runner/canopy_runner/inbox.py
+++ b/runner/canopy_runner/canopy_runner/inbox.py
@@ -16,6 +16,7 @@ import json
 import re
 import subprocess
 import time
+from pathlib import Path
 from typing import NamedTuple
 
 # UNREAD only — the "new email" signal. Critically NOT "all recent threads":
@@ -262,15 +263,87 @@ OK_PAIRING_WINDOW_S = 2 * 60 * 60
 #: ``{(mailbox, alarm_name): wall-clock time we last ENQUEUED a turn for it}``. Written
 #: only on a real enqueue, never when coalescing — so a flapping alarm is quiet for one
 #: window and then genuinely re-notifies, rather than being suppressed forever by its own
-#: repeats. Process-local for the same reason as `_seen_state`: losing it on restart costs
-#: one redundant turn, never a dropped incident. That is the fail-open direction.
+#: repeats.
+#:
+#: PERSISTED, unlike `_seen_state` — and the difference is the whole point (#714). This
+#: used to say "process-local for the same reason as `_seen_state`: losing it on restart
+#: costs one redundant turn." Half of that inheritance was wrong. `_seen_state` is cheap
+#: to lose because *the server is the authority on idempotency* — that is its docstring's
+#: actual argument, and it holds. But the enqueue key is `email-<agent>-<thread>-<count>`:
+#: **nothing anywhere is keyed on the alarm NAME**, so when this dict is lost, nothing
+#: else in the system knows the incident already has an owner.
+#:
+#: And "one redundant turn" assumed restarts are rare and random. The runner SELF-UPDATES,
+#: so they are routine and scheduled, and the blast radius is every alarm storm in flight
+#: at that moment. Measured 2026-09-09: `labs-jj-web-cpu-high-actionable`'s `OK:` thread
+#: had been correctly suppressed for 50 minutes (its `ALARM:` owner had diagnosed the
+#: alarm, merged a fix and marked the storm read twice). An upgrade restart landed at
+#: 00:52:50Z; **23 seconds later** the first poll enqueued that thread as a fresh hal
+#: session whose entire job was to rediscover it should stand down — exactly the outcome
+#: #670 exists to prevent. Its `messageCount` had bumped after the owner's last sweep, so
+#: the server key was novel and server-side dedup could not help either.
+#:
+#: Loading stays fail-OPEN in every direction: a missing, unreadable, malformed or
+#: partially-corrupt file yields an empty dict, i.e. precisely today's behaviour. Entries
+#: older than the longest window are dropped on load, so the file is self-limiting and a
+#: long downtime cannot resurrect stale ownership.
 _alarm_enqueued: dict[tuple[str, str], float] = {}
+
+#: Set once per process by the first `check_inbox` call that is given a path; `None` keeps
+#: the dict purely in-memory, which is what every test and any embedding caller gets by
+#: default.
+_alarm_state_path: Path | None = None
+_alarm_state_loaded = False
+
+#: Entries this old cannot affect any decision — both windows have expired — so they are
+#: dropped rather than written back forever.
+_ALARM_STATE_TTL_S = max(OK_PAIRING_WINDOW_S, ALARM_REPEAT_WINDOW_S)
+
+
+def _load_alarm_enqueued(path: Path, now: float) -> None:
+    """Seed `_alarm_enqueued` from `path`, dropping expired entries.
+
+    Every failure mode — no file, bad JSON, wrong shape, a non-numeric timestamp — leaves
+    the dict as it was. Suppressing a turn requires an entry, so an empty dict enqueues,
+    which is the safe direction.
+    """
+    try:
+        raw = json.loads(path.read_text())
+    except (OSError, ValueError):
+        return
+    if not isinstance(raw, list):
+        return
+    for row in raw:
+        # Row-level tolerance: one corrupt entry must not discard the rest.
+        if not isinstance(row, list) or len(row) != 3:
+            continue
+        box, name, ts = row
+        if not isinstance(box, str) or not isinstance(name, str):
+            continue
+        if not isinstance(ts, (int, float)) or isinstance(ts, bool):
+            continue
+        if now - ts >= _ALARM_STATE_TTL_S:
+            continue
+        _alarm_enqueued[(box, name)] = float(ts)
+
+
+def _save_alarm_enqueued(path: Path, now: float) -> None:
+    """Write `_alarm_enqueued` to `path`, expired entries omitted. Best-effort: a failed
+    write costs at most the redundant turn this file exists to prevent, so it must never
+    take the poll loop down."""
+    rows = [[box, name, ts] for (box, name), ts in _alarm_enqueued.items()
+            if now - ts < _ALARM_STATE_TTL_S]
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(rows))
+    except (OSError, ValueError):
+        pass
 
 
 def check_inbox(client, agent: str, *, mailbox: str, gog_client: str,
                 query: str = DEFAULT_QUERY, max_threads: int = 15, runner=subprocess.run,
                 sender_of=None, facts_of=None, discovered_by: str = "poll",
-                clock=time.time) -> dict:
+                clock=time.time, alarm_state_path=None) -> dict:
     """Enqueue an email-origin turn for each new thread state. Returns
     {"new": [thread_ids that became a NEW turn], "seen": [ids already tracked],
     "skipped": [ids whose newest message is the agent's own reply],
@@ -294,7 +367,19 @@ def check_inbox(client, agent: str, *, mailbox: str, gog_client: str,
     and fails open (unknown -> enqueue) so an unreadable thread never silently drops a
     real reply. `sender_of(thread_id) -> str|None` is the narrower legacy seam, kept
     because existing callers and tests inject it; supplying it opts out of every fact
-    that needs the body, so a `sender_of`-injected call behaves exactly as before."""
+    that needs the body, so a `sender_of`-injected call behaves exactly as before.
+
+    `alarm_state_path` is where the alarm incident-ownership record (`_alarm_enqueued`)
+    is persisted so an upgrade restart cannot re-dispatch an already-owned `OK:` (#714).
+    Read once per process and rewritten only when an alarm turn is actually enqueued.
+    Omit it and the record stays purely in memory — exactly the pre-#714 behaviour."""
+    global _alarm_state_path, _alarm_state_loaded
+    if alarm_state_path is not None and not _alarm_state_loaded:
+        # Once per process: the file is the previous process's memory, not a cache to be
+        # re-read on every poll (this process is the only writer while it lives).
+        _alarm_state_path = Path(alarm_state_path)
+        _alarm_state_loaded = True
+        _load_alarm_enqueued(_alarm_state_path, clock())
     if facts_of is None:
         if sender_of is not None:
             def facts_of(tid: str) -> ThreadFacts:
@@ -396,7 +481,13 @@ def check_inbox(client, agent: str, *, mailbox: str, gog_client: str,
         # not extend its own suppression, or an alarm flapping for an hour would be
         # reported once and then silently held down for the whole hour.
         if key and key[0] == "ALARM":
-            _alarm_enqueued[(box, key[1])] = clock()
+            now = clock()
+            _alarm_enqueued[(box, key[1])] = now
+            # Persist immediately: the gap this closes is a restart, and a restart is not
+            # something we get to flush before. Only on a real stamp, so a quiet poll
+            # writes nothing.
+            if _alarm_state_path is not None:
+                _save_alarm_enqueued(_alarm_state_path, now)
         (new if (res or {}).get("_created") else seen).append(tid)
     return {"new": new, "seen": seen, "skipped": skipped, "coalesced": coalesced,
             "ok_without_alarm": ok_without_alarm}

--- a/runner/canopy_runner/canopy_runner/main.py
+++ b/runner/canopy_runner/canopy_runner/main.py
@@ -202,6 +202,11 @@ def _maybe_check_inboxes(cfg: Config, client: Client, now_fn=time.time,
 
     from . import inbox as inbox_mod
     cap = getattr(cfg, "inbox_max_threads", 8)
+    # Which alarm incidents already have an owner — the one piece of dedup state with no
+    # server-side equivalent, so it has to survive the runner's own self-update restart
+    # (#714). Sibling of inbox-last.json / gmail-watch.json.
+    alarm_state = (Path(cfg.state_path).with_name("alarm-incidents.json")
+                   if cfg.state_path else Path("alarm-incidents.json"))
     for agent in due_slugs:
         box = cfg.mailboxes[agent]
         if paused and agent in paused:
@@ -211,6 +216,7 @@ def _maybe_check_inboxes(cfg: Config, client: Client, now_fn=time.time,
                 client, agent, mailbox=box["account"], gog_client=box["client"],
                 query=box.get("query", inbox_mod.DEFAULT_QUERY), max_threads=cap,
                 discovered_by=inbox_due.discovered_by(agent, rung_slugs),
+                alarm_state_path=alarm_state,
             )
             n_new, n_seen = len(res["new"]), len(res["seen"])
             n_skip = len(res.get("skipped", []))

--- a/runner/canopy_runner/tests/test_inbox.py
+++ b/runner/canopy_runner/tests/test_inbox.py
@@ -133,9 +133,22 @@ def _clear_seen_state():
     """`_seen_state` is module-global and these tests reuse thread ids."""
     inbox._seen_state.clear()
     inbox._alarm_enqueued.clear()
+    inbox._alarm_state_path = None
+    inbox._alarm_state_loaded = False
     yield
     inbox._seen_state.clear()
     inbox._alarm_enqueued.clear()
+    inbox._alarm_state_path = None
+    inbox._alarm_state_loaded = False
+
+
+def _restart():
+    """Everything a runner restart destroys: both process-local caches and the
+    once-per-process load flag. What survives is only what reached disk."""
+    inbox._seen_state.clear()
+    inbox._alarm_enqueued.clear()
+    inbox._alarm_state_path = None
+    inbox._alarm_state_loaded = False
 
 
 def _clock(t):
@@ -320,6 +333,108 @@ def test_ok_is_coalesced_even_when_its_alarm_was_an_earlier_batch():
     assert res["new"] == []
     assert res["coalesced"] == ["thr-ok"]
     assert len(client.enqueued) == 1
+
+
+def test_ok_is_still_coalesced_across_a_runner_restart(tmp_path):
+    """#714 — the regression this file could not previously see.
+
+    `_alarm_enqueued` was process-local, so the runner's own self-update restart erased
+    which incidents had an owner and the next poll re-dispatched an already-owned `OK:`.
+    Measured 2026-09-09: an upgrade restart, then a CREATE 23 seconds later on a thread
+    the previous process had been suppressing for 50 minutes.
+    """
+    state = tmp_path / "alarm-incidents.json"
+    client = FakeClient()
+    inbox.check_inbox(client, "hal", mailbox="hal@dimagi-ai.com", gog_client="canopy",
+                      runner=_runner(_alarm_thread(1)), sender_of=lambda tid: SNS.lower(),
+                      clock=_clock(0), alarm_state_path=state)
+    assert len(client.enqueued) == 1
+
+    _restart()
+
+    ok_only = [{"id": "thr-ok", "from": SNS, "subject": _OK, "messageCount": 2}]
+    res = inbox.check_inbox(client, "hal", mailbox="hal@dimagi-ai.com", gog_client="canopy",
+                            runner=_runner(ok_only), sender_of=lambda tid: SNS.lower(),
+                            clock=_clock(50 * 60), alarm_state_path=state)
+    assert res["new"] == []
+    assert res["coalesced"] == ["thr-ok"]
+    assert len(client.enqueued) == 1
+
+
+def test_restart_state_expires_so_a_later_ok_is_a_real_incident(tmp_path):
+    """The persisted record must not resurrect ownership forever — past the longest
+    window it is dropped on load and the `OK:` fires, as it would have pre-#714."""
+    state = tmp_path / "alarm-incidents.json"
+    client = FakeClient()
+    inbox.check_inbox(client, "hal", mailbox="hal@dimagi-ai.com", gog_client="canopy",
+                      runner=_runner(_alarm_thread(1)), sender_of=lambda tid: SNS.lower(),
+                      clock=_clock(0), alarm_state_path=state)
+    _restart()
+    ok_only = [{"id": "thr-ok", "from": SNS, "subject": _OK, "messageCount": 2}]
+    res = inbox.check_inbox(client, "hal", mailbox="hal@dimagi-ai.com", gog_client="canopy",
+                            runner=_runner(ok_only), sender_of=lambda tid: SNS.lower(),
+                            clock=_clock(inbox._ALARM_STATE_TTL_S + 1),
+                            alarm_state_path=state)
+    assert res["new"] == ["thr-ok"]
+
+
+@pytest.mark.parametrize("payload", ["", "not json", '{"a": 1}', '[["hal"]]',
+                                     '[["hal", "x", "soon"]]', '[["hal", 5, 1.0]]'])
+def test_unreadable_alarm_state_fails_open(tmp_path, payload):
+    """Every corruption mode enqueues rather than suppressing. Suppression requires a
+    valid entry, so a damaged file can only ever cost the redundant turn we were already
+    paying before #714 — never a dropped incident."""
+    state = tmp_path / "alarm-incidents.json"
+    state.write_text(payload)
+    client = FakeClient()
+    ok_only = [{"id": "thr-ok", "from": SNS, "subject": _OK, "messageCount": 1}]
+    res = inbox.check_inbox(client, "hal", mailbox="hal@dimagi-ai.com", gog_client="canopy",
+                            runner=_runner(ok_only), sender_of=lambda tid: SNS.lower(),
+                            clock=_clock(0), alarm_state_path=state)
+    assert res["new"] == ["thr-ok"]
+
+
+def test_missing_alarm_state_file_fails_open(tmp_path):
+    client = FakeClient()
+    ok_only = [{"id": "thr-ok", "from": SNS, "subject": _OK, "messageCount": 1}]
+    res = inbox.check_inbox(client, "hal", mailbox="hal@dimagi-ai.com", gog_client="canopy",
+                            runner=_runner(ok_only), sender_of=lambda tid: SNS.lower(),
+                            clock=_clock(0),
+                            alarm_state_path=tmp_path / "nope" / "alarm-incidents.json")
+    assert res["new"] == ["thr-ok"]
+
+
+def test_no_state_path_keeps_the_record_in_memory_only(tmp_path):
+    """Omitting the path must behave exactly as before #714 — and write nothing."""
+    client = FakeClient()
+    inbox.check_inbox(client, "hal", mailbox="hal@dimagi-ai.com", gog_client="canopy",
+                      runner=_runner(_alarm_thread(1)), sender_of=lambda tid: SNS.lower(),
+                      clock=_clock(0))
+    assert inbox._alarm_state_path is None
+    assert list(tmp_path.iterdir()) == []
+    _restart()
+    ok_only = [{"id": "thr-ok", "from": SNS, "subject": _OK, "messageCount": 2}]
+    res = inbox.check_inbox(client, "hal", mailbox="hal@dimagi-ai.com", gog_client="canopy",
+                            runner=_runner(ok_only), sender_of=lambda tid: SNS.lower(),
+                            clock=_clock(60), alarm_state_path=None)
+    assert res["new"] == ["thr-ok"]
+
+
+def test_a_coalesced_ok_does_not_extend_its_own_suppression_on_disk(tmp_path):
+    """The stamp is written only on a real enqueue. A recovery folding into an existing
+    incident must not refresh the window, or a flapping alarm would be reported once and
+    then held down forever — the property the in-memory version already had."""
+    state = tmp_path / "alarm-incidents.json"
+    client = FakeClient()
+    inbox.check_inbox(client, "hal", mailbox="hal@dimagi-ai.com", gog_client="canopy",
+                      runner=_runner(_alarm_thread(1)), sender_of=lambda tid: SNS.lower(),
+                      clock=_clock(0), alarm_state_path=state)
+    before = state.read_text()
+    ok_only = [{"id": "thr-ok", "from": SNS, "subject": _OK, "messageCount": 2}]
+    inbox.check_inbox(client, "hal", mailbox="hal@dimagi-ai.com", gog_client="canopy",
+                      runner=_runner(ok_only), sender_of=lambda tid: SNS.lower(),
+                      clock=_clock(60 * 60), alarm_state_path=state)
+    assert state.read_text() == before
 
 
 def test_ok_with_no_recent_alarm_still_enqueues():


### PR DESCRIPTION
Closes #714.

`_alarm_enqueued` is the record of which alarm incidents already have an owning turn. It
was process-local, so the runner's **own self-update restart** erased it and the next poll
re-dispatched an `OK:` whose incident had been diagnosed, fixed and closed out.

## The measurement

`labs-jj-web-cpu-high-actionable`'s `OK:` thread had been correctly suppressed for 50
minutes — its `ALARM:` owner (a hal session) had measured the alarm, merged
[connect-labs#1633](https://github.com/dimagi-internal/connect-labs/pull/1633), and marked
the whole storm read at `23:51:25Z` and again at `00:02:37Z`. One more `OK:` landed at
`00:03Z`, bumping `messageCount` — a **new** server idempotency key, so server-side dedup
could not help. The coalescing rail could, and did, for 50 minutes of polls.

Then:

```
18:52:47 update nudge: kickstarted com.canopy.runner.updater
18:52:50 canopy-runner starting
18:53:13 inbox[hal]: polled — 2 unread (1 NEW -> session, ...)
18:53:18 CREATE turn=6cb9f618-... thread=1a07f6c43c16784c -> new session (NEW claude session = tokens)
```

23 seconds after the new process started, a full agent session was dispatched whose entire
job was to rediscover it should stand down — the exact outcome #670 exists to prevent.

## Why the recorded rationale didn't cover it

The docstring justified being process-local by pointing at `_seen_state`. Splitting that:

* **The safety claim holds and is preserved** — losing the memory must never drop an
  incident, so every path here still fails open.
* **The cost claim doesn't transfer.** `_seen_state` is cheap to lose because *the server is
  the authority on idempotency* — its own docstring's argument. The enqueue key is
  `email-<agent>-<thread>-<count>`; **nothing is keyed on the alarm name**. Lose this dict
  and nothing else in the system knows the incident has an owner.
* **"One redundant turn" assumed restarts are rare and random.** The runner self-updates, so
  they are routine and scheduled, and the blast radius is every storm in flight.

## The change

Persist only this record, as `alarm-incidents.json` beside the runner's existing state files
(`inbox-last.json`, `gmail-watch.json` already use the `cfg.state_path` sibling pattern).

* Read **once per process**, not per poll — the file is the previous process's memory, and
  this process is the only writer while it lives.
* Written **only on a real enqueue**, preserving the existing property that a coalesced
  `OK:` never extends its own suppression.
* Entries past the longest window are dropped on load, so the file is self-limiting and a
  long downtime cannot resurrect stale ownership.
* **Fail-open everywhere**: missing, unreadable, malformed, or row-level-corrupt all yield an
  empty dict — precisely today's behaviour, since suppression requires a valid entry.
* Omitting the path keeps it purely in memory, so every existing caller and test is unchanged.

`_seen_state` is deliberately **not** persisted: its docstring's reasoning is sound as
written, and it is an unbounded cache where this is a handful of entries.

## Verification

| Gate | Result |
|---|---|
| `uv run ruff check . --select F --ignore F403,F405` (repo-wide) | `All checks passed!` |
| `runner/canopy_runner` → `uv run --with pytest pytest` | **629 passed** |
| `bin/hal-ci-gates` denominator | only `ci.yml` fires; `regen-openapi.yml` excluded by its `paths:` filter, the other three have no push/PR trigger |

The regression test was **verified to fail** with the load path disabled (`1 failed, 17
passed`) and pass with it — so it is testing the fix, not passing vacuously. New coverage:
the restart regression, window expiry, six corruption modes, the missing-file path,
no-path-means-in-memory, and that a coalesced `OK:` does not refresh the on-disk stamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017cjGrAAGDynJiRiAAHCd43
