### PR TITLE
runner: node 20 silently pinned the ACP adapter 26 versions back

### DIFF
--- a/runner/ec2/runner.cfn.yaml
+++ b/runner/ec2/runner.cfn.yaml
@@ -364,7 +364,16 @@ Resources:
             # the service user) so it never needs root just to mkdir. Harmless to
             # run before credentials exist; both start empty.
             - [ install, -d, -o, ubuntu, -g, ubuntu, /opt/canopy-web, /opt/agents ]
-            - [ bash, -c, "curl -fsSL https://deb.nodesource.com/setup_20.x | bash -" ]
+            # node 22, and the version is load-bearing rather than "latest LTS".
+            # @agentclientprotocol/claude-agent-acp declares `engines: {node: >=22}`
+            # from 0.63.0 onward, so on node 20 npm does not fail — it silently
+            # RESOLVES DOWN. Measured 2026-09-09: `npm i -g` on this box installed
+            # 0.49.0 while the registry's latest was 0.75.1, twenty-six versions
+            # back, and the ACP executor then ran without `session/prompt` steering
+            # because 0.49.0 predates it. Nothing reported a problem: the install
+            # succeeded, the executor worked, and only the absent capability in
+            # `initialize` gave it away.
+            - [ bash, -c, "curl -fsSL https://deb.nodesource.com/setup_22.x | bash -" ]
             - [ bash, -c, "DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs unzip gnupg python3-websocket" ]
             - [ bash, -c, "npm i -g @anthropic-ai/claude-code" ]
             - [ bash, -c, "curl -fsSL https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o /tmp/awscliv2.zip && cd /tmp && unzip -q awscliv2.zip && ./aws/install" ]

--- a/runner/ec2/tests/test_node_supports_the_acp_adapter.py
+++ b/runner/ec2/tests/test_node_supports_the_acp_adapter.py
@@ -1,0 +1,44 @@
+"""The box's node must be new enough for the ACP adapter it is asked to run.
+
+@agentclientprotocol/claude-agent-acp declares `engines: {node: >=22}` from
+0.63.0. On an older node, `npm i -g` does not fail — it resolves DOWN to the
+newest version whose engines still match. Measured 2026-09-09 on cloud-ec2-1:
+node 20.20.2 got adapter 0.49.0 while the registry's latest was 0.75.1, and the
+ACP executor then ran with no steering support, because steering landed after
+0.49.0. Every layer reported success; only the missing capability in
+`initialize` showed it.
+
+That is the shape worth pinning: a silent downgrade, not an error.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+
+TEMPLATE = pathlib.Path(__file__).resolve().parent.parent / "runner.cfn.yaml"
+
+#: The floor the adapter's own `engines` field demands.
+MIN_NODE_MAJOR = 22
+
+
+def test_the_nodesource_channel_is_new_enough_for_the_adapter():
+    setups = re.findall(r"deb\.nodesource\.com/setup_(\d+)\.x", TEMPLATE.read_text())
+    assert setups, "no NodeSource setup line found — did node installation move?"
+    for major in setups:
+        assert int(major) >= MIN_NODE_MAJOR, (
+            f"node {major} installs claude-agent-acp <0.63.0 by silent npm "
+            f"downgrade, which has no steering support; the adapter needs "
+            f"node >={MIN_NODE_MAJOR}"
+        )
+
+
+def test_the_reason_is_written_down_next_to_the_pin():
+    """A bare version bump gets 'tidied' back to whatever looks current. The
+    constraint is another package's engines field, so it has to be legible here."""
+    text = TEMPLATE.read_text()
+    idx = text.index("deb.nodesource.com/setup_")
+    preamble = text[max(0, idx - 900):idx]
+    assert "engines" in preamble and "claude-agent-acp" in preamble, (
+        "the node pin must say WHY it is pinned — it is the ACP adapter's "
+        "engines constraint, not a general preference"
+    )


### PR DESCRIPTION
## The silent downgrade

`@agentclientprotocol/claude-agent-acp` declares `engines: {node: >=22}` from **0.63.0** onward. On node 20, `npm i -g` does **not** fail — it resolves *down* to the newest version whose engines still match.

Measured on `cloud-ec2-1` (2026-09-09):

```
node on the box:            v20.20.2
npm registry latest:        0.75.1
what npm actually installed: 0.49.0     ← 26 versions back
```

The install reported success. The ACP executor ran real turns correctly. The only trace was a capability **absent** from `initialize` — steering, which landed after 0.49.0 and is the single biggest reason to prefer ACP over `claude -p`. The adoption spec spiked 0.63.0 and recorded steering working; **this box could never have installed that version.**

I spent four probes chasing steering as a client bug before checking `engines`. The failure mode is a success at every layer.

## The fix

`setup_20.x` → `setup_22.x`, with the reason written next to it.

## Tests

`runner/ec2/tests/test_node_supports_the_acp_adapter.py`, both red against the old pin:

- the NodeSource channel is >= 22 (the adapter's own floor)
- **the reason stays written next to the pin** — a bare version number gets tidied back to whatever looks current by someone with no way to know that another package's `engines` field is the constraint

## Scope

These boxes are meant to be destroyable and rebuildable, so the template is the real fix. The live box is being upgraded in place to match rather than waiting for a replacement — I'll confirm the adapter version and re-run the steering test after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
