### PR TITLE
runner: send Enter as its own keypress when typing a mint code

### DIFF
--- a/runner/ec2/cloud_runner.py
+++ b/runner/ec2/cloud_runner.py
@@ -1836,6 +1836,13 @@ def _diagnostic_tail(raw: bytes, limit: int = 600) -> str:
     return " | ".join(reversed(keep))[:limit]
 
 
+#: How long to let a pasted code settle before sending Enter as a separate
+#: keypress. Generous on purpose: it is paid once per sign-in, against a human
+#: who has just spent a minute in a browser, and the failure it prevents costs
+#: them the whole attempt plus 90 seconds of watching a spinner.
+_PASTE_SETTLE_SECONDS = 0.5
+
+
 class MintTimeout(RuntimeError):
     """The CLI never reached the expected step. Always fatal to the attempt:
     a half-driven TUI is not a state worth resuming."""
@@ -1888,10 +1895,34 @@ class MintSession:
         return url
 
     def submit_code(self, code: str, timeout: float = 90.0) -> str:
-        """Type the code the human pasted, and return the minted token."""
+        """Type the code the human pasted, and return the minted token.
+
+        The RETURN IS ITS OWN WRITE, and the settle between the two is the whole
+        fix rather than caution. Sent as one chunk — `code + b"\\r"` — an older
+        CLI reads the arrival as a PASTE and takes the trailing carriage return
+        as the last CHARACTER of the pasted text, not as Enter. The code lands
+        in the input, nothing submits, and the CLI says nothing at all: the pump
+        then burns its full timeout and reports "never printed a token" for what
+        is really "never asked".
+
+        Measured on the box (`claude` 2.1.197, 2026-09-08), all three variants
+        against a live `setup-token`:
+
+            code + CR, one write   -> silent, no submit      <- the bug
+            code, settle, then CR  -> submits, CLI answers in 0.6s
+            code, settle, then LF  -> silent, no submit
+
+        The render is the tell: the one-write case masks the WHOLE field, the
+        split case reveals its last six characters — because in the first the
+        carriage return is sitting in the value. Newer CLIs (2.1.266) submit
+        either way, which is why this was invisible in development and cost a
+        human four sign-in attempts against a box one npm-install behind.
+        """
         if self._fd is None:
             raise MintTimeout("this mint session is not running")
-        os.write(self._fd, code.strip().encode() + b"\r")
+        os.write(self._fd, code.strip().encode())
+        time.sleep(_PASTE_SETTLE_SECONDS)
+        os.write(self._fd, b"\r")
         token = self._pump(timeout, extract_token)
         tail = _diagnostic_tail(self._buf)
         self.close()

--- a/runner/ec2/tests/test_claude_mint.py
+++ b/runner/ec2/tests/test_claude_mint.py
@@ -169,3 +169,54 @@ def test_spinner_frames_do_not_crowd_out_the_message(cm):
 def test_the_tail_is_bounded(cm, raw):
     """It rides in a failure detail that a human reads, not a log."""
     assert len(cm._diagnostic_tail(raw)) <= 600
