### PR TITLE
Serve the app shell from the network, not from a cache that is a build old

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 import environ
 
+from config.static_cache import add_cache_headers
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
@@ -194,6 +196,14 @@ STATIC_ROOT = BASE_DIR / "staticfiles"
 # that; the spec and Lighthouse don't, and the manifest is the thing that makes
 # /supervisor installable.
 WHITENOISE_MIMETYPES = {".webmanifest": "application/manifest+json"}
+
+# Cache policy for those same files. WhiteNoise's default is max-age=60 on
+# EVERYTHING, which serves a stale index.html for up to a minute after a deploy
+# (so a fresh visit renders the previous build until you hard-refresh) while
+# also re-validating content-hashed assets that can never change. The hook
+# splits them: hashed ⇒ immutable, everything else ⇒ revalidate. See
+# config/static_cache.py.
+WHITENOISE_ADD_HEADERS_FUNCTION = add_cache_headers
 
 # Frontend SPA build output (served by catch-all view; WhiteNoise handles assets)
 FRONTEND_DIST_DIR = BASE_DIR / "frontend" / "dist"

--- a/config/static_cache.py
+++ b/config/static_cache.py
@@ -1,0 +1,50 @@
+"""HTTP cache policy for the built SPA, served by WhiteNoise.
+
+The SPA is two kinds of file with opposite needs, and WhiteNoise's default
+``max-age=60`` on everything gets both of them wrong:
+
+* ``index.html`` (and ``sw.js``) must be CURRENT. It is the only file that says
+  which hashed assets this build uses, so a stale copy renders a stale app —
+  and a minute of that is a minute in which the only way to see a deploy is a
+  hard refresh. That is one half of the bug this module exists for; the other
+  half was the service worker serving its precached shell (see
+  ``frontend/vite.config.ts``). Fixing only the service worker left a 60-second
+  window where a fresh visit still rendered the previous build — measured in a
+  browser against a two-deploy reproduction, not reasoned about.
+
+* ``assets/index-D2OGee1N.js`` and friends can never change: the hash IS the
+  content, and a new build writes a new name. Revalidating them every 60
+  seconds is pure round-trips.
+
+So: hashed ⇒ cache forever, everything else ⇒ revalidate every time. A
+revalidation of a 2 KB shell is one conditional request answered with 304, and
+it is what makes "I opened the page" mean "I am on the current build".
+"""
+from __future__ import annotations
+
+import re
+
+# Vite writes `assets/<name>-<hash>.<ext>`, where <hash> is base64url. The name
+# can itself contain dashes (`geist-latin-wght-normal-Dm3htQBi.woff2`), so the
+# hash is anchored as the LAST dash-separated segment before the extension.
+_HASHED_ASSET = re.compile(r"/assets/[^/]+-[A-Za-z0-9_-]{8,}\.[A-Za-z0-9]+$")
+
+IMMUTABLE = "public, max-age=31536000, immutable"
+REVALIDATE = "no-cache"
+
+
+def is_hashed_asset(url: str) -> bool:
+    """True for a build artifact whose name already encodes its content."""
+    return bool(_HASHED_ASSET.search(url))
+
+
+def add_cache_headers(headers, path: str, url: str) -> None:
+    """WhiteNoise ``add_headers_function`` hook — overwrites its Cache-Control.
+
+    Deliberately a total rule rather than a list of exceptions: a file we have
+    not thought about (a new icon, ``manifest.webmanifest``, ``sw-push.js``,
+    ``workbox-<hash>.js``) lands on "revalidate", which costs a 304 and can
+    never serve something stale. Only a name that provably encodes its own
+    content opts into being cached forever.
+    """
+    headers["Cache-Control"] = IMMUTABLE if is_hashed_asset(url) else REVALIDATE

--- a/config/views.py
+++ b/config/views.py
@@ -8,6 +8,8 @@ from django.http import FileResponse, HttpResponse, JsonResponse
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.decorators.http import require_GET
 
+from config.static_cache import REVALIDATE
+
 
 def health_check(request):
     """Simple health check endpoint."""
@@ -27,6 +29,13 @@ def spa_view(request):
     In production, WhiteNoise serves /static/ and /assets/ assets referenced
     by index.html. In development, Vite serves the SPA directly — this view
     is only hit when the frontend build output is present.
