### PR TITLE
runner: the ACP adapter installer could not have worked, and lied when it failed

### DIFF
--- a/runner/ec2/cloud_runner.py
+++ b/runner/ec2/cloud_runner.py
@@ -1423,24 +1423,51 @@ def _install_transcript_core(repo_dir: pathlib.Path) -> None:
     _install_acp_adapter()
 
 
+#: The adapter's binary and package names. `find_adapter` in canopy_acp resolves
+#: the binary off PATH first, so having it there is the whole success condition.
+ACP_ADAPTER_BIN = "claude-agent-acp"
+ACP_ADAPTER_PACKAGE = "@agentclientprotocol/claude-agent-acp"
+
+
 def _install_acp_adapter() -> None:
-    """Install the Node ACP adapter the executor drives.
+    """Put the Node ACP adapter on PATH, if it is not already there.
 
     Skipped entirely unless RUNNER_EXECUTOR=acp: it costs an npm install and a
     Node dependency on every boot, and the `claude -p` path needs neither.
     `run_acp` falls back to `claude -p` when the adapter is missing, so a failure
     here degrades rather than breaks.
+
+    Two things this got wrong, both measured on cloud-ec2-1 on 2026-09-09, and
+    both already solved a few hundred lines away for `tsx` in
+    bootstrap_agents.sh's `ensure_plugin_runtime`:
+
+    * **A bare `npm install -g` cannot work here.** This runs as the SERVICE user
+      (ubuntu), which cannot write /usr/lib/node_modules, so npm exits 243
+      (EACCES). `$HOME/.local/bin` is already first on the unit's PATH
+      (runner.cfn.yaml), so `--prefix "$HOME/.local"` installs somewhere the
+      adapter is actually found.
+    * **It never asked whether the adapter was already installed.** With one
+      present at /usr/bin/claude-agent-acp it still ran the doomed install and
+      logged "could not install the ACP adapter … the ACP executor will fall
+      back to claude -p" — on a boot that then executed every turn over ACP
+      perfectly well. A warning that names the wrong outcome is worse than
+      silence: it sends the next person debugging in the opposite direction.
     """
     if RUNNER_EXECUTOR != "acp":
         return
-    if shutil.which("node") is None:
-        _log("warn: node not on PATH; the ACP executor will fall back to claude -p")
+    existing = shutil.which(ACP_ADAPTER_BIN)
+    if existing:
+        _log(f"ACP adapter already on PATH ({existing})")
         return
+    if shutil.which("node") is None or shutil.which("npm") is None:
+        _log("warn: node/npm not on PATH; the ACP executor will fall back to claude -p")
+        return
+    prefix = str(pathlib.Path.home() / ".local")
     try:
-        subprocess.run(["npm", "install", "-g", "@agentclientprotocol/claude-agent-acp"],
+        subprocess.run(["npm", "install", "-g", "--prefix", prefix, ACP_ADAPTER_PACKAGE],
                        check=True, timeout=300,
                        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-        _log("installed @agentclientprotocol/claude-agent-acp")
+        _log(f"installed {ACP_ADAPTER_PACKAGE} into {prefix}")
     except Exception as exc:  # noqa: BLE001
         _log(f"warn: could not install the ACP adapter ({exc}); "
              "the ACP executor will fall back to claude -p")

--- a/runner/ec2/tests/test_cloud_runner.py
+++ b/runner/ec2/tests/test_cloud_runner.py
@@ -1725,3 +1725,60 @@ def test_a_failed_steady_state_post_does_not_advance_the_offset(cloud_runner, mo
     st = cloud_runner._STREAM_READERS["s"]
     assert st["reader"] is None, "a failed post must drop the tailer"
     assert st["count"] == 0, "count must not advance past records the server never took"
+
+
+# ── the ACP adapter has to actually land on PATH ────────────────────────────
+#
+# Measured on cloud-ec2-1, 2026-09-09. Two faults, both already solved for `tsx`
+# in bootstrap_agents.sh's ensure_plugin_runtime a few hundred lines away:
+# a bare `npm install -g` cannot work as the service user (EACCES, exit 243),
+# and the installer never asked whether the adapter was already there — so with
+# one present at /usr/bin/claude-agent-acp it ran the doomed install and logged
+# "the ACP executor will fall back to claude -p" on a boot that then ran every
+# turn over ACP. A warning naming the wrong outcome sends the next debugger the
+# opposite way.
+
+def _acp_install(cloud_runner, monkeypatch, *, executor="acp", on_path=None,
+                 has_node=True):
+    runs: list = []
+    logs: list = []
+    which = {"claude-agent-acp": on_path,
+             "node": "/usr/bin/node" if has_node else None,
+             "npm": "/usr/bin/npm" if has_node else None}
+    monkeypatch.setattr(cloud_runner, "RUNNER_EXECUTOR", executor)
+    monkeypatch.setattr(cloud_runner.shutil, "which", lambda n: which.get(n))
+    monkeypatch.setattr(cloud_runner, "_log", lambda m: logs.append(m))
+    monkeypatch.setattr(cloud_runner.subprocess, "run",
+                        lambda cmd, **kw: runs.append(cmd))
+    cloud_runner._install_acp_adapter()
+    return runs, logs
+
+
+def test_an_adapter_already_on_path_is_left_alone(cloud_runner, monkeypatch):
+    runs, logs = _acp_install(cloud_runner, monkeypatch,
+                              on_path="/usr/bin/claude-agent-acp")
+    assert runs == [], "reinstalled an adapter that was already installed"
+    assert not any("fall back" in m for m in logs), (
+        f"claimed a fallback that did not happen: {logs}")
+    assert any("already on PATH" in m for m in logs), logs
+
+
+def test_the_install_targets_a_prefix_the_service_user_can_write(cloud_runner, monkeypatch):
+    """A bare `npm install -g` is EACCES for the ubuntu service user."""
+    runs, _ = _acp_install(cloud_runner, monkeypatch, on_path=None)
+    assert len(runs) == 1, runs
+    cmd = runs[0]
+    assert "--prefix" in cmd, f"bare global install cannot work as this user: {cmd}"
+    assert cmd[cmd.index("--prefix") + 1].endswith("/.local"), cmd
+    assert cmd[-1] == cloud_runner.ACP_ADAPTER_PACKAGE, cmd
+
+
+def test_nothing_is_installed_when_the_executor_is_not_acp(cloud_runner, monkeypatch):
+    runs, _ = _acp_install(cloud_runner, monkeypatch, executor="cli", on_path=None)
+    assert runs == []
+
+
+def test_a_missing_node_degrades_without_attempting_npm(cloud_runner, monkeypatch):
+    runs, logs = _acp_install(cloud_runner, monkeypatch, on_path=None, has_node=False)
+    assert runs == []
+    assert any("fall back" in m for m in logs), logs


### PR DESCRIPTION
Found flipping `RUNNER_EXECUTOR=acp` on `cloud-ec2-1` for the first time (2026-09-09). Two faults, both **already solved for `tsx`** a few hundred lines away in `bootstrap_agents.sh`'s `ensure_plugin_runtime`:

### 1. A bare `npm install -g` cannot work here

This runs as the **service user** (`ubuntu`), which cannot write `/usr/lib/node_modules` — npm exits **243** (EACCES), every time. `$HOME/.local/bin` is already first on the unit's PATH (`runner.cfn.yaml`), so `--prefix "$HOME/.local"` installs somewhere the adapter is actually found. That's verbatim the reasoning the `tsx` installer already carries.

### 2. It never asked whether the adapter was already installed

With one present at `/usr/bin/claude-agent-acp` it still ran the doomed install and logged:

> `warn: could not install the ACP adapter (…243); the ACP executor will fall back to claude -p`

…on a boot that then executed **every turn over ACP** perfectly well. A warning that names the wrong outcome is worse than silence — it sends the next person debugging in the opposite direction, and it sent me there for a while before I checked `exec:` in the journal.

## On "install it in bootstrap too"

Deliberately **not** done. Fixing this installer is what makes a fresh box work unattended, because it's already gated on `RUNNER_EXECUTOR` and already runs on every boot. A second install site in `bootstrap_agents.sh` would be the same logic twice — and this repo already pays for that pattern elsewhere (`encode_project_dir` lives in three files with "keep the two in step" comments, because `cloud_runner.py` ships as one stdlib-only blob).

## Tests

4 new, in `runner/ec2/tests/test_cloud_runner.py`:

- an adapter already on PATH is left alone, **and no fallback is claimed** ← regression
- the install targets a prefix the service user can write ← regression
- nothing installs when the executor is not `acp`
- missing node/npm degrades without attempting the install

The two regressions go **red** against the old installer (verified by reverting). 86 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
