### PR TITLE
runner: the canopy CLI on a cloud box could never update itself

### DIFF
--- a/runner/ec2/bootstrap_agents.sh
+++ b/runner/ec2/bootstrap_agents.sh
@@ -1114,9 +1114,29 @@ reinstall_cli_from_marketplace_clone() {
     warn "marketplace clone not at $clone — leaving the CLI on its VCS install"
     return
   fi
-  if grep -q 'directory = ' "$receipt" 2>/dev/null; then
-    ok "canopy CLI already installed from a directory requirement"
+  # The guard is BOTH provenance AND version. It used to be provenance alone,
+  # which made this a one-shot repair that could never update: once the receipt
+  # recorded a directory it returned early forever, so the CLI froze at whatever
+  # the clone happened to be on the day it was first re-pointed while the clone
+  # itself kept advancing underneath it. A laptop hides this because a human runs
+  # /canopy:update; nobody types that on a cloud box.
+  #
+  # Measured 2026-09-09: CLI 0.2.471 against a 0.2.479 clone, eight releases
+  # behind, and `bin/hal-email`'s engine-staleness guard refused every send —
+  # so the box could think but could not answer anyone. Found by a readiness
+  # drill, not by the box reporting it.
+  local clone_version installed_version
+  clone_version="$(sed -nE 's/^version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' \
+                   "$clone/pyproject.toml" 2>/dev/null | head -1)"
+  installed_version="$(canopy --version 2>/dev/null \
+                       | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+  if grep -q 'directory = ' "$receipt" 2>/dev/null \
+     && [[ -n "$clone_version" && "$installed_version" == "$clone_version" ]]; then
+    ok "canopy CLI at $installed_version, matching the marketplace clone"
     return
+  fi
+  if [[ -n "$clone_version" && -n "$installed_version" && "$installed_version" != "$clone_version" ]]; then
+    log "canopy CLI $installed_version lags the clone's $clone_version — reinstalling"
   fi
   if uv tool install --force --reinstall "$clone" >/dev/null 2>&1; then
     ok "canopy CLI re-pointed at the marketplace clone ($clone)"
@@ -1160,9 +1180,15 @@ done
 
 main() {
   if (( CREDENTIALS_ONLY )); then
-    log "credentials-only pass (client creds + gmail token + readiness report)"
+    log "credentials-only pass (client creds + gmail token + CLI sync + readiness report)"
     step2_gog_config
     step3_agents
+    # Cheap and idempotent: a version compare, and a reinstall only on drift.
+    # It belongs here because the timer is the ONLY thing that runs regularly on
+    # this box — step4, its other caller, needs a service restart, and nothing
+    # restarts the service. A staleness check that runs only when someone
+    # reboots the box is a staleness check that does not run.
+    reinstall_cli_from_marketplace_clone
     return 0
   fi
   step1_tooling

--- a/runner/ec2/tests/test_cli_stays_current.py
+++ b/runner/ec2/tests/test_cli_stays_current.py
@@ -1,0 +1,99 @@
+"""The canopy CLI on a cloud box must track the marketplace clone.
+
+`reinstall_cli_from_marketplace_clone` was provenance-only: its guard asked
+"does the uv receipt record a directory requirement?", so once the CLI had been
+re-pointed at the clone ONCE it returned early forever and could never update.
+The clone kept advancing (Claude Code pulls the marketplace on SessionStart);
+the CLI did not. A laptop hides this because a human runs /canopy:update — on a
+cloud box nobody does.
+
+Measured 2026-09-09: CLI 0.2.471 against a 0.2.479 clone, and `bin/hal-email`'s
+engine-staleness guard refused every send, so the box could think but could not
+answer anyone. Surfaced by a readiness drill, not by the box.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+import subprocess
+
+SOURCE = pathlib.Path(__file__).resolve().parent.parent / "bootstrap_agents.sh"
+
+
+def _function_body() -> str:
+    """Extract the one function — the script runs `main "$@"` at the bottom, so
+    it cannot simply be sourced."""
+    text = SOURCE.read_text()
+    m = re.search(r"^reinstall_cli_from_marketplace_clone\(\) \{.*?^\}", text, re.S | re.M)
+    assert m, "function not found — did it get renamed?"
+    return m.group(0)
+
+
+def _run(tmp_path, *, clone_version: str, installed_version: str, receipt_has_dir: bool):
+    home = tmp_path / "home"
+    clone = home / ".claude/plugins/marketplaces/canopy"
+    clone.mkdir(parents=True)
+    (clone / "pyproject.toml").write_text(f'[project]\nname = "canopy"\nversion = "{clone_version}"\n')
+    receipt = home / ".local/share/uv/tools/canopy/uv-receipt.toml"
+    receipt.parent.mkdir(parents=True)
+    receipt.write_text('[tool]\ndirectory = "/somewhere"\n' if receipt_has_dir else '[tool]\ngit = "https://x"\n')
+
+    binv = tmp_path / "bin"
+    binv.mkdir()
+    (binv / "canopy").write_text(f"#!/bin/sh\necho 'canopy {installed_version}'\n")
+    marker = tmp_path / "uv-was-called"
+    (binv / "uv").write_text(f"#!/bin/sh\necho \"$@\" >> {marker}\nexit 0\n")
+    for f in ("canopy", "uv"):
+        (binv / f).chmod(0o755)
+
+    script = "\n".join([
+        "set -uo pipefail",
+        "ok()   { echo \"OK: $*\"; }",
+        "warn() { echo \"WARN: $*\"; }",
+        "log()  { echo \"LOG: $*\"; }",
+        _function_body(),
+        "reinstall_cli_from_marketplace_clone",
+    ])
+    proc = subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True,
+        env={"HOME": str(home), "PATH": f"{binv}:/usr/bin:/bin"},
+    )
+    return proc.stdout + proc.stderr, marker.exists()
+
+
+def test_a_lagging_cli_is_reinstalled(tmp_path):
+    """The regression: same provenance, older version — must NOT short-circuit."""
+    out, reinstalled = _run(tmp_path, clone_version="0.2.479",
+                            installed_version="0.2.471", receipt_has_dir=True)
+    assert reinstalled, f"CLI was left stale; output was:\n{out}"
+    assert "0.2.471" in out and "0.2.479" in out, out
+
+
+def test_a_current_cli_is_left_alone(tmp_path):
+    """Idempotence is what makes this safe to run on a timer."""
+    out, reinstalled = _run(tmp_path, clone_version="0.2.479",
+                            installed_version="0.2.479", receipt_has_dir=True)
+    assert not reinstalled, f"needless reinstall; output was:\n{out}"
+    assert "matching the marketplace clone" in out, out
+
+
+def test_a_vcs_install_is_still_re_pointed(tmp_path):
+    """The original provenance repair must survive the new version check."""
+    _, reinstalled = _run(tmp_path, clone_version="0.2.479",
+                          installed_version="0.2.479", receipt_has_dir=False)
+    assert reinstalled
+
+
+def test_the_timer_path_actually_calls_it(tmp_path):
+    """A staleness check wired only into full bootstrap never runs: step4 needs a
+    service restart, and nothing restarts this service. The timer
+    (--credentials-only) is the only thing that runs regularly."""
+    text = SOURCE.read_text()
+    # `main()`'s branch specifically — step3_agents has its own CREDENTIALS_ONLY
+    # early-return, and matching the first one in the file tests the wrong thing.
+    m = re.search(r"^main\(\) \{.*?^\}", text, re.S | re.M)
+    assert m, "main() not found"
+    branch = re.search(r"if \(\( CREDENTIALS_ONLY \)\); then(.*?)\n  fi", m.group(0), re.S)
+    assert branch, "credentials-only branch not found inside main()"
+    assert "reinstall_cli_from_marketplace_clone" in branch.group(1), \
+        "the timer path does not sync the CLI, so drift can never self-heal"


### PR DESCRIPTION
## Why the box drifts and your laptop doesn't

`reinstall_cli_from_marketplace_clone` guarded on **provenance alone**:

```bash
if grep -q 'directory = ' "$receipt"; then
    ok "canopy CLI already installed from a directory requirement"
    return          # ← forever
fi
```

It exists to re-point the CLI from a `git+URL` install to the local clone — a one-time repair. Once the receipt records a directory it **never runs again and never compares versions**. The clone keeps advancing (Claude Code pulls the marketplace on SessionStart, which is why the *plugin cache* was current at 0.2.479); the CLI stays frozen.

A laptop hides this because a human runs `/canopy:update`. Nobody types that on a cloud box.

## What it cost

Measured 2026-09-09 on `cloud-ec2-1`: CLI **0.2.471** against a **0.2.479** clone — eight releases behind — and `bin/hal-email`'s engine-staleness guard refused every send. The box could think but could not answer anyone.

It surfaced through a readiness drill, not through the box reporting it. There was nothing to report it. That's the actual defect.

## The fix

- **Guard is now provenance AND version.** Reinstall on drift, skip when they match, and still do the original one-time VCS→directory repair.
- **The timer path calls it.** Previously its only caller was `step4_claude_plugins`, which runs on a full bootstrap — a service restart — and *nothing restarts this service*. A staleness check that only runs when someone reboots the box is a staleness check that does not run.

## Tests

`runner/ec2/tests/test_cli_stays_current.py` — extracts the function (the script runs `main "$@"`, so it can't be sourced) and runs it against stub `canopy`/`uv` binaries:

- lagging CLI is reinstalled ← the regression
- current CLI is left alone (idempotence is what makes it timer-safe)
- a VCS install is still re-pointed (original behaviour preserved)
- `main()`'s credentials-only branch actually calls it

**3 of 4 go red against the old script** (verified by reverting). 4 passed with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
