### PR TITLE
auth: keep Google sign-up open for new users — closing the local form also closed social sign-in

### DIFF
--- a/apps/common/auth_adapter.py
+++ b/apps/common/auth_adapter.py
@@ -61,6 +61,24 @@ class CustomSocialAccountAdapter(DefaultSocialAccountAdapter):
             request, provider, error=error, exception=exception, extra_context=extra_context
         )
 
+    def is_open_for_signup(self, request, sociallogin):
+        """Social sign-up stays OPEN — it is the only legitimate account-creation path.
+
+        allauth's default delegates this to the ACCOUNT adapter, and
+        `CustomAccountAdapter.is_open_for_signup` answers False to close the local
+        username/password form. Left delegated, that also closed FIRST-TIME Google
+        sign-in: `pre_social_login` admitted the (allowlisted or invited) email,
+        then `process_signup` asked this gate, got False, and rendered "Sign Up
+        Closed" to every person without an existing `User` row — while everyone
+        who signed in before the form was closed never reached the check, so
+        nobody on the inside saw it (canopy-web#740, 2026-09-10).
+
+        The gate that matters — domain allowlist or live workspace invite, on a
+        PROVIDER-verified email — has already run in `pre_social_login` below by
+        the time allauth asks this, so there is nothing left for it to refuse.
+        """
+        return True
+
     def pre_social_login(self, request, sociallogin):
         email = (sociallogin.account.extra_data.get("email") or "").strip().lower()
         admitted_outside_domain = False
@@ -165,6 +183,10 @@ class CustomAccountAdapter(DefaultAccountAdapter):
     never touching Google. Every legitimate identity here comes from the
     social provider (or is provisioned server-side by a management command
     with an unusable password), so nothing is lost by closing it.
+
+    This adapter answers for the LOCAL form only. allauth's social adapter
+    would otherwise inherit this False for first-time Google sign-in too, which
+    is why `CustomSocialAccountAdapter.is_open_for_signup` overrides it.
 
     NOTE: `ACCOUNT_LOGIN_METHODS` / `ACCOUNT_SIGNUP_FIELDS` in settings are
     allauth>=65 names and are INERT on the pinned 0.63.x — they look like

--- a/apps/common/tests/test_social_signup_open.py
+++ b/apps/common/tests/test_social_signup_open.py
@@ -1,0 +1,83 @@
+"""First-time Google sign-in at an allowed domain must CREATE the account.
+
+Local username/password signup is closed (test_local_signup_closed.py) by
+CustomAccountAdapter.is_open_for_signup returning False. allauth's social adapter
+delegates ITS OWN signup gate to that same account adapter, so closing the form
+also closed first-time Google sign-in: pre_social_login admitted the allowlisted
+email, then process_signup asked is_open_for_signup, got False, and rendered
+"Sign Up Closed" to every user who did not already have a row — observed
+2026-09-10 when a Dimagi associate was locked out of every /canopy/ review link
+(canopy-web#740). Social sign-in is the ONLY legitimate account-creation path and
+pre_social_login already gates it (domain allowlist or live invite, on a
+provider-verified email), so it must stay open while the local form stays closed.
+
+These tests drive allauth's real flow (`complete_social_login`), the way allauth's
+own suite does, rather than asserting on the adapter method in isolation.
+"""
+from __future__ import annotations
+
+import pytest
+from allauth.account.models import EmailAddress
+from allauth.socialaccount.helpers import complete_social_login
+from allauth.socialaccount.models import SocialAccount, SocialLogin
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
+from django.contrib.messages.middleware import MessageMiddleware
+from django.contrib.sessions.middleware import SessionMiddleware
+
+pytestmark = pytest.mark.django_db
+
+
+def _google_login(email: str) -> SocialLogin:
+    """A SocialLogin shaped like allauth's Google callback for a brand-new user:
+    no User row yet, provider-verified email."""
+    User = get_user_model()
+    user = User(username=email.split("@")[0], email=email)
+    account = SocialAccount(
+        provider="google",
+        uid="118273645509",
+        extra_data={"email": email, "email_verified": True},
+    )
+    sociallogin = SocialLogin(user=user, account=account)
+    sociallogin.email_addresses = [EmailAddress(email=email, verified=True, primary=True)]
+    return sociallogin
+
+
+def _callback_request(rf):
+    request = rf.get("/accounts/google/login/callback/")
+    SessionMiddleware(lambda r: None).process_request(request)
+    MessageMiddleware(lambda r: None).process_request(request)
+    request.user = AnonymousUser()
+    return request
+
+
+def test_first_google_login_at_allowed_domain_creates_the_user(rf, settings):
+    settings.AUTH_ALLOWED_EMAIL_DOMAIN = "dimagi.com,dimagi-associate.com"
+    email = "newcomer@dimagi-associate.com"
+    User = get_user_model()
+    assert not User.objects.filter(email__iexact=email).exists()
+
+    resp = complete_social_login(_callback_request(rf), _google_login(email))
+
+    body = getattr(resp, "content", b"")
+    assert b"Sign Up Closed" not in body, "social sign-up is closed for a new allowlisted user"
+    assert resp.status_code == 302, body[:300]
+    assert User.objects.filter(email__iexact=email).exists()
+
+
+def test_first_google_login_outside_allowlist_is_still_rejected(rf, settings):
+    """Opening social signup must not weaken the domain gate: pre_social_login
+    still refuses a non-allowlisted, non-invited email before signup is reached."""
+    settings.AUTH_ALLOWED_EMAIL_DOMAIN = "dimagi.com"
+    email = "stranger@example.org"
+
+    resp = complete_social_login(_callback_request(rf), _google_login(email))
+
+    assert resp.status_code == 403
+    assert not get_user_model().objects.filter(email__iexact=email).exists()
+
+
+def test_local_form_stays_closed_alongside():
+    from allauth.account.adapter import get_adapter
+
+    assert get_adapter().is_open_for_signup(None) is False


### PR DESCRIPTION
Fixes #740.

**What Sophie hit:** the "full package" review link redirects to Google sign-in on `/canopy/`; her first-ever sign-in ended on allauth's bare "Sign Up Closed" page.

**Why:** #390 closed the local username/password form by making `CustomAccountAdapter.is_open_for_signup` return `False`. allauth's `DefaultSocialAccountAdapter.is_open_for_signup` delegates to the account adapter (`allauth/socialaccount/adapter.py:168` on the pinned 0.63.6), and `CustomSocialAccountAdapter` never overrode it. So `pre_social_login` admits the allowlisted email, `process_signup` asks the gate, gets `False`, raises `SignupClosedException` → "Sign Up Closed". Anyone with a `User` row from before 25 July never reaches that step, which is why nobody inside noticed.

**Fix:** override `is_open_for_signup` on the social adapter to return `True`. The gate that matters (domain allowlist or live workspace invite, on a provider-verified email) already ran in `pre_social_login`. Local form stays closed — `test_local_signup_closed.py` is unchanged and still passes.

**Test:** `apps/common/tests/test_social_signup_open.py` drives allauth's real `complete_social_login`:
- new user at an allowed domain → `302` + `User` row created (failed before this PR with the exact "Sign Up Closed" body)
- new user outside the allowlist → still `403`, no row
- local adapter still reports closed

**Residual:** the live Google round-trip is not exercised by CI; the first real new-user sign-in after deploy (Sophie's) is the confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jvivuQFKGzQhRBgaWYuvy
