### PR TITLE
runner: a cloud turn was invisible to the duplicate/sibling check

### DIFF
--- a/runner/ec2/cloud_runner.py
+++ b/runner/ec2/cloud_runner.py
@@ -397,7 +397,25 @@ def _chunk_transcript_lines(
 
 def _claude_cmd(prompt: str, resume_session_id: str | None = None) -> list[str]:
     """The `claude -p` argv for one invocation. Split out from `run_claude` so the
-    `--resume` wiring is unit-testable without touching subprocess."""
+    `--resume` wiring is unit-testable without touching subprocess.
+
+    A FRESH turn names its session id explicitly, and that is a safety property
+    rather than tidiness. canopy's duplicate/sibling check (`live-turns.sh`)
+    enumerates live sessions out of argv — `--session-id|--resume <uuid>` — which
+    is the only handle a process has on which session it is. A bare `claude -p`
+    matches neither, so on this box the check found NO sessions, could not even
+    see itself, and exited 2 ("could not enumerate") on every single turn.
+
+    That is the check behaving correctly — it must never render "I could not
+    look" as "nobody is there" — but it means the fleet's protection against two
+    turns working the same thread simply did not exist on a cloud runner. The
+    fix belongs here, not in the check: make the box visible, rather than teach
+    the check to guess. Found by an ACE turn on cloud-ec2-1, 2026-09-09, which
+    verified it against its own /proc/<pid>/cmdline.
+
+    Not set when resuming: `--resume` already names the session, and passing
+    both asks the CLI to be two sessions at once.
+    """
     cmd = [
         CLAUDE_BIN, "-p", prompt,
         "--output-format", "stream-json", "--verbose",
@@ -405,6 +423,8 @@ def _claude_cmd(prompt: str, resume_session_id: str | None = None) -> list[str]:
     ]
     if resume_session_id:
         cmd += ["--resume", resume_session_id]
+    else:
+        cmd += ["--session-id", str(uuid.uuid4())]
     return cmd
 
 

--- a/runner/ec2/tests/test_cloud_runner.py
+++ b/runner/ec2/tests/test_cloud_runner.py
@@ -220,6 +220,47 @@ def test_claude_cmd_without_resume(cloud_runner):
 def test_claude_cmd_with_resume(cloud_runner):
     cmd = cloud_runner._claude_cmd("hello", "sess-123")
     assert cmd[-2:] == ["--resume", "sess-123"]
+    # Both would ask the CLI to be two sessions at once.
+    assert "--session-id" not in cmd
+
+
+# ── a turn must be VISIBLE to the duplicate/sibling check ───────────────────
+#
+# canopy's live-turns.sh enumerates live sessions out of argv
+# (`--session-id|--resume <uuid>`) — the only handle a process has on which
+# session it is. A bare `claude -p` matches neither, so on cloud-ec2-1 the check
+# found no sessions, could not see itself, and exited 2 on every turn. The check
+# was right to refuse ("I could not look" must not read as "nobody is there");
+# the consequence was that the fleet's protection against two turns working the
+# same thread did not exist on a cloud runner at all.
+
+def test_a_fresh_turn_names_its_session_so_it_can_be_enumerated(cloud_runner):
+    cmd = cloud_runner._claude_cmd("hello")
+    assert "--session-id" in cmd, (
+        "a turn with no session id in argv is invisible to live-turns.sh, "
+        "which disables duplicate-turn protection on this box"
+    )
+    import uuid as _uuid
+    sid = cmd[cmd.index("--session-id") + 1]
+    _uuid.UUID(sid)  # raises if it is not a real uuid
+
+
+def test_each_turn_gets_its_own_session_id(cloud_runner):
+    """A shared id would make two concurrent turns look like one session."""
+    a = cloud_runner._claude_cmd("one")
+    b = cloud_runner._claude_cmd("two")
+    assert a[a.index("--session-id") + 1] != b[b.index("--session-id") + 1]
+
+
+def test_the_enumeration_pattern_live_turns_uses_actually_matches(cloud_runner):
+    """Pinned against the REAL regex from live-turns.sh, not a paraphrase of it:
+    `grep -oE -- '--(session-id|resume) [0-9a-f-]{36}'`. If that pattern and this
+    argv ever drift apart again, the failure is silent everywhere else."""
+    import re
+    pattern = re.compile(r"--(session-id|resume) [0-9a-f-]{36}")
+    for cmd in (cloud_runner._claude_cmd("fresh"),
+                cloud_runner._claude_cmd("resumed", "0e2f1c9a-4b7d-4f0e-9a11-2b3c4d5e6f70")):
+        assert pattern.search(" ".join(cmd)), f"not enumerable: {cmd}"
 
 
 # ── resume-target existence check (review C2 / I1) ──────────────────────────


### PR DESCRIPTION
## The gap

canopy's `live-turns.sh` enumerates live sessions out of argv:

```bash
grep -oE -- '--(session-id|resume) [0-9a-f-]{36}'
```

That's the only handle a process has on which session it is. This runner dispatched a bare `claude -p`, matching neither — so on `cloud-ec2-1` the check found **no sessions, could not see itself, and exited 2 on every turn.**

The check was *right* to refuse; its governing invariant is that "I could not look" must never render as "nobody is there." The defect is the consequence: **the fleet's protection against two turns working the same thread did not exist on a cloud runner at all** — silently, for as long as that box has run agent turns. And that protection matters most exactly there, since unattended dispatches are what cloud runners are for.

## The fix

Make the box visible, rather than teach the check to guess. A fresh turn names its own session id; a resumed one doesn't, because `--resume` already names the session and passing both asks the CLI to be two sessions at once.

## Provenance

Found by an ACE turn running on `cloud-ec2-1` (2026-09-09), which verified it against its own `/proc/<pid>/cmdline` — then couldn't file it, because the box's `GH_TOKEN` has no write access to `dimagi-internal/canopy`. Worth fixing separately: an agent that can find a defect but not report it will keep re-finding it.

## Tests

Pinned against the **real regex from `live-turns.sh`**, not a paraphrase, so argv and matcher can't drift apart again without CI noticing:

- a fresh turn names a valid uuid session id ← the regression
- each turn gets its own id (a shared one would make two concurrent turns look like one)
- `--resume` still excludes `--session-id`
- both shapes satisfy the enumeration pattern

**3 go red against the old argv** (verified by reverting). 82 passed with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
