### PR TITLE
A storyboards index under Demos, so a shared arc can be found again

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,6 +130,7 @@ the active workspace. `/ddd-plans` and `/reviews` now redirect to `/`.
 - `/w/:workspace/activity` — Fleet turn log scoped to that workspace (see `/activity` below)
 - `/w/:workspace/shareouts` (+ `/shareouts/:period`) — Dated, teammate-facing work briefings (what shipped, why, how to leverage) posted by `/canopy:shareout`; `:period` is a copy-linkable permalink to one briefing
 - `/w/:workspace/walkthroughs` — Sharable demos uploaded from `/canopy:walkthrough`
+- `/w/:workspace/storyboards` — Index of the workspace's storyboards (the shared arcs): title, layout (review / reel), act count, and the token-bearing share link to copy. Under the Demos menu. The board itself opens at `/storyboard/:slug`
 - `/w/:workspace/ddd` (+ `/ddd/:narrative`, `/ddd/:narrative/:runId`) — Demo-driven-development (DDD) views: narrative → version → run → package (video + deck + narrative + links)
 - `/w/:workspace/agents` — First-class AI agents list (e.g. "Echo")
 - `/w/:workspace/members` — Members + invites admin surface (owner-only actions): list members, remove a member, invite by email, list/revoke pending invites. Canopy sends no email — invite by copying the generated `/invite/:token` link and sending it yourself.

--- a/frontend/src/api/storyboards.ts
+++ b/frontend/src/api/storyboards.ts
@@ -121,3 +121,20 @@ export async function leaveFeedback(
   }
   return resp.json()
 }
+
+/** One row of the index — what a member sees before opening a board. */
+export interface StoryboardListItem {
+  slug: string
+  title: string
+  lede: string
+  capability: Capability
+  layout: Layout
+  act_count: number
+  /** Absolute, token-bearing link. Members only — this is the thing you send. */
+  share_url: string | null
+}
+
+/** Every board in a workspace the caller belongs to. Members only. */
+export function listStoryboards(): Promise<{ items: StoryboardListItem[] }> {
+  return getJson('/api/storyboards/')
+}

--- a/frontend/src/components/AppLayout/nav.test.ts
+++ b/frontend/src/components/AppLayout/nav.test.ts
@@ -10,14 +10,15 @@ const authed = { isAuthed: true, active: 'connect' }
 
 describe('NAV_GROUPS', () => {
   it('keeps every destination the flat nav carried', () => {
-    // The row this replaced held 15 links. Grouping is meant to reorganize the
-    // header, never to quietly drop a surface out of it.
+    // The row this replaced held 15 links (Storyboards is the one added since).
+    // Grouping is meant to reorganize the header, never to quietly drop a
+    // surface out of it.
     const labels = NAV_GROUPS.flatMap((g) => g.items.map((i) => i.label))
     expect(labels.sort()).toEqual(
       [
         'Activity', 'Agents', 'Chats', 'DDD', 'Inbound', 'Insights', 'Members',
-        'Projects', 'Schedule', 'Sessions', 'Shareouts', 'Supervisor', 'System',
-        'Timeline', 'Walkthroughs',
+        'Projects', 'Schedule', 'Sessions', 'Shareouts', 'Storyboards', 'Supervisor',
+        'System', 'Timeline', 'Walkthroughs',
       ].sort(),
     )
   })
@@ -57,8 +58,8 @@ describe('resolveNavGroups', () => {
   })
 
   it('drops a group whose items are all tenant-scoped while the workspace is unknown', () => {
-    // Demos is DDD + Walkthroughs, both tenant items — an empty menu would be
-    // a trigger that opens onto nothing.
+    // Demos is DDD + Walkthroughs + Storyboards, all tenant items — an empty
+    // menu would be a trigger that opens onto nothing.
     const labels = resolveNavGroups({ isAuthed: true, active: null }).map((g) => g.label)
     expect(labels).not.toContain('Demos')
     expect(labels).toEqual(['Work', 'Fleet', 'Workspace'])
@@ -116,7 +117,7 @@ describe('isNavGroupActive', () => {
     for (const pathname of [
       '/w/connect', '/w/connect/chat', '/insights', '/supervisor',
       '/w/connect/agents', '/activity', '/schedules', '/w/connect/ddd',
-      '/w/connect/walkthroughs', '/w/connect/shareouts', '/w/connect/timeline',
+      '/w/connect/walkthroughs', '/w/connect/storyboards', '/w/connect/shareouts', '/w/connect/timeline',
       '/sessions', '/w/connect/members', '/w/connect/inbound', '/system',
     ]) {
       const hits = groups.filter((g) => isNavGroupActive(g, pathname)).map((g) => g.label)
@@ -126,5 +127,12 @@ describe('isNavGroupActive', () => {
 
   it('marks no group on a route the nav does not own', () => {
     expect(groups.some((g) => isNavGroupActive(g, '/settings'))).toBe(false)
+  })
+
+  it('does not light Demos up on the public storyboard page', () => {
+    // /storyboard/:slug is the chrome-less share page, not the index; the
+    // index is the tenant route /w/:ws/storyboards.
+    expect(groups.some((g) => isNavGroupActive(g, '/storyboard/oes-supply'))).toBe(false)
+    expect(isNavGroupActive(group('Demos'), '/w/connect/storyboards')).toBe(true)
   })
 })

--- a/frontend/src/components/AppLayout/nav.ts
+++ b/frontend/src/components/AppLayout/nav.ts
@@ -59,6 +59,9 @@ export const NAV_GROUPS: NavGroup[] = [
     items: [
       { path: 'ddd', label: 'DDD', tenant: true },
       { path: 'walkthroughs', label: 'Walkthroughs', tenant: true },
+      // The shared arcs — several narratives as one link. Without this entry a
+      // board was reachable only from the link it was last pasted into.
+      { path: 'storyboards', label: 'Storyboards', tenant: true },
     ],
   },
   {

--- a/frontend/src/pages/StoryboardsPage.test.tsx
+++ b/frontend/src/pages/StoryboardsPage.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import StoryboardsPage from './StoryboardsPage'
+import * as api from '@/api/storyboards'
+
+vi.mock('@/api/storyboards', async () => {
+  const actual = await vi.importActual<typeof api>('@/api/storyboards')
+  return { ...actual, listStoryboards: vi.fn() }
+})
+
+const listStoryboards = api.listStoryboards as unknown as ReturnType<typeof vi.fn>
+
+function item(over: Partial<api.StoryboardListItem> = {}): api.StoryboardListItem {
+  return {
+    slug: 'oes-supply',
+    title: 'From the appropriation to the child',
+    lede: 'Four countries, one therapeutic-food supply base.',
+    capability: 'suggest',
+    layout: 'review',
+    act_count: 5,
+    share_url: 'https://labs.example/canopy/storyboard/oes-supply?t=abc',
+    ...over,
+  }
+}
+
+function mount() {
+  return render(
+    <MemoryRouter>
+      <StoryboardsPage />
+    </MemoryRouter>,
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('StoryboardsPage', () => {
+  it('lists every board with its layout, and links into the board itself', async () => {
+    listStoryboards.mockResolvedValue({
+      items: [item(), item({ slug: 'rf-surveys-quick', title: 'Impact evaluation on Connect', layout: 'reel', act_count: 1, capability: 'read' })],
+    })
+    mount()
+    const first = await screen.findByRole('link', { name: 'From the appropriation to the child' })
+    expect(first.getAttribute('href')).toBe('/storyboard/oes-supply')
+    expect(screen.getByText('Review')).toBeTruthy()
+    expect(screen.getByText('Reel')).toBeTruthy()
+    expect(screen.getByText(/5 acts/)).toBeTruthy()
+    expect(screen.getByText(/1 act ·/)).toBeTruthy()
+  })
+
+  it('offers the share link only when the API returned one', async () => {
+    listStoryboards.mockResolvedValue({ items: [item(), item({ slug: 'no-link', title: 'Unshared', share_url: null })] })
+    mount()
+    await screen.findByText('Unshared')
+    expect(screen.getAllByRole('button', { name: /Copy the share link/ })).toHaveLength(1)
+  })
+
+  it('says so when there is nothing yet', async () => {
+    listStoryboards.mockResolvedValue({ items: [] })
+    mount()
+    await waitFor(() => expect(screen.getByText(/No storyboards yet/)).toBeTruthy())
+  })
+
+  it('reports a failed load rather than an empty list', async () => {
+    listStoryboards.mockRejectedValue(new Error('Request failed (401)'))
+    mount()
+    await waitFor(() => expect(screen.getByText(/Couldn’t load storyboards: Request failed \(401\)/)).toBeTruthy())
+  })
+})

--- a/frontend/src/pages/StoryboardsPage.tsx
+++ b/frontend/src/pages/StoryboardsPage.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { listStoryboards, type StoryboardListItem } from '@/api/storyboards'
+
+/**
+ * The index of storyboards — the shared arcs, one row each.
+ *
+ * A storyboard is the thing you SEND: several DDD narratives as one link,
+ * gated by its own token. Until this page existed the only way to find one
+ * again was the API, so a board's share link lived wherever it was last
+ * pasted. This is the member-side list; the board itself opens at
+ * /storyboard/:slug, which a member reaches without the token.
+ */
+
+type LoadState =
+  | { kind: 'loading' }
+  | { kind: 'ready'; items: StoryboardListItem[] }
+  | { kind: 'error'; message: string }
+
+const LAYOUT_LABEL: Record<StoryboardListItem['layout'], string> = {
+  review: 'Review',
+  reel: 'Reel',
+}
+
+const CAPABILITY_LABEL: Record<StoryboardListItem['capability'], string> = {
+  read: 'Read only',
+  comment: 'Can comment',
+  suggest: 'Can suggest edits',
+}
+
+export default function StoryboardsPage() {
+  const [state, setState] = useState<LoadState>({ kind: 'loading' })
+
+  useEffect(() => {
+    let cancelled = false
+    listStoryboards()
+      .then((data) => {
+        if (!cancelled) setState({ kind: 'ready', items: data.items })
+      })
+      .catch((e: unknown) => {
+        if (!cancelled) setState({ kind: 'error', message: e instanceof Error ? e.message : String(e) })
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return (
+    <div className="mx-auto max-w-5xl p-6">
+      <header className="mb-6 flex flex-wrap items-baseline justify-between gap-2">
+        <h1 className="text-2xl font-semibold">Storyboards</h1>
+        <p className="text-sm text-muted-foreground">
+          Several demos as one shareable link — a review board for feedback, a reel for the finished videos
+        </p>
+      </header>
+
+      {state.kind === 'error' && (
+        <div className="text-sm text-destructive">Couldn’t load storyboards: {state.message}</div>
+      )}
+      {state.kind === 'loading' && <div className="text-sm text-muted-foreground">Loading…</div>}
+      {state.kind === 'ready' && state.items.length === 0 && (
+        <div className="text-sm text-muted-foreground">
+          No storyboards yet. Author one beside its narratives and import it with{' '}
+          <code>manage.py import_storyboard</code>.
+        </div>
+      )}
+      {state.kind === 'ready' && state.items.length > 0 && (
+        <ul className="flex flex-col gap-3">
+          {state.items.map((b) => (
+            <StoryboardRow key={b.slug} board={b} />
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+function StoryboardRow({ board }: { board: StoryboardListItem }) {
+  const [copied, setCopied] = useState(false)
+
+  async function copyLink() {
+    if (!board.share_url) return
+    try {
+      await navigator.clipboard.writeText(board.share_url)
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 1500)
+    } catch {
+      /* the field beside the button still shows the link */
+    }
+  }
+
+  return (
+    <li className="grid gap-3 rounded-lg border border-border bg-card p-4 sm:grid-cols-[1fr_auto]">
+      <div className="min-w-0">
+        <div className="flex flex-wrap items-center gap-2">
+          <Link
+            to={`/storyboard/${encodeURIComponent(board.slug)}`}
+            className="text-[15px] font-semibold text-foreground hover:underline"
+          >
+            {board.title}
+          </Link>
+          <span className="rounded bg-muted px-2 py-0.5 text-xs text-foreground-secondary">
+            {LAYOUT_LABEL[board.layout] ?? board.layout}
+          </span>
+          <span className="text-xs text-muted-foreground">
+            {board.act_count} {board.act_count === 1 ? 'act' : 'acts'} · {CAPABILITY_LABEL[board.capability] ?? board.capability}
+          </span>
+        </div>
+        {board.lede && <p className="mt-1 max-w-prose text-sm text-muted-foreground">{board.lede}</p>}
+        <p className="mt-2 font-mono text-xs text-muted-foreground">{board.slug}</p>
+      </div>
+      <div className="flex items-start gap-2 sm:justify-end">
+        {board.share_url && (
+          <button
+            type="button"
+            onClick={copyLink}
+            className="rounded border border-border px-3 py-1.5 text-sm hover:bg-muted"
+            aria-label={`Copy the share link for ${board.title}`}
+          >
+            {copied ? 'Copied' : 'Copy share link'}
+          </button>
+        )}
+      </div>
+    </li>
+  )
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -26,6 +26,7 @@ import { AgentWorkspacePage } from './pages/AgentWorkspacePage'
 import SessionSharePage from './pages/SessionSharePage'
 import DddReleasePage from './pages/DddReleasePage'
 import StoryboardPage from './pages/StoryboardPage'
+import StoryboardsPage from './pages/StoryboardsPage'
 import NarrativeReviewPage from './pages/NarrativeReviewPage'
 import { PublicLayout } from './components/PublicLayout'
 import SupervisorPage from '@/pages/SupervisorPage'
@@ -204,6 +205,7 @@ export const router = createBrowserRouter(guarded([
       { path: '/w/:workspace/shareouts', element: <ShareoutsPage /> },
       { path: '/w/:workspace/shareouts/:period', element: <ShareoutsPage /> },
       { path: '/w/:workspace/walkthroughs', element: <WalkthroughsPage /> },
+      { path: '/w/:workspace/storyboards', element: <StoryboardsPage /> },
       { path: '/w/:workspace/agents', element: <AgentsPage /> },
       { path: '/w/:workspace/schedules', element: <SchedulesPage /> },
       {
@@ -251,6 +253,7 @@ export const router = createBrowserRouter(guarded([
       { path: '/timeline', element: <TenantRedirect to="timeline" /> },
       { path: '/shareouts/*', element: <TenantRedirect to="shareouts" /> },
       { path: '/walkthroughs', element: <TenantRedirect to="walkthroughs" /> },
+      { path: '/storyboards', element: <TenantRedirect to="storyboards" /> },
       { path: '/agents/*', element: <TenantRedirect to="agents" /> },
       { path: '/ddd/*', element: <TenantRedirect to="ddd" /> },
       { path: '/ddd-plans', element: <Navigate to="/" replace /> },


### PR DESCRIPTION
## What

A `Storyboards` entry under the **Demos** menu, opening `/w/:workspace/storyboards`: every storyboard in a workspace you belong to, with its layout (review / reel), act count, what the share link grants, and a copy button for the token-bearing share URL. Titles open the board at `/storyboard/:slug`. `/storyboards` redirects into the active workspace like the other flat paths.

## Why

A storyboard is the thing you send — several DDD narratives as one link — and it had no page in the app. The list endpoint and the public board both existed, but nothing linked to them, so finding a board again meant the API or the email its link was last pasted into. The OES arc (`oes-supply`) was lost that way this week.

## Testing

- `StoryboardsPage.test.tsx`: lists boards with layout and act count, links into the board, offers the copy button only when the API returned a share URL, empty and error states.
- `nav.test.ts`: the pinned destination list gains `Storyboards`; a new case checks the public `/storyboard/:slug` page does not activate Demos while the index does.
- `npx vitest run`: 73 files, 783 tests pass. `tsc -b` clean.
- No API or schema change, so no `gen:api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LxzheKs4pgiTJWf4U8NsWT
