### PR TITLE
deploy: stop spending five minutes draining a task nobody is using

### DIFF
--- a/deploy/aws/canopy-web.cfn.yaml
+++ b/deploy/aws/canopy-web.cfn.yaml
@@ -193,9 +193,25 @@ Resources:
       Protocol: HTTP
       TargetType: ip
       HealthCheckPath: /canopy/health/
-      HealthCheckIntervalSeconds: 30
+      # Measured 2026-09-08: a deploy took 12.9 minutes, of which 10.3 was this
+      # ECS rolling replace — the image build was 26 SECONDS. Two ALB defaults
+      # were the whole cost, and neither buys anything at this scale.
+      #
+      # 30s x 2 checks meant a healthy new task still waited ~60s to be admitted.
+      # /canopy/health/ is cheap, and a task that is up answers it immediately.
+      HealthCheckIntervalSeconds: 5
       HealthyThresholdCount: 2
+      HealthCheckTimeoutSeconds: 4
       Matcher: { HttpCode: "200" }
+      TargetGroupAttributes:
+        # THE BIG ONE: deregistration_delay defaults to 300s and was never set
+        # here, so every deploy spent five minutes draining a task the new one
+        # had already replaced. That default protects long-lived requests; this
+        # app serves a SPA, an API and a WebSocket, and the ALB stops sending it
+        # new connections the moment draining starts. Five seconds is ample for
+        # in-flight requests to land. Raise it if long-poll/upload work appears.
+        - Key: deregistration_delay.timeout_seconds
+          Value: "5"
 
   ListenerRule:
     Type: AWS::ElasticLoadBalancingV2::ListenerRule


### PR DESCRIPTION
## Where the 13 minutes actually went

Step-level timing from a real deploy (run 34303785291) rather than a guess:

| step | time |
|---|---|
| Build & push image | **26 s** |
| Run database migrations | 96 s |
| **Deploy (ECS rolling replace)** | **617 s** |

The build pipeline was never the problem. Two ALB defaults were.

## The two knobs

| setting | was | now | why |
|---|---|---|---|
| `deregistration_delay` | **300 s** (AWS default, never set in the template) | 5 s | Every deploy spent five minutes draining a task the new one had already replaced |
| health check interval | 30 s × 2 = ~60 s | 5 s × 2 = ~10 s | A healthy new task waited a minute to be admitted; `/canopy/health/` is cheap |

Expected: **~13 min → ~3–4 min.**

## What is deliberately unchanged

`MinimumHealthyPercent: 100` / `MaximumPercent: 200` stay, so the deploy remains **zero-downtime** — new task healthy first, then drain. The speedup comes from not *waiting* on a drain that has nothing to drain, not from giving up the guarantee. The deployment circuit breaker stays on for the same reason: most deploys here are unattended, and a wedged service is worse than a slow one.

## The condition to watch

The 300 s default exists to protect long-lived in-flight requests. This app serves a SPA, an API and a WebSocket, and the ALB stops sending new connections the moment draining begins — so 5 s is ample for in-flight requests to land. If long-poll or large-upload work appears, raise it. That's the trigger to watch for, not a number to preserve.

Template validated with `aws cloudformation validate-template` before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
