### PR TITLE
runner: the setup-token's prefix is Anthropic's to choose, not ours to pin

### DIFF
--- a/runner/ec2/cloud_runner.py
+++ b/runner/ec2/cloud_runner.py
@@ -1740,8 +1740,25 @@ _CSI = re.compile(rb"\x1b\[[0-9;?]*[ -/]*[@-~]")
 #: those finds nothing at runtime.
 _AUTHORIZE = re.compile(r"https://claude\.com/cai/oauth/authorize\?[^\s\x00-\x1f\"'<>]+")
 
-#: A setup-token is an OAuth token — `sk-ant-oat…`, distinct from an API key.
-_TOKEN = re.compile(r"\bsk-ant-oat[A-Za-z0-9_\-]+")
+#: The minted credential. The PREFIX IS NOT OURS TO PIN: the token is chosen by
+#: Anthropic's token endpoint and merely displayed by the CLI (`children: S.token`
+#: in the setup-token view), so `\bsk-ant-oat…` made this runner depend on a
+#: taxonomy nobody promised us. On 2026-09-08 a sign-in COMPLETED — the CLI
+#: printed "Long-lived authentication token created successfully!" — and the
+#: runner discarded the credential and reported failure, because it did not
+#: start with `oat`. The human did everything right and was told it had failed.
+#:
+#: So the CLI's OWN ANNOUNCEMENT is the anchor, not a guess at the format. Note
+#: the whitespace-tolerance: the TUI positions text with cursor moves rather than
+#: spaces, so after `strip_terminal` the banner reads "YourOAuthtoken(validfor1year):".
+_TOKEN_BANNER = re.compile(
+    r"Your\s*OAuth\s*token.{0,120}?(sk-ant-[A-Za-z0-9_\-]{16,})", re.S | re.I)
+#: Preferred when it is present — a known-good historical format.
+_TOKEN_OAT = re.compile(r"sk-ant-oat[A-Za-z0-9_\-]{8,}")
+#: Last resort: any credential that is NOT one of the kinds we know are wrong.
+#: `api…`/`admin…` are different credentials that would be staged into the wrong
+#: env var and fail confusingly.
+_TOKEN_ANY = re.compile(r"sk-ant-(?!api|admin)[A-Za-z0-9_\-]{16,}")
 
 
 def strip_terminal(raw: bytes) -> str:
@@ -1801,8 +1818,18 @@ def extract_authorize_url(raw: bytes) -> str | None:
 
 
 def extract_token(raw: bytes) -> str | None:
-    """The minted long-lived token, once the exchange has completed."""
-    m = _TOKEN.search(strip_terminal(raw))
+    """The minted long-lived token, once the exchange has completed.
+
+    Three passes, most-grounded first: what the CLI SAID is its OAuth token,
+    then the known `oat` format, then anything credential-shaped that is not a
+    kind we know is wrong. A miss here is not cosmetic — it throws away a
+    credential the human has already successfully created.
+    """
+    text = strip_terminal(raw)
+    m = _TOKEN_BANNER.search(text)
+    if m:
+        return m.group(1)
+    m = _TOKEN_OAT.search(text) or _TOKEN_ANY.search(text)
     return m.group(0) if m else None
 
 
@@ -2063,7 +2090,11 @@ def _drain_mint(runner_id: str) -> None:
                 # encrypted bundle — it never touches the browser, so the only
                 # secret a human handled was the single-use code.
                 _api("POST", f"/runners/{runner_id}/mint/result", {"token": token})
-                _log(f"mint {mint_id[:8]}: signed in; new token stored")
+                # The FORMAT, never the secret: 12 characters is the prefix and
+                # nothing else, and it is the one fact we lacked when a real
+                # token was discarded for not looking like the format we assumed.
+                _log(f"mint {mint_id[:8]}: signed in; new token stored "
+                     f"(format {token[:12]}…)")
                 if _reload_claude_credentials():
                     _log("picked up the freshly minted credential")
             finally:

--- a/runner/ec2/tests/test_claude_mint.py
+++ b/runner/ec2/tests/test_claude_mint.py
@@ -246,3 +246,49 @@ def test_a_single_over_long_line_is_still_reported(cm):
     tail = cm._diagnostic_tail(out)
     assert len(tail) <= 600
     assert tail.startswith("Invalid authorization code.")