+
+
+# ── typing the code in ─────────────────────────────────────────────────────
+#
+# Sent as ONE chunk (`code + b"\r"`), an older CLI reads the arrival as a paste
+# and keeps the carriage return as the last CHARACTER of the pasted text rather
+# than acting on it. Nothing submits and the CLI says nothing, so the pump burns
+# its full 90s and reports "never printed a token" for what is really "never
+# asked". Measured against a live `setup-token` on claude 2.1.197: one write is
+# silent, code-settle-CR answers in 0.6s, code-settle-LF is silent. Newer CLIs
+# (2.1.266) submit either way — which is exactly why this was invisible in
+# development and cost a human four sign-in attempts.
+
+def _fake_submit(cm, monkeypatch, code="THECODE#THESTATE"):
+    """Drive submit_code with the pty and the pump stubbed, recording the
+    ordered sequence of writes and sleeps it performs."""
+    events: list = []
+    monkeypatch.setattr(cm.os, "write",
+                        lambda fd, data: (events.append(data), len(data))[1])
+    monkeypatch.setattr(cm.time, "sleep", lambda s: events.append(("sleep", s)))
+    session = cm.MintSession()
+    session._fd = 7
+    monkeypatch.setattr(session, "_pump", lambda timeout, extract: "sk-ant-oat01-ok")
+    monkeypatch.setattr(session, "close", lambda: None)
+    token = session.submit_code(code)
+    return token, events
+
+
+def test_the_return_is_a_keypress_of_its_own_not_the_tail_of_the_paste(cm, monkeypatch):
+    token, events = _fake_submit(cm, monkeypatch)
+    assert token == "sk-ant-oat01-ok"
+    assert events[0] == b"THECODE#THESTATE", "the code must go in without a return attached"
+    assert events[-1] == b"\r", "Enter must arrive as its own write"
+    assert not any(isinstance(e, bytes) and e.endswith(b"\r") and len(e) > 1
+                   for e in events), "a code with the return glued on is the bug"
+
+
+def test_the_paste_is_allowed_to_settle_before_enter(cm, monkeypatch):
+    """Without a pause the two writes can still coalesce into one read on the
+    CLI's side, which is the same failure with extra steps."""
+    _, events = _fake_submit(cm, monkeypatch)
+    kinds = [("sleep" if isinstance(e, tuple) else "write") for e in events]
+    assert kinds == ["write", "sleep", "write"], kinds
+    assert events[1][1] > 0, "a zero settle is not a settle"
+
+
+def test_the_code_is_stripped_before_it_is_typed(cm, monkeypatch):
+    """A code arrives from a browser field; trailing whitespace is the human's,
+    not the credential's."""
+    _, events = _fake_submit(cm, monkeypatch, code="  THECODE#THESTATE\n ")
+    assert events[0] == b"THECODE#THESTATE"


### PR DESCRIPTION
## What was happening

Every browser-driven sign-in against `cloud-ec2-1` failed the same way: paste the code, watch "finishing sign-on" for 90 seconds, get `setup-token never printed a token` with a transcript that ends at a fully-masked input field. No CLI error, no token.

**The code was never submitted.** `submit_code` wrote `code + b"\r"` as one chunk. An older CLI reads that arrival as a *paste* and keeps the trailing carriage return as the last **character** of the pasted text instead of acting on it — so the code sits in the input box, the pump waits out its full 90 s, and the failure is reported as "never printed a token" when it is really "never asked".

## The measurement

Run against a live `setup-token` on the box itself (`claude` 2.1.197, via SSM, 2026-09-08):

| write pattern | result |
|---|---|
| `code + CR`, one write (**current**) | silent, no submit |
| `code`, settle, then `CR` | **submits** — CLI answers in 0.6 s |
| `code`, settle, then `LF` | silent, no submit |

The render is the tell, and it matches the real failure byte for byte: the one-write case masks the **whole** field, the split case reveals its last six characters — because in the first, the carriage return is sitting in the value. The failed mint recorded 49 masked glyphs with no reveal.

## What this is not

Three plausible theories, each disproven by observation rather than argument:

- **Wrong/expired code** — prints `OAuth error: Request failed with status code 400`. Nothing printed.
- **Partial copy, missing the `#state` half** — prints `Invalid code. Please make sure the full code was copied` instantly, no network. Nothing printed.
- **Blocked egress** — curled from the box: `claude.com` 200, `platform.claude.com` 200, `console.anthropic.com/v1/oauth/token` 405, all <10 ms.

Timing from CloudWatch + the runner journal is exact: URL published `01:14:37.8`, code posted `01:14:52.9`, `submit_code` entered `01:14:54.1`, failure `01:16:24.3` — **90.2 s**, the pump's full timeout, not a crash and not a slow network.

## Scope

Newer CLIs (2.1.266, verified locally on the same code path) submit either way — which is why this was invisible in development. The box is one unpinned `npm i -g` behind, and `runner.cfn.yaml:347` installs `claude` once at bootstrap and never again.

**That drift is real and is deliberately not fixed here.** Keeping `claude` current on a live runner is a separate design question (when to upgrade, not mid-turn, how to roll back), and this fix works on both old and new CLIs, so the sign-in no longer depends on the box being current.

## Tests

Three new tests in `runner/ec2/tests/test_claude_mint.py` pin the invariant — the return is its own write, the paste is allowed to settle, and the code is stripped before it is typed. All three go **red** against the old single write and green against the fix (verified by reverting the change and re-running). 18 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
