### PR TITLE
runner: the cloud box answers the Gmail doorbell, using the laptop's reader

### DIFF
--- a/runner/ec2/cloud_runner.py
+++ b/runner/ec2/cloud_runner.py
@@ -140,6 +140,14 @@ WORK_DIR = os.environ.get("WORK_DIR", "/tmp/canopy-runner-work")
 # Agent-fleet bootstrap (runner/ec2/bootstrap_agents.sh) — see
 # bootstrap_agent_fleet() below for why this runs from here and not cloud-init.
 AGENT_ROOT = os.environ.get("AGENT_ROOT", "/opt/agents")
+#: Which agents this box has clones (and gog credentials) for. Set by cloud-init
+#: from the same CFN parameter bootstrap_agents.sh provisions from, so the list
+#: the mailbox map is built from is the list that was actually provisioned.
+AGENT_SLUGS = os.environ.get("AGENT_SLUGS", "")
+#: The timer half of inbox delivery. The doorbell is the delivery mechanism; this
+#: is the AUDITOR — mail the timer finds is mail push failed to ring for, which is
+#: what makes a broken watch loud instead of silent. Same 300s as the laptop.
+INBOX_POLL_SECONDS = int(os.environ.get("INBOX_POLL_SECONDS", "300"))
 CANOPY_WEB_REPO_DIR = os.environ.get("CANOPY_WEB_REPO_DIR", "/opt/canopy-web")
 CANOPY_WEB_REPO_URL = os.environ.get("CANOPY_WEB_REPO_URL", "https://github.com/dimagi-internal/canopy-web.git")
 POLL_SECONDS = int(os.environ.get("POLL_SECONDS", "15"))
@@ -1425,6 +1433,15 @@ def _install_transcript_core(repo_dir: pathlib.Path) -> None:
     # canopy_acp lives beside the runner programs (runner/canopy_acp), not in
     # packages/ — looking for it there disabled the ACP executor on every boot.
     _expose_repo_package(repo_dir, "canopy_acp", "the ACP executor", parent="runner")
+    # The SAME inbox reader the laptop runs, imported rather than reimplemented.
+    # `canopy_runner.inbox` and `.inbox_due` are stdlib-only and its package
+    # __init__ is a version string, so this costs nothing and — more to the point
+    # — means the doorbell, the (thread, messageCount) idempotency key, the
+    # own-reply skip and the CloudWatch alarm coalescing have ONE implementation
+    # and one set of tests. A second copy of that logic would drift the way
+    # `encode_project_dir` already has (three files, "keep the two in step").
+    _expose_repo_package(repo_dir, "canopy_runner", "the shared inbox reader",
+                         parent="runner")
     _install_acp_adapter()
 
 
@@ -2264,6 +2281,129 @@ def _drain_mint(runner_id: str) -> None:
         _log(f"mint drain error: {exc}")
 
 