+
+
+# ── the token's format is Anthropic's to choose, not ours to pin ───────────
+#
+# 2026-09-08, live: a sign-in COMPLETED. The CLI printed "Long-lived
+# authentication token created successfully!" and rendered the credential. The
+# runner discarded it and reported "setup-token never printed a token", because
+# `\bsk-ant-oat…` did not match. The token is returned by Anthropic's token
+# endpoint and merely displayed by the CLI, so pinning the prefix bound this
+# runner to a taxonomy nobody promised us — and cost a human a real sign-in.
+
+#: The success screen as `strip_terminal` renders it. Spaces are largely absent
+#: on purpose: the TUI positions text with cursor moves, which the CSI strip
+#: removes, so words glue together. Anything matching the banner must tolerate it.
+_SUCCESS = (
+    "Pastecodehereifprompted>\n"
+    "*********************nAa-r0\n"
+    "✓Long-livedauthenticationtokencreatedsuccessfully!\n"
+    "YourOAuthtoken(validfor1year):\n"
+    "{token}\n"
+    "Storethistokensecurely.Youwon'tbeabletoseeitagain.\n"
+)
+
+
+def test_a_token_the_cli_announces_is_taken_whatever_its_prefix(cm):
+    """The regression. A prefix we have never seen is still the credential the
+    human just created, and throwing it away is the worst outcome available."""
+    out = _SUCCESS.format(token="sk-ant-zzz99-QqWwEe_rTtYy-0123456789abcdef").encode()
+    assert cm.extract_token(out) == "sk-ant-zzz99-QqWwEe_rTtYy-0123456789abcdef"
+
+
+def test_the_known_format_still_wins_when_present(cm):
+    out = _SUCCESS.format(token="sk-ant-oat01-AbC_dEf-0123456789abcdefghij").encode()
+    assert cm.extract_token(out) == "sk-ant-oat01-AbC_dEf-0123456789abcdefghij"
+
+
+def test_the_banner_is_matched_through_the_tuis_missing_spaces(cm):
+    """`YourOAuthtoken(validfor1year):` — not a typo, that is what the terminal
+    strip actually yields."""
+    assert cm._TOKEN_BANNER.search("YourOAuthtoken(validfor1year):\nsk-ant-x-0123456789abcdef")
+
+
+def test_an_unannounced_api_key_is_still_refused(cm):
+    """Loosening the prefix must not start staging the wrong credential."""
+    assert cm.extract_token(b"sk-ant-api03-nope0123456789abcdefghij") is None
+    assert cm.extract_token(b"sk-ant-admin01-nope0123456789abcdefgh") is None


### PR DESCRIPTION
## What happened

A browser-driven sign-in **completed**. The CLI printed:

```
✓ Long-lived authentication token created successfully!
Your OAuth token (valid for 1 year):
<token>
Store this token securely.
```

…and the runner discarded the credential and reported `setup-token never printed a token`, because `\bsk-ant-oat…` did not match. The human did everything right and was told it failed. The token is real and valid for a year; it is simply orphaned.

## Why the old regex was wrong in principle, not just in detail

The token is chosen by **Anthropic's token endpoint** and merely *displayed* by the CLI — in the setup-token view it is rendered as `children: S.token`, an opaque string. Pinning `sk-ant-oat` bound this runner to a taxonomy nobody promised us. (The redaction in the failure detail fired on `sk-ant-`, which is how we know the credential was there and simply unrecognised.)

## The fix

`extract_token` now runs three passes, most-grounded first:

1. **What the CLI said is its OAuth token** — its own banner is the anchor
2. The known `oat` format, preferred when present
3. Anything credential-shaped that is not a kind we know is wrong

Whitespace tolerance in the banner match is load-bearing rather than defensive: the TUI positions text with cursor moves instead of spaces, so after the CSI strip the line reads `YourOAuthtoken(validfor1year):`.

`api…`/`admin…` are still refused — loosening the prefix must not start staging the wrong credential into `CLAUDE_CODE_OAUTH_TOKEN`.

Also logs the token's 12-character **format** (never the secret) on success. Not knowing the real prefix is exactly what made this failure unreadable.

## Tests

- `test_a_token_the_cli_announces_is_taken_whatever_its_prefix` — the regression, using the success screen as `strip_terminal` actually renders it (glued words and all). Goes **red** against the old regex, verified by reverting.
- `test_the_known_format_still_wins_when_present`
- `test_the_banner_is_matched_through_the_tuis_missing_spaces`
- `test_an_unannounced_api_key_is_still_refused`

24 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
