### PR TITLE
runner: the cloud inbox reader presents the client whose token authenticates (#738)

### DIFF
--- a/runner/ec2/cloud_runner.py
+++ b/runner/ec2/cloud_runner.py
@@ -2342,8 +2342,10 @@ def _agent_mailboxes() -> dict:
     `/api/inbound/runner-mailboxes` deliberately serves only address + topic —
     "the runner intersects this with the mailboxes it actually holds credentials
     for". On this box that intersection IS the clone: bootstrap provisions gog
-    per agent, and each repo's config/agent.json is the single source for its
-    mailbox and gog client (a per-agent mailbox, the SHARED fleet client).
+    per agent, and each repo's config/agent.json names its mailbox and the gog
+    client its turns DECLARE. That client is intent, not fact — see
+    `_resolve_mailbox_clients`, which replaces it with the one whose token
+    actually authenticates before anything is read.
     """
     boxes: dict = {}
     for slug in [s.strip() for s in AGENT_SLUGS.split(",") if s.strip()]:
@@ -2360,6 +2362,94 @@ def _agent_mailboxes() -> dict:
 
 
 _INBOX_STAMPS: dict = {}
+
+#: account -> the gog client whose token PROVED it can read that mailbox. Filled
+#: by `_resolve_mailbox_clients`, evicted by `_drain_inbox` on a "No auth" failure
+#: so a rotated token is re-probed on the next tick rather than mourned forever.
+_GOG_CLIENT_LIVE: dict = {}
+
+
+def _gog_config_dir() -> pathlib.Path:
+    """gog's own config dir on Linux — $GOG_HOME, else $XDG_CONFIG_HOME/gogcli,
+    else ~/.config/gogcli. Mirrors bootstrap_agents.sh `gog_config_dir`."""
+    home = os.environ.get("GOG_HOME", "").strip()
+    if home:
+        return pathlib.Path(os.path.expanduser(home))
+    base = os.environ.get("XDG_CONFIG_HOME", "").strip() or os.path.join(
+        os.path.expanduser("~"), ".config")
+    return pathlib.Path(base) / "gogcli"
+
+
+def _candidate_gog_clients(account: str, declared: str) -> list:
+    """Every client this box could present for `account`, most likely first.
+
+    Order: what the agent's config declares; what gog's own `account_clients`
+    map says (bootstrap writes it); then every `credentials-<client>.json` in the
+    config dir. None of these is authoritative on its own — a token is minted FOR
+    a client and only that client can use it — so the list is a search order,
+    not an answer. `_resolve_mailbox_clients` asks the token.
+    """
+    order = [declared]
+    cfg_dir = _gog_config_dir()
+    try:
+        data = json.loads((cfg_dir / "config.json").read_text())
+        order.append(((data.get("account_clients") or {}).get(account) or ""))
+    except Exception:  # noqa: BLE001 — no map yet is a normal first-boot state
+        pass
+    try:
+        for f in sorted(cfg_dir.glob("credentials-*.json")):
+            order.append(f.name[len("credentials-"):-len(".json")])
+    except Exception:  # noqa: BLE001
+        pass
+    seen: list = []
+    for c in order:
+        c = (c or "").strip()
+        if c and c not in seen:
+            seen.append(c)
+    return seen
+
+
+def _resolve_mailbox_clients(boxes: dict, probe) -> dict:
+    """Replace each mailbox's DECLARED gog client with the one that AUTHENTICATES.
+
+    `probe(account, client)` makes one real gog call and raises if the token
+    under `client` cannot read `account`. The first candidate that succeeds is
+    cached in `_GOG_CLIENT_LIVE`; a mailbox no candidate can open is dropped
+    from the returned map with one log line naming what was tried.
+
+    Why a probe and not a lookup: every agent's config declares the shared
+    `canopy` client, but on this box echo's live token sits under `echo` (and
+    ace's `ace` token is expired, so ace only works under `canopy`). Neither
+    config/agent.json nor gog's account_clients map gets both right —
+    bootstrap_agents.sh spells out why, and canopy-web#661 (reverted the same
+    day) is what trusting the declaration cost. The token is the only authority
+    (canopy-web#738).
+    """
+    resolved: dict = {}
+    for slug, box in boxes.items():
+        account = (box.get("account") or "").strip()
+        declared = (box.get("client") or "").strip()
+        live = _GOG_CLIENT_LIVE.get(account)
+        if not live:
+            tried = _candidate_gog_clients(account, declared)
+            for client in tried:
+                try:
+                    probe(account, client)
+                except Exception:  # noqa: BLE001 — this candidate cannot open it
+                    continue
+                live = client
+                _GOG_CLIENT_LIVE[account] = client
+                if client != declared:
+                    _log(f"inbox {slug}: token for {account} lives under client "
+                         f"{client!r}, config declares {declared!r} — reading "
+                         f"with {client!r}")
+                break
+            if not live:
+                _log(f"inbox {slug}: no gog client can read {account} "
+                     f"(tried: {', '.join(tried) or 'none'})")
+                continue
+        resolved[slug] = {**box, "client": live}
+    return resolved
 
 
 def _drain_inbox(runner_id: str) -> None:
@@ -2378,6 +2468,23 @@ def _drain_inbox(runner_id: str) -> None:
         return
     try:
         rung = inbox_due.take_pending()
+        # Resolve only the mailboxes that are DUE, so a mailbox nobody rang and
+        # whose timer has not elapsed costs no gog call this tick.
+        due_declared = inbox_due.due(boxes, _INBOX_STAMPS, now=time.time(),
+                                     interval=INBOX_POLL_SECONDS, rung=rung)
+        boxes = {
+            **{s: b for s, b in boxes.items() if s not in due_declared},
+            **_resolve_mailbox_clients(
+                {s: boxes[s] for s in due_declared},
+                lambda account, client: inbox_mod.search_threads(
+                    account, client, max_threads=1),
+            ),
+        }
+        # A mailbox no client could open is stamped like any other failure, or
+        # it is re-probed every tick.
+        for slug in due_declared:
+            if slug not in boxes:
+                _INBOX_STAMPS[slug] = time.time()
         due = inbox_due.due(boxes, _INBOX_STAMPS, now=time.time(),
                             interval=INBOX_POLL_SECONDS, rung=rung)
         rung_slugs = {
@@ -2397,6 +2504,10 @@ def _drain_inbox(runner_id: str) -> None:
                          f"({inbox_due.discovered_by(slug, rung_slugs)})")
             except Exception as exc:  # noqa: BLE001
                 _log(f"inbox {slug}: check failed ({exc})")
+                # A token that stopped authenticating (rotated, revoked) must be
+                # re-probed next time, not presented forever from the cache.
+                if "no auth" in str(exc).lower():
+                    _GOG_CLIENT_LIVE.pop(box.get("account"), None)
             finally:
                 # Stamp even on failure, or a broken mailbox is retried every tick.
                 _INBOX_STAMPS[slug] = time.time()

--- a/runner/ec2/tests/test_cloud_runner.py
+++ b/runner/ec2/tests/test_cloud_runner.py
@@ -1939,6 +1939,8 @@ def test_a_broken_mailbox_is_stamped_so_it_is_not_retried_every_tick(cloud_runne
 
     class _Inbox:
         @staticmethod
+        def search_threads(account, client, max_threads=15): return []   # the client probe
+        @staticmethod
         def check_inbox(client, slug, **kw):
             calls.append(slug)
             raise RuntimeError("auth is dead")
@@ -1965,3 +1967,144 @@ def test_a_broken_mailbox_is_stamped_so_it_is_not_retried_every_tick(cloud_runne
 def test_a_missing_reader_disables_mail_without_taking_the_loop_down(cloud_runner, monkeypatch):
     monkeypatch.setattr(cloud_runner, "_inbox_core", lambda: None)
     cloud_runner._drain_inbox("runner-1")   # must not raise
+
+
+# ── the client is the token's, not the config's (canopy-web#738) ──────────────
+#
+# Every agent declares `gog_client: canopy`, but a token is minted FOR a client
+# and only that client can use it. On the live box echo's token sits under
+# `echo`, so a reader that presents the declaration logged `No auth for gmail
+# echo@dimagi-ai.com` 59 times in five hours — for the one mailbox whose default
+# runner list actually rings this box. bootstrap_agents.sh already says "pick
+# the client whose token AUTHENTICATES"; #661 (reverted the same day) is what
+# trusting the declaration cost. The reader now asks the token.
+
+def _gog_home(tmp_path, monkeypatch, *, account_clients=None, credentials=()):
+    home = tmp_path / "gogcli"
+    home.mkdir()
+    if account_clients is not None:
+        (home / "config.json").write_text(json.dumps({"account_clients": account_clients}))
+    for c in credentials:
+        (home / f"credentials-{c}.json").write_text("{}")
+    monkeypatch.setenv("GOG_HOME", str(home))
+    return home
+
+
+def test_candidate_clients_declared_then_gogs_map_then_credential_files(cloud_runner, tmp_path, monkeypatch):
+    _gog_home(tmp_path, monkeypatch,
+              account_clients={"echo@dimagi-ai.com": "echo"},
+              credentials=("ace", "canopy", "echo"))
+    assert cloud_runner._candidate_gog_clients("echo@dimagi-ai.com", "canopy") == [
+        "canopy", "echo", "ace"], "declared first, gog's own map second, then every credential file, deduped"
+    assert cloud_runner._candidate_gog_clients("x@y.z", "") == ["ace", "canopy", "echo"], \
+        "an empty declaration must not become a candidate (an empty --client points gog at the wrong app silently)"
+
+
+def test_the_reader_presents_the_client_whose_token_authenticates(cloud_runner, tmp_path, monkeypatch):
+    _gog_home(tmp_path, monkeypatch, account_clients={"echo@dimagi-ai.com": "echo"})
+    logs = []
+    monkeypatch.setattr(cloud_runner, "_log", logs.append)
+    probed = []
+
+    def probe(account, client):
+        probed.append((account, client))
+        if client != "echo":
+            raise RuntimeError(f"No auth for gmail {account}.")
+
+    cloud_runner._GOG_CLIENT_LIVE.clear()
+    out = cloud_runner._resolve_mailbox_clients(
+        {"echo": {"account": "echo@dimagi-ai.com", "client": "canopy"}}, probe)
+    assert out == {"echo": {"account": "echo@dimagi-ai.com", "client": "echo"}}
+    assert probed == [("echo@dimagi-ai.com", "canopy"), ("echo@dimagi-ai.com", "echo")], \
+        "the declared client is tried FIRST — when it works (ace/ada/eva/hal) there is exactly one call"
+    assert any("lives under client 'echo'" in m and "declares 'canopy'" in m for m in logs), \
+        "a disagreement between token and declaration is said out loud, naming both"
+
+
+def test_a_working_declaration_costs_one_probe_and_is_then_cached(cloud_runner, tmp_path, monkeypatch):
+    _gog_home(tmp_path, monkeypatch)
+    monkeypatch.setattr(cloud_runner, "_log", lambda m: None)
+    probed = []
+    boxes = {"hal": {"account": "hal@dimagi-ai.com", "client": "canopy"}}
+    cloud_runner._GOG_CLIENT_LIVE.clear()
+    cloud_runner._resolve_mailbox_clients(boxes, lambda a, c: probed.append(c))
+    cloud_runner._resolve_mailbox_clients(boxes, lambda a, c: probed.append(c))
+    assert probed == ["canopy"], "proved once per process, not once per tick"
+
+
+def test_a_mailbox_no_client_can_open_is_dropped_and_names_what_was_tried(cloud_runner, tmp_path, monkeypatch):
+    _gog_home(tmp_path, monkeypatch, credentials=("canopy", "echo"))
+    logs = []
+    monkeypatch.setattr(cloud_runner, "_log", logs.append)
+
+    def probe(account, client):
+        raise RuntimeError("No auth")
+
+    cloud_runner._GOG_CLIENT_LIVE.clear()
+    out = cloud_runner._resolve_mailbox_clients(
+        {"echo": {"account": "echo@dimagi-ai.com", "client": "canopy"}}, probe)
+    assert out == {}
+    assert any("no gog client can read echo@dimagi-ai.com (tried: canopy, echo)" in m for m in logs)
+
+
+def test_a_no_auth_failure_evicts_the_cached_client_so_a_rotated_token_is_reprobed(cloud_runner, monkeypatch):
+    class _Inbox:
+        @staticmethod
+        def search_threads(account, client, max_threads=15): return []
+        @staticmethod
+        def check_inbox(client, slug, **kw):
+            raise RuntimeError("No auth for gmail echo@dimagi-ai.com.")
+
+    class _Due:
+        @staticmethod
+        def take_pending(): return set()
+        @staticmethod
+        def due(boxes, stamps, **kw): return [s for s in boxes if s not in stamps]
+        @staticmethod
+        def discovered_by(slug, rung): return "poll"
+
+    monkeypatch.setattr(cloud_runner, "_inbox_core", lambda: (_Inbox, _Due))
+    monkeypatch.setattr(cloud_runner, "_agent_mailboxes",
+                        lambda: {"echo": {"account": "echo@dimagi-ai.com", "client": "canopy"}})
+    monkeypatch.setattr(cloud_runner, "_log", lambda m: None)
+    cloud_runner._INBOX_STAMPS.clear()
+    cloud_runner._GOG_CLIENT_LIVE.clear()
+    cloud_runner._drain_inbox("runner-1")
+    assert "echo@dimagi-ai.com" not in cloud_runner._GOG_CLIENT_LIVE, \
+        "the token that just failed must not be presented from the cache next tick"
+    assert "echo" in cloud_runner._INBOX_STAMPS, "still stamped — no every-tick retry"
+    cloud_runner._INBOX_STAMPS.clear()
+
+
+def test_the_drain_probes_only_mailboxes_that_are_due(cloud_runner, monkeypatch):
+    probed, checked = [], []
+
+    class _Inbox:
+        @staticmethod
+        def search_threads(account, client, max_threads=15):
+            probed.append((account, client)); return []
+        @staticmethod
+        def check_inbox(client, slug, **kw):
+            checked.append((slug, kw["gog_client"])); return {"new": []}
+
+    class _Due:
+        @staticmethod
+        def take_pending(): return set()
+        @staticmethod
+        def due(boxes, stamps, **kw): return [s for s in boxes if s not in stamps]
+        @staticmethod
+        def discovered_by(slug, rung): return "poll"
+
+    monkeypatch.setattr(cloud_runner, "_inbox_core", lambda: (_Inbox, _Due))
+    monkeypatch.setattr(cloud_runner, "_agent_mailboxes", lambda: {
+        "ace": {"account": "ace@dimagi-ai.com", "client": "canopy"},
+        "hal": {"account": "hal@dimagi-ai.com", "client": "canopy"},
+    })
+    monkeypatch.setattr(cloud_runner, "_log", lambda m: None)
+    cloud_runner._INBOX_STAMPS.clear()
+    cloud_runner._GOG_CLIENT_LIVE.clear()
+    cloud_runner._INBOX_STAMPS["hal"] = 10**12   # not due
+    cloud_runner._drain_inbox("runner-1")
+    assert probed == [("ace@dimagi-ai.com", "canopy")], "a mailbox that is not due costs no gog call"
+    assert checked == [("ace", "canopy")]
+    cloud_runner._INBOX_STAMPS.clear()


### PR DESCRIPTION
Closes #738.

## What was wrong

#736 gave the cloud box the laptops' inbox reader, and built its mailbox map from each clone's `config/agent.json` — including the `gog_client` the agent's turns *declare*. Every agent declares `canopy`. But a gog token is minted FOR a client and only that client can use it, and on the live box echo's token sits under `echo`. So the reader asked for `echo@` under `canopy` and got `No auth for gmail echo@dimagi-ai.com` — 59 times between the deploy and 11:37Z, for the one mailbox whose default runner list actually rings this box.

`bootstrap_agents.sh` already says this in so many words ("DO NOT 'fix' this by reading each agent's config/agent.json `gog_client`" — #661, reverted the same day). #736 re-made that inference on the read path.

Verified live under the runner's own env on i-04f6d84089e0b715c (full table on #738):

```
echo  under canopy -> No auth for gmail echo@dimagi-ai.com.
echo  under echo   -> {"threads":[]}
ace   under ace    -> refresh token expired or revoked      (so gog's own account_clients map is wrong for ace)
ace   under canopy -> OK
```

Neither the declaration nor gog's `account_clients` map gets both agents right. The token is the only authority.

## What this does

`_resolve_mailbox_clients(boxes, probe)` replaces each due mailbox's declared client with the first candidate whose token authenticates — one real call through the shared reader's `search_threads(..., max_threads=1)` — and caches it per account. Candidate order is the declaration, then gog's `account_clients` entry, then every `credentials-<client>.json` on the box; so the common case (ace/ada/eva/hal, where the declaration works) costs exactly one probe per process, and echo lands on `echo` with a log line naming both clients. A `No auth` failure on a later read evicts the cache entry, so a rotated token is re-probed next tick rather than presented forever. A mailbox no client can open is dropped with one line listing what was tried, and stamped like any other failure.

Only DUE mailboxes are resolved, so the probe never adds a gog call to a tick that would not have read that mailbox anyway.

## Tests

6 new; 5 of them fail without the fix (the resolver does not exist / the reader presents `canopy`), 104 pass with it. One existing fake reader gained the `search_threads` surface the probe uses.

## Residual

Not re-observed on the box before merge: the deploy self-updates the runner, after which the journal should show `inbox echo: token for echo@dimagi-ai.com lives under client 'echo', config declares 'canopy'` once and no further `check failed` for echo. I will confirm that after the deploy and note it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3NusdwbrWGsWRwp8wgxHb
