### PR TITLE
runner: an updater-only change is a deploy — update_runner.sh joins SHA_PATHS

### DIFF
--- a/.github/workflows/deploy-labs.yml
+++ b/.github/workflows/deploy-labs.yml
@@ -134,7 +134,7 @@ jobs:
       - name: Resolve cloud runner code sha
         id: cloud_sha
         run: |
-          PATHS="runner/ec2/cloud_runner.py runner/ec2/bootstrap_agents.sh"
+          PATHS="runner/ec2/cloud_runner.py runner/ec2/bootstrap_agents.sh runner/ec2/update_runner.sh"
           SHA="$(git log -1 --format=%H -- $PATHS)"
           TS="$(git log -1 --format=%ct -- $PATHS)"
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"

--- a/runner/ec2/tests/test_update_runner_sh.py
+++ b/runner/ec2/tests/test_update_runner_sh.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import pathlib
+import re
 import subprocess
 import time
 
@@ -79,12 +80,14 @@ class Box:
         src.mkdir(parents=True, exist_ok=True)
         (src / "cloud_runner.py").write_text(runner_source)
         (src / "bootstrap_agents.sh").write_text("#!/bin/bash\n")
+        (src / "update_runner.sh").write_text("#!/bin/bash\n")
         if first:
             _git(self.repo.parent, "init", "-q", "canopy-web")
         _git(self.repo, "add", "-A")
         _git(self.repo, "commit", "-q", "--allow-empty", "-m", "runner")
         return _git(self.repo, "log", "-1", "--format=%H", "--",
-                    "runner/ec2/cloud_runner.py", "runner/ec2/bootstrap_agents.sh")
+                    "runner/ec2/cloud_runner.py", "runner/ec2/bootstrap_agents.sh",
+                    "runner/ec2/update_runner.sh")
 
     def stamp(self, sha: str, committed_at: int = 1) -> None:
         (self.home / "build-info.json").write_text(
@@ -314,3 +317,35 @@ def test_the_credentials_refresh_sees_the_runners_env(box):
     assert "args=--credentials-only" in lines
     assert "CANOPY_TOKEN=tok" in lines, "no token → no vault config, no canopy-web token"
     assert "GOG_KEYRING_PASSWORD=kp" in lines, "no keyring password → every mailbox reads as dead"
+
+
+# --- the updater itself ships by deploy -------------------------------------
+#
+# The shim reads update_runner.sh from the clone's origin/main WITHOUT fetching;
+# origin/main only moves when the install path runs, and that only happens when a
+# SHA_PATHS file changes. With update_runner.sh absent from the list, an updater-
+# only change never reached a box (#742: merged, and the next tick still ran the
+# old script). The two lists — here and in deploy-labs.yml — must agree, and both
+# must name the updater.
+def test_the_updater_is_in_both_sha_path_lists_and_they_agree():
+    script = SCRIPT.read_text()
+    m = re.search(r'^SHA_PATHS=\((.*)\)$', script, re.M)
+    assert m, "SHA_PATHS not found in update_runner.sh"
+    script_paths = re.findall(r'"([^"]+)"', m.group(1))
+    workflow = (SCRIPT.parent.parent.parent / ".github" / "workflows" / "deploy-labs.yml").read_text()
+    m2 = re.search(r'^\s*PATHS="([^"]+)"', workflow, re.M)
+    assert m2, "cloud_sha PATHS not found in deploy-labs.yml"
+    workflow_paths = m2.group(1).split()
+    assert script_paths == workflow_paths, "the script and the deploy compute the sha over different files"
+    assert "runner/ec2/update_runner.sh" in script_paths, "an updater-only change must be a deploy"
+
+
+def test_a_change_to_the_updater_alone_moves_the_deployed_sha(box):
+    before = box.seed_repo(GOOD_RUNNER)
+    (box.repo / "runner" / "ec2" / "update_runner.sh").write_text("#!/bin/bash\n# changed\n")
+    _git(box.repo, "add", "-A")
+    _git(box.repo, "commit", "-q", "-m", "updater only")
+    after = _git(box.repo, "log", "-1", "--format=%H", "--",
+                 "runner/ec2/cloud_runner.py", "runner/ec2/bootstrap_agents.sh",
+                 "runner/ec2/update_runner.sh")
+    assert after != before

--- a/runner/ec2/update_runner.sh
+++ b/runner/ec2/update_runner.sh
@@ -60,7 +60,15 @@ RUNNER_SRC="runner/ec2/cloud_runner.py"
 # The paths the DEPLOYED sha is computed over (deploy-labs.yml's cloud_sha step).
 # Kept identical here so a stamp written by this script names the same commit the
 # server expects — bootstrap_agents.sh included, because a restart is how it ships.
-SHA_PATHS=("runner/ec2/cloud_runner.py" "runner/ec2/bootstrap_agents.sh")
+# update_runner.sh is in this list ON PURPOSE. The shim at
+# /usr/local/bin/canopy-runner-update reads THIS script from the clone's origin/main
+# without fetching, and origin/main only moves when the install path runs — which
+# only happens when one of these files changes. So an updater-only change never
+# reached a box: #742 merged 13:3xZ on 2026-09-10 and the 13:40Z tick still ran the
+# old script. Listing it here makes an updater change a deploy, as the shim's own
+# comment already claims. Keep in step with deploy-labs.yml's cloud_sha step —
+# runner/ec2/tests/test_update_runner_sh.py pins the two lists equal.
+SHA_PATHS=("runner/ec2/cloud_runner.py" "runner/ec2/bootstrap_agents.sh" "runner/ec2/update_runner.sh")
 # The daemon rewrites the busy marker every heartbeat (20s). Older than this means
 # it is not running its loop at all — stopped, wedged, or crash-looping. That is
 # NOT busy: it is the case this script exists to rescue, so it must never block.


### PR DESCRIPTION
Follow-up to #742.

## What was wrong

The shim at `/usr/local/bin/canopy-runner-update` says "the updater itself ships by deploy rather than being frozen here". It does not. The shim reads `origin/main:runner/ec2/update_runner.sh` from the clone **without fetching**; `origin/main` in the clone only moves when the install path runs (`git fetch origin main` is its fallback), and the install path only runs when a `SHA_PATHS` file changes. `update_runner.sh` was not in that list — in the script or in `deploy-labs.yml`'s `cloud_sha` step.

So an updater-only change never reaches a box. Measured: #742 merged at 13:3xZ on 2026-09-10; the 13:40Z tick on cloud-ec2-1 still ran the old script (the clone's `origin/main` sat at `9f50d91`, 11:50Z). It ran the new one only after a hand `git fetch origin main` in the clone at 13:43Z.

## What this does

Adds `runner/ec2/update_runner.sh` to `SHA_PATHS` in the script and to `PATHS` in the workflow's `cloud_sha` step, so a change to the updater is a deploy like a change to `bootstrap_agents.sh` already is: the install path fetches, `origin/main` moves, the shim reads the new script on its next tick. The fixture in `test_update_runner_sh.py` mirrors the list.

## Tests

Two new. `test_the_updater_is_in_both_sha_path_lists_and_they_agree` parses both lists and pins them equal and containing the updater — fails on main (`an updater-only change must be a deploy`). `test_a_change_to_the_updater_alone_moves_the_deployed_sha` shows the path-scoped sha moves on an updater-only commit. 32 pass across the updater suites.

## Residual

Merging this changes a SHA_PATHS file, so it deploys itself: the box will install and restart once on the next deploy-labs run. Not re-observed before merge; I will confirm the runner's `code_sha` advances and note it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3NusdwbrWGsWRwp8wgxHb
