### PR TITLE
runner: the diagnostic tail must keep the CLI's verdict, not drop it

### DIFF
--- a/runner/ec2/cloud_runner.py
+++ b/runner/ec2/cloud_runner.py
@@ -1825,15 +1825,31 @@ def _diagnostic_tail(raw: bytes, limit: int = 600) -> str:
     # Collapse the TUI's redraw frames — spinner rows carry no information and
     # would otherwise be the entire tail.
     lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
-    seen, keep = set(), []
+    seen, newest_first = set(), []
     for ln in reversed(lines):
         if ln in seen:
             continue
         seen.add(ln)
-        keep.append(ln)
-        if sum(len(k) for k in keep) > limit:
+        newest_first.append(ln)
+        if sum(len(k) for k in newest_first) > limit:
             break
-    return " | ".join(reversed(keep))[:limit]
+    # Trim from the OLD end. This used to join oldest-first and then slice
+    # `[:limit]`, which deletes the NEWEST line — the CLI's verdict, and the
+    # entire reason this function exists. Seen live on 2026-09-08: a tail whose
+    # final segment was the single character "O", the decapitated head of
+    # "OAuth error: Request failed with status code 400". It reads as "the CLI
+    # said nothing", which is the exact wrong conclusion, and it was reached.
+    chosen: list[str] = []
+    total = 0
+    for ln in newest_first:
+        cost = len(ln) + (3 if chosen else 0)
+        if chosen and total + cost > limit:
+            break
+        chosen.append(ln)
+        total += cost
+    # The slice now bites only when a SINGLE line is over budget; for one line
+    # the head is the informative half, so keeping it is right.
+    return " | ".join(reversed(chosen))[:limit]
 
 
 #: How long to let a pasted code settle before sending Enter as a separate

--- a/runner/ec2/tests/test_claude_mint.py
+++ b/runner/ec2/tests/test_claude_mint.py
@@ -220,3 +220,29 @@ def test_the_code_is_stripped_before_it_is_typed(cm, monkeypatch):
     not the credential's."""
     _, events = _fake_submit(cm, monkeypatch, code="  THECODE#THESTATE\n ")
     assert events[0] == b"THECODE#THESTATE"
+
+
+def test_the_verdict_survives_the_length_cap(cm):
+    """The LAST thing the CLI said is the reason this function exists, so the
+    cap must eat the oldest lines, never the newest.
+
+    Regression: the tail was joined oldest-first and then sliced `[:limit]`,
+    which trims the end — the newest line. On 2026-09-08 a real failure detail
+    ended with the single character "O", the decapitated head of "OAuth error:
+    Request failed with status code 400", and was read as "the CLI printed
+    nothing at all"."""
+    noise = b"".join(b"\r\n" + f"chatter line {i} that is here only to fill the budget".encode()
+                     for i in range(40))
+    out = noise + b"\r\nOAuth error: Request failed with status code 400\r\n"
+    tail = cm._diagnostic_tail(out)
+    assert len(tail) <= 600
+    assert tail.endswith("OAuth error: Request failed with status code 400"), tail[-120:]
+
+
+def test_a_single_over_long_line_is_still_reported(cm):
+    """One line longer than the whole budget must not collapse to nothing —
+    and its HEAD is the informative half."""
+    out = b"\r\n" + b"Invalid authorization code. " + b"x" * 4000 + b"\r\n"
+    tail = cm._diagnostic_tail(out)
+    assert len(tail) <= 600
+    assert tail.startswith("Invalid authorization code.")


### PR DESCRIPTION
`_diagnostic_tail` exists to report **the last thing `setup-token` said**. It walked lines newest-first, stopped at ~600 characters, then joined oldest-first and sliced `[:limit]` — which trims the **end**, deleting exactly the newest line it was built to surface.

## How it showed up

While verifying #717 on the box, a real failure detail ended with the single character `O` — the decapitated head of `OAuth error: Request failed with status code 400`. A check for that string reported the CLI had printed *nothing*, which is the precise wrong conclusion. I stated it before the raw buffer corrected me.

It also means any `setup-token` failure whose transcript hit the cap may have had its verdict silently removed — including the one that motivated #717.

## The fix

Trim from the **old** end: take newest-first lines until the budget is spent, then join. The residual `[:limit]` now bites only when a single line is over budget on its own, where the head is the informative half.

Same class as #706 (*report what the CLI actually said*): a truncation that silently removes the evidence is worse than a shorter transcript, because **absence reads as a finding**.

## Tests

- `test_the_verdict_survives_the_length_cap` — 40 lines of filler plus a trailing `OAuth error: ...`; asserts the tail *ends* with the error. Goes **red** against the old code (verified by reverting), where it ends mid-word on filler.
- `test_a_single_over_long_line_is_still_reported` — a line longer than the whole budget must not collapse to nothing, and keeps its head.

20 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
