### PR TITLE
runner: a created token we cannot read is not a missing token

### DIFF
--- a/runner/ec2/cloud_runner.py
+++ b/runner/ec2/cloud_runner.py
@@ -1753,6 +1753,10 @@ _AUTHORIZE = re.compile(r"https://claude\.com/cai/oauth/authorize\?[^\s\x00-\x1f
 #: spaces, so after `strip_terminal` the banner reads "YourOAuthtoken(validfor1year):".
 _TOKEN_BANNER = re.compile(
     r"Your\s*OAuth\s*token.{0,120}?(sk-ant-[A-Za-z0-9_\-]{16,})", re.S | re.I)
+#: The CLI's own declaration that the exchange COMPLETED. Whitespace-tolerant
+#: for the same reason as the banner: the TUI positions with cursor moves.
+_TOKEN_ANNOUNCED = re.compile(
+    r"Long-lived\s*authentication\s*token\s*created|Your\s*OAuth\s*token", re.I)
 #: Preferred when it is present — a known-good historical format.
 _TOKEN_OAT = re.compile(r"sk-ant-oat[A-Za-z0-9_\-]{8,}")
 #: Last resort: any credential that is NOT one of the kinds we know are wrong.
@@ -1824,6 +1828,14 @@ def extract_token(raw: bytes) -> str | None:
     then the known `oat` format, then anything credential-shaped that is not a
     kind we know is wrong. A miss here is not cosmetic — it throws away a
     credential the human has already successfully created.
+
+    THE BANNER OUTRANKS OUR PREFIX OPINION, and that ordering is deliberate:
+    under "Your OAuth token (valid for 1 year):" the CLI is naming the value,
+    and pass 1 therefore does NOT apply the api/admin exclusion that pass 3
+    does. Adding it there would re-create the very bug this function exists to
+    fix — our taxonomy overruling a direct statement from the tool that owns
+    the credential. The exclusion belongs on the UNANCHORED pass, where we are
+    guessing, and nowhere else.
     """
     text = strip_terminal(raw)
     m = _TOKEN_BANNER.search(text)
@@ -1889,6 +1901,22 @@ _PASTE_SETTLE_SECONDS = 0.5
 class MintTimeout(RuntimeError):
     """The CLI never reached the expected step. Always fatal to the attempt:
     a half-driven TUI is not a state worth resuming."""
+
+
+class MintUnreadableToken(MintTimeout):
+    """The sign-in SUCCEEDED and we could not read the credential out.
+
+    A different fault from "no token appeared", and collapsing the two is what
+    made 2026-09-08 expensive: a human signed in correctly, Claude issued a
+    year-long token, the runner failed to match its prefix, and the operator was
+    told "setup-token never printed a token". That sentence sent the debugging
+    at the sign-in — which had worked perfectly — instead of at the six-line
+    parser, and cost a second attempt to notice.
+
+    Distinguished because the two need OPPOSITE responses: this one is a runner
+    bug to fix and never to retry blindly, while a real failure is worth another
+    go. It is also the more urgent of the two, since a credential was minted and
+    then lost."""
 
 
 class MintSession:
@@ -1968,7 +1996,17 @@ class MintSession:
         os.write(self._fd, b"\r")
         token = self._pump(timeout, extract_token)
         tail = _diagnostic_tail(self._buf)
+        # Ask BEFORE close(): the buffer is the only witness that the exchange
+        # completed, and the redaction in `tail` deliberately removes the token
+        # itself, so this is the last moment the distinction can be drawn.
+        announced = bool(_TOKEN_ANNOUNCED.search(strip_terminal(self._buf)))
         self.close()
+        if token is None and announced:
+            raise MintUnreadableToken(
+                "the sign-in SUCCEEDED — Claude issued a token — but this runner "
+                "could not read it out of the CLI's output, so the credential is "
+                "lost and a new sign-in is needed. That is a bug in the runner, "
+                "not anything you did. What it said: " + (tail or "(nothing)"))
         if token is None:
             raise MintTimeout(
                 "setup-token never printed a token. What it said: " + (tail or "(nothing)"))

--- a/runner/ec2/tests/test_claude_mint.py
+++ b/runner/ec2/tests/test_claude_mint.py
@@ -292,3 +292,55 @@ def test_an_unannounced_api_key_is_still_refused(cm):
     """Loosening the prefix must not start staging the wrong credential."""
     assert cm.extract_token(b"sk-ant-api03-nope0123456789abcdefghij") is None
     assert cm.extract_token(b"sk-ant-admin01-nope0123456789abcdefgh") is None
+
+
+# ── a created token we cannot read is NOT a missing token ──────────────────
+#
+# 2026-09-08: a human signed in correctly, Claude issued a year-long token, the
+# runner failed to match its prefix, and the operator was told "setup-token
+# never printed a token". That sentence pointed the debugging at the sign-in —
+# which had worked perfectly — instead of at the parser, and cost a second
+# attempt to notice. The two faults need opposite responses, so they get
+# different exceptions.
+
+def _submit_expecting(cm, monkeypatch, buf: bytes):
+    monkeypatch.setattr(cm.os, "write", lambda fd, data: len(data))
+    monkeypatch.setattr(cm.time, "sleep", lambda s: None)
+    session = cm.MintSession()
+    session._fd = 7
+    session._buf = buf
+    monkeypatch.setattr(session, "_pump", lambda timeout, extract: extract(buf))
+    monkeypatch.setattr(session, "close", lambda: None)
+    with pytest.raises(cm.MintTimeout) as exc:
+        session.submit_code("THECODE#THESTATE")
+    return exc.value
+
+
+def test_an_unreadable_credential_is_reported_as_its_own_fault(cm, monkeypatch):
+    """The CLI announced success; extraction found nothing it recognised."""
+    buf = ("YourOAuthtoken(validfor1year):\n"
+           "totally-unrecognisable-credential-value\n").encode()
+    err = _submit_expecting(cm, monkeypatch, buf)
+    assert isinstance(err, cm.MintUnreadableToken)
+    assert "SUCCEEDED" in str(err)
+    assert "bug in the runner" in str(err)
+
+
+def test_a_genuine_failure_is_still_a_plain_timeout(cm, monkeypatch):
+    """Nothing was announced, so a new attempt is the right response."""
+    buf = b"Pastecodehereifprompted>\n****************\n"
+    err = _submit_expecting(cm, monkeypatch, buf)
+    assert not isinstance(err, cm.MintUnreadableToken)
+    assert "never printed a token" in str(err)
+
+
+def test_the_banner_outranks_our_prefix_opinion(cm):
+    """DELIBERATE, and load-bearing: under the CLI's own "Your OAuth token"
+    label the value IS the token, so pass 1 does not apply pass 3's api/admin
+    exclusion. Applying it there would re-create the 2026-09-08 bug — our
+    taxonomy overruling the tool that owns the credential. Documented as a test
+    so it is not "tidied up" into a regression."""
+    announced = b"YourOAuthtoken(validfor1year):\nsk-ant-api03-0123456789abcdefghij\n"
+    assert cm.extract_token(announced) == "sk-ant-api03-0123456789abcdefghij"
+    # ...but unanchored, the same string is refused.
+    assert cm.extract_token(b"sk-ant-api03-0123456789abcdefghij") is None


### PR DESCRIPTION
## The conflation

On 2026-09-08 a human signed in correctly, Claude issued a year-long token, the runner failed to match its prefix, and the operator was told:

> `setup-token never printed a token`

That sentence sent the debugging at the **sign-in** — which had worked perfectly — instead of at the six-line parser, and cost a second sign-in attempt to notice. The credential was minted and then dropped.

## The fix

`MintUnreadableToken` (a `MintTimeout` subclass, so existing handling is unchanged) is raised when the CLI **announced success** but extraction found nothing. It says plainly that the sign-in succeeded, the credential is lost, and the fault is the runner's — not the human's.

The two need opposite responses: an unreadable token is a bug to fix and never to retry blindly; a genuine failure is worth another attempt. The check runs *before* `close()`, because the buffer is the only witness and `_diagnostic_tail` deliberately redacts the token itself.

## A precedence rule, now pinned

Also documents as a test that **the CLI's banner outranks our prefix opinion**: under `Your OAuth token (valid for 1 year):` the value *is* the token, so pass 1 deliberately does **not** apply pass 3's api/admin exclusion. Applying it there would re-create the bug #719 fixed — our taxonomy overruling the tool that owns the credential.

This surfaced from an on-box probe that asserted the opposite. The probe was wrong, but the rule was clearly worth writing down so it isn't "tidied up" into a regression later.

27 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
