### PR TITLE
runner: the credentials refresh runs under the runner's env, not the timer's

### DIFF
--- a/runner/ec2/tests/test_update_runner_sh.py
+++ b/runner/ec2/tests/test_update_runner_sh.py
@@ -281,3 +281,36 @@ def test_ref_installs_something_else_on_purpose(box):
     assert out.returncode == 0, out.stderr
     assert "print('branch build')" in box.installed
     assert box.restarted
+
+
+# --- the credentials refresh runs under the RUNNER'S env ----------------------
+#
+# canopy-runner.service loads runner.env; canopy-runner-update.service does not.
+# So the --credentials-only pass — whose whole purpose is to pick up a credential
+# set in canopy-web — ran with no GOG_KEYRING_PASSWORD and no CANOPY_TOKEN, saw
+# every mailbox as dead, and re-reported that to the control plane every 30 min
+# (cloud-ec2-1, 2026-09-10 11:59Z: "no gog token anywhere" for ace, seven seconds
+# before the service start read ace's vault AND its canopy-web token).
+def test_the_credentials_refresh_sees_the_runners_env(box):
+    (box.home / "runner.env").write_text(
+        "CANOPY_BASE_URL=https://labs.example/canopy\nCANOPY_TOKEN=tok\n"
+        "GOG_KEYRING_PASSWORD=kp\n"
+    )
+    sha = box.seed_repo(GOOD_RUNNER)   # seed FIRST — it rewrites bootstrap_agents.sh
+    seen = box.root / "bootstrap-env.txt"
+    stub = box.repo / "runner" / "ec2" / "bootstrap_agents.sh"
+    stub.write_text(
+        "#!/bin/bash\n"
+        f'printf "%s\\n" "args=$*" "CANOPY_TOKEN=${{CANOPY_TOKEN:-}}" '
+        f'"GOG_KEYRING_PASSWORD=${{GOG_KEYRING_PASSWORD:-}}" > "{seen}"\n'
+    )
+    stub.chmod(0o755)
+    box.stamp(sha)
+    box.expect(sha)          # current → nothing to install, refresh still runs
+    r = box.run()
+    assert r.returncode == 0, r.stderr
+    assert seen.exists(), "the credentials-only pass did not run"
+    lines = seen.read_text().splitlines()
+    assert "args=--credentials-only" in lines
+    assert "CANOPY_TOKEN=tok" in lines, "no token → no vault config, no canopy-web token"
+    assert "GOG_KEYRING_PASSWORD=kp" in lines, "no keyring password → every mailbox reads as dead"

--- a/runner/ec2/update_runner.sh
+++ b/runner/ec2/update_runner.sh
@@ -293,7 +293,16 @@ if [ "$V" = "busy" ]; then
   log "busy — skipping the credentials refresh too."
 elif [ -x "$REPO_DIR/runner/ec2/bootstrap_agents.sh" ]; then
   log "refreshing credentials (config changes reach the box here, not via a deploy)"
-  ( set +e; "$REPO_DIR/runner/ec2/bootstrap_agents.sh" --credentials-only ) \
+  # Under the RUNNER'S environment, not this timer's. canopy-runner.service loads
+  # runner.env; canopy-runner-update.service does not, so this pass used to run
+  # with no GOG_KEYRING_PASSWORD (every keyring read fails: "mailbox NOT live" for
+  # all five agents) and no CANOPY_TOKEN (no per-agent vault, no canopy-web token:
+  # "no gog token anywhere" for ace while the very next service start read both).
+  # Measured 2026-09-10 11:59Z on cloud-ec2-1 — and this pass re-reports readiness,
+  # so the control plane was told the fleet's mailboxes were dead every 30 minutes.
+  ( set +e
+    if [ -r "$ENV_FILE" ]; then set -a; . "$ENV_FILE"; set +a; fi
+    "$REPO_DIR/runner/ec2/bootstrap_agents.sh" --credentials-only ) \
     || log "credentials refresh returned non-zero — the box is otherwise untouched."
 fi
 exit 0


### PR DESCRIPTION
## What was wrong

`canopy-runner.service` loads `/opt/canopy-runner/runner.env`. `canopy-runner-update.service` does not (`runner.cfn.yaml`: the update unit has `User`, `HOME`, `PATH`, and nothing else). So the `--credentials-only` bootstrap pass the updater runs every 30 minutes — the one whose stated purpose is "config changes reach the box here, not via a deploy" — ran with:

- no `GOG_KEYRING_PASSWORD` → every keyring read fails → `mailbox NOT live` for all five agents;
- no `CANOPY_TOKEN` → `agent_vault_config` and `fetch_canopy_web_token` return nothing → `no gog token anywhere` for every agent, including ace, whose vault AND canopy-web token the service-start pass read seven seconds later.

And it re-reports readiness, so the control plane was told the fleet's mailboxes were dead twice an hour.

Measured on cloud-ec2-1, 2026-09-10:

```
11:59:38 canopy-runner-update: refreshing credentials (config changes reach the box here, not via a deploy)
11:59:39 canopy-runner-update[152416]: [bootstrap-agents] ace: gmail token not live — taking the NEWEST of the vault and canopy-web
11:59:39 canopy-runner-update[152416]: [bootstrap-agents] WARN: ace: no gog token anywhere — neither op://Agent-Ace/gog-token/credential nor canopy-web has one for ace
11:59:39 canopy-runner-update[152416]: [bootstrap-agents] WARN: ace: mailbox NOT live (account=ace@dimagi-ai.com client=ace) ...
11:59:46 python3[152484]:               [bootstrap-agents] ace: gmail token not live — taking the NEWEST of the vault and canopy-web
11:59:47 python3[152484]:               [bootstrap-agents] OK: ace: using canopy-web's token (newer: 1788789853 > 1777670602)
11:59:48 python3[152484]:               [bootstrap-agents] OK: ace: mailbox verified live (account=ace@dimagi-ai.com client=canopy)
```

Same script, same box, same minute; the only difference is the environment. Under the update unit's env on the box, `op whoami` says "No accounts configured" — it cannot even see 1Password.

## What this does

Sources `$ENV_FILE` (`set -a; . …; set +a`) inside the subshell that runs `bootstrap_agents.sh --credentials-only`. Nothing else changes; the install path is untouched. The shim at `/usr/local/bin/canopy-runner-update` pulls `origin/main:runner/ec2/update_runner.sh` on every timer tick, so this lands on the box at the next 30-minute run with no deploy.

An alternative was `EnvironmentFile=` on the update unit in `runner.cfn.yaml`, but that needs a stack update to reach a live box; this ships by itself.

## Tests

One new test: a stub `bootstrap_agents.sh` dumps its env, and the test asserts `CANOPY_TOKEN` and `GOG_KEYRING_PASSWORD` reach it. Fails without the fix (`AssertionError: no token → no vault config, no canopy-web token`), 16 pass with it.

## Residual

Not yet re-observed: the next timer tick after this merges should log `ace: gmail token already live` (not "no gog token anywhere") and `mailbox verified live` for the four vault-sourced agents. I will confirm on the box and note it here.

Found while answering "where did the tokens come from" after #738/#739.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3NusdwbrWGsWRwp8wgxHb