+# ── inbox (the Gmail doorbell, and the timer that audits it) ───────────────
+#
+# Until now this box had no inbox code at all, so a `check_inbox` frame reached a
+# runner that could not act on it. That was invisible because the LAPTOPS' 300s
+# timer found the same mail a few minutes later and enqueued it — push looked
+# slow rather than dead. canopy-web logged the truth all along:
+#
+#   gmail.push.missed x18, since 2026-08-01
+#   "the 300s poll found mail that push never rang for — push is registered but
+#    not delivering"
+#
+# The box HAS the credentials (bootstrap_agents.sh runs step2_gog_config +
+# refresh_gmail_token per agent, and a live `gog gmail search` succeeds here); it
+# only ever lacked the code. So: same modules, same behaviour, same tests.
+_INBOX_CORE: object = False
+
+
+def _inbox_core():
+    """`canopy_runner.inbox` + `.inbox_due`, imported lazily off the clone."""
+    global _INBOX_CORE
+    if _INBOX_CORE is not False:
+        return _INBOX_CORE
+    try:
+        from canopy_runner import inbox, inbox_due  # noqa: PLC0415
+        _INBOX_CORE = (inbox, inbox_due)
+    except Exception as exc:  # noqa: BLE001
+        _log(f"inbox reader unavailable ({exc}); this box will not read mail")
+        _INBOX_CORE = None
+    return _INBOX_CORE
+
+
+class _InboxClient:
+    """The one method `check_inbox` needs, over this runner's own `_api`.
+
+    Deliberately a shim rather than a shared client class: the two runners differ in
+    transport (this one has `_api`, the laptop has a Client object), and the
+    thing worth sharing is the READING logic, not the plumbing under it.
+    """
+
+    def __init__(self, runner_id: str) -> None:
+        self._runner_id = runner_id
+
+    def enqueue_turn(self, agent_slug: str, origin: str, idempotency_key: str, *,
+                     prompt: str = "", origin_ref: dict | None = None,
+                     routing: str = "prefer_local") -> dict:
+        status, payload = _api("POST", "/turns/", {
+            "agent_slug": agent_slug, "origin": origin,
+            "idempotency_key": idempotency_key, "prompt": prompt,
+            "origin_ref": origin_ref or {}, "routing": routing,
+        })
+        # 201 = new, 200 = idempotent hit. The caller logs the difference so a
+        # re-poll of the same unread mail reads as "nothing new", not fresh work.
+        return {**(payload or {}), "_created": status == 201}
+
+
+def _agent_mailboxes() -> dict:
+    """{agent_slug: {"account": ..., "client": ...}} from the agent clones.
+
+    `/api/inbound/runner-mailboxes` deliberately serves only address + topic —
+    "the runner intersects this with the mailboxes it actually holds credentials
+    for". On this box that intersection IS the clone: bootstrap provisions gog
+    per agent, and each repo's config/agent.json is the single source for its
+    mailbox and gog client (a per-agent mailbox, the SHARED fleet client).
+    """
+    boxes: dict = {}
+    for slug in [s.strip() for s in AGENT_SLUGS.split(",") if s.strip()]:
+        cfg = pathlib.Path(AGENT_ROOT) / slug / "config" / "agent.json"
+        try:
+            data = json.loads(cfg.read_text())
+        except Exception:  # noqa: BLE001 — an agent without one simply has no mailbox
+            continue
+        account = (data.get("email") or "").strip()
+        client = (data.get("gog_client") or "").strip()
+        if account and client:
+            boxes[slug] = {"account": account, "client": client}
+    return boxes
+
+
+_INBOX_STAMPS: dict = {}
+
+
+def _drain_inbox(runner_id: str) -> None:
+    """Check every mailbox that is due — rung by the doorbell, or timed out.
+
+    Modelled on `_drain_mint`: polled from the same tick, and every failure is
+    logged rather than raised, because a mailbox whose auth died must not take
+    the turn loop down with it.
+    """
+    core = _inbox_core()
+    if core is None:
+        return
+    inbox_mod, inbox_due = core
+    boxes = _agent_mailboxes()
+    if not boxes:
+        return
+    try:
+        rung = inbox_due.take_pending()
+        due = inbox_due.due(boxes, _INBOX_STAMPS, now=time.time(),
+                            interval=INBOX_POLL_SECONDS, rung=rung)
+        rung_slugs = {
+            slug for slug in boxes
+            if (boxes[slug].get("account") or "").strip().lower() in rung
+        }
+        client = _InboxClient(runner_id)
+        for slug in due:
+            box = boxes[slug]
+            try:
+                res = inbox_mod.check_inbox(
+                    client, slug, mailbox=box["account"], gog_client=box["client"],
+                    discovered_by=inbox_due.discovered_by(slug, rung_slugs),
+                )
+                if res.get("new"):
+                    _log(f"inbox {slug}: {len(res['new'])} new turn(s) "
+                         f"({inbox_due.discovered_by(slug, rung_slugs)})")
+            except Exception as exc:  # noqa: BLE001
+                _log(f"inbox {slug}: check failed ({exc})")
+            finally:
+                # Stamp even on failure, or a broken mailbox is retried every tick.
+                _INBOX_STAMPS[slug] = time.time()
+    except Exception as exc:  # noqa: BLE001
+        _log(f"inbox drain error: {exc}")
+
+
 # ── session continuity (resolve-session / record-session round-trip) ───────
 def _session_thread_key(turn: dict) -> str:
     """The key resolve-session/record-session use for a SESSION-targeted turn, or
@@ -2754,6 +2894,7 @@ def run_over_rest(runner_id: str) -> None:
         # likely to need one, and leaving this on the WS path only would strand
         # the operator on the runners that fail most.
         _drain_mint(runner_id)
+        _drain_inbox(runner_id)
         if len(_in_flight_ids()) >= MAX_CONCURRENT_TURNS:
             time.sleep(POLL_SECONDS)
             continue
@@ -2981,6 +3122,15 @@ def run_over_ws(runner_id: str) -> bool:
                         else:
                             _log(f"interject turn={t_id[:8]}: NOT delivered "
                                  f"(no live ACP turn) — {body[:60]!r}")
+                    elif mtype == "check_inbox":
+                        # Mark it due; the POLL thread does the read. Same split
+                        # the laptop uses, for the same reason: a `gog` subprocess
+                        # on the wake-listener would block the socket that keeps
+                        # this runner alive.
+                        core = _inbox_core()
+                        if core is not None:
+                            core[1].ring(str(msg.get("mailbox") or ""))
+                            _log(f"doorbell: {msg.get('mailbox')} marked due")
                     elif mtype == "stream":
                         # Latency optimization only — /streams is polled below
                         # regardless, so a dropped frame costs one tick, never
@@ -3006,6 +3156,7 @@ def run_over_ws(runner_id: str) -> bool:
                     _drain(ws, runner_id)
                     _sync_session_views(runner_id)          # incl. backfills
                     _drain_mint(runner_id)
+                    _drain_inbox(runner_id)
                     last_poll = time.monotonic()
                     last_stream = time.monotonic()
                 elif time.monotonic() - last_stream >= STREAM_POLL_SECONDS:

--- a/runner/ec2/tests/test_cloud_runner.py
+++ b/runner/ec2/tests/test_cloud_runner.py
@@ -1859,3 +1859,109 @@ def test_the_turn_unregisters_before_the_connection_closes(cloud_runner):
            if hasattr(cloud_runner, "__file__") else "")
     body = re.search(r"finally:\n\s*# Unregister BEFORE close.*?agent\.close\(\)", src, re.S)
     assert body, "run_acp's finally no longer unregisters before closing"
+
+
+# ── the doorbell, answered ──────────────────────────────────────────────────
+#
+# This box had no inbox code at all, so canopy-web's `check_inbox` frame reached
+# a runner that could not act on it. Invisible, because the LAPTOPS' 300s timer
+# found the same mail minutes later — push looked slow rather than dead. The
+# server had been saying so since 2026-08-01:
+#
+#   gmail.push.missed x18 — "the 300s poll found mail that push never rang for"
+#
+# The credentials were never the gap (bootstrap runs step2_gog_config +
+# refresh_gmail_token per agent, and a live `gog gmail search` succeeds here);
+# only the code was.
+
+def test_the_inbox_reader_is_the_laptops_not_a_copy(cloud_runner):
+    """DRY, pinned. A second implementation of the (thread, messageCount)
+    idempotency key, the own-reply skip and the alarm coalescing would drift the
+    way `encode_project_dir` already has — three files and a comment asking
+    people to keep them in step."""
+    import pathlib as _pl
+    src = _pl.Path(cloud_runner.__file__).read_text()
+    assert "from canopy_runner import inbox, inbox_due" in src, (
+        "the cloud runner must IMPORT the shared reader, not reimplement it")
+    # CODE only. The first version of this test scanned the whole file and
+    # tripped on its own explanatory comments — a check that fails on prose
+    # teaches people to delete the prose.
+    code = "\n".join(
+        ln for ln in src.splitlines() if not ln.lstrip().startswith("#")
+    )
+    for reimplemented in ("messageCount", "def check_inbox", "gog gmail search"):
+        assert reimplemented not in code, (
+            f"{reimplemented!r} looks reimplemented here; it belongs to "
+            "canopy_runner.inbox")
+
+
+def test_the_shared_reader_is_exposed_off_the_clone(cloud_runner):
+    import pathlib as _pl
+    src = _pl.Path(cloud_runner.__file__).read_text()
+    assert '_expose_repo_package(repo_dir, "canopy_runner"' in src
+
+
+def test_the_mailbox_map_comes_from_the_agent_clones(cloud_runner, tmp_path, monkeypatch):
+    """`/api/inbound/runner-mailboxes` serves address + topic only — the runner
+    "intersects this with the mailboxes it actually holds credentials for", and
+    on this box that intersection is the clone bootstrap provisioned."""
+    for slug, email, client in (("ace", "ace@dimagi-ai.com", "canopy"),
+                                ("hal", "hal@dimagi-ai.com", "canopy")):
+        d = tmp_path / slug / "config"
+        d.mkdir(parents=True)
+        (d / "agent.json").write_text(
+            f'{{"email": "{email}", "gog_client": "{client}"}}')
+    (tmp_path / "nomail" / "config").mkdir(parents=True)
+    (tmp_path / "nomail" / "config" / "agent.json").write_text('{"name": "no mailbox"}')
+    monkeypatch.setattr(cloud_runner, "AGENT_ROOT", str(tmp_path))
+    monkeypatch.setattr(cloud_runner, "AGENT_SLUGS", "ace,hal,nomail,missing")
+    boxes = cloud_runner._agent_mailboxes()
+    assert boxes == {
+        "ace": {"account": "ace@dimagi-ai.com", "client": "canopy"},
+        "hal": {"account": "hal@dimagi-ai.com", "client": "canopy"},
+    }, "an agent with no mailbox, or no clone, must simply not appear"
+
+
+def test_a_doorbell_frame_marks_the_mailbox_due(cloud_runner, monkeypatch):
+    """Marks due only — the gog subprocess belongs on the poll thread, or it
+    blocks the socket keeping this runner alive."""
+    rung = []
+    fake_due = type("D", (), {"ring": staticmethod(lambda m: rung.append(m))})
+    monkeypatch.setattr(cloud_runner, "_inbox_core", lambda: (object(), fake_due))
+    monkeypatch.setattr(cloud_runner, "_log", lambda m: None)
+    core = cloud_runner._inbox_core()
+    core[1].ring("ace@dimagi-ai.com")
+    assert rung == ["ace@dimagi-ai.com"]
+
+
+def test_a_broken_mailbox_is_stamped_so_it_is_not_retried_every_tick(cloud_runner, monkeypatch):
+    calls = []
+
+    class _Inbox:
+        @staticmethod
+        def check_inbox(client, slug, **kw):
+            calls.append(slug)
+            raise RuntimeError("auth is dead")
+
+    class _Due:
+        @staticmethod
+        def take_pending(): return set()
+        @staticmethod
+        def due(boxes, stamps, **kw): return [s for s in boxes if s not in stamps]
+        @staticmethod
+        def discovered_by(slug, rung): return "poll"
+
+    monkeypatch.setattr(cloud_runner, "_inbox_core", lambda: (_Inbox, _Due))
+    monkeypatch.setattr(cloud_runner, "_agent_mailboxes",
+                        lambda: {"ace": {"account": "a@b.c", "client": "canopy"}})
+    monkeypatch.setattr(cloud_runner, "_log", lambda m: None)
+    cloud_runner._INBOX_STAMPS.clear()
+    cloud_runner._drain_inbox("runner-1")
+    cloud_runner._drain_inbox("runner-1")
+    assert calls == ["ace"], "a failing mailbox must not be retried on every tick"
+    cloud_runner._INBOX_STAMPS.clear()
+
+
+def test_a_missing_reader_disables_mail_without_taking_the_loop_down(cloud_runner, monkeypatch):
+    monkeypatch.setattr(cloud_runner, "_inbox_core", lambda: None)
+    cloud_runner._drain_inbox("runner-1")   # must not raise


### PR DESCRIPTION
## The gap

This box had **no inbox code at all**. canopy-web's `check_inbox` frame reached a runner that could not act on it, so the push path produced nothing for every mailbox routed here.

Invisible, because the laptops' 300 s timer found the same mail minutes later — push looked *slow*, not dead. canopy-web had been saying otherwise since **1 August**:

```
gmail.push.missed  x18
"the 300s poll found mail on ace@dimagi-ai.com that push never rang for
 — push is registered but not delivering"
```

**Credentials were never the gap.** `bootstrap_agents.sh` runs `step2_gog_config` + `refresh_gmail_token` per agent, the box holds `GOG_KEYRING_PASSWORD`, and a live `gog gmail search` succeeds here. Only the code was missing.

## DRY by import, not by copy

`canopy_runner.inbox` and `.inbox_due` are **stdlib-only** and their package `__init__` is a version string — so this box exposes them off the clone exactly as it already does `canopy_acp` and `canopy_transcript`, and calls the **same functions the laptop calls**.

The `(thread, messageCount)` idempotency key, the own-reply skip, the CloudWatch alarm coalescing and the doorbell/timer split keep **one implementation and one set of tests**. A second copy would drift the way `encode_project_dir` already has — three files carrying a comment asking people to keep them in step.

What is genuinely local, and therefore *not* shared: the transport shim (`_InboxClient.enqueue_turn` over this runner's `_api`). The two runners differ in plumbing, not in how mail is read.

## Where the mailbox map comes from

`/api/inbound/runner-mailboxes` deliberately serves address + topic only — *"the runner intersects this with the mailboxes it actually holds credentials for"*. On this box that intersection **is** the clone: each agent repo's `config/agent.json` is the single source for its mailbox and gog client.

## Threading

Same split as the laptop: the frame marks a mailbox **due** on the wake thread, the **poll** thread runs the `gog` subprocess. Reading on the socket thread would block the connection keeping this box alive.

## Tests

6, all red against main — including **one that pins the DRY property itself**, so a future copy of the reader fails CI rather than drifting quietly. (Its first version scanned the whole file and tripped on its own explanatory comments; a check that fails on prose teaches people to delete the prose, so it scans code only.)

98 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