+
+    This is the SECOND way the shell reaches a browser: WhiteNoise answers
+    `/canopy/` (its index file), and every deep link — `/supervisor`,
+    `/w/<ws>/…`, `/share/<token>` — lands here. It shipped with no cache headers
+    at all, which leaves the freshness of the one file that names the current
+    asset hashes up to each browser's heuristics. Same `no-cache` as WhiteNoise
+    now sends, so both doors agree; see config/static_cache.py.
     """
     index_path: Path = settings.FRONTEND_DIST_DIR / "index.html"
     if not index_path.exists():
@@ -36,4 +45,6 @@ def spa_view(request):
             status=503,
             content_type="text/plain",
         )
-    return FileResponse(open(index_path, "rb"), content_type="text/html")
+    response = FileResponse(open(index_path, "rb"), content_type="text/html")
+    response["Cache-Control"] = REVALIDATE
+    return response

--- a/frontend/src/pwa/navigation-fallback.test.ts
+++ b/frontend/src/pwa/navigation-fallback.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { shouldServeShell } from './navigation-fallback'
+import {
+  navigationMatcher,
+  navigationMatcherSource,
+  shouldServeShell,
+} from './navigation-fallback'
 
 const UUID = '11111111-2222-3333-4444-555555555555'
 
@@ -68,5 +72,86 @@ describe('navigate-fallback ownership', () => {
     it('unknown under /canopy → network', () => {
       expect(shouldServeShell('/canopy/foo/bar')).toBe(false)
     })
+  })
+})
+
+/**
+ * The rule above is what `shouldServeShell` implements; what the browser
+ * actually runs is the matcher whose source workbox-build inlines into sw.js.
+ * They are generated from the same two arrays, and these tests are what stops
+ * them drifting: every path asserted above is re-asserted through the real
+ * matcher, so a change that only fixes one of the two fails here.
+ */
+describe('the matcher workbox inlines into the SW', () => {
+  const matches = (path: string, mode = 'navigate'): boolean =>
+    navigationMatcher()({
+      request: { mode },
+      url: new URL(path, 'https://labs.connect.dimagi.com'),
+    })
+
+  const everyPath = [
+    '/',
+    '/supervisor',
+    '/insights',
+    '/system',
+    '/settings',
+    '/sessions',
+    '/schedules',
+    '/activity',
+    '/timeline',
+    '/shareouts/2026-07',
+    '/walkthroughs',
+    '/agents/echo',
+    '/ddd-plans',
+    '/reviews',
+    '/review/abc',
+    '/share/tok123',
+    '/invite/tok123',
+    '/ddd-release/nutrition-demo/run-1',
+    '/w/connect',
+    '/w/connect/ddd/nutrition-demo/nutrition-demo-2026-07-22-004',
+    `/walkthrough/${UUID}`,
+    '/api/ddd/runs/x',
+    '/accounts/google/login/',
+    '/admin/',
+    '/static/app.js',
+    '/auth/cli/authorize/',
+    '/health/',
+    `/walkthrough/${UUID}/content`,
+    `/walkthrough/${UUID}/content?t=tok`,
+    `/w/${UUID}/content`,
+    '/foo/bar',
+    '/nope',
+    '/canopy/supervisor',
+    `/canopy/walkthrough/${UUID}`,
+    `/canopy/walkthrough/${UUID}/content`,
+    '/canopy/api/me/',
+    '/canopy/accounts/google/login/',
+    '/canopy/foo/bar',
+  ]
+
+  for (const path of everyPath) {
+    it(`agrees with shouldServeShell on ${path}`, () => {
+      expect(matches(path)).toBe(shouldServeShell(path))
+    })
+  }
+
+  it('only claims navigations — a fetch/XHR for the same path is left alone', () => {
+    // Everything the app fetches at runtime (the API above all) must bypass the
+    // SW. The route is the only runtimeCaching entry, so `request.mode` is the
+    // whole guard.
+    expect(matches('/supervisor')).toBe(true)
+    expect(matches('/supervisor', 'cors')).toBe(false)
+    expect(matches('/supervisor', 'no-cors')).toBe(false)
+    expect(matches('/api/me/', 'cors')).toBe(false)
+  })
+
+  it('is self-contained — it closes over nothing from this module', () => {
+    // workbox-build serialises the function with String(fn) and drops the text
+    // into sw.js, where NAVIGATE_FALLBACK_ALLOWLIST does not exist. A matcher
+    // that referenced it would build fine and fail only in a real browser.
+    const source = navigationMatcherSource()
+    expect(source).not.toMatch(/NAVIGATE_FALLBACK_(ALLOW|DENY)LIST/)
+    expect(source).toContain('request.mode')
   })
 })

--- a/frontend/src/pwa/navigation-fallback.ts
+++ b/frontend/src/pwa/navigation-fallback.ts
@@ -2,10 +2,15 @@
  * Service-worker navigate-fallback ownership — the fail-safe rule.
  *
  * A same-origin *navigation* (including every `<iframe src>` load; a `<video
- * src>` load is NOT one) is answered by the SW from the precached SPA shell
- * (`index.html`) ONLY when its path matches an ALLOWLISTed SPA route prefix and
- * does NOT match a DENYLISTed server route. Everything else goes to the network
- * and reaches Django.
+ * src>` load is NOT one) is HANDLED BY THE SW ONLY when its path matches an
+ * ALLOWLISTed SPA route prefix and does NOT match a DENYLISTed server route.
+ * Everything else goes to the network and reaches Django.
+ *
+ * "Handled" means network-first with the precached `index.html` as the OFFLINE
+ * fallback — not "served from the precache". Serving the precached shell to an
+ * online navigation is what made every visit render the previous deploy until
+ * someone hard-refreshed; see vite.config.ts for that story. The allow/deny
+ * rule below is unchanged by it.
  *
  * This inverts the historical "shell for everything except a denylist of server
  * prefixes" default, which silently swallowed any server route nobody
@@ -90,4 +95,46 @@ export function shouldServeShell(path: string): boolean {
   const allowed = NAVIGATE_FALLBACK_ALLOWLIST.some((re) => re.test(path))
   const denied = NAVIGATE_FALLBACK_DENYLIST.some((re) => re.test(path))
   return allowed && !denied
+}
+
+/**
+ * The same decision, as source for the service worker's route matcher.
+ *
+ * Navigations are served NETWORK-FIRST (see vite.config.ts) rather than from
+ * the precache, so this rule now selects which navigations the SW *handles at
+ * all* — and the precached shell is only its offline fallback. The predicate is
+ * unchanged; what changed is that a cache hit is the exception, not the rule.
+ *
+ * workbox-build serialises a `runtimeCaching.urlPattern` function with
+ * `String(fn)` and inlines the text into the generated SW, where none of this
+ * module's bindings exist. So the matcher has to be SELF-CONTAINED: the regexes
+ * are baked into the source here rather than closed over. Building that source
+ * from the same two arrays is what stops the SW and `shouldServeShell` drifting
+ * — `navigation-fallback.test.ts` runs both over the same paths.
+ *
+ * workbox matches against `pathname + search` (which is why the `/content`
+ * carve-outs end in `(?:\?.*)?$`), so the generated matcher does too.
+ */
+export function navigationMatcherSource(): string {
+  const list = (res: RegExp[]): string => `[${res.map((re) => re.toString()).join(',')}]`
+  return `if (request.mode !== 'navigate') return false
+const path = url.pathname + url.search
+if (${list(NAVIGATE_FALLBACK_DENYLIST)}.some(function (re) { return re.test(path) })) return false
+return ${list(NAVIGATE_FALLBACK_ALLOWLIST)}.some(function (re) { return re.test(path) })`
+}
+
+/**
+ * The matcher workbox will run, built from that source. vite.config.ts hands
+ * this straight to `runtimeCaching.urlPattern`; the test calls it directly to
+ * prove it agrees with `shouldServeShell` on every path.
+ */
+export function navigationMatcher(): (arg: {
+  request: { mode: string }
+  url: URL
+}) => boolean {
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval
+  return new Function('{ request, url }', navigationMatcherSource()) as (arg: {
+    request: { mode: string }
+    url: URL
+  }) => boolean
 }

--- a/frontend/src/pwa/registerPwa.ts
+++ b/frontend/src/pwa/registerPwa.ts
@@ -19,6 +19,12 @@ import { registerSW } from 'virtual:pwa-register'
 // moment. The polling below is kept — a long-lived client (installed PWA, menubar
 // WKWebView, a tab open for days) otherwise never discovers a deploy at all, which
 // is how the Sessions surface once got stuck on a pre-feature bundle.
+//
+// SINCE THEN: navigations are network-first, so the account above is history, not
+// current behaviour — a page is no longer served a stale shell in the first place,
+// and none of the rest can follow from it. What is still true is that a waiting SW
+// holds a stale PRECACHE, which is what the app would fall back to offline. That is
+// all adopting it promptly buys now, so waiting for `hidden` costs nothing.
 const UPDATE_INTERVAL_MS = 60_000
 
 /** Apply a waiting update only when the page is HIDDEN.

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,10 +4,7 @@ import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import path from 'path'
 import { VitePWA } from 'vite-plugin-pwa'
-import {
-  NAVIGATE_FALLBACK_ALLOWLIST,
-  NAVIGATE_FALLBACK_DENYLIST,
-} from './src/pwa/navigation-fallback'
+import { navigationMatcher } from './src/pwa/navigation-fallback'
 
 // Same override as playwright.config/backend.sh — see E2E_API_PORT there.
 const API_ORIGIN = `http://localhost:${process.env.E2E_API_PORT ?? '8000'}`
@@ -58,8 +55,10 @@ export default defineConfig({
         ],
       },
       workbox: {
-        // Cache the shell so the app opens instantly and survives a labs outage
-        // (this is also what makes the menubar's WKWebView resilient in Phase 5).
+        // Precache the shell so the app still opens during a labs outage (this
+        // is what makes the menubar's WKWebView resilient in Phase 5). It is the
+        // OFFLINE copy only — see the navigation route below for why serving it
+        // to an online visitor was the bug.
         globPatterns: ['**/*.{js,css,html,svg,png,woff2}'],
         // A new SW must NOT take over a page that has already been served the
         // old shell. registerType 'autoUpdate' turns both of these on, and the
@@ -78,9 +77,10 @@ export default defineConfig({
         // Which is exactly the report: white on first load, fine after a manual
         // refresh, and it went from rare to constant on a day with six deploys.
         //
-        // With both false the new SW waits. The loading page keeps the precache
-        // it was built against and renders; the update applies on the next
-        // navigation. Still automatic — just never underneath a live page.
+        // With both false the new SW waits, and src/pwa/registerPwa.ts adopts it
+        // when the page is hidden. Still needed, but no longer urgent: step 1 is
+        // gone now that navigations are network-first, so a waiting SW only means
+        // a stale OFFLINE precache, not a stale page.
         skipWaiting: false,
         clientsClaim: false,
         // vite-plugin-pwa's generated SW only caches — it has no push listener.
@@ -88,19 +88,71 @@ export default defineConfig({
         // no notification). importScripts (not injectManifest) keeps the
         // plugin's own precaching intact while adding push handling.
         importScripts: ['sw-push.js'],
-        // Fail-safe navigate-fallback ownership (issue #345): the SW serves the
-        // cached SPA shell ONLY for allowlisted SPA route prefixes; every other
-        // navigation (unknown paths, Django routes, the /walkthrough/<id>/content
-        // streams) goes to the network. Inverting the old "shell for everything
-        // minus a denylist" default means a NEW server route can't be silently
-        // swallowed. The rule + both lists live in — and are unit-tested in —
-        // src/pwa/navigation-fallback.ts.
-        navigateFallbackAllowlist: NAVIGATE_FALLBACK_ALLOWLIST,
-        navigateFallbackDenylist: NAVIGATE_FALLBACK_DENYLIST,
-        // No runtimeCaching routes registered: all non-precached fetches bypass the SW and hit
-        // the network. This keeps the API uncached (stale "0 waiting" is worse than a spinner).
-        // When adding entries here, take care not to match /api/ — nothing else guards against that.
-        runtimeCaching: [],
+        // Must be set EXPLICITLY, not just omitted: vite-plugin-pwa's own
+        // defaults are `Object.assign({}, {navigateFallback: 'index.html'},
+        // yourWorkboxOptions)`, so leaving the key out silently reinstates the
+        // cache-first NavigationRoute — and it would be registered BEFORE the
+        // runtimeCaching route below, which in workbox means it wins outright.
+        // Verified by reading the emitted sw.js, not by reasoning about it.
+        navigateFallback: undefined,
+        // …and removing the NavigationRoute is not enough on its own, because
+        // the PRECACHE route answers a bare `/` too: workbox defaults
+        // `directoryIndex: 'index.html'`, so a request whose path ends in `/`
+        // is also looked up as `<path>index.html` — which IS precached. That is
+        // registered ahead of any runtimeCaching route, so `/` (the entry point
+        // this bug is reported against) kept being served the stale shell while
+        // `/supervisor` was already fixed. Measured in a browser: no `app-shell`
+        // cache was ever created because the route never ran.
+        //
+        // null turns the aliasing off. `index.html` stays precached and is still
+        // reachable by explicit lookup — which is exactly what the offline
+        // fallback below does.
+        directoryIndex: null,
+        // `navigateFallback: 'index.html'` builds a
+        // NavigationRoute around createHandlerBoundToURL('index.html'), which
+        // answers every navigation from the PRECACHE — a copy of index.html
+        // frozen at build time, naming that build's hashed assets.
+        //
+        // That is why the app kept needing a hard refresh. index.html is the one
+        // file that must be current, because it is the only thing that says which
+        // asset hashes to load; serving it from cache means a fresh visit renders
+        // the PREVIOUS deploy, and only a hard refresh (which bypasses the SW
+        // entirely) reaches the new one. #711 changed WHEN a new SW is adopted
+        // but not WHERE the HTML comes from, so the staleness survived it — and
+        // it is also the first step of the white-page race #711 describes: the
+        // page can only ask for asset hashes that have been deleted if it was
+        // handed a stale shell to begin with.
+        //
+        // So navigations are NETWORK-FIRST instead, with the precached shell
+        // demoted to the offline fallback (PrecacheFallbackPlugin). Online you
+        // always get the current build on the first paint, with no reload; the
+        // app still opens offline, and an installed PWA / the menubar WKWebView
+        // still survive a labs outage. networkTimeoutSeconds bounds a hanging
+        // network so a bad connection degrades to the cached shell rather than a
+        // spinner.
+        //
+        // Which navigations the SW handles at all is unchanged (issue #345's
+        // fail-safe rule): allowlisted SPA prefixes minus denylisted server
+        // routes, so a NEW server route still can't be silently swallowed. The
+        // rule and both lists live in — and are unit-tested in —
+        // src/pwa/navigation-fallback.ts; workbox-build inlines the matcher's
+        // source into the generated SW.
+        //
+        // This is the ONLY runtimeCaching route, and it matches navigations
+        // only. Nothing here may match /api/ — a cached "0 waiting" is worse
+        // than a spinner, and nothing else guards against it.
+        runtimeCaching: [
+          {
+            urlPattern: navigationMatcher(),
+            handler: 'NetworkFirst',
+            options: {
+              cacheName: 'app-shell',
+              networkTimeoutSeconds: 4,
+              expiration: { maxEntries: 32 },
+              precacheFallback: { fallbackURL: 'index.html' },
+            },
+          },
+        ],
       },
       devOptions: { enabled: false },
     }),

--- a/tests/test_static_cache_headers.py
+++ b/tests/test_static_cache_headers.py
@@ -1,0 +1,79 @@
+"""The SPA shell must never be served stale; hashed assets must never expire.
+
+Both halves are load-bearing for "do I have to hard-refresh to see a deploy?".
+A stale `index.html` names the previous build's asset hashes, so the browser
+renders the previous app — for however long the Cache-Control allows. WhiteNoise
+defaulted that to 60 seconds and `spa_view` sent nothing at all.
+"""
+import pytest
+from django.conf import settings
+from django.test import Client
+
+from config.static_cache import IMMUTABLE, REVALIDATE, add_cache_headers, is_hashed_asset
+
+
+class TestHashedAssetDetection:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "/assets/index-D2OGee1N.js",
+            "/assets/index-e91UaNHK.css",
+            # the name itself contains dashes — the hash is the LAST segment
+            "/assets/geist-latin-wght-normal-Dm3htQBi.woff2",
+            "/assets/workbox-window.prod.es5-Bd17z0YL.js",
+            "/canopy/assets/ChatPage-BnQUZ0gB.js",
+        ],
+    )
+    def test_hashed_assets_are_immutable(self, url):
+        assert is_hashed_asset(url)
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "/index.html",
+            "/canopy/index.html",
+            "/sw.js",  # names the whole precache manifest — must be current
+            "/sw-push.js",
+            "/manifest.webmanifest",
+            "/favicon.svg",
+            "/icons/icon-192.png",
+            # unhashed file that happens to live under assets/
+            "/assets/logo.svg",
+        ],
+    )
+    def test_everything_else_revalidates(self, url):
+        assert not is_hashed_asset(url)
+
+    def test_the_hook_sets_the_two_policies(self):
+        headers = {}
+        add_cache_headers(headers, "/x", "/assets/index-D2OGee1N.js")
+        assert headers["Cache-Control"] == IMMUTABLE
+
+        headers = {}
+        add_cache_headers(headers, "/x", "/index.html")
+        assert headers["Cache-Control"] == REVALIDATE
+
+    def test_the_hook_overwrites_whitenoises_own_value(self):
+        # WhiteNoise sets max-age=60 first; the hook runs after and must win,
+        # not append.
+        headers = {"Cache-Control": "max-age=60, public"}
+        add_cache_headers(headers, "/x", "/index.html")
+        assert headers["Cache-Control"] == REVALIDATE
+
+    def test_it_is_wired_into_whitenoise(self):
+        assert settings.WHITENOISE_ADD_HEADERS_FUNCTION is add_cache_headers
+
+
+@pytest.mark.django_db
+def test_spa_view_marks_the_shell_no_cache(tmp_path, settings):
+    """A deep link (/supervisor, /share/<token>, …) is served by spa_view, not
+    WhiteNoise. It shipped with no Cache-Control at all."""
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    (dist / "index.html").write_text("<!doctype html><html></html>")
+    settings.FRONTEND_DIST_DIR = dist
+
+    response = Client().get("/share/some-token")
+
+    assert response.status_code == 200
+    assert response["Cache-Control"] == REVALIDATE


### PR DESCRIPTION
Reported again after #711: canopy web still needs a hard refresh on every visit.

#711 fixed **when** a new service worker is adopted. It never changed **where the
HTML comes from**, and that is the whole bug. `index.html` is the only file that
names a build's hashed assets, so a stale copy renders a stale app. Two layers
were serving one, and each was sufficient on its own.

Both were found by driving a browser through a real two-deploy sequence, not by
reading the code.

## 1. The service worker served the shell from its precache

`navigateFallback: 'index.html'` builds a NavigationRoute around
`createHandlerBoundToURL()`, so every navigation was answered from the precache —
a copy frozen at build time.

Measured: deploy v2, navigate → v1. Navigate again → v1. Only a hard refresh,
which bypasses the SW entirely, reached v2.

It is also step 1 of the white-page race #711 documents: a page can only ask for
asset hashes that have been deleted if it was handed a stale shell to begin with.

Navigations are now **NetworkFirst**, with the precached shell demoted to the
offline fallback (`PrecacheFallbackPlugin`). Which navigations the SW handles is
unchanged — issue #345's allowlist-minus-denylist rule still applies, and its two
lists still live in one unit-tested module.

**Two things had to go, not one:**

- Omitting `navigateFallback` silently reinstates it. vite-plugin-pwa's defaults
  are `Object.assign({navigateFallback: 'index.html'}, yours)`, so it must be set
  to `undefined` explicitly.
- That alone still left `/` broken while `/supervisor` worked. Workbox defaults
  `directoryIndex: 'index.html'`, so a path ending in `/` is *also* looked up as
  `<path>index.html` — which is precached — and the precache route is registered
  ahead of any runtimeCaching route. `/` is the entry point this was reported
  against. Caught by the `app-shell` cache never appearing in the browser.

## 2. The HTTP cache served the shell too

WhiteNoise defaults to `max-age=60` on everything, so even with the SW fixed, a
fresh visit rendered the previous build for up to a minute (reproduced) — while
content-hashed assets that can never change were revalidated every minute.
`spa_view`, which serves every deep link, sent no `Cache-Control` at all.

Now: hashed name ⇒ `immutable`, one year. Everything else ⇒ `no-cache`. A total
rule, so a file nobody thought about costs a 304 rather than serving something
stale.

## Verification

End to end against a two-build reproduction with the fixed cache headers:

- deploy, navigate with **no hard refresh** → new build on first paint, app
  mounted, no console errors
- server stopped → still opens offline, both a previously visited URL and a route
  never visited

Suites: 2412 backend passed, 764 frontend passed, build + `manage.py check` +
ruff clean. New tests cover both halves — the emitted SW matcher is asserted to
agree with `shouldServeShell` on every path, so the two cannot drift.

## One residual, inherent to service workers

A browser holding the *current* SW gets its shell from that worker one more time,
so the first visit after this deploys can still be stale. From the visit after
that, the new worker is in charge and the shell comes from the network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)