### PR TITLE
harness: an email thread becomes a session a human can open and steer

### DIFF
--- a/apps/harness/services.py
+++ b/apps/harness/services.py
@@ -78,6 +78,43 @@ def enqueue_turn(
     # silent rewrite); this is the leg that catches stored payloads and internal
     # callers. Remove with the aliases, one release on.
     origin = Turn.LEGACY_ORIGIN_ALIASES.get(origin, origin)
+    # An email thread IS a conversation, so it targets a SESSION rather than the
+    # agent directly. A Turn is a fine unit of execution and a poor unit of
+    # conversation: it ends, and leaves a human nothing to open, watch or type
+    # into. A Session is what ace-web already renders through the shared canopy
+    # chat kit, so this is what turns "ACE replied to that eventually" into
+    # "here is the run, live, and you can steer it".
+    #
+    # A CONVERSION, not an addition, and not by choice: `turn_targets_agent_xor
+    # _project_xor_session` is a database CHECK constraint, so a turn carrying
+    # both an agent and a session cannot be written at all. Found by running the
+    # tests — reading the service function suggested the opposite.
+    #
+    # What moves, deliberately:
+    #   * serialization is per SESSION, not per agent, so two email threads to
+    #     the same agent now run in parallel — the behaviour a reader expects of
+    #     separate conversations, and the reason to key on the thread at all;
+    #   * tenancy derives from session.workspace, which is set to the agent's own.
+    # What does NOT move, verified: routing resolves a session turn's agent via
+    # `chat_session.agent_id` (claim_next_turn's agent_ids is a union of both
+    # legs), so the source/actor rules still apply; `resolve_agent_slug` already
+    # surfaces `chat_session.agent.slug`, so the runner drives the same agent in
+    # the same clone; and every runner in the fleet declares sessions=true, so
+    # nothing is stranded on one box.
+    if session is None and agent is not None and origin == Turn.ORIGIN_EMAIL:
+        thread_id = str((origin_ref or {}).get("thread_id") or "")
+        if thread_id:
+            try:
+                session = email_thread_session(
+                    agent, thread_id, str((origin_ref or {}).get("subject") or ""))
+                agent = None          # the session now carries the agent
+            except Exception:  # noqa: BLE001
+                # Degrade to the previous behaviour. A turn that runs without a
+                # session is the status quo; a turn that fails to EXIST because
+                # its session could not be made is a regression, and mail is not
+                # a surface that tolerates one.
+                logger.exception("could not bind an email turn to a session")
+                session = None
     if sum([bool(agent), bool(project), bool(session)]) != 1:
         raise ValueError("a turn targets exactly one of agent / project / session")
     if project and workspace is None:
@@ -1431,6 +1468,63 @@ def _thread_session(agent, project, workspace, thread_key):
         workspace=workspace or (agent.workspace if agent else None) or wsvc.ensure_default_workspace(),
         origin=Session.ORIGIN_RUNNER,
         title=thread_key[:200],
+    )
+
+
+#: How an email thread names its Session. Namespaced like `emdash:<task>` so the
+#: three producers of a thread_key cannot collide.
+EMAIL_THREAD_PREFIX = "email:"
+
+#: Where the Gmail thread id is remembered on the Session, so the SECOND message
+#: on a thread finds the FIRST message's session instead of making a new one.
+#: `_thread_session` cannot serve this: it looks a thread_key up only as a
+#: Session UUID, so any non-UUID key creates a fresh row every single time.
+EMAIL_THREAD_KEY = "email_thread_key"
+
+
+def email_thread_session(agent, thread_id: str, subject: str = ""):
+    """The durable Session for one Gmail thread — found, or created once.
+
+    An inbound email already becomes a Turn. A Turn is a fine unit of execution
+    and a poor unit of CONVERSATION: it ends, and there is nothing left for a
+    human to open, watch, or type into. A Session is the thing ace-web already
+    renders through the shared chat kit, so binding the two is what turns "ACE
+    replied to that email eventually" into "here is the run, live, and you can
+    steer it".
+
+    Keyed on the Gmail thread, which gives the behaviour a reader expects for
+    free: a reply on the same thread continues the same session; a new thread
+    opens a parallel one.
+
+    `origin_key` is stamped because that is the field ace-web's session list
+    filters on — a session without it exists and is invisible, which is the
+    least useful possible outcome.
+    """
+    from apps.canopy_sessions.models import Session
+
+    key = f"{EMAIL_THREAD_PREFIX}{thread_id}"
+    # A KEY-PATH lookup, not `metadata__contains`: `contains` on a JSONField is
+    # PostgreSQL-only and raises NotSupportedError on SQLite, so the production
+    # path would have worked while every test errored — found by running them.
+    existing = (
+        Session.objects.filter(agent=agent, **{f"metadata__{EMAIL_THREAD_KEY}": key})
+        .order_by("created_at")
+        .first()
+    )
+    if existing is not None:
+        return existing
+    workspace = (agent.workspace if agent else None) or wsvc.ensure_default_workspace()
+    return Session.objects.create(
+        agent=agent,
+        workspace=workspace,
+        origin=Session.ORIGIN_RUNNER,
+        title=(subject or key)[:200],
+        metadata={
+            EMAIL_THREAD_KEY: key,
+            # ace-web lists sessions by this; see its CLAUDE.md § canopy-hosted chat.
+            "origin_key": f"ace-web:{workspace.slug}",
+            "source": "email",
+        },
     )
 
 

--- a/tests/test_email_thread_session.py
+++ b/tests/test_email_thread_session.py
@@ -1,0 +1,137 @@
+"""An inbound email thread becomes a Session a human can open, watch and steer.
+
+A Turn is a fine unit of EXECUTION and a poor unit of CONVERSATION: it ends, and
+leaves nothing to open or type into. A Session is what ace-web already renders
+through the shared canopy chat kit, so binding an email turn to one is what turns
+"ACE replied to that eventually" into "here is the run, live".
+
+Everything here is about the binding being ADDITIVE. The turn stays an AGENT turn
+— routing (including the source/actor rules), tenancy and per-agent
+serialization must all be exactly what they were, or a change meant to give
+someone a URL has quietly rerouted the fleet's mail.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from apps.agents.models import Agent
+from apps.harness import services
+from apps.harness.models import Turn
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def owner(django_user_model):
+    return django_user_model.objects.create_user(
+        username="owner", email="owner@dimagi.com", password="x")
+
+
+@pytest.fixture
+def workspace(owner):
+    from apps.workspaces.models import Workspace, WorkspaceMembership
+    ws = Workspace.objects.create(slug="connect", display_name="Connect", created_by=owner)
+    WorkspaceMembership.objects.create(
+        user=owner, workspace=ws, role=WorkspaceMembership.OWNER)
+    return ws
+
+
+@pytest.fixture
+def agent(workspace):
+    return Agent.objects.create(slug="ace", name="ACE", workspace=workspace)
+
+
+def _email_turn(agent, thread_id, subject="Pipeline test", key=None):
+    return services.enqueue_turn(
+        agent=agent,
+        origin=Turn.ORIGIN_EMAIL,
+        idempotency_key=key or f"email:{uuid.uuid4().hex}",
+        prompt="handle this thread",
+        origin_ref={"from": "hal@dimagi-ai.com", "subject": subject,
+                    "thread_id": thread_id, "discovered_by": "poll"},
+    )
+
+
+def test_an_email_turn_gets_a_session_to_watch(agent):
+    turn, _ = _email_turn(agent, "1a085da485720e8a")
+    assert turn.chat_session_id is not None, "nothing for a human to open"
+    assert turn.chat_session.agent_id == agent.id
+
+
+def test_the_same_thread_continues_the_same_session(agent):
+    """A reply is the same conversation. `_thread_session` could not do this — it
+    resolves a thread_key only as a Session UUID, so a non-UUID key creates a
+    fresh row every time."""
+    first, _ = _email_turn(agent, "thread-A")
+    second, _ = _email_turn(agent, "thread-A")
+    # Not-None FIRST: without it this passes vacuously when both bindings fail
+    # and the assertion becomes None == None. It did exactly that on the first run.
+    assert first.chat_session_id is not None
+    assert first.chat_session_id == second.chat_session_id
+
+
+def test_a_new_thread_opens_a_parallel_session(agent):
+    a, _ = _email_turn(agent, "thread-A")
+    b, _ = _email_turn(agent, "thread-B")
+    assert a.chat_session_id != b.chat_session_id
+
+
+def test_the_session_is_listable_by_ace_web(agent):
+    """ace-web filters its session list on metadata.origin_key. Without it the
+    session exists and is invisible, which is the least useful outcome available."""
+    turn, _ = _email_turn(agent, "thread-C")
+    meta = turn.chat_session.metadata
+    assert meta.get("origin_key", "").startswith("ace-web:"), meta
+    assert meta.get("source") == "email", meta
+
+
+def test_the_turn_targets_the_session_and_still_names_its_agent(agent):
+    """`turn_targets_agent_xor_project_xor_session` is a DB CHECK constraint, so
+    a turn cannot carry both. What must survive the conversion is the agent: the
+    runner drives it (`resolve_agent_slug` reads chat_session.agent.slug) and
+    routing resolves the source/actor rules through it."""
+    from apps.harness.schemas import TurnOut
+    turn, _ = _email_turn(agent, "thread-D")
+    assert turn.agent_id is None
+    assert turn.chat_session.agent_id == agent.id
+    assert TurnOut.resolve_agent_slug(turn) == agent.slug
+    assert turn.workspace_id is None, "tenancy derives from the session, never denormalized"
+
+
+def test_two_threads_are_not_serialized_behind_each_other(agent):
+    """The point of keying on the thread: separate conversations run in parallel
+    rather than queueing behind one agent."""
+    a, _ = _email_turn(agent, "thread-P1")
+    b, _ = _email_turn(agent, "thread-P2")
+    assert a.chat_session_id != b.chat_session_id
+    assert a.agent_id is None and b.agent_id is None
+
+
+def test_a_non_email_turn_gets_no_session(agent):
+    turn, _ = services.enqueue_turn(
+        agent=agent, origin=Turn.ORIGIN_API,
+        idempotency_key=f"api:{uuid.uuid4().hex}", prompt="hi",
+    )
+    assert turn.chat_session_id is None
+
+
+def test_an_email_turn_with_no_thread_id_still_runs(agent):
+    """Degrade, never block: mail is not a surface that tolerates a turn failing
+    to exist because its session could not be made."""
+    turn, _ = services.enqueue_turn(
+        agent=agent, origin=Turn.ORIGIN_EMAIL,
+        idempotency_key=f"email:{uuid.uuid4().hex}", prompt="hi",
+        origin_ref={"from": "x@y.z", "subject": "no thread id"},
+    )
+    assert turn.pk is not None
+    assert turn.chat_session_id is None
+
+
+def test_a_session_failure_does_not_lose_the_turn(agent, monkeypatch):
+    monkeypatch.setattr(services, "email_thread_session",
+                        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("db sad")))
+    turn, _ = _email_turn(agent, "thread-E")
+    assert turn.pk is not None, "the mail still has to be handled"
+    assert turn.chat_session_id is None


### PR DESCRIPTION
## What this is for

A colleague emails ACE, then wants to **watch the run and steer it**. Everything else for that already exists — ace-web renders canopy sessions through the shared chat kit, and #731 made a running turn accept a mid-turn message. The missing piece was that an inbound email produced only a **Turn**, which ends and leaves nothing to open.

Now it targets a durable **Session** keyed `email:<gmail-thread-id>`, stamped with `origin_key` so ace-web's list picks it up. Same thread → same session. New thread → parallel session.

## I got the design wrong first, and the DB said so

I wrote this as *additive* — turn stays an agent turn, gains a `chat_session`, routing and concurrency untouched — and argued it from the service function's validation. It's impossible:

```
CHECK constraint failed: turn_targets_agent_xor_project_xor_session
```

**Running the tests found that. Reading the service function suggested the opposite.**

## What moves

- **Serialization is per session, not per agent** — two email threads to the same agent now run in parallel. That's the behaviour separate conversations should have, and the reason to key on the thread.
- **Tenancy** derives from `session.workspace`, set to the agent's own.

## What does not move — each verified, not assumed

| | |
|---|---|
| Source/actor routing (incl. email-from-hal → cloud-ec2-1) | `claim_next_turn`'s `agent_ids` is a **union** of `agent_id` and `chat_session.agent_id` |
| Runner drives the same agent, same clone | `resolve_agent_slug` already reads `chat_session.agent.slug` |
| Nothing stranded on one box | all three runners declare `sessions=true` |

## Degrades, never blocks

An email with no `thread_id`, or a session that can't be created, still produces the turn. Mail is not a surface where a turn should fail to exist because a nicety failed.

## Tests

9 new. **Two exist only because the first run caught them:**
- a JSON `contains` lookup that is PostgreSQL-only and errored on SQLite — production would have worked while every test failed
- an assertion of mine that passed vacuously on `None == None`

**Full suite: 2422 passed, 1 skipped, 0 failed.**

## Not proven, and why auto-merge is not armed

The tests cover the binding and every routing consequence reachable in Python. They do **not** cover the live path: real mail arriving, a runner claiming a session-shaped email turn, the transcript rendering in ace-web. This changes how every agent's mail routes, so it wants a human read and a watched first email rather than an unattended merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
