### PR TITLE
Opening canopy to other people: first run, /guide, /about

### DIFF
--- a/apps/common/api.py
+++ b/apps/common/api.py
@@ -41,6 +41,8 @@ def health(request: HttpRequest) -> HealthOut:
 
 @common_router.get("/me/", response=MeOut, summary="Current user")
 def me(request: HttpRequest) -> MeOut:
+    from apps.workspaces.services import can_create_workspace
+
     user = request.user
     avatar_url = ""
     social = (
@@ -54,6 +56,7 @@ def me(request: HttpRequest) -> MeOut:
         email=user.email,
         name=(user.get_full_name() or user.username or user.email),
         avatar_url=avatar_url,
+        can_create_workspace=can_create_workspace(user),
     )
 
 

--- a/apps/common/middleware.py
+++ b/apps/common/middleware.py
@@ -40,7 +40,10 @@ PUBLIC_PATH_PREFIXES = (
     "/api/auth/token-exchange",  # auth=None — self-enforces via the AppCredential Bearer header
     "/api/inbound/",          # auth=None — self-enforces via the Google-signed OIDC push token
     "/api/system/public-stats",  # auth=None — aggregates only, no names/ids (public explainer)
-    "/about",  # the public explainer page shell (its stats API is allowlisted above)
+    # NOTE: "/about" is NOT here. Every other entry above ends in "/" (or is a
+    # full path), so prefix-matching it is safe; "/about" alone would also
+    # admit any future "/about-billing" or "/aboutus" route as a side effect.
+    # See `_is_about` below for the exact-match version.
 )
 
 
@@ -138,6 +141,14 @@ def _is_storyboard_link(request) -> bool:
     return path.startswith("/api/storyboards/")
 
 
+def _is_about(path: str) -> bool:
+    # The public explainer page shell. Exact match ONLY — its stats API is
+    # allowlisted separately in PUBLIC_PATH_PREFIXES — so a future route that
+    # merely begins "/about" (e.g. "/about-billing", "/aboutus") does not
+    # silently become public too.
+    return path == "/about"
+
+
 def _is_ddd_release_link(request) -> bool:
     # /ddd-release/<slug>/<run_id> (SPA shell) and the read API
     # (/api/ddd/release/<run_id>/) self-enforce the ?t=<share_token> gate (or a
@@ -173,6 +184,7 @@ class LoginRequiredMiddleware:
         if (
             request.user.is_authenticated
             or _is_public(request.path)
+            or _is_about(request.path)
             or _is_walkthrough_link(request)
             or _is_review_link(request.path)
             or _is_share_link(request.path)

--- a/apps/common/middleware.py
+++ b/apps/common/middleware.py
@@ -40,6 +40,7 @@ PUBLIC_PATH_PREFIXES = (
     "/api/auth/token-exchange",  # auth=None — self-enforces via the AppCredential Bearer header
     "/api/inbound/",          # auth=None — self-enforces via the Google-signed OIDC push token
     "/api/system/public-stats",  # auth=None — aggregates only, no names/ids (public explainer)
+    "/about",  # the public explainer page shell (its stats API is allowlisted above)
 )
 
 

--- a/apps/common/middleware.py
+++ b/apps/common/middleware.py
@@ -39,6 +39,7 @@ PUBLIC_PATH_PREFIXES = (
     # query string too AND keeps the prefix, so it is the correct handler.
     "/api/auth/token-exchange",  # auth=None — self-enforces via the AppCredential Bearer header
     "/api/inbound/",          # auth=None — self-enforces via the Google-signed OIDC push token
+    "/api/system/public-stats",  # auth=None — aggregates only, no names/ids (public explainer)
 )
 
 

--- a/apps/common/schemas.py
+++ b/apps/common/schemas.py
@@ -41,11 +41,15 @@ class MeOut(StrictModel):
     email: EmailStr
     name: str
     avatar_url: str
-    can_create_workspace: bool = False
-    """Whether this caller may POST /api/workspaces/. False for an
-    invite-admitted user holding no membership — see the F1 finding in
-    apps.workspaces.services.can_create_workspace. The first-run screen reads
-    this so it never offers a button that 403s."""
+    can_create_workspace: bool = Field(
+        default=False,
+        description=(
+            "Whether this caller may POST /api/workspaces/. False for an "
+            "invite-admitted user holding no membership — see the F1 finding "
+            "in apps.workspaces.services.can_create_workspace. The first-run "
+            "screen reads this so it never offers a button that 403s."
+        ),
+    )
 
 
 class PresencePreferenceOut(StrictModel):

--- a/apps/common/schemas.py
+++ b/apps/common/schemas.py
@@ -41,6 +41,11 @@ class MeOut(StrictModel):
     email: EmailStr
     name: str
     avatar_url: str
+    can_create_workspace: bool = False
+    """Whether this caller may POST /api/workspaces/. False for an
+    invite-admitted user holding no membership — see the F1 finding in
+    apps.workspaces.services.can_create_workspace. The first-run screen reads
+    this so it never offers a button that 403s."""
 
 
 class PresencePreferenceOut(StrictModel):

--- a/apps/system/api.py
+++ b/apps/system/api.py
@@ -44,9 +44,9 @@ def public_stats(request: HttpRequest) -> dict:
     NOTE: `auth=None` is half the story — apps/common/middleware.py is
     default-deny, so this path is also allowlisted there. Both are required.
 
-    Placement matters: declared ABOVE `detail()` (`/{kind}/{name}`), since
-    Ninja resolves routes in declaration order and `detail` would otherwise
-    capture `public-stats` as a `kind`.
+    Declared above `detail()` for readability. `/{kind}/{name}` is two path
+    segments, so it cannot capture this single-segment route — the order is
+    not load-bearing.
     """
     return stats.public_stats()
 

--- a/apps/system/api.py
+++ b/apps/system/api.py
@@ -14,8 +14,8 @@ from ninja import Router
 from apps.api.auth import session_auth
 from apps.api.errors import TYPE_NOT_FOUND, ProblemError
 
-from . import reader
-from .schemas import CapabilityCatalogOut, CapabilityDetailOut
+from . import reader, stats
+from .schemas import CapabilityCatalogOut, CapabilityDetailOut, PublicStatsOut
 
 router = Router(auth=session_auth, tags=["system"])
 
@@ -30,6 +30,25 @@ def overview(request: HttpRequest) -> dict:
         **cat,
         "items": [{k: v for k, v in item.items() if k != "body"} for item in cat["items"]],
     }
+
+
+@router.get(
+    "/public-stats",
+    response=PublicStatsOut,
+    auth=None,
+    summary="Aggregate counts for the public explainer (anonymous)",
+)
+def public_stats(request: HttpRequest) -> dict:
+    """Anonymous, aggregates only.
+
+    NOTE: `auth=None` is half the story — apps/common/middleware.py is
+    default-deny, so this path is also allowlisted there. Both are required.
+
+    Placement matters: declared ABOVE `detail()` (`/{kind}/{name}`), since
+    Ninja resolves routes in declaration order and `detail` would otherwise
+    capture `public-stats` as a `kind`.
+    """
+    return stats.public_stats()
 
 
 @router.get("/{kind}/{name}", response=CapabilityDetailOut)

--- a/apps/system/schemas.py
+++ b/apps/system/schemas.py
@@ -32,3 +32,13 @@ class CapabilityCatalogOut(StrictModel):
     counts: dict[str, int]
     plugin_version: str | None = None
     warning: str | None = None
+
+
+class PublicStatsOut(StrictModel):
+    """Aggregates for the public explainer. Integers only — see apps/system/stats.py."""
+
+    agents: int
+    skills: int
+    runners_online: int
+    turns_executed: int
+    demos_published: int

--- a/apps/system/stats.py
+++ b/apps/system/stats.py
@@ -13,9 +13,12 @@ accepted:
     ACTIVITY: throughput per minute, whether any box is currently up at all
     (effectively presence for a small named team), and the moment a demo
     package gets created (a step change in `demos_published`).
-  - `demos_published` counts distinct `run_id`s across ALL tenants and ALL
-    visibilities, including `private` walkthroughs — a private run still
-    increments the public total.
+  - `demos_published` counts distinct `run_id`s across ALL tenants, but only
+    `link`-visibility walkthroughs — a `private` run does NOT increment the
+    public total. Now that canopy is open to a second tenant, folding another
+    tenant's private packages into a number the internet can see would be a
+    disclosure made on their behalf without asking, even though the count
+    itself carries no name/slug/id. See apps/walkthroughs/apps.py.
 Neither is a names/slugs/ids leak, so neither changes the type-closed
 contract this module enforces. But "aggregates are safe" is not an
 unconditional license — a future stat that narrows the denominator (e.g. "per
@@ -95,6 +98,10 @@ def _extra(name: str) -> int:
     """
     fn = _EXTRA.get(name)
     if fn is None:
+        # CI catches a de-registration today (a coverage test would fail), but
+        # an INSTALLED_APPS change plus a matching test edit would not — log so
+        # there's a signal even then.
+        logger.warning("public stats contributor %r is not registered", name)
         return 0
     try:
         return int(fn())

--- a/apps/system/stats.py
+++ b/apps/system/stats.py
@@ -6,11 +6,28 @@ whole reason this is safe to serve anonymously. Adding a non-integer field here
 is a security change, and tests/test_public_stats.py fails on the type rather
 than on a denylist of names so that it cannot be done by accident.
 
+That said, "a count cannot leak what it is a count of" is the right frame for
+*identity*, not for everything else these numbers can carry. Considered and
+accepted:
+  - Five monotonic global counters, pollable at 60s granularity, reveal fleet
+    ACTIVITY: throughput per minute, whether any box is currently up at all
+    (effectively presence for a small named team), and the moment a demo
+    package gets created (a step change in `demos_published`).
+  - `demos_published` counts distinct `run_id`s across ALL tenants and ALL
+    visibilities, including `private` walkthroughs — a private run still
+    increments the public total.
+Neither is a names/slugs/ids leak, so neither changes the type-closed
+contract this module enforces. But "aggregates are safe" is not an
+unconditional license — a future stat that narrows the denominator (e.g. "per
+customer" instead of "global") would reopen exactly the question this module
+was written to close.
+
 No Django request object — pure functions over the ORM, so they are testable
 directly.
 """
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 
 from django.conf import settings
@@ -21,6 +38,8 @@ from apps.agents.models import Agent
 from apps.harness.models import HEARTBEAT_ONLINE_WINDOW, Runner, Turn
 
 from . import reader
+
+logger = logging.getLogger(__name__)
 
 #: Product apps contribute counts here from their AppConfig.ready(). This app is
 #: FRAMEWORK and must not import PRODUCT (tests/test_architecture_boundary.py),
@@ -37,26 +56,34 @@ def register_extra_stat(name: str, fn: Callable[[], int]) -> None:
 def _skill_count() -> int:
     try:
         cat = reader.load_catalog(settings.CANOPY_PLUGIN_PATH)
+        return int(cat.get("counts", {}).get("skill", 0))
     except Exception:  # noqa: BLE001 — a missing plugin path must not 500 a public page
         return 0
-    return int(cat.get("counts", {}).get("skill", 0))
 
 
 def _runners_online() -> int:
-    """Runners with a fresh heartbeat, excluding retired boxes.
+    """Runners with a fresh heartbeat, ONLINE, and not paused.
 
     `Runner.live_status` is a PROPERTY, not a column, so it cannot be filtered
-    on. This is its DB-expressible core: the same 90-second window
-    (HEARTBEAT_ONLINE_WINDOW) that live_status uses to demote a runner to STALE.
-    Deliberately NOT `is_available` — readiness is an operational detail and
-    "how many boxes are up" is the honest public number.
+    on directly — but its ONLINE branch is fully reproducible in SQL, which is
+    what this does: a fresh heartbeat (the same 90-second HEARTBEAT_ONLINE_WINDOW
+    that live_status uses to demote a runner to STALE) on a runner whose
+    self-reported `status` is ONLINE and whose `paused` column (a real field,
+    not derived) is False.
+
+    Excluding RETIRED alone is not enough: pausing a box is routine in this
+    fleet (token exhaustion -> shift to the next account), and a paused or
+    degraded runner still heartbeats — so counting on heartbeat-freshness alone
+    would inflate "online" exactly when the fleet is degraded, which is the one
+    time this number matters most. Deliberately NOT `is_available` — readiness
+    (whether it's REPORTING ITSELF ready to claim work) is an operational
+    detail; "how many boxes are up and not deliberately parked" is the honest
+    public number.
     """
     cutoff = timezone.now() - HEARTBEAT_ONLINE_WINDOW
-    return (
-        Runner.objects.exclude(status=Runner.RETIRED)
-        .filter(last_heartbeat_at__gte=cutoff)
-        .count()
-    )
+    return Runner.objects.filter(
+        status=Runner.ONLINE, paused=False, last_heartbeat_at__gte=cutoff
+    ).count()
 
 
 def _extra(name: str) -> int:
@@ -72,15 +99,23 @@ def _extra(name: str) -> int:
     try:
         return int(fn())
     except Exception:  # noqa: BLE001 — one bad contributor must not 500 a public page
+        # Logged, not silent: a contributor that silently fails (e.g. after a
+        # field rename in the registering app) would otherwise report 0
+        # forever with no signal that anything is wrong.
+        logger.exception("public stats contributor %r failed", name)
         return 0
 
 
 #: Short TTL on an ANONYMOUS endpoint, so an unauthenticated caller cannot turn
-#: this into a free load generator against the database. 60s is well inside what
-#: a counts display needs to be truthful. The project configures no `CACHES`, so
-#: this is Django's default per-process LocMemCache — each web process computing
-#: the counts once a minute is fine, and the pattern matches
-#: `apps/canopy_sessions/attach.py` and `apps/mcp/rate_limit.py`.
+#: this into a free load generator against the database. 60s is well inside
+#: what a counts display needs to be truthful. In production
+#: (config/settings/connectlabs.py) `CACHES` points at the shared ElastiCache
+#: Redis whenever `REDIS_URL` is set, so this is one recompute per 60s for the
+#: WHOLE FLEET, not per process — a better bound than a per-process cache would
+#: give. Locally/in tests, with no `CACHES` configured, Django falls back to
+#: its default per-process LocMemCache. Either way `public_stats()` below
+#: treats the cache as unreliable (network-backed in prod) and never lets a
+#: cache outage 500 this page.
 _CACHE_KEY = "system:public-stats:v1"
 _CACHE_TTL = 60
 
@@ -98,9 +133,15 @@ def _compute() -> dict[str, int]:
 
 
 def public_stats() -> dict[str, int]:
-    cached = cache.get(_CACHE_KEY)
+    try:
+        cached = cache.get(_CACHE_KEY)
+    except Exception:  # noqa: BLE001 — Redis in prod; an outage must not 500 a public page
+        return _compute()
     if cached is not None:
         return cached
     stats = _compute()
-    cache.set(_CACHE_KEY, stats, timeout=_CACHE_TTL)
+    try:
+        cache.set(_CACHE_KEY, stats, timeout=_CACHE_TTL)
+    except Exception:  # noqa: BLE001 — same: a failed cache WRITE must not 500 either
+        pass
     return stats

--- a/apps/system/stats.py
+++ b/apps/system/stats.py
@@ -1,0 +1,106 @@
+"""Aggregate counts for the public explainer page.
+
+Aggregates ONLY — no names, no slugs, no ids, no per-agent or per-tenant
+breakdown, no content. A count cannot leak what it is a count of, which is the
+whole reason this is safe to serve anonymously. Adding a non-integer field here
+is a security change, and tests/test_public_stats.py fails on the type rather
+than on a denylist of names so that it cannot be done by accident.
+
+No Django request object — pure functions over the ORM, so they are testable
+directly.
+"""
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from django.conf import settings
+from django.core.cache import cache
+from django.utils import timezone
+
+from apps.agents.models import Agent
+from apps.harness.models import HEARTBEAT_ONLINE_WINDOW, Runner, Turn
+
+from . import reader
+
+#: Product apps contribute counts here from their AppConfig.ready(). This app is
+#: FRAMEWORK and must not import PRODUCT (tests/test_architecture_boundary.py),
+#: so the arrow has to point inward: product names framework, never the reverse.
+#: Same reason apps/timeline reads product events through a registry.
+_EXTRA: dict[str, Callable[[], int]] = {}
+
+
+def register_extra_stat(name: str, fn: Callable[[], int]) -> None:
+    """Register a product-owned count. Idempotent — re-registering replaces."""
+    _EXTRA[name] = fn
+
+
+def _skill_count() -> int:
+    try:
+        cat = reader.load_catalog(settings.CANOPY_PLUGIN_PATH)
+    except Exception:  # noqa: BLE001 — a missing plugin path must not 500 a public page
+        return 0
+    return int(cat.get("counts", {}).get("skill", 0))
+
+
+def _runners_online() -> int:
+    """Runners with a fresh heartbeat, excluding retired boxes.
+
+    `Runner.live_status` is a PROPERTY, not a column, so it cannot be filtered
+    on. This is its DB-expressible core: the same 90-second window
+    (HEARTBEAT_ONLINE_WINDOW) that live_status uses to demote a runner to STALE.
+    Deliberately NOT `is_available` — readiness is an operational detail and
+    "how many boxes are up" is the honest public number.
+    """
+    cutoff = timezone.now() - HEARTBEAT_ONLINE_WINDOW
+    return (
+        Runner.objects.exclude(status=Runner.RETIRED)
+        .filter(last_heartbeat_at__gte=cutoff)
+        .count()
+    )
+
+
+def _extra(name: str) -> int:
+    """A registered product count, or 0 if that app did not register one.
+
+    Defaulting to 0 rather than omitting the key keeps PublicStatsOut's field set
+    CLOSED, which is what the leak test asserts — a dynamic response shape would
+    make "only integers, only these keys" unenforceable.
+    """
+    fn = _EXTRA.get(name)
+    if fn is None:
+        return 0
+    try:
+        return int(fn())
+    except Exception:  # noqa: BLE001 — one bad contributor must not 500 a public page
+        return 0
+
+
+#: Short TTL on an ANONYMOUS endpoint, so an unauthenticated caller cannot turn
+#: this into a free load generator against the database. 60s is well inside what
+#: a counts display needs to be truthful. The project configures no `CACHES`, so
+#: this is Django's default per-process LocMemCache — each web process computing
+#: the counts once a minute is fine, and the pattern matches
+#: `apps/canopy_sessions/attach.py` and `apps/mcp/rate_limit.py`.
+_CACHE_KEY = "system:public-stats:v1"
+_CACHE_TTL = 60
+
+
+def _compute() -> dict[str, int]:
+    return {
+        "agents": Agent.objects.count(),
+        "skills": _skill_count(),
+        "runners_online": _runners_online(),
+        # DONE only — "turns executed" should not count failures or cancellations.
+        # Hits the ("status", "created_at") index on its leading column.
+        "turns_executed": Turn.objects.filter(status=Turn.DONE).count(),
+        "demos_published": _extra("demos_published"),
+    }
+
+
+def public_stats() -> dict[str, int]:
+    cached = cache.get(_CACHE_KEY)
+    if cached is not None:
+        return cached
+    stats = _compute()
+    cache.set(_CACHE_KEY, stats, timeout=_CACHE_TTL)
+    return stats

--- a/apps/walkthroughs/apps.py
+++ b/apps/walkthroughs/apps.py
@@ -4,3 +4,26 @@ from django.apps import AppConfig
 class WalkthroughsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "apps.walkthroughs"
+
+    def ready(self) -> None:
+        # Contribute the published-demo count to the framework's public stats.
+        # Registered from HERE, not imported from there: apps/system is FRAMEWORK
+        # and must not name a PRODUCT module (tests/test_architecture_boundary.py).
+        # In ready() so it runs once, after the app registry is populated.
+        from apps.system.stats import register_extra_stat
+
+        from .models import Walkthrough
+
+        def demos_published() -> int:
+            # A "run package" is a derived grouping of Walkthrough rows by
+            # run_id (apps/runs/aggregate.py) — apps/runs has no models. Counting
+            # rows would inflate it: one package is a video AND a deck.
+            return (
+                Walkthrough.objects.exclude(run_id__isnull=True)
+                .exclude(run_id="")
+                .values("run_id")
+                .distinct()
+                .count()
+            )
+
+        register_extra_stat("demos_published", demos_published)

--- a/apps/walkthroughs/apps.py
+++ b/apps/walkthroughs/apps.py
@@ -18,8 +18,15 @@ class WalkthroughsConfig(AppConfig):
             # A "run package" is a derived grouping of Walkthrough rows by
             # run_id (apps/runs/aggregate.py) — apps/runs has no models. Counting
             # rows would inflate it: one package is a video AND a deck.
+            #
+            # Excludes `private` walkthroughs. This is a public counter spanning
+            # every tenant, and canopy is now open to a second tenant — counting
+            # another tenant's private packages into a number the internet can
+            # see is a disclosure made on their behalf without asking, even
+            # though the count itself carries no name/slug/id.
             return (
-                Walkthrough.objects.exclude(run_id__isnull=True)
+                Walkthrough.objects.filter(visibility=Walkthrough.VISIBILITY_LINK)
+                .exclude(run_id__isnull=True)
                 .exclude(run_id="")
                 .values("run_id")
                 .distinct()

--- a/docs/architecture/api-surface.md
+++ b/docs/architecture/api-surface.md
@@ -412,6 +412,22 @@ Push needs BOTH keys: either one empty → the endpoints 503 (`_push_configured`
 ### System (`apps/system`)
 - `GET /api/system/overview` — Capability catalog: the canopy plugin's skills/agents/commands, read live from the plugin.
 - `GET /api/system/{kind}/{name}` — Capability detail for one skill/agent/command. Drives the `/system` Workflows view.
+- `GET /api/system/public-stats` — **The only anonymous route in this surface** (`auth=None`).
+  Five aggregate integers — agents, skills, runners online, turns executed, published demo
+  packages — powering the live counts on the public explainer at `/about`. Safe to serve
+  unauthenticated for one reason: *a count cannot leak what it is a count of.* Hence the
+  guards: integers ONLY (no names, slugs, ids, timestamps, or per-agent/per-tenant
+  breakdown), the response shape closed by TYPE in `tests/test_public_stats.py` rather than
+  by a denylist of field names (the realistic failure is a helpful field added months from
+  now, which no denylist anticipates), and a 60s cache so an anonymous caller cannot turn it
+  into a free load generator. Being public needs TWO changes, not one — `auth=None` here AND
+  an entry in `apps/common/middleware.py`'s `PUBLIC_PATH_PREFIXES`, since the login
+  middleware is default-deny; `tests/test_public_routes_reachable.py` pins the second half,
+  which is otherwise untested because `REQUIRE_AUTH=False` makes that middleware inert
+  suite-wide. Accepted residual: monotonic counters polled at 60s reveal fleet *activity*
+  (throughput, whether any box is up, when a demo appears) even though they reveal no
+  identity, and `demos_published` counts runs across all tenants and visibilities including
+  private. See `docs/superpowers/specs/2026-09-12-opening-canopy-to-other-people-design.md`.
 
 ### MCP (`apps/mcp`, mounted at `/api/mcp/`)
 Not a Ninja router — a FastMCP 3.x Streamable-HTTP ASGI app mounted in `config/asgi.py`. Auth is enforced inside the server via `MultiAuth` (per-user PAT `CanopyPATVerifier`, always on; interactive Google OAuth is an env-gated seam, `MCP_OAUTH_ENABLED`). Every tool call writes an `MCPAuditLog` row; mutating tools are rate-limited per user. Tools today: `list_insights` + `clear_insights` (insights), and `list_schedules` / `preview_cron` (read) + `create_schedule` / `update_schedule` / `delete_schedule` / `run_schedule_now` (write) for recurring turns. The schedule tools call `apps/harness/schedule_services.py`, the same request-free service layer the REST routes call, so the MCP and REST surfaces can't drift. The legacy single-shared `CANOPY_MCP_BEARER` and the hand-rolled ASGI gate are gone. See `docs/architecture/mcp-surface.md`.

--- a/docs/superpowers/plans/2026-09-12-opening-canopy-to-other-people.md
+++ b/docs/superpowers/plans/2026-09-12-opening-canopy-to-other-people.md
@@ -41,10 +41,22 @@ for generated API types.
 - **Backend tests** go in root `tests/test_*.py` for cross-cutting concerns, or
   `apps/<app>/tests/test_*.py` where that app already has a `tests/` package
   (`apps/workspaces/tests/` does).
-- **Frontend tests** are vitest, colocated as `<module>.test.ts(x)`. There is **no
-  jsdom / testing-library** configured — test pure functions and extracted logic, never
-  by mounting React components. This is why logic gets extracted into plain `.ts` modules
-  (the precedent is `frontend/src/workspace/resolveActiveWorkspace.ts`).
+- **Frontend tests** are vitest, colocated as `<module>.test.ts(x)`. **jsdom 29 and
+  `@testing-library/react` 16 ARE installed and used** — there are ~10 component tests
+  calling `render()` (`PublicHeader.test.tsx`, `ChatSessionsPanel.test.tsx`,
+  `RunnerAssignments.test.tsx`, …), so mounting a component in a test is available to you.
+  (An earlier revision of this plan claimed otherwise, propagating a stale comment at
+  `frontend/src/workspace/resolveActiveWorkspace.ts:2`. That comment is wrong; the plan
+  was wrong for repeating it.) Still prefer extracting decision logic into a plain `.ts`
+  module and testing it directly — it is faster and less brittle than asserting on
+  rendered output — but a component test is a legitimate choice where the behaviour only
+  exists once mounted.
+- **A task that changes a Pydantic response schema MUST run `cd frontend && npm run build`,
+  not just the backend tests.** Fields in `generated.ts` are non-optional, so adding one
+  to a response model breaks every test file that constructs a mock of it — and those
+  files are usually nowhere near your diff. Task 1 shipped exactly this break (two
+  `tsc` failures in `PublicHeader.test.tsx` and `NoteComposer.test.tsx`) because its
+  verification ran `pytest` only. Task 10 adds `PublicStatsOut`; do not repeat it.
 - **Open PRs with auto-merge armed**: `gh pr merge <n> --auto`. Never pass `--squash` or
   any strategy flag — the merge queue owns the strategy and a strategy flag leaves
   auto-merge UNARMED. Verify with `gh pr view <n> --json autoMergeRequest`.
@@ -260,8 +272,9 @@ F1 finding). Surfacing the gate is what lets the UI show the right thing."
 workspace. A signed-in user with no membership therefore sees an empty app shell — no
 error, no message, nothing. This is the literal first screen of the power-user rollout.
 
-The state logic goes in a plain `.ts` module because there is no jsdom in this project;
-pure logic is the only thing that can be unit-tested here.
+The state logic goes in a plain `.ts` module because a pure function is the cheapest,
+least brittle place to pin a three-way decision — not because component testing is
+unavailable (it is available; see Global Constraints).
 
 **No backend test needed for the create endpoint.** `apps/workspaces/tests/test_api.py`
 already covers both error paths this screen must handle: the 403 for an ineligible caller
@@ -329,9 +342,9 @@ Create `frontend/src/pages/firstRun.ts`:
 
 ```typescript
 /**
- * Which first-run state applies. Extracted as a pure function because this
- * project has no jsdom/testing-library — logic in a .ts module is the only
- * thing unit-testable here (same reason as workspace/resolveActiveWorkspace.ts).
+ * Which first-run state applies. Extracted as a pure function so the three-way
+ * decision can be pinned directly, without mounting anything — cheaper and less
+ * brittle than asserting on rendered output.
  *
  * There are THREE zero-workspace states, not one. An invite-admitted user who
  * holds no membership may not create a workspace (the F1 finding — see
@@ -371,7 +384,11 @@ export async function createWorkspace(
   const res = await apiV2.POST('/api/workspaces/', {
     body: { slug, display_name: displayName },
   })
-  if (res.error) {
+  // Branch on `res.response.ok`, NOT on `res.error` — this endpoint declares only a
+  // 201 in the OpenAPI schema, so `res.error` narrows to `never` and `if (res.error)`
+  // fails tsc. `frontend/src/api/workspaces.ts:32-36` documents this convention and
+  // every other function in the file follows it.
+  if (!res.response.ok) {
     // 409 = slug taken, 403 = not eligible (F1), 422 = bad slug charset.
     // The server's problem+json `detail` is the only message worth showing:
     // the slug rules are enforced by Workspace.SLUG_PATTERN server-side and

--- a/docs/superpowers/plans/2026-09-12-opening-canopy-to-other-people.md
+++ b/docs/superpowers/plans/2026-09-12-opening-canopy-to-other-people.md
@@ -1,0 +1,2480 @@
+# Opening Canopy To Other People — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make canopy-web usable by a power user who is not Jonathan — close the four
+first-run dead ends, add a route-derived in-app guide that cannot silently miss a
+surface, and publish a public explainer with live counts.
+
+**Architecture:** Three independent parts. **A1** wires four existing API writes to UI
+that does not exist (workspace create, PAT management, a real first-run screen).
+**B** adds a colocated descriptor registry keyed by the route table, a `/guide` page that
+renders it grouped by the existing nav, and one fast two-direction coverage test. **C**
+adds an anonymous aggregates-only `/api/system/public-stats` and a chrome-less public
+explainer page on `PublicLayout`. B and C share one registry of user paths so the public
+promise cannot drift from the internal docs.
+
+**Tech Stack:** Django 5 + Django Ninja 1.x + Pydantic v2 (backend), React 19 + Vite +
+Tailwind 4 (frontend), pytest (backend tests), vitest (frontend tests), `openapi-typescript`
+for generated API types.
+
+**Spec:** `docs/superpowers/specs/2026-09-12-opening-canopy-to-other-people-design.md`
+
+## Global Constraints
+
+- **Design tokens only.** Never introduce raw Tailwind palette literals (`stone-*`,
+  `orange-*`, `zinc-*`, `slate-*`, `red-*`, `amber-*`, `emerald-*`, `sky-*`, `violet-*`).
+  Use `bg-background`, `bg-card`, `bg-muted`, `border-border`, `text-foreground`,
+  `text-foreground-secondary`, `text-muted-foreground`, `text-foreground-subtle`,
+  `bg-primary`/`text-primary`, and the status tokens `success`/`warning`/`info`/`special`/`destructive`.
+- **All schemas subclass `StrictModel`** from `apps.common.schemas`.
+- **Errors are RFC 7807.** Raise `ProblemError` from `apps.api.errors`, or `HttpError`
+  where the surrounding file already does.
+- **When you change an `apps/**/schemas.py` or `api.py`, regenerate frontend types and
+  commit them**: `cd frontend && npm run gen:api` with the backend up on :8000, or
+  `npm run gen:api:local` against a dumped `openapi.json`.
+- **A public endpoint needs TWO changes, not one**: `auth=None` on the route AND an entry
+  in `PUBLIC_PATH_PREFIXES` (or a matcher) in `apps/common/middleware.py`. The login
+  middleware is default-deny; `auth=None` alone still bounces an anonymous caller to Google.
+- **No new CI workflow and no new CI job.** Everything runs inside the existing
+  `uv run pytest` and `cd frontend && npm run test` commands.
+- **Backend tests** go in root `tests/test_*.py` for cross-cutting concerns, or
+  `apps/<app>/tests/test_*.py` where that app already has a `tests/` package
+  (`apps/workspaces/tests/` does).
+- **Frontend tests** are vitest, colocated as `<module>.test.ts(x)`. There is **no
+  jsdom / testing-library** configured — test pure functions and extracted logic, never
+  by mounting React components. This is why logic gets extracted into plain `.ts` modules
+  (the precedent is `frontend/src/workspace/resolveActiveWorkspace.ts`).
+- **Open PRs with auto-merge armed**: `gh pr merge <n> --auto`. Never pass `--squash` or
+  any strategy flag — the merge queue owns the strategy and a strategy flag leaves
+  auto-merge UNARMED. Verify with `gh pr view <n> --json autoMergeRequest`.
+
+---
+
+## File Structure
+
+**Part A1 — first run**
+
+| File | Responsibility |
+|---|---|
+| `apps/common/schemas.py` (modify) | `MeOut` gains `can_create_workspace: bool` |
+| `apps/common/api.py` (modify, ~line 42) | `me()` populates it from `workspaces.services.can_create_workspace` |
+| `frontend/src/api/workspaces.ts` (modify) | `createWorkspace()` client call |
+| `frontend/src/api/tokens.ts` (create) | List / mint / revoke PAT client calls |
+| `frontend/src/pages/FirstRunPage.tsx` (create) | The zero-workspace screen |
+| `frontend/src/pages/firstRun.ts` (create) | Pure state logic — which of the three first-run states applies |
+| `frontend/src/pages/firstRun.test.ts` (create) | Tests for that logic |
+| `frontend/src/router.tsx` (modify) | `RootRedirect`/`TenantRedirect` render `FirstRunPage` instead of `null` |
+| `frontend/src/components/AppLayout/AppLayout.tsx` (modify, ~line 188) | Split the switcher guard from the create affordance |
+| `frontend/src/components/settings/TokensPanel.tsx` (create) | PAT list / mint / revoke UI |
+| `frontend/src/pages/SettingsPage.tsx` (modify) | Mount `TokensPanel` |
+
+**Part B — the self-documenting app**
+
+| File | Responsibility |
+|---|---|
+| `frontend/src/router.tsx` (modify) | Extract the inline route array to `export const routeTable` |
+| `frontend/src/guide/surfaces.ts` (create) | One descriptor per documented route — the registry |
+| `frontend/src/guide/paths.ts` (create) | The five ways in; shared by `/guide` and the public page |
+| `frontend/src/guide/coverage.ts` (create) | Pure helpers: flatten the route table, classify redirects |
+| `frontend/src/guide/coverage.test.ts` (create) | The two-direction coverage test |
+| `frontend/src/pages/GuidePage.tsx` (create) | Renders descriptors grouped by `NAV_GROUPS` |
+
+**Part C — the public explainer**
+
+| File | Responsibility |
+|---|---|
+| `apps/system/stats.py` (create) | Pure aggregate computation, no Django request objects |
+| `apps/system/schemas.py` (modify) | `PublicStatsOut` |
+| `apps/system/api.py` (modify) | `GET /public-stats`, `auth=None` |
+| `apps/common/middleware.py` (modify, `PUBLIC_PATH_PREFIXES`) | Allowlist `/api/system/public-stats` |
+| `tests/test_public_stats.py` (create) | Anonymous access + the no-leak assertion |
+| `frontend/src/api/publicStats.ts` (create) | Anonymous client call |
+| `frontend/src/pages/AboutPage.tsx` (create) | The public explainer |
+| `frontend/src/guide/components.ts` (create) | The five-component view data, shared by both pages |
+
+---
+
+## Task 1: Expose workspace-creation eligibility on `/api/me/`
+
+The first-run screen has **three** states, not two, and the third is a security
+invariant. `apps/workspaces/services.py:497` gates creation: an *invite-admitted* user
+who holds no membership must NOT be able to create a workspace, because that would make
+invite-admission transitively delegable (create a workspace → mint invites → each
+invitee clears the login gate too). This is the F1 security finding. So a first-run
+screen that always shows a create form would 403 for exactly those users. The screen has
+to know, which means `/api/me/` has to say.
+
+**Files:**
+- Modify: `apps/common/schemas.py:38-43` (`MeOut`)
+- Modify: `apps/common/api.py:42-57` (`me`)
+- Test: `tests/test_me_can_create_workspace.py`
+
+**Interfaces:**
+- Consumes: `apps.workspaces.services.can_create_workspace(user) -> bool` (exists).
+- Produces: `MeOut.can_create_workspace: bool`, reaching the frontend as
+  `components["schemas"]["MeOut"]["can_create_workspace"]`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_me_can_create_workspace.py`:
+
+```python
+"""GET /api/me/ reports whether the caller may create a workspace.
+
+The first-run screen needs this to avoid offering a button that 403s. The gate
+itself is apps.workspaces.services.can_create_workspace (the F1 finding).
+"""
+import pytest
+from django.contrib.auth import get_user_model
+
+from apps.workspaces.models import Workspace, WorkspaceMembership
+
+User = get_user_model()
+
+
+@pytest.fixture
+def allowlisted(db):
+    return User.objects.create_user(username="ally", email="ally@dimagi.com")
+
+
+@pytest.fixture
+def invited(db):
+    return User.objects.create_user(username="guest", email="guest@example.org")
+
+
+def test_allowlisted_domain_may_create(client, allowlisted):
+    client.force_login(allowlisted)
+    body = client.get("/api/me/").json()
+    assert body["can_create_workspace"] is True
+
+
+def test_invite_admitted_with_no_membership_may_not_create(client, invited):
+    client.force_login(invited)
+    body = client.get("/api/me/").json()
+    assert body["can_create_workspace"] is False
+
+
+def test_invite_admitted_with_a_membership_may_create(client, invited):
+    ws = Workspace.objects.create(slug="acme", display_name="Acme")
+    WorkspaceMembership.objects.create(
+        workspace=ws, user=invited, role=WorkspaceMembership.OWNER
+    )
+    client.force_login(invited)
+    body = client.get("/api/me/").json()
+    assert body["can_create_workspace"] is True
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `uv run pytest tests/test_me_can_create_workspace.py -v`
+Expected: FAIL — `KeyError: 'can_create_workspace'` on all three tests.
+
+- [ ] **Step 3: Add the field to `MeOut`**
+
+In `apps/common/schemas.py`, extend `MeOut`:
+
+```python
+class MeOut(StrictModel):
+    """Response for /api/me/."""
+
+    email: EmailStr
+    name: str
+    avatar_url: str
+    can_create_workspace: bool = False
+    """Whether this caller may POST /api/workspaces/. False for an
+    invite-admitted user holding no membership — see the F1 finding in
+    apps.workspaces.services.can_create_workspace. The first-run screen reads
+    this so it never offers a button that 403s."""
+```
+
+- [ ] **Step 4: Populate it in the view**
+
+In `apps/common/api.py`, inside `me()`, add the import at the top of the function body
+(a local import — `apps.common` is framework and must not grow a module-level dependency
+on another app's services at import time):
+
+```python
+def me(request: HttpRequest) -> MeOut:
+    from apps.workspaces.services import can_create_workspace
+
+    user = request.user
+    avatar_url = ""
+    social = (
+        user.socialaccount_set.filter(provider="google").first()
+        if hasattr(user, "socialaccount_set")
+        else None
+    )
+    if social:
+        avatar_url = social.extra_data.get("picture", "") or ""
+    return MeOut(
+        email=user.email,
+        name=(user.get_full_name() or user.username or user.email),
+        avatar_url=avatar_url,
+        can_create_workspace=can_create_workspace(user),
+    )
+```
+
+- [ ] **Step 5: Run the test and confirm it passes**
+
+Run: `uv run pytest tests/test_me_can_create_workspace.py -v`
+Expected: 3 passed.
+
+- [ ] **Step 6: Regenerate the frontend types**
+
+With the backend running on :8000:
+
+```bash
+cd frontend && npm run gen:api
+```
+
+Confirm `can_create_workspace` now appears in `src/api/generated.ts` under `MeOut`:
+
+```bash
+grep -n -A6 "MeOut:" src/api/generated.ts | head -12
+```
+
+- [ ] **Step 7: Run the full backend suite to check nothing else asserted MeOut's shape**
+
+Run: `uv run pytest -q`
+Expected: no new failures. `StrictModel` forbids unknown fields on *input*; adding an
+output field is safe, but a test asserting an exact response dict would break — fix any
+such test by adding the new key.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/common/schemas.py apps/common/api.py tests/test_me_can_create_workspace.py frontend/src/api/generated.ts
+git commit -m "api: /api/me/ reports workspace-creation eligibility
+
+The first-run screen must not offer a create button to an invite-admitted
+user with no membership — can_create_workspace 403s for exactly them (the
+F1 finding). Surfacing the gate is what lets the UI show the right thing."
+```
+
+---
+
+## Task 2: The first-run screen replaces the blank page
+
+`frontend/src/router.tsx:126` and `:135` both `return null` when the user has no
+workspace. A signed-in user with no membership therefore sees an empty app shell — no
+error, no message, nothing. This is the literal first screen of the power-user rollout.
+
+The state logic goes in a plain `.ts` module because there is no jsdom in this project;
+pure logic is the only thing that can be unit-tested here.
+
+**No backend test needed for the create endpoint.** `apps/workspaces/tests/test_api.py`
+already covers both error paths this screen must handle: the 403 for an ineligible caller
+(line 68) and the 409 for a duplicate slug (line 105). What is untested is the *screen's*
+three-state logic, which is what `firstRun.test.ts` below covers.
+
+**Files:**
+- Create: `frontend/src/pages/firstRun.ts`
+- Create: `frontend/src/pages/firstRun.test.ts`
+- Create: `frontend/src/pages/FirstRunPage.tsx`
+- Modify: `frontend/src/api/workspaces.ts`
+- Modify: `frontend/src/router.tsx:120-140`
+
+**Interfaces:**
+- Consumes: `MeOut.can_create_workspace` (Task 1); `useWorkspace()` from
+  `@/workspace/WorkspaceProvider` returning `{ workspaces, active, loading }`;
+  `getMe()` from `@/api/me`.
+- Produces: `firstRunState(args) -> 'loading' | 'can-create' | 'needs-invite' | 'ready'`,
+  and `createWorkspace(slug, displayName) -> Promise<WorkspaceOut>` in `api/workspaces.ts`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/pages/firstRun.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest'
+import { firstRunState } from './firstRun'
+
+describe('firstRunState', () => {
+  it('is loading while either the workspace list or me is unresolved', () => {
+    expect(firstRunState({ loading: true, workspaceCount: 0, canCreate: null })).toBe('loading')
+    expect(firstRunState({ loading: false, workspaceCount: 0, canCreate: null })).toBe('loading')
+  })
+
+  it('is ready once the user has at least one workspace', () => {
+    expect(firstRunState({ loading: false, workspaceCount: 1, canCreate: false })).toBe('ready')
+  })
+
+  it('offers creation to an eligible user with no workspace', () => {
+    expect(firstRunState({ loading: false, workspaceCount: 0, canCreate: true })).toBe('can-create')
+  })
+
+  it('asks an ineligible user for an invite instead of offering a button that 403s', () => {
+    expect(firstRunState({ loading: false, workspaceCount: 0, canCreate: false })).toBe('needs-invite')
+  })
+
+  it('prefers ready over creation when the user already belongs somewhere', () => {
+    // Guards the ordering: an eligible user WITH a workspace must be routed on,
+    // not parked on the first-run screen.
+    expect(firstRunState({ loading: false, workspaceCount: 2, canCreate: true })).toBe('ready')
+  })
+})
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `cd frontend && npx vitest run src/pages/firstRun.test.ts`
+Expected: FAIL — cannot resolve `./firstRun`.
+
+- [ ] **Step 3: Write the logic module**
+
+Create `frontend/src/pages/firstRun.ts`:
+
+```typescript
+/**
+ * Which first-run state applies. Extracted as a pure function because this
+ * project has no jsdom/testing-library — logic in a .ts module is the only
+ * thing unit-testable here (same reason as workspace/resolveActiveWorkspace.ts).
+ *
+ * There are THREE zero-workspace states, not one. An invite-admitted user who
+ * holds no membership may not create a workspace (the F1 finding — see
+ * apps/workspaces/services.py::can_create_workspace), so offering them a button
+ * would 403. `canCreate: null` means /api/me/ has not answered yet.
+ */
+export interface FirstRunInput {
+  loading: boolean
+  workspaceCount: number
+  canCreate: boolean | null
+}
+
+export type FirstRunState = 'loading' | 'can-create' | 'needs-invite' | 'ready'
+
+export function firstRunState({ loading, workspaceCount, canCreate }: FirstRunInput): FirstRunState {
+  if (workspaceCount > 0) return 'ready'
+  if (loading || canCreate === null) return 'loading'
+  return canCreate ? 'can-create' : 'needs-invite'
+}
+```
+
+- [ ] **Step 4: Run the test and confirm it passes**
+
+Run: `cd frontend && npx vitest run src/pages/firstRun.test.ts`
+Expected: 5 passed.
+
+- [ ] **Step 5: Add the `createWorkspace` client call**
+
+Append to `frontend/src/api/workspaces.ts`, matching the `apiV2` style already in that
+file:
+
+```typescript
+export async function createWorkspace(
+  slug: string,
+  displayName: string,
+): Promise<{ slug: string } | { error: string }> {
+  const res = await apiV2.POST('/api/workspaces/', {
+    body: { slug, display_name: displayName },
+  })
+  if (res.error) {
+    // 409 = slug taken, 403 = not eligible (F1), 422 = bad slug charset.
+    // The server's problem+json `detail` is the only message worth showing:
+    // the slug rules are enforced by Workspace.SLUG_PATTERN server-side and
+    // restating them here would be a second copy free to drift.
+    const detail = (res.error as { detail?: string })?.detail
+    return { error: detail || 'Could not create the workspace.' }
+  }
+  return { slug: res.data.slug }
+}
+```
+
+- [ ] **Step 6: Write the first-run screen**
+
+Create `frontend/src/pages/FirstRunPage.tsx`:
+
+```tsx
+import { useEffect, useState } from 'react'
+import { useWorkspace } from '@/workspace/WorkspaceProvider'
+import { getMe } from '@/api/me'
+import { createWorkspace } from '@/api/workspaces'
+import { firstRunState } from './firstRun'
+
+/**
+ * What a brand-new user sees. Replaces the two `return null` sites in
+ * router.tsx, which rendered a blank page for anyone with no workspace
+ * membership — the first screen of the power-user rollout.
+ *
+ * Doubles as documentation: this is the only page every new user is
+ * guaranteed to read, so it explains what a workspace IS rather than just
+ * asking for a slug.
+ */
+export function FirstRunPage() {
+  const { workspaces, loading } = useWorkspace()
+  const [canCreate, setCanCreate] = useState<boolean | null>(null)
+  const [slug, setSlug] = useState('')
+  const [displayName, setDisplayName] = useState('')
+  const [error, setError] = useState('')
+  const [busy, setBusy] = useState(false)
+
+  useEffect(() => {
+    void getMe().then((me) => setCanCreate(me?.can_create_workspace ?? false))
+  }, [])
+
+  const state = firstRunState({
+    loading,
+    workspaceCount: workspaces.length,
+    canCreate,
+  })
+
+  if (state === 'loading' || state === 'ready') return null
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault()
+    setBusy(true)
+    setError('')
+    const res = await createWorkspace(slug.trim(), displayName.trim() || slug.trim())
+    setBusy(false)
+    if ('error' in res) {
+      setError(res.error)
+      return
+    }
+    // Full reload rather than client navigation: the workspace list is fetched
+    // once by WorkspaceProvider, and a brand-new membership has to be visible
+    // to every consumer (nav, switcher, tenancy resolution) before any tenant
+    // route renders.
+    window.location.assign(`${import.meta.env.BASE_URL.replace(/\/$/, '')}/w/${res.slug}`)
+  }
+
+  return (
+    <div className="mx-auto max-w-xl px-6 py-16">
+      <h1 className="text-lg font-semibold text-foreground">Welcome to Canopy</h1>
+      <p className="mt-3 text-[13px] leading-relaxed text-foreground-secondary">
+        Canopy runs a fleet of AI agents and keeps the record of what they do. Everything
+        that belongs to a team — projects, agents, chats, demos — lives inside a{' '}
+        <span className="font-medium text-foreground">workspace</span>. You are not in one yet.
+      </p>
+
+      {state === 'can-create' ? (
+        <form onSubmit={submit} className="mt-8 space-y-4">
+          <div>
+            <label htmlFor="ws-slug" className="block text-xs font-medium text-foreground-secondary">
+              Workspace address
+            </label>
+            <input
+              id="ws-slug"
+              value={slug}
+              onChange={(e) => setSlug(e.target.value)}
+              placeholder="acme"
+              required
+              className="mt-1 w-full rounded border border-input bg-input px-2 py-1.5 text-[13px] text-foreground"
+            />
+            <p className="mt-1 text-[11px] text-muted-foreground">
+              Used in every URL: /w/&lt;address&gt;. Lowercase letters, numbers and dashes.
+            </p>
+          </div>
+          <div>
+            <label htmlFor="ws-name" className="block text-xs font-medium text-foreground-secondary">
+              Display name <span className="text-muted-foreground">(optional)</span>
+            </label>
+            <input
+              id="ws-name"
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              placeholder="Acme"
+              className="mt-1 w-full rounded border border-input bg-input px-2 py-1.5 text-[13px] text-foreground"
+            />
+          </div>
+          {error ? <p className="text-[13px] text-destructive">{error}</p> : null}
+          <button
+            type="submit"
+            disabled={busy || !slug.trim()}
+            className="rounded bg-primary px-3 py-1.5 text-[13px] font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+          >
+            {busy ? 'Creating…' : 'Create workspace'}
+          </button>
+          <p className="text-[12px] text-muted-foreground">
+            Already invited to one? Open the /invite/… link a colleague sent you instead.
+          </p>
+        </form>
+      ) : (
+        <div className="mt-8 rounded-lg border border-border bg-card p-4">
+          <h2 className="text-sm font-semibold text-foreground">You need an invite</h2>
+          <p className="mt-2 text-[13px] leading-relaxed text-foreground-secondary">
+            Your account can join a workspace but cannot create one. Ask a workspace owner
+            to invite you — they can do it from their workspace&apos;s Members page — and open
+            the /invite/… link they send you.
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 7: Wire it into the router**
+
+In `frontend/src/router.tsx`, import it and replace both `return null` sites:
+
+```tsx
+import { FirstRunPage } from './pages/FirstRunPage'
+```
+
+In `TenantRedirect` (was line 126):
+
+```tsx
+  if (loading) return null
+  if (!active) return <FirstRunPage />  // no membership yet — explain, don't blank
+```
+
+In `RootRedirect` (was line 135):
+
+```tsx
+function RootRedirect() {
+  const { active, loading } = useWorkspace()
+  if (loading) return null
+  if (!active) return <FirstRunPage />
+  return <Navigate to={`/w/${active}`} replace />
+}
+```
+
+- [ ] **Step 8: Verify the build and the full frontend suite**
+
+Run: `cd frontend && npm run build && npm run test`
+Expected: build succeeds (tsc clean), all tests pass.
+
+- [ ] **Step 9: Verify in the real app, not with curl**
+
+canopy-web is a PWA and a stale service worker will serve an old bundle, so curl proves
+nothing. Start the app (`uv run honcho start -f Procfile.dev`), sign in, and confirm:
+a user with a workspace still lands on their workbench; then check the zero-workspace
+case by visiting as a user with no membership (create one in the Django shell:
+`User.objects.create_user(username="t", email="t@dimagi.com")`, then
+`client.force_login`, or remove your own membership in a scratch database). You should
+see the welcome copy and a create form, not a blank page.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add frontend/src/pages/firstRun.ts frontend/src/pages/firstRun.test.ts frontend/src/pages/FirstRunPage.tsx frontend/src/api/workspaces.ts frontend/src/router.tsx
+git commit -m "ui: a new user gets a first-run screen, not a blank page
+
+router.tsx returned null for anyone with no workspace membership, so a
+signed-in new user saw an empty shell. Three states, not two: an
+invite-admitted user with no membership cannot create a workspace (F1), so
+the screen reads /api/me/ and asks them for an invite instead of offering a
+button that 403s."
+```
+
+---
+
+## Task 3: Always offer "create workspace" from the header
+
+`frontend/src/components/AppLayout/AppLayout.tsx:188` reads
+`if (workspaces.length <= 1) return null`, which conflates *nothing to switch between*
+with *nothing you can do*. A user with one workspace has no way to make a second.
+
+**Files:**
+- Modify: `frontend/src/components/AppLayout/AppLayout.tsx:185-200`
+
+**Interfaces:**
+- Consumes: `useWorkspace()`, `getMe()`, `FirstRunPage`'s sibling `createWorkspace`
+  (already added in Task 2).
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Split the guard**
+
+In `WorkspaceSwitcher`, keep hiding the `<select>` when there is nothing to switch
+between, but render a create entry regardless. Replace the early return:
+
+```tsx
+function WorkspaceSwitcher() {
+  const { workspaces, active } = useWorkspace()
+  const navigate = useNavigate()
+  // Hide the SWITCHER when there is nothing to switch between — but never hide
+  // the way to make another one. Conflating those two is what left a
+  // one-workspace user with no path to a second (and a zero-workspace user
+  // with no path at all).
+  if (workspaces.length <= 1) {
+    return <NewWorkspaceLink />
+  }
+  return (
+    <select
+      /* ...existing props unchanged... */
+    >
+      {/* ...existing options unchanged... */}
+    </select>
+  )
+}
+```
+
+- [ ] **Step 2: Add the link component**
+
+In the same file, beside `WorkspaceSwitcher`:
+
+```tsx
+/** The one affordance that must never be conditional on how many workspaces
+ *  you already have. Routes to the first-run screen, which owns the form. */
+function NewWorkspaceLink() {
+  return (
+    <a
+      href={`${import.meta.env.BASE_URL.replace(/\/$/, '')}/new-workspace`}
+      className="text-xs text-muted-foreground hover:text-foreground"
+    >
+      + Workspace
+    </a>
+  )
+}
+```
+
+- [ ] **Step 3: Add the `/new-workspace` route**
+
+In `frontend/src/router.tsx`, inside the `AppLayout` children, beside the other
+personal/global routes:
+
+```tsx
+      { path: '/new-workspace', element: <FirstRunPage /> },
+```
+
+`FirstRunPage` already handles the `ready` state by rendering `null`, which is wrong for
+this route — a user who already has a workspace must still see the form. Add an explicit
+prop:
+
+In `FirstRunPage.tsx`, change the signature and the guard:
+
+```tsx
+export function FirstRunPage({ alwaysOfferForm = false }: { alwaysOfferForm?: boolean }) {
+```
+
+```tsx
+  if (state === 'loading') return null
+  if (state === 'ready' && !alwaysOfferForm) return null
+  // On /new-workspace an eligible user sees the form even though they already
+  // belong somewhere; `needs-invite` still applies, because eligibility is the
+  // server's call either way.
+  const offerForm = alwaysOfferForm ? canCreate === true : state === 'can-create'
+```
+
+and use `offerForm` in place of `state === 'can-create'` in the JSX conditional.
+
+Then pass the prop on that route only:
+
+```tsx
+      { path: '/new-workspace', element: <FirstRunPage alwaysOfferForm /> },
+```
+
+- [ ] **Step 4: Extend the logic test for the new route's behaviour**
+
+Append to `frontend/src/pages/firstRun.test.ts`:
+
+```typescript
+  it('still reports ready for a member — /new-workspace opts out via a prop, not this fn', () => {
+    // Documents the seam: firstRunState stays a pure description of the user's
+    // standing. The route decides whether to show a form anyway.
+    expect(firstRunState({ loading: false, workspaceCount: 3, canCreate: true })).toBe('ready')
+  })
+```
+
+- [ ] **Step 5: Run the frontend suite and build**
+
+Run: `cd frontend && npm run test && npm run build`
+Expected: all pass, tsc clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/AppLayout/AppLayout.tsx frontend/src/router.tsx frontend/src/pages/FirstRunPage.tsx frontend/src/pages/firstRun.test.ts
+git commit -m "ui: '+ Workspace' is always reachable from the header
+
+The switcher hid itself at <=1 workspace, which also hid the only way to
+create another. Hide the switcher, keep the create affordance."
+```
+
+---
+
+## Task 4: Personal Access Token management on `/settings`
+
+`POST /api/tokens/` and `DELETE /api/tokens/{pk}/` exist with zero UI
+(`apps/tokens/api.py`). A PAT is the gate on two of the five ways in — pointing another
+tool at the MCP surface, and setting up the plugin — and today the only way to get one is
+to run a skill that requires the plugin you are trying to set up.
+
+The raw value is returned **exactly once**, by `PersonalTokenCreatedOut`. The UI must
+show it once and never pretend it can be retrieved again.
+
+**This task is frontend-only — do not add backend tests.** `apps/tokens/tests/test_api.py`
+already covers the API with 12 tests, including `test_revoke_other_users_token_404`,
+`test_revoke_idempotent`, `test_list_tokens_only_mine` and
+`test_create_token_defaults_to_expiring`. The spec's "404 on revoking someone else's
+token" requirement is already satisfied there; duplicating it here would be a second copy
+free to drift.
+
+**Files:**
+- Create: `frontend/src/api/tokens.ts`
+- Create: `frontend/src/components/settings/TokensPanel.tsx`
+- Modify: `frontend/src/pages/SettingsPage.tsx`
+
+**Interfaces:**
+- Consumes: `apiV2` from `@/api/client.v2`; the generated `PersonalTokenOut` /
+  `PersonalTokenCreatedOut` schemas; the existing `CopyBlock` component in
+  `SettingsPage.tsx` (used by `DebugAccessPanel`).
+- Produces: `listTokens()`, `mintToken(label, ttlDays)`, `revokeToken(id)` in
+  `api/tokens.ts`.
+
+- [ ] **Step 1: Write the client module**
+
+Create `frontend/src/api/tokens.ts`:
+
+```typescript
+/**
+ * Personal Access Tokens. The raw value comes back from mint() exactly once —
+ * PersonalTokenCreatedOut is the only shape that carries it, and the server
+ * stores a hash. The UI must therefore show it immediately and never imply it
+ * can be recovered.
+ */
+import { apiV2 } from './client.v2'
+import type { components } from './generated'
+
+export type PersonalToken = components['schemas']['PersonalTokenOut']
+export type MintedToken = components['schemas']['PersonalTokenCreatedOut']
+
+export async function listTokens(): Promise<PersonalToken[]> {
+  const { data, error } = await apiV2.GET('/api/tokens/')
+  if (error) return []
+  return data
+}
+
+export async function mintToken(
+  label: string,
+  ttlDays: number | null,
+): Promise<MintedToken | { error: string }> {
+  const { data, error } = await apiV2.POST('/api/tokens/', {
+    body: { label, ttl_days: ttlDays },
+  })
+  if (error || !data) {
+    const detail = (error as { detail?: string })?.detail
+    return { error: detail || 'Could not mint a token.' }
+  }
+  return data
+}
+
+export async function revokeToken(id: number): Promise<boolean> {
+  const { error } = await apiV2.DELETE('/api/tokens/{pk}/', {
+    params: { path: { pk: id } },
+  })
+  return !error
+}
+```
+
+- [ ] **Step 2: Confirm the generated types already carry these schemas**
+
+Run:
+
+```bash
+cd frontend && grep -c "PersonalTokenCreatedOut" src/api/generated.ts
+```
+
+Expected: a non-zero count. The tokens router is already registered
+(`apps/api/api.py:175`), so no backend change and no regen is needed for this task. If
+the count is 0, run `npm run gen:api` with the backend up and commit the result.
+
+- [ ] **Step 3: Write the panel**
+
+Create `frontend/src/components/settings/TokensPanel.tsx`:
+
+```tsx
+import { useEffect, useState } from 'react'
+import { listTokens, mintToken, revokeToken, type PersonalToken } from '@/api/tokens'
+
+/**
+ * List / mint / revoke Personal Access Tokens.
+ *
+ * A PAT is how a machine caller authenticates (Authorization: Bearer <raw>) —
+ * the canopy plugin, the MCP surface at /api/mcp/, and any script. It had no UI
+ * at all, so the only way to get one was a skill that needs the plugin you are
+ * trying to set up.
+ */
+export function TokensPanel() {
+  const [tokens, setTokens] = useState<PersonalToken[]>([])
+  const [label, setLabel] = useState('')
+  const [minted, setMinted] = useState<string>('')
+  const [error, setError] = useState('')
+  const [busy, setBusy] = useState(false)
+
+  async function refresh() {
+    setTokens(await listTokens())
+  }
+
+  useEffect(() => {
+    void refresh()
+  }, [])
+
+  async function onMint(e: React.FormEvent) {
+    e.preventDefault()
+    setBusy(true)
+    setError('')
+    const res = await mintToken(label.trim(), null)
+    setBusy(false)
+    if ('error' in res) {
+      setError(res.error)
+      return
+    }
+    setMinted(res.raw)
+    setLabel('')
+    await refresh()
+  }
+
+  async function onRevoke(t: PersonalToken) {
+    if (!window.confirm(`Revoke "${t.label}"? Anything using it stops working immediately.`)) return
+    if (await revokeToken(t.id)) await refresh()
+    else setError('Could not revoke that token.')
+  }
+
+  return (
+    <section className="rounded-lg border border-border bg-card p-4">
+      <h2 className="text-sm font-semibold text-foreground">Personal access tokens</h2>
+      <p className="mt-1 text-[12px] leading-relaxed text-muted-foreground">
+        How a machine authenticates as you — the canopy plugin, the MCP endpoint, or your
+        own scripts. Sent as <code>Authorization: Bearer &lt;token&gt;</code>.
+      </p>
+
+      {minted ? (
+        <div className="mt-3 rounded border border-warning/30 bg-warning/10 p-3">
+          <p className="text-[12px] font-medium text-warning">
+            Copy this now — it is not shown again.
+          </p>
+          <div className="mt-2 flex items-center gap-2">
+            <code className="flex-1 truncate rounded bg-muted px-2 py-1 text-[12px] text-foreground">
+              {minted}
+            </code>
+            <button
+              type="button"
+              onClick={() => void navigator.clipboard.writeText(minted)}
+              className="rounded bg-primary px-2 py-1 text-[12px] font-medium text-primary-foreground hover:bg-primary/90"
+            >
+              Copy
+            </button>
+            <button
+              type="button"
+              onClick={() => setMinted('')}
+              className="text-[12px] text-muted-foreground hover:text-foreground"
+            >
+              Done
+            </button>
+          </div>
+        </div>
+      ) : null}
+
+      <form onSubmit={onMint} className="mt-3 flex items-end gap-2">
+        <div className="flex-1">
+          <label htmlFor="pat-label" className="block text-xs font-medium text-foreground-secondary">
+            What is it for?
+          </label>
+          <input
+            id="pat-label"
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            placeholder="my laptop's canopy plugin"
+            required
+            className="mt-1 w-full rounded border border-input bg-input px-2 py-1.5 text-[13px] text-foreground"
+          />
+        </div>
+        <button
+          type="submit"
+          disabled={busy || !label.trim()}
+          className="rounded bg-primary px-3 py-1.5 text-[13px] font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+        >
+          {busy ? 'Minting…' : 'Mint token'}
+        </button>
+      </form>
+      {error ? <p className="mt-2 text-[13px] text-destructive">{error}</p> : null}
+
+      {tokens.length === 0 ? (
+        <p className="mt-4 text-[13px] text-muted-foreground">No tokens yet.</p>
+      ) : (
+        <table className="mt-4 w-full text-[12px]">
+          <thead>
+            <tr className="text-left text-muted-foreground">
+              <th className="py-1 font-medium">Label</th>
+              <th className="py-1 font-medium">Created</th>
+              <th className="py-1 font-medium">Last used</th>
+              <th className="py-1 font-medium">Status</th>
+              <th />
+            </tr>
+          </thead>
+          <tbody>
+            {tokens.map((t) => (
+              <tr key={t.id} className="border-t border-border">
+                <td className="py-1.5 text-foreground">{t.label}</td>
+                <td className="py-1.5 text-muted-foreground">{t.created_at.slice(0, 10)}</td>
+                <td className="py-1.5 text-muted-foreground">
+                  {t.last_used_at ? t.last_used_at.slice(0, 10) : 'never'}
+                </td>
+                <td className="py-1.5 text-muted-foreground">
+                  {t.revoked_at ? 'revoked' : t.expires_at ? `expires ${t.expires_at.slice(0, 10)}` : 'active'}
+                </td>
+                <td className="py-1.5 text-right">
+                  {t.revoked_at ? null : (
+                    <button
+                      type="button"
+                      onClick={() => void onRevoke(t)}
+                      className="text-destructive hover:underline"
+                    >
+                      Revoke
+                    </button>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </section>
+  )
+}
+```
+
+- [ ] **Step 4: Mount it on the settings page**
+
+In `frontend/src/pages/SettingsPage.tsx`, import and render it after the Presence
+section and before `DebugAccessPanel`:
+
+```tsx
+import { TokensPanel } from '@/components/settings/TokensPanel'
+```
+
+```tsx
+        <TokensPanel />
+```
+
+- [ ] **Step 5: Build and run the frontend suite**
+
+Run: `cd frontend && npm run build && npm run test`
+Expected: tsc clean, tests pass.
+
+- [ ] **Step 6: Verify against the running app**
+
+With the app running and signed in, open `/settings`: mint a token, confirm the raw value
+appears once with a warning, reload the page and confirm the raw value is gone but the row
+remains, then revoke it and confirm the row reads `revoked`. Then check the token actually
+works: `curl -H "Authorization: Bearer <raw>" http://localhost:8000/api/me/`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/api/tokens.ts frontend/src/components/settings/TokensPanel.tsx frontend/src/pages/SettingsPage.tsx
+git commit -m "ui: manage personal access tokens from /settings
+
+POST/DELETE /api/tokens/ existed with no UI, so the only way to get a PAT
+was a skill requiring the plugin the PAT is for. Raw value is shown exactly
+once, because that is all the server can ever return."
+```
+
+---
+
+## Task 5: Extract `routeTable` from the router
+
+Recovering paths from a *built* `createBrowserRouter` result is awkward; reading them
+from an exported array is three lines. Pure refactor — no behaviour change.
+
+**Files:**
+- Modify: `frontend/src/router.tsx:178-297`
+
+**Interfaces:**
+- Produces: `export const routeTable: RouteObject[]` — the same array previously passed
+  inline to `guarded()`. Consumed by Task 6's coverage test.
+
+- [ ] **Step 1: Extract the array**
+
+In `frontend/src/router.tsx`, change:
+
+```tsx
+export const router = createBrowserRouter(guarded([
+  { /* ... */ },
+]), { basename: /* ... */ })
+```
+
+to:
+
+```tsx
+/**
+ * The route table, as data.
+ *
+ * Exported so the guide's coverage test can read it: every documented surface
+ * must have a descriptor in guide/surfaces.ts, and every descriptor must name a
+ * real route. Extracting paths from a BUILT router is awkward; reading them from
+ * this array is three lines.
+ */
+export const routeTable: RouteObject[] = [
+  { /* ...the existing array, verbatim and unchanged... */ },
+]
+
+export const router = createBrowserRouter(guarded(routeTable), {
+  basename: import.meta.env.BASE_URL.replace(/\/$/, '') || '/',
+})
+```
+
+Move nothing else. The array's contents, ordering and comments stay byte-identical —
+ordering is load-bearing (the catch-all must stay last).
+
+- [ ] **Step 2: Verify the build is clean**
+
+Run: `cd frontend && npm run build`
+Expected: tsc clean. `RouteObject` is already imported in this file (used by `guarded`).
+
+- [ ] **Step 3: Verify the app still routes**
+
+Run the app and click through three routes including a tenant one (`/w/<ws>/agents`), a
+global one (`/settings`) and a redirect (`/timeline` → `/w/<ws>/timeline`). A reordering
+mistake shows up as a route resolving to the catch-all.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/router.tsx
+git commit -m "refactor: export routeTable as data
+
+No behaviour change. The guide's coverage test needs to read the route
+paths, and reading them from an exported array beats introspecting a built
+router."
+```
+
+---
+
+## Task 6: The descriptor registry and its coverage test
+
+**Files:**
+- Create: `frontend/src/guide/coverage.ts`
+- Create: `frontend/src/guide/surfaces.ts`
+- Create: `frontend/src/guide/coverage.test.ts`
+
+**Interfaces:**
+- Consumes: `routeTable` (Task 5).
+- Produces:
+  - `flattenRoutePaths(routes: RouteObject[]): string[]` — every declared path, with
+    child paths joined onto their parent.
+  - `isDocumentable(path: string): boolean` — false for redirects, legacy aliases and
+    the catch-all.
+  - `SURFACES: SurfaceDescriptor[]` where
+    `SurfaceDescriptor = { path: string; title: string; audience: string; what: string; needsFirst?: string; actions?: string[] }`.
+  - `describedPaths(): Set<string>`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/guide/coverage.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest'
+import { routeTable } from '../router'
+import { flattenRoutePaths, isDocumentable } from './coverage'
+import { SURFACES } from './surfaces'
+
+const declared = flattenRoutePaths(routeTable).filter(isDocumentable)
+const described = new Set(SURFACES.map((s) => s.path))
+
+describe('guide coverage', () => {
+  it('finds the real routes', () => {
+    // A sanity floor: if the flattener silently returns nothing, both
+    // directions below pass vacuously and the test proves nothing.
+    expect(declared.length).toBeGreaterThan(20)
+    expect(declared).toContain('/settings')
+    expect(declared).toContain('/w/:workspace/agents')
+  })
+
+  it('documents every documentable route', () => {
+    const missing = declared.filter((p) => !described.has(p))
+    expect(missing, `routes with no descriptor in guide/surfaces.ts: ${missing.join(', ')}`).toEqual([])
+  })
+
+  it('has no descriptor for a route that does not exist', () => {
+    // The direction that catches a descriptor orphaned by a deleted route —
+    // which is how a generated guide starts lying.
+    const declaredSet = new Set(declared)
+    const orphans = [...described].filter((p) => !declaredSet.has(p))
+    expect(orphans, `descriptors naming no real route: ${orphans.join(', ')}`).toEqual([])
+  })
+
+  it('gives every descriptor the fields the guide renders', () => {
+    for (const s of SURFACES) {
+      expect(s.title, `${s.path} has no title`).toBeTruthy()
+      expect(s.what, `${s.path} has no 'what'`).toBeTruthy()
+      expect(s.audience, `${s.path} has no audience`).toBeTruthy()
+    }
+  })
+})
+
+describe('isDocumentable', () => {
+  it('excludes the catch-all and legacy aliases', () => {
+    expect(isDocumentable('*')).toBe(false)
+    expect(isDocumentable('/ddd-plans')).toBe(false)
+    expect(isDocumentable('/w/:workspace/agents/:slug/needs-you')).toBe(false)
+  })
+
+  it('includes real surfaces', () => {
+    expect(isDocumentable('/settings')).toBe(true)
+    expect(isDocumentable('/w/:workspace/chat/:id')).toBe(true)
+  })
+})
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `cd frontend && npx vitest run src/guide/coverage.test.ts`
+Expected: FAIL — cannot resolve `./coverage`.
+
+- [ ] **Step 3: Write the coverage helpers**
+
+Create `frontend/src/guide/coverage.ts`:
+
+```typescript
+import type { RouteObject } from 'react-router-dom'
+
+/**
+ * Flatten the route table into absolute path strings, joining child paths onto
+ * their parent (the agent workspace's rail sections are children).
+ */
+export function flattenRoutePaths(routes: RouteObject[], parent = ''): string[] {
+  const out: string[] = []
+  for (const r of routes) {
+    const raw = (r as { path?: string }).path
+    const here =
+      raw === undefined
+        ? parent
+        : raw.startsWith('/')
+          ? raw
+          : `${parent.replace(/\/$/, '')}/${raw}`
+    if (raw !== undefined) out.push(here)
+    const kids = (r as { children?: RouteObject[] }).children
+    if (kids?.length) out.push(...flattenRoutePaths(kids, here))
+  }
+  return out
+}
+
+/**
+ * Paths that need no descriptor: the catch-all, and anything whose only job is
+ * to send the browser somewhere else. These are listed explicitly rather than
+ * detected from the element, because an explicit list fails LOUDLY when a new
+ * redirect is added (the coverage test names it) instead of silently excusing it.
+ */
+const NOT_DOCUMENTABLE = new Set([
+  '*',
+  '/',
+  '/timeline',
+  '/shareouts/*',
+  '/walkthroughs',
+  '/storyboards',
+  '/agents/*',
+  '/ddd/*',
+  '/ddd-plans',
+  '/reviews',
+  '/w/:workspace/agents/:slug/needs-you',
+  '/w/:workspace/agents/:slug',
+])
+
+export function isDocumentable(path: string): boolean {
+  if (NOT_DOCUMENTABLE.has(path)) return false
+  if (path.endsWith('/*')) return false
+  return true
+}
+```
+
+Note on `/w/:workspace/agents/:slug`: it is the rail *shell* whose index redirects to
+`inbox`; the documented surfaces are its children. `/` is excluded because it is the
+root redirect — the first-run experience it now shows is documented as a path in
+`paths.ts`, not as a route descriptor.
+
+- [ ] **Step 4: Run the test to see the real list of paths needing descriptors**
+
+Run: `cd frontend && npx vitest run src/guide/coverage.test.ts`
+Expected: FAIL on `documents every documentable route`, with the failure message listing
+every path. **Copy that list** — it is the exact set of descriptors to write next.
+
+- [ ] **Step 5: Write the descriptor registry**
+
+Create `frontend/src/guide/surfaces.ts`. **Step 4's failure message is the authoritative
+list of paths** — it names every one that needs a descriptor. The six entries below
+establish the shape and the voice; write the rest from what each page actually does,
+reading the component where the path alone is not enough. You cannot finish this step
+early: the coverage test stays red, naming each gap, until every path is covered.
+
+```typescript
+/**
+ * One descriptor per documented surface — the in-app guide's content, as DATA.
+ *
+ * Data, not prose in a wiki, for the same reason systemWorkflows.ts is data: a
+ * test can read this and a page can render it; prose in another repo can do
+ * neither. guide/coverage.test.ts asserts this file covers every route and
+ * names no route that does not exist.
+ *
+ * `path` MUST match the route path in router.tsx character for character.
+ */
+export interface SurfaceDescriptor {
+  /** Exactly the route path from routeTable. */
+  path: string
+  title: string
+  /** Who this is for, in a few words. */
+  audience: string
+  /** What it is, one line. */
+  what: string
+  /** What you need before it does anything useful. */
+  needsFirst?: string
+  /** What you can actually do here. */
+  actions?: string[]
+}
+
+export const SURFACES: SurfaceDescriptor[] = [
+  {
+    path: '/w/:workspace',
+    title: 'Project workbench',
+    audience: 'Anyone in a workspace',
+    what: 'The workspace home — a tile per project, ranked by how many insights are waiting on it, with the top three surfaced as a hero.',
+    actions: ['Triage an insight inline', 'Open a project'],
+  },
+  {
+    path: '/w/:workspace/chat',
+    title: 'Chats',
+    audience: 'An operator who wants work done',
+    what: 'Your chat sessions with agents, so you can pick one up from any device.',
+    needsFirst: 'An agent in this workspace, and a runner online to execute its turns.',
+    actions: ['Start a new chat with an agent', 'Continue an existing session'],
+  },
+  {
+    path: '/w/:workspace/chat/:id',
+    title: 'One chat',
+    audience: 'An operator',
+    what: 'A live multiplayer chat with an agent. Sending enqueues a turn; the reply streams back as the agent works.',
+    needsFirst: 'A runner online and assigned to this agent.',
+    actions: ['Send a message', 'Answer a question the agent is blocked on', 'Move the session to another runner'],
+  },
+  {
+    path: '/supervisor',
+    title: 'Supervisor',
+    audience: 'Someone who owns agents',
+    what: 'The cross-fleet "waiting on you" inbox, agent KPI cards and runner status. Spans every workspace, which is why it is not tenant-scoped.',
+    needsFirst: 'At least one agent you own.',
+    actions: ['Answer a blocked agent', 'See which runners are online', 'Install it as a phone app and get pushed when an agent needs you'],
+  },
+  {
+    path: '/settings',
+    title: 'Settings',
+    audience: 'Everyone',
+    what: 'Your account and this deployment: which AI backend is in use, your Claude subscription connection, presence visibility, and your personal access tokens.',
+    actions: ['Mint a personal access token', 'Revoke a token', 'Switch AI backend', 'Toggle presence'],
+  },
+  {
+    path: '/system',
+    title: 'Capabilities',
+    audience: 'Anyone deciding what canopy can do',
+    what: "Every skill, agent and command the canopy plugin ships, read live from the plugin's own files, plus curated chains showing how they compose.",
+    actions: ['Browse the catalog', 'Read a capability in full'],
+  },
+  // Every remaining path printed by Step 4 gets an entry in this same shape.
+  // This is not left to judgement about WHICH ones: the coverage test fails,
+  // naming each missing path, until the list is complete — so "done" is a test
+  // result, not an opinion. Write the prose from what the page actually does;
+  // read the component if you are unsure rather than guessing from the path.
+]
+
+export function describedPaths(): Set<string> {
+  return new Set(SURFACES.map((s) => s.path))
+}
+```
+
+- [ ] **Step 6: Run the coverage test until it is green**
+
+Run: `cd frontend && npx vitest run src/guide/coverage.test.ts`
+Expected: all pass. Iterate: each failure names exactly which path is missing a
+descriptor or which descriptor names no route.
+
+- [ ] **Step 7: Confirm it is fast**
+
+Run: `cd frontend && npx vitest run src/guide/coverage.test.ts --reporter=verbose`
+Expected: the file's duration is milliseconds, not seconds. If it is slow, something is
+importing React components transitively — the test must only pull in `routeTable`'s
+*paths*. If `router.tsx`'s lazy imports make the import heavy, move `routeTable` into its
+own module (`frontend/src/routeTable.ts`) that holds paths and element references only.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add frontend/src/guide/coverage.ts frontend/src/guide/surfaces.ts frontend/src/guide/coverage.test.ts
+git commit -m "guide: descriptor registry with two-direction coverage
+
+Every documented route must have a descriptor and every descriptor must
+name a real route. The second direction is what catches a descriptor
+orphaned by a deleted route, which is how a generated guide starts lying."
+```
+
+---
+
+## Task 7: The five-ways-in registry
+
+Shared by `/guide` and the public explainer so the public promise cannot drift from the
+internal documentation. This is the spec's only deliberate coupling between the two pages.
+
+**Files:**
+- Create: `frontend/src/guide/paths.ts`
+- Create: `frontend/src/guide/paths.test.ts`
+
+**Interfaces:**
+- Consumes: `SURFACES` (Task 6) for cross-referencing.
+- Produces: `USER_PATHS: UserPath[]` where
+  `UserPath = { id: string; title: string; who: string; startHere: string; surfaces: string[]; note?: string }`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/guide/paths.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest'
+import { USER_PATHS } from './paths'
+import { describedPaths } from './surfaces'
+
+describe('USER_PATHS', () => {
+  it('describes the five ways in', () => {
+    expect(USER_PATHS).toHaveLength(5)
+  })
+
+  it('has unique ids', () => {
+    const ids = USER_PATHS.map((p) => p.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('only references surfaces that are actually documented', () => {
+    // The coupling that keeps the public page honest: it cannot promise a
+    // surface the guide does not describe.
+    const known = describedPaths()
+    const dangling = USER_PATHS.flatMap((p) =>
+      p.surfaces.filter((s) => s.startsWith('/') && !known.has(s)),
+    )
+    expect(dangling, `paths referencing undocumented surfaces: ${dangling.join(', ')}`).toEqual([])
+  })
+
+  it('tells every path where to start', () => {
+    for (const p of USER_PATHS) {
+      expect(p.startHere, `${p.id} has no starting point`).toBeTruthy()
+      expect(p.who, `${p.id} does not say who it is for`).toBeTruthy()
+    }
+  })
+})
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `cd frontend && npx vitest run src/guide/paths.test.ts`
+Expected: FAIL — cannot resolve `./paths`.
+
+- [ ] **Step 3: Write the registry**
+
+Create `frontend/src/guide/paths.ts`:
+
+```typescript
+/**
+ * The five ways into canopy. Rendered by BOTH the public explainer and the
+ * in-app guide, so the public promise cannot drift from the internal docs —
+ * paths.test.ts asserts every referenced surface is one the guide describes.
+ *
+ * Two notes on this taxonomy, because it differs from the obvious one.
+ * "Watch a turn in the browser" and "watch a turn on your laptop" are NOT two
+ * paths: they are one job with a deployment choice inside it, and the choice is
+ * the interesting part. And "you were sent a link" is first, because it is
+ * almost certainly the highest-volume interaction anyone has with canopy.
+ */
+export interface UserPath {
+  id: string
+  title: string
+  /** Who you are, if this is your path. */
+  who: string
+  /** The literal first thing to do. */
+  startHere: string
+  /** Route paths (from surfaces.ts) or external entry points. */
+  surfaces: string[]
+  note?: string
+}
+
+export const USER_PATHS: UserPath[] = [
+  {
+    id: 'audience',
+    title: 'You were sent a link',
+    who: 'An audience. No login, no install, nothing to set up.',
+    startHere: 'Open the link. That is the whole path.',
+    surfaces: ['/storyboard/:slug', '/narrative/:slug', '/walkthrough/:id', '/share/:token'],
+    note: 'Storyboards, narratives, demo walkthroughs and shared transcripts are all public when shared.',
+  },
+  {
+    id: 'operator',
+    title: 'You want an agent to do work',
+    who: 'An operator with a job to hand off.',
+    startHere: 'Open Chats in a workspace and start a chat with an agent.',
+    surfaces: ['/w/:workspace/chat', '/w/:workspace/chat/:id', '/w/:workspace/activity'],
+    note: 'Then choose where it runs: a cloud runner needs nothing from you, or pair your own laptop so you can jump into the terminal mid-turn.',
+  },
+  {
+    id: 'supervisor',
+    title: 'You keep agents unblocked',
+    who: 'Someone who owns agents and is not driving every turn.',
+    startHere: 'Open Supervisor, then install it as a phone app.',
+    surfaces: ['/supervisor', '/schedules'],
+    note: 'It pushes a notification when any agent you own starts waiting on you.',
+  },
+  {
+    id: 'skills',
+    title: "You want canopy's skills in your own sessions",
+    who: 'A Claude Code user who does not want to run a fleet.',
+    startHere: 'Mint a token in Settings, then install the canopy plugin.',
+    surfaces: ['/settings', '/system'],
+    note: 'No agents, no runners. Just the capability library in your own Claude Code.',
+  },
+  {
+    id: 'builder',
+    title: 'You want to build an agent',
+    who: 'A builder who needs a persona of their own.',
+    startHere: 'Run /canopy:create-agent, then register it in the workspace.',
+    surfaces: ['/w/:workspace/agents'],
+    note: 'The scaffold is a skeleton — persona and domain skills are yours to write.',
+  },
+]
+```
+
+- [ ] **Step 4: Run the test and confirm it passes**
+
+Run: `cd frontend && npx vitest run src/guide/paths.test.ts`
+Expected: all pass. If `only references surfaces that are actually documented` fails, the
+named surface is missing from `surfaces.ts` — add its descriptor rather than deleting the
+reference.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/guide/paths.ts frontend/src/guide/paths.test.ts
+git commit -m "guide: the five ways in, as a shared registry
+
+Consumed by both the public explainer and the in-app guide, with a test
+asserting it never promises a surface the guide does not describe."
+```
+
+---
+
+## Task 8: The `/guide` page
+
+**Files:**
+- Create: `frontend/src/pages/GuidePage.tsx`
+- Modify: `frontend/src/router.tsx` (add the route)
+- Modify: `frontend/src/components/AppLayout/nav.ts` (add the nav entry)
+
+**Interfaces:**
+- Consumes: `SURFACES` (Task 6), `USER_PATHS` (Task 7), `NAV_GROUPS` from
+  `@/components/AppLayout/nav`.
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Write the grouping helper and its test**
+
+Create `frontend/src/guide/grouping.ts`:
+
+```typescript
+import { NAV_GROUPS } from '@/components/AppLayout/nav'
+import { SURFACES, type SurfaceDescriptor } from './surfaces'
+
+/**
+ * Group descriptors by the header's existing nav groups, so the guide's shape
+ * matches the menu people actually look at. Anything the nav does not mention
+ * (public viewers, agent rail sections) lands in a trailing "Elsewhere" group
+ * rather than being dropped — a guide that silently omits a surface is the
+ * failure this whole registry exists to prevent.
+ */
+export interface GuideGroup {
+  label: string
+  surfaces: SurfaceDescriptor[]
+}
+
+/** The route path a nav item points at, in routeTable's notation. */
+function navItemPath(item: { path: string; tenant: boolean }): string {
+  if (!item.tenant) return item.path
+  return item.path ? `/w/:workspace/${item.path}` : '/w/:workspace'
+}
+
+export function guideGroups(surfaces: SurfaceDescriptor[] = SURFACES): GuideGroup[] {
+  const claimed = new Set<string>()
+  const groups: GuideGroup[] = []
+
+  for (const nav of NAV_GROUPS) {
+    const wanted = nav.items.map(navItemPath)
+    const members = surfaces.filter((s) => wanted.includes(s.path))
+    members.forEach((m) => claimed.add(m.path))
+    if (members.length) groups.push({ label: nav.label, surfaces: members })
+  }
+
+  const rest = surfaces.filter((s) => !claimed.has(s.path))
+  if (rest.length) groups.push({ label: 'Elsewhere', surfaces: rest })
+  return groups
+}
+```
+
+Create `frontend/src/guide/grouping.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest'
+import { guideGroups } from './grouping'
+import { SURFACES } from './surfaces'
+
+describe('guideGroups', () => {
+  it('places every surface in exactly one group', () => {
+    const grouped = guideGroups().flatMap((g) => g.surfaces.map((s) => s.path))
+    expect(grouped.length).toBe(SURFACES.length)
+    expect(new Set(grouped).size).toBe(SURFACES.length)
+  })
+
+  it('uses the nav group labels', () => {
+    const labels = guideGroups().map((g) => g.label)
+    expect(labels).toContain('Work')
+    expect(labels).toContain('Fleet')
+  })
+
+  it('never drops a surface the nav does not mention', () => {
+    const groups = guideGroups([
+      { path: '/share/:token', title: 'Shared session', audience: 'Anyone', what: 'x' },
+    ])
+    expect(groups).toEqual([
+      { label: 'Elsewhere', surfaces: [expect.objectContaining({ path: '/share/:token' })] },
+    ])
+  })
+})
+```
+
+- [ ] **Step 2: Run and confirm it fails, then passes**
+
+Run: `cd frontend && npx vitest run src/guide/grouping.test.ts`
+Expected: FAIL (unresolved import) before Step 1's file exists; PASS after.
+
+- [ ] **Step 3: Write the page**
+
+Create `frontend/src/pages/GuidePage.tsx`:
+
+```tsx
+import { guideGroups } from '@/guide/grouping'
+import { USER_PATHS } from '@/guide/paths'
+
+/**
+ * The in-app guide: what every surface is, generated from guide/surfaces.ts and
+ * grouped by the header nav. A coverage test guarantees nothing is missing;
+ * empty states deep-link here with #<route-path> anchors, so the stuck-user
+ * surface and the documentation surface are the same content.
+ */
+export function GuidePage() {
+  return (
+    <div className="mx-auto max-w-4xl px-6 py-8">
+      <h1 className="text-lg font-semibold text-foreground">Guide</h1>
+      <p className="mt-2 text-[13px] leading-relaxed text-foreground-secondary">
+        What each part of Canopy is for. Generated from the app&apos;s own route table, so
+        it cannot quietly miss a page.
+      </p>
+
+      <section className="mt-8">
+        <h2 className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+          Start here
+        </h2>
+        <ol className="mt-3 space-y-3">
+          {USER_PATHS.map((p, i) => (
+            <li key={p.id} className="flex gap-3 rounded-lg border border-border bg-card p-3">
+              <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-muted text-[10px] font-semibold text-muted-foreground">
+                {i + 1}
+              </span>
+              <div>
+                <h3 className="text-sm font-semibold text-foreground">{p.title}</h3>
+                <p className="mt-0.5 text-[12px] text-muted-foreground">{p.who}</p>
+                <p className="mt-1.5 text-[13px] text-foreground-secondary">{p.startHere}</p>
+                {p.note ? <p className="mt-1 text-[12px] text-foreground-subtle">{p.note}</p> : null}
+              </div>
+            </li>
+          ))}
+        </ol>
+      </section>
+
+      {guideGroups().map((group) => (
+        <section key={group.label} className="mt-8">
+          <h2 className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+            {group.label}
+          </h2>
+          <div className="mt-3 space-y-3">
+            {group.surfaces.map((s) => (
+              <article
+                key={s.path}
+                id={s.path}
+                className="scroll-mt-20 rounded-lg border border-border bg-card p-4"
+              >
+                <div className="flex items-baseline justify-between gap-3">
+                  <h3 className="text-sm font-semibold text-foreground">{s.title}</h3>
+                  <code className="shrink-0 text-[11px] text-foreground-subtle">{s.path}</code>
+                </div>
+                <p className="mt-1 text-[12px] text-muted-foreground">{s.audience}</p>
+                <p className="mt-2 text-[13px] leading-relaxed text-foreground-secondary">{s.what}</p>
+                {s.needsFirst ? (
+                  <p className="mt-2 text-[12px] text-warning">Needs first: {s.needsFirst}</p>
+                ) : null}
+                {s.actions?.length ? (
+                  <ul className="mt-2 list-disc space-y-0.5 pl-5 text-[12px] text-foreground-secondary">
+                    {s.actions.map((a) => (
+                      <li key={a}>{a}</li>
+                    ))}
+                  </ul>
+                ) : null}
+              </article>
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Add the route and the nav entry**
+
+In `frontend/src/router.tsx`, import `GuidePage` and add beside the other global routes:
+
+```tsx
+      { path: '/guide', element: <GuidePage /> },
+```
+
+Then add its descriptor to `frontend/src/guide/surfaces.ts` (the coverage test will
+demand it):
+
+```typescript
+  {
+    path: '/guide',
+    title: 'Guide',
+    audience: 'Anyone finding their way around',
+    what: "What every surface in Canopy is for, generated from the app's own route table.",
+    actions: ['Find the page you need', 'See what a surface needs before it works'],
+  },
+```
+
+In `frontend/src/components/AppLayout/nav.ts`, add it to the last group (the
+team/admin one), so it is reachable without knowing the URL.
+
+- [ ] **Step 5: Run the whole frontend suite and build**
+
+Run: `cd frontend && npm run test && npm run build`
+Expected: all pass. The coverage test now includes `/guide` itself.
+
+- [ ] **Step 6: Verify by rendering the page**
+
+Open `/guide` in the running app. Confirm: the five paths appear numbered at the top,
+groups match the header menus, and a deep link works — `/guide#/settings` should scroll
+to the Settings entry.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/guide/grouping.ts frontend/src/guide/grouping.test.ts frontend/src/pages/GuidePage.tsx frontend/src/guide/surfaces.ts frontend/src/router.tsx frontend/src/components/AppLayout/nav.ts
+git commit -m "guide: /guide renders the registry grouped by the nav
+
+Grouped by NAV_GROUPS so the guide's shape matches the menu people look at,
+with anything the nav omits landing in a trailing group rather than being
+dropped."
+```
+
+---
+
+## Task 9: Empty states link into the guide
+
+Per the spec, the stuck-user surface and the documentation surface should be the same
+content. The agents empty state also *teaches* the create-agent flow rather than offering
+a button, because a web-created agent has no repo and cannot take a turn until the
+companion spec ships.
+
+**Files:**
+- Modify: `frontend/src/pages/AgentsPage.tsx`
+- Modify: `frontend/src/pages/ChatListPage.tsx`
+
+**Interfaces:**
+- Consumes: `USER_PATHS` (Task 7) for the copy's starting points.
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Read both pages to find the current empty rendering**
+
+Run:
+
+```bash
+grep -n "length === 0\|No agents\|empty\|length ? " frontend/src/pages/AgentsPage.tsx frontend/src/pages/ChatListPage.tsx
+```
+
+Note what each renders when its list is empty. If a page has no empty branch at all, add
+one — an empty table with headers and no rows is the same dead end in a smaller frame.
+
+- [ ] **Step 2: Add the agents empty state**
+
+In `frontend/src/pages/AgentsPage.tsx`, where the list is empty:
+
+```tsx
+<div className="rounded-lg border border-border bg-card p-4">
+  <h2 className="text-sm font-semibold text-foreground">No agents in this workspace</h2>
+  <p className="mt-2 text-[13px] leading-relaxed text-foreground-secondary">
+    An agent is a persona with its own git repo — skills, hooks and an identity. It is
+    not created here: run <code className="text-primary">/canopy:create-agent</code> in
+    Claude Code, which scaffolds the repo, then it appears in this list.
+  </p>
+  <p className="mt-2 text-[12px] text-muted-foreground">
+    You will also need a runner online to execute its turns.{' '}
+    <a href="../../guide#/w/:workspace/agents" className="text-primary hover:underline">
+      Read more in the guide
+    </a>
+    .
+  </p>
+</div>
+```
+
+Do **not** add a create button. Until GitHub-backed creation ships, `POST /api/agents/`
+produces a record with no repo, no persona and no skills — an agent that cannot take a
+turn, which is worse than no button. See
+`docs/superpowers/specs/2026-09-12-github-backed-agent-creation-design.md`.
+
+- [ ] **Step 3: Add the chats empty state**
+
+In `frontend/src/pages/ChatListPage.tsx`, where the session list is empty:
+
+```tsx
+<div className="rounded-lg border border-border bg-card p-4">
+  <h2 className="text-sm font-semibold text-foreground">No chats yet</h2>
+  <p className="mt-2 text-[13px] leading-relaxed text-foreground-secondary">
+    Start a chat to hand an agent a job. Sending a message enqueues a turn, and a runner
+    picks it up and streams the reply back as it works.
+  </p>
+  <p className="mt-2 text-[12px] text-muted-foreground">
+    Nothing to chat with?{' '}
+    <a href="../guide#/w/:workspace/agents" className="text-primary hover:underline">
+      You need an agent first
+    </a>
+    .
+  </p>
+</div>
+```
+
+- [ ] **Step 4: Build and run the suite**
+
+Run: `cd frontend && npm run build && npm run test`
+Expected: tsc clean, tests pass.
+
+- [ ] **Step 5: Verify the links resolve**
+
+In the running app, open a workspace with no agents, click through to the guide from the
+empty state, and confirm it lands on the Agents entry rather than the top of the page.
+Relative hrefs under `/w/:workspace/...` are easy to get wrong by one `../` — check the
+resulting URL in the address bar.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/pages/AgentsPage.tsx frontend/src/pages/ChatListPage.tsx
+git commit -m "ui: empty states teach and link into the guide
+
+The agents empty state deliberately hands over /canopy:create-agent rather
+than offering a button: until GitHub-backed creation ships, a web-created
+agent has no repo and cannot take a turn."
+```
+
+---
+
+## Task 10: `GET /api/system/public-stats`
+
+Anonymous, aggregates only. **Two** changes are needed for anything to be public here:
+`auth=None` on the route, and an allowlist entry in `apps/common/middleware.py` — the
+login middleware is default-deny, so `auth=None` alone still bounces an anonymous caller
+to Google.
+
+**Files:**
+- Create: `apps/system/stats.py`
+- Modify: `apps/system/schemas.py`
+- Modify: `apps/system/api.py`
+- Modify: `apps/common/middleware.py` (`PUBLIC_PATH_PREFIXES`)
+- Test: `tests/test_public_stats.py`
+
+**Interfaces:**
+- Consumes: `apps.agents.models.Agent`, `apps.harness.models.Runner`,
+  `apps.harness.models.Turn`, `apps.runs` release models, and
+  `apps.system.reader.load_catalog` for the skill count.
+- Produces: `apps.system.stats.public_stats() -> dict` with keys
+  `agents`, `skills`, `runners_online`, `turns_executed`, `demos_published` (all `int`),
+  and `PublicStatsOut` with exactly those fields.
+
+- [ ] **Step 1: Read the three facts this task depends on**
+
+These were verified while writing the plan. Read them yourself before coding — two of
+them will crash your code if you assume the obvious thing instead.
+
+1. **`Runner.live_status` is a computed `@property`, not a database column**
+   (`apps/harness/models.py:255-272`). It derives from `status`, `paused` and
+   `last_heartbeat_at` against `HEARTBEAT_ONLINE_WINDOW` (90 seconds, line 20). So
+   `Runner.objects.filter(live_status=Runner.ONLINE)` raises `FieldError`. The
+   DB-expressible equivalent of "online" is a fresh heartbeat on a non-retired runner.
+2. **`Turn.DONE == "done"`** (`apps/harness/models.py:301`), and `Turn.TERMINAL` is the
+   set of finished states. Count `DONE` only — "turns executed" should not include
+   failures and cancellations.
+3. **`apps/runs` has no `models.py` at all.** DDD runs are a *derived read model* over
+   `apps.walkthroughs.models.Walkthrough` (grouped by `run_id`) and
+   `apps.reviews.models.ReviewRequest` — see `apps/runs/aggregate.py:17-23`. There is no
+   "published demo" row to count. `Walkthrough.run_id` is the run grouping key and is
+   indexed (`apps/walkthroughs/models.py:41`, `:101`), so the honest metric is the number
+   of distinct non-empty `run_id` values.
+
+Confirm each for yourself:
+
+4. **`apps/system` is FRAMEWORK and `apps/walkthroughs` is PRODUCT**
+   (`tests/test_architecture_boundary.py:27-28`). Framework code must never import
+   product code — and the test blocks even a **string** reference to a product module.
+   So `apps/system/stats.py` **cannot** import `Walkthrough`. The demos count is
+   contributed by the product app through a registry instead, which is the pattern
+   `apps/timeline` already uses to aggregate product events without importing product
+   (`apps/timeline/sources.py:25`). Getting this wrong fails CI, not just review.
+
+```bash
+sed -n 255,272p apps/harness/models.py      # live_status is a property
+grep -n 'DONE, FAILED' apps/harness/models.py
+ls apps/runs/                                # no models.py
+grep -n 'run_id' apps/walkthroughs/models.py
+grep -n 'FRAMEWORK = \|PRODUCT = ' tests/test_architecture_boundary.py
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `tests/test_public_stats.py`:
+
+```python
+"""GET /api/system/public-stats — anonymous, aggregates only.
+
+The leak assertion is the load-bearing one. An anonymous endpoint on a
+multi-tenant system is exactly where a field gets added later without anyone
+re-asking whether it should be public, so the test asserts the SHAPE is closed
+rather than only that today's fields are fine.
+"""
+import pytest
+
+ALLOWED_KEYS = {
+    "agents",
+    "skills",
+    "runners_online",
+    "turns_executed",
+    "demos_published",
+}
+
+
+def test_reachable_without_authentication(client, db):
+    resp = client.get("/api/system/public-stats")
+    assert resp.status_code == 200, resp.content
+
+
+def test_returns_only_integer_aggregates(client, db):
+    body = client.get("/api/system/public-stats").json()
+    assert set(body) == ALLOWED_KEYS
+    for key, value in body.items():
+        assert isinstance(value, int), f"{key} is {type(value)}, not an int"
+
+
+def test_leaks_no_names_slugs_or_ids(client, db):
+    # A count cannot leak what it is a count of. Anything that is not an int
+    # could — so the guard is on the type, not on a denylist of field names.
+    body = client.get("/api/system/public-stats").json()
+    assert not any(isinstance(v, (str, list, dict)) for v in body.values())
+
+
+def test_counts_reflect_reality(client, db):
+    from apps.agents.models import Agent
+    from apps.workspaces.models import Workspace
+
+    ws = Workspace.objects.create(slug="acme", display_name="Acme")
+    Agent.objects.create(slug="a1", display_name="A1", workspace=ws)
+    Agent.objects.create(slug="a2", display_name="A2", workspace=ws)
+
+    body = client.get("/api/system/public-stats").json()
+    assert body["agents"] == 2
+```
+
+- [ ] **Step 3: Run it and confirm it fails**
+
+Run: `uv run pytest tests/test_public_stats.py -v`
+Expected: FAIL — 404 or a redirect to login on every test.
+
+- [ ] **Step 4: Write the stats module**
+
+Create `apps/system/stats.py`:
+
+```python
+"""Aggregate counts for the public explainer page.
+
+Aggregates ONLY — no names, no slugs, no ids, no per-agent or per-tenant
+breakdown, no content. A count cannot leak what it is a count of, which is the
+whole reason this is safe to serve anonymously. Adding a non-integer field here
+is a security change, and tests/test_public_stats.py fails on the type rather
+than on a denylist of names so that it cannot be done by accident.
+
+No Django request object — pure functions over the ORM, so they are testable
+directly.
+"""
+from __future__ import annotations
+
+from django.conf import settings
+from django.utils import timezone
+
+from apps.agents.models import Agent
+from apps.harness.models import HEARTBEAT_ONLINE_WINDOW, Runner, Turn
+
+from . import reader
+
+#: Product apps contribute counts here from their AppConfig.ready(). This app is
+#: FRAMEWORK and must not import PRODUCT (tests/test_architecture_boundary.py),
+#: so the arrow has to point inward: product names framework, never the reverse.
+#: Same reason apps/timeline reads product events through a registry.
+_EXTRA: dict[str, "Callable[[], int]"] = {}
+
+
+def register_extra_stat(name: str, fn: "Callable[[], int]") -> None:
+    """Register a product-owned count. Idempotent — re-registering replaces."""
+    _EXTRA[name] = fn
+
+
+def _skill_count() -> int:
+    try:
+        cat = reader.load_catalog(settings.CANOPY_PLUGIN_PATH)
+    except Exception:  # noqa: BLE001 — a missing plugin path must not 500 a public page
+        return 0
+    return int(cat.get("counts", {}).get("skill", 0))
+
+
+def _runners_online() -> int:
+    """Runners with a fresh heartbeat, excluding retired boxes.
+
+    `Runner.live_status` is a PROPERTY, not a column, so it cannot be filtered
+    on. This is its DB-expressible core: the same 90-second window
+    (HEARTBEAT_ONLINE_WINDOW) that live_status uses to demote a runner to STALE.
+    Deliberately NOT `is_available` — readiness is an operational detail and
+    "how many boxes are up" is the honest public number.
+    """
+    cutoff = timezone.now() - HEARTBEAT_ONLINE_WINDOW
+    return (
+        Runner.objects.exclude(status=Runner.RETIRED)
+        .filter(last_heartbeat_at__gte=cutoff)
+        .count()
+    )
+
+
+def _extra(name: str) -> int:
+    """A registered product count, or 0 if that app did not register one.
+
+    Defaulting to 0 rather than omitting the key keeps PublicStatsOut's field set
+    CLOSED, which is what the leak test asserts — a dynamic response shape would
+    make "only integers, only these keys" unenforceable.
+    """
+    fn = _EXTRA.get(name)
+    if fn is None:
+        return 0
+    try:
+        return int(fn())
+    except Exception:  # noqa: BLE001 — one bad contributor must not 500 a public page
+        return 0
+
+
+def public_stats() -> dict[str, int]:
+    return {
+        "agents": Agent.objects.count(),
+        "skills": _skill_count(),
+        "runners_online": _runners_online(),
+        "turns_executed": Turn.objects.filter(status=Turn.DONE).count(),
+        "demos_published": _extra("demos_published"),
+    }
+```
+
+Add `from collections.abc import Callable` to the imports (used in the annotations above).
+
+Then register the product-owned count from the **product** side, in
+`apps/walkthroughs/apps.py`:
+
+```python
+class WalkthroughsConfig(AppConfig):
+    name = "apps.walkthroughs"
+
+    def ready(self) -> None:
+        # Contribute the published-demo count to the framework's public stats.
+        # Registered from HERE, not imported from there: apps/system is FRAMEWORK
+        # and must not name a PRODUCT module (tests/test_architecture_boundary.py).
+        # In ready() so it runs once, after the app registry is populated.
+        from apps.system.stats import register_extra_stat
+
+        from .models import Walkthrough
+
+        def demos_published() -> int:
+            # A "run package" is a derived grouping of Walkthrough rows by
+            # run_id (apps/runs/aggregate.py) — apps/runs has no models. Counting
+            # rows would inflate it: one package is a video AND a deck.
+            return (
+                Walkthrough.objects.exclude(run_id__isnull=True)
+                .exclude(run_id="")
+                .values("run_id")
+                .distinct()
+                .count()
+            )
+
+        register_extra_stat("demos_published", demos_published)
+```
+
+Keep whatever `AppConfig` attributes the existing file already sets (`default_auto_field`,
+`label`, `verbose_name`) — only the `ready()` method is being added.
+
+- [ ] **Step 5: Add the schema**
+
+In `apps/system/schemas.py`:
+
+```python
+class PublicStatsOut(StrictModel):
+    """Aggregates for the public explainer. Integers only — see apps/system/stats.py."""
+
+    agents: int
+    skills: int
+    runners_online: int
+    turns_executed: int
+    demos_published: int
+```
+
+- [ ] **Step 6: Add the route**
+
+In `apps/system/api.py`, import the new pieces and add the route **above** the
+`/{kind}/{name}` catch-all — otherwise `public-stats` is captured as a `kind`:
+
+```python
+from . import reader, stats
+from .schemas import CapabilityCatalogOut, CapabilityDetailOut, PublicStatsOut
+```
+
+```python
+@router.get(
+    "/public-stats",
+    response=PublicStatsOut,
+    auth=None,
+    summary="Aggregate counts for the public explainer (anonymous)",
+)
+def public_stats(request: HttpRequest) -> dict:
+    """Anonymous, aggregates only.
+
+    NOTE: `auth=None` is half the story — apps/common/middleware.py is
+    default-deny, so this path is also allowlisted there. Both are required.
+    """
+    return stats.public_stats()
+```
+
+Placement matters: `detail()` matches `/{kind}/{name}`, and Ninja resolves in
+declaration order.
+
+- [ ] **Step 7: Allowlist the path in the login middleware**
+
+In `apps/common/middleware.py`, add to `PUBLIC_PATH_PREFIXES`:
+
+```python
+    "/api/system/public-stats",  # auth=None — aggregates only, no names/ids (public explainer)
+```
+
+- [ ] **Step 8: Run the test and the architecture boundary test**
+
+Run:
+
+```bash
+uv run pytest tests/test_public_stats.py tests/test_architecture_boundary.py -v
+```
+
+Expected: 4 passed for the stats, and the boundary tests green. If
+`test_framework_apps_do_not_import_product` or
+`test_framework_source_does_not_reference_product_modules` fails, `apps/system/stats.py`
+is still naming `apps.walkthroughs` — the count must come through
+`register_extra_stat`, called from the walkthroughs app, not from an import here.
+
+Add one more test to `tests/test_public_stats.py` covering the registry, since a
+contributor that silently fails to register would report 0 forever:
+
+```python
+def test_demos_published_comes_from_the_registry(client, db):
+    from apps.walkthroughs.models import Walkthrough
+
+    # Two rows, one run package — the count must be 1, not 2.
+    Walkthrough.objects.create(title="v", kind="video", run_id="demo-2026-09-12-001")
+    Walkthrough.objects.create(title="d", kind="html", run_id="demo-2026-09-12-001")
+
+    body = client.get("/api/system/public-stats").json()
+    assert body["demos_published"] == 1
+```
+
+If `Walkthrough.objects.create` needs more required fields than shown, supply them —
+check `apps/walkthroughs/models.py` for non-null fields without defaults.
+
+- [ ] **Step 9: Confirm it is genuinely anonymous end to end**
+
+Run, with the backend up and **no** session cookie:
+
+```bash
+curl -sS -i http://localhost:8000/api/system/public-stats | head -20
+```
+
+Expected: `HTTP/1.1 200` and a JSON body of five integers. A `302` to Google means the
+middleware allowlist entry is missing or mis-spelled; a `401` means `auth=None` did not
+take.
+
+- [ ] **Step 10: Regenerate the frontend types and run the backend suite**
+
+```bash
+cd frontend && npm run gen:api
+cd .. && uv run pytest -q
+```
+
+Expected: `PublicStatsOut` appears in `generated.ts`; no new backend failures.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add apps/system/stats.py apps/system/schemas.py apps/system/api.py apps/walkthroughs/apps.py apps/common/middleware.py tests/test_public_stats.py frontend/src/api/generated.ts
+git commit -m "api: anonymous aggregate stats for the public explainer
+
+Integers only, and the test asserts the shape is closed by TYPE rather than
+by a denylist of field names — an anonymous endpoint on a multi-tenant
+system is exactly where a leaky field gets added later by accident.
+
+Public needs two changes, not one: auth=None on the route AND an allowlist
+entry, because the login middleware is default-deny."
+```
+
+---
+
+## Task 11: The public explainer page
+
+Chrome-less, anonymous, on `PublicLayout` — mounted **outside** `AppLayout` so the
+shell's authed calls do not bounce an anonymous visitor to login. The SPA route also
+needs the PWA navigate-fallback allowlist and the login middleware's page allowlist.
+
+**Files:**
+- Create: `frontend/src/api/publicStats.ts`
+- Create: `frontend/src/guide/components.ts`
+- Create: `frontend/src/pages/AboutPage.tsx`
+- Modify: `frontend/src/router.tsx`
+- Modify: `frontend/src/pwa/navigation-fallback.ts`
+- Modify: `apps/common/middleware.py`
+
+**Interfaces:**
+- Consumes: `USER_PATHS` (Task 7), `PublicStatsOut` (Task 10), `PublicLayout`.
+- Produces: `COMPONENTS: SystemComponent[]` where
+  `SystemComponent = { name: string; what: string }`; `getPublicStats(): Promise<PublicStats | null>`.
+
+- [ ] **Step 1: Write the component-view data and its test**
+
+Create `frontend/src/guide/components.ts`:
+
+```typescript
+/**
+ * The five components of canopy, and the one sentence that connects them.
+ * This is the "component view" the public explainer is built around — the thing
+ * that was actually missing from /system, which catalogues the plugin's
+ * capabilities and never says what the system is made of.
+ */
+export interface SystemComponent {
+  name: string
+  what: string
+}
+
+export const COMPONENTS: SystemComponent[] = [
+  {
+    name: 'canopy-web',
+    what: 'The system of record and every human surface. Owns workspaces, agents, turns, items, schedules, sessions and published artifacts.',
+  },
+  {
+    name: 'The canopy plugin',
+    what: 'The capability library — skills, agents and commands, installed into Claude Code. What an agent knows how to do.',
+  },
+  {
+    name: 'Runners',
+    what: 'The execution substrate. A paired laptop or a cloud box. Claims turns and runs Claude Code.',
+  },
+  {
+    name: 'Agents',
+    what: 'Persona repos stamped from a factory — identity, domain skills, hooks.',
+  },
+  {
+    name: 'The harness',
+    what: 'The control plane joining them: turn lifecycle, claim and lease, the event ledger, routing.',
+  },
+]
+
+export const ONE_SENTENCE =
+  'A turn is the unit of work: canopy-web owns the record of turns, runners execute them wherever your compute happens to live, and the plugin is the library of what an agent knows how to do.'
+```
+
+Create `frontend/src/guide/components.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest'
+import { COMPONENTS, ONE_SENTENCE } from './components'
+
+describe('COMPONENTS', () => {
+  it('names five components with unique names', () => {
+    expect(COMPONENTS).toHaveLength(5)
+    expect(new Set(COMPONENTS.map((c) => c.name)).size).toBe(5)
+  })
+
+  it('explains each one', () => {
+    for (const c of COMPONENTS) expect(c.what.length).toBeGreaterThan(20)
+  })
+
+  it('has a connecting sentence', () => {
+    expect(ONE_SENTENCE).toContain('turn')
+  })
+})
+```
+
+- [ ] **Step 2: Run it and confirm it passes**
+
+Run: `cd frontend && npx vitest run src/guide/components.test.ts`
+Expected: 3 passed.
+
+- [ ] **Step 3: Write the anonymous client call**
+
+Create `frontend/src/api/publicStats.ts`:
+
+```typescript
+/**
+ * Aggregate counts for the public explainer. Anonymous — deliberately a bare
+ * fetch with no credentials and no CSRF, because this page is served to
+ * visitors with no session and sending cookies would gain nothing.
+ */
+import { apiUrl } from './base'
+
+export interface PublicStats {
+  agents: number
+  skills: number
+  runners_online: number
+  turns_executed: number
+  demos_published: number
+}
+
+export async function getPublicStats(): Promise<PublicStats | null> {
+  try {
+    const resp = await fetch(apiUrl('/api/system/public-stats'))
+    if (!resp.ok) return null
+    return (await resp.json()) as PublicStats
+  } catch {
+    // The page must render without numbers rather than fail — a visitor who
+    // cannot reach the API should still learn what canopy is.
+    return null
+  }
+}
+```
+
+- [ ] **Step 4: Write the page**
+
+Create `frontend/src/pages/AboutPage.tsx`:
+
+```tsx
+import { useEffect, useState } from 'react'
+import { COMPONENTS, ONE_SENTENCE } from '@/guide/components'
+import { USER_PATHS } from '@/guide/paths'
+import { getPublicStats, type PublicStats } from '@/api/publicStats'
+
+/**
+ * The public explainer. Chrome-less, anonymous, mounted OUTSIDE AppLayout so
+ * the shell's authed calls cannot bounce a visitor to login.
+ *
+ * Counts are live because prose goes stale within a month — "we run a fleet of
+ * agents" reads as a claim, while "2 runners online" reads as a fact. The page
+ * renders fine without them.
+ */
+export function AboutPage() {
+  const [stats, setStats] = useState<PublicStats | null>(null)
+
+  useEffect(() => {
+    void getPublicStats().then(setStats)
+  }, [])
+
+  const figures: Array<[string, number | undefined]> = [
+    ['agents', stats?.agents],
+    ['skills', stats?.skills],
+    ['runners online', stats?.runners_online],
+    ['turns executed', stats?.turns_executed],
+    ['demos published', stats?.demos_published],
+  ]
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="mx-auto max-w-3xl px-6 py-16">
+        <h1 className="text-2xl font-semibold text-foreground">Canopy</h1>
+        <p className="mt-4 text-[15px] leading-relaxed text-foreground-secondary">
+          Canopy runs a fleet of AI agents that do real work — shipping code, triaging
+          mail, building demos — and keeps the durable record of what they did, so the
+          work survives the session it happened in.
+        </p>
+
+        {stats ? (
+          <dl className="mt-8 grid grid-cols-2 gap-4 sm:grid-cols-3">
+            {figures.map(([label, value]) => (
+              <div key={label} className="rounded-lg border border-border bg-card p-3">
+                <dd className="text-xl font-semibold text-foreground">{value ?? '—'}</dd>
+                <dt className="mt-0.5 text-[11px] uppercase tracking-wide text-muted-foreground">
+                  {label}
+                </dt>
+              </div>
+            ))}
+          </dl>
+        ) : null}
+
+        <section className="mt-12">
+          <h2 className="text-sm font-semibold text-foreground">How it fits together</h2>
+          <p className="mt-2 text-[13px] leading-relaxed text-foreground-secondary">{ONE_SENTENCE}</p>
+          <div className="mt-4 space-y-2">
+            {COMPONENTS.map((c) => (
+              <div key={c.name} className="rounded-lg border border-border bg-card p-3">
+                <h3 className="text-[13px] font-semibold text-foreground">{c.name}</h3>
+                <p className="mt-1 text-[13px] leading-relaxed text-foreground-secondary">{c.what}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="mt-12">
+          <h2 className="text-sm font-semibold text-foreground">Five ways in</h2>
+          <div className="mt-4 space-y-3">
+            {USER_PATHS.map((p) => (
+              <div key={p.id} className="rounded-lg border border-border bg-card p-4">
+                <h3 className="text-[13px] font-semibold text-foreground">{p.title}</h3>
+                <p className="mt-0.5 text-[12px] text-muted-foreground">{p.who}</p>
+                <p className="mt-2 text-[13px] text-foreground-secondary">{p.startHere}</p>
+                {p.note ? <p className="mt-1 text-[12px] text-foreground-subtle">{p.note}</p> : null}
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <footer className="mt-12 border-t border-border pt-6 text-[12px] text-muted-foreground">
+          <a href="./api/docs/" className="text-primary hover:underline">
+            API reference
+          </a>
+        </footer>
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 5: Mount the route on `PublicLayout`**
+
+In `frontend/src/router.tsx`, add to the existing `PublicLayout` children array (beside
+`/ddd-release/...`, `/storyboard/:slug`, `/narrative/:slug`):
+
+```tsx
+      { path: '/about', element: <AboutPage /> },
+```
+
+It must go in the `PublicLayout` block, **not** the `AppLayout` block — `AppLayout` fires
+authed calls that bounce anonymous visitors to login.
+
+- [ ] **Step 6: Allowlist the page path in the login middleware**
+
+In `apps/common/middleware.py`, add to `PUBLIC_PATH_PREFIXES`:
+
+```python
+    "/about",  # the public explainer page shell (its stats API is allowlisted above)
+```
+
+- [ ] **Step 7: Add it to the PWA navigate-fallback allowlist**
+
+In `frontend/src/pwa/navigation-fallback.ts`, add `/about` to
+`NAVIGATE_FALLBACK_ALLOWLIST` following the existing entries' regex style, and add a unit
+test beside the existing ones asserting `/about` is handled and, say, `/api/whatever` is
+not. The allowlist is fail-safe by design: a forgotten SPA route only loses *offline*
+shell fallback, but adding it is one line and the file is already unit-tested.
+
+- [ ] **Step 8: Run everything**
+
+```bash
+cd frontend && npm run test && npm run build
+cd .. && uv run pytest -q
+```
+
+Expected: all green. The `paths.test.ts` coupling test still passes because `/about` is a
+public page, not a referenced surface.
+
+- [ ] **Step 9: Verify anonymously in a real browser**
+
+Start the app. Open `/about` in a **private/incognito window** with no session. Confirm:
+the page renders, the counts appear, and you are **not** redirected to Google. Then check
+the dark and light themes both read correctly (`PublicLayout` wraps `ThemeProvider`), and
+confirm no raw palette literals slipped in:
+
+```bash
+cd frontend && grep -nE "stone-|orange-|zinc-|slate-|red-[0-9]|amber-|emerald-|sky-|violet-" src/pages/AboutPage.tsx src/pages/GuidePage.tsx src/pages/FirstRunPage.tsx src/components/settings/TokensPanel.tsx
+```
+
+Expected: no matches.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add frontend/src/guide/components.ts frontend/src/guide/components.test.ts frontend/src/api/publicStats.ts frontend/src/pages/AboutPage.tsx frontend/src/router.tsx frontend/src/pwa/navigation-fallback.ts apps/common/middleware.py
+git commit -m "web: public explainer at /about
+
+Chrome-less on PublicLayout, anonymous, with live aggregate counts because
+prose goes stale within a month. Its five-ways-in section renders the same
+registry the in-app guide does, so the public promise cannot drift from the
+internal documentation."
+```
+
+---
+
+## Task 12: Open the PR
+
+- [ ] **Step 1: Run the full suite one more time**
+
+```bash
+uv run pytest -q
+cd frontend && npm run test && npm run build
+```
+
+Expected: all green. Do not proceed on a failure — report it instead.
+
+- [ ] **Step 2: Confirm generated types are committed and fresh**
+
+```bash
+cd frontend && npm run gen:api && git diff --stat src/api/generated.ts
+```
+
+Expected: no diff. A diff means `generated.ts` is stale; commit the regenerated file.
+`regen-openapi.yml` checks this but is **not** a required check, so a stale file can merge
+past it.
+
+- [ ] **Step 3: Push and open the PR with auto-merge armed**
+
+```bash
+git push -u origin HEAD
+gh pr create --title "Opening canopy to other people: first run, /guide, /about" --body-file - <<'BODY'
+Implements `docs/superpowers/specs/2026-09-12-opening-canopy-to-other-people-design.md`.
+
+**A1 — first run works.** A signed-in user with no workspace membership previously
+landed on a blank page (`router.tsx` returned `null`). They now get a real first-run
+screen with three states — including the case that matters for security: an
+invite-admitted user with no membership *cannot* create a workspace (the F1 finding), so
+`/api/me/` now reports eligibility and the screen asks them for an invite instead of
+offering a button that 403s. Plus "+ Workspace" always reachable from the header, and
+PAT list/mint/revoke on `/settings`.
+
+**B — the app documents itself.** A descriptor registry keyed by the route table, a
+`/guide` page grouped by the existing nav, and one fast two-direction coverage test:
+every documented route has a descriptor, and every descriptor names a real route. The
+second direction is what catches a descriptor orphaned by a deleted route. Empty states
+deep-link into the guide so the stuck-user surface and the docs are the same content.
+
+**C — a public explainer.** `/about`, chrome-less and anonymous, with the component view
+and live aggregate counts from a new `GET /api/system/public-stats` (integers only; the
+test asserts the shape is closed by type rather than by a denylist of field names).
+
+Deliberately **not** here: GitHub-backed agent creation, which is its own spec
+(`2026-09-12-github-backed-agent-creation-design.md`) because it needs a GitHub App
+registered before it can be tested. The agents empty state teaches
+`/canopy:create-agent` for now and becomes a button later without a rewrite.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+BODY
+```
+
+- [ ] **Step 4: Arm auto-merge and verify it took**
+
+```bash
+gh pr merge <n> --auto
+gh pr view <n> --json autoMergeRequest
+```
+
+Never pass `--squash` or any strategy flag: the merge queue owns the strategy, and `gh`
+answers a strategy flag with a warning that leaves auto-merge UNARMED. If
+`autoMergeRequest` is `null`, re-run `gh pr merge <n> --auto`.

--- a/docs/superpowers/plans/2026-09-12-opening-canopy-to-other-people.md
+++ b/docs/superpowers/plans/2026-09-12-opening-canopy-to-other-people.md
@@ -632,15 +632,19 @@ In the same file, beside `WorkspaceSwitcher`:
  *  you already have. Routes to the first-run screen, which owns the form. */
 function NewWorkspaceLink() {
   return (
-    <a
-      href={`${import.meta.env.BASE_URL.replace(/\/$/, '')}/new-workspace`}
+    <Link
+      to="/new-workspace"
       className="text-xs text-muted-foreground hover:text-foreground"
     >
       + Workspace
-    </a>
+    </Link>
   )
 }
 ```
+
+Use react-router `<Link>`, not a hand-built `href` off `BASE_URL` — `Link` applies the
+router's basename itself, and this file already imports from `react-router-dom`
+(`useNavigate`). Same reasoning as Task 9's links.
 
 - [ ] **Step 3: Add the `/new-workspace` route**
 
@@ -661,13 +665,17 @@ In `FirstRunPage.tsx`, change the signature and the guard:
 export function FirstRunPage({ alwaysOfferForm = false }: { alwaysOfferForm?: boolean }) {
 ```
 
+After Task 2's fix round the guard is a SINGLE combined line —
+`if (state === 'loading' || state === 'ready') return null` — and `canCreate` is a
+plain `boolean` local derived from `useAuth()`. Replace that one line with:
+
 ```tsx
   if (state === 'loading') return null
   if (state === 'ready' && !alwaysOfferForm) return null
   // On /new-workspace an eligible user sees the form even though they already
   // belong somewhere; `needs-invite` still applies, because eligibility is the
   // server's call either way.
-  const offerForm = alwaysOfferForm ? canCreate === true : state === 'can-create'
+  const offerForm = alwaysOfferForm ? canCreate : state === 'can-create'
 ```
 
 and use `offerForm` in place of `state === 'can-create'` in the JSX conditional.

--- a/docs/superpowers/plans/2026-09-12-opening-canopy-to-other-people.md
+++ b/docs/superpowers/plans/2026-09-12-opening-canopy-to-other-people.md
@@ -734,6 +734,8 @@ free to drift.
 
 **Files:**
 - Create: `frontend/src/api/tokens.ts`
+- Create: `frontend/src/api/tokenStatus.ts`
+- Test: `frontend/src/api/tokenStatus.test.ts`
 - Create: `frontend/src/components/settings/TokensPanel.tsx`
 - Modify: `frontend/src/pages/SettingsPage.tsx`
 
@@ -812,6 +814,56 @@ Expected: a non-zero count. The tokens router is already registered
 (`apps/api/api.py:175`), so no backend change and no regen is needed for this task. If
 the count is 0, run `npm run gen:api` with the backend up and commit the result.
 
+- [ ] **Step 2b: Extract and pin the status ladder**
+
+The panel renders a three-way status per token. It is a silent, user-visible derivation —
+showing "active" for a revoked token would be the worst possible bug on a credentials
+screen — so it goes in a pure module and gets a test, the same way `firstRun.ts` holds the
+first-run decision. Create `frontend/src/api/tokenStatus.ts`:
+
+```typescript
+import type { PersonalToken } from './tokens'
+
+/**
+ * What to show in the Status column. Order matters: a revoked token may ALSO
+ * carry an expiry, and "revoked" is the answer that matters — it is the one
+ * that means "this credential is dead right now".
+ */
+export function tokenStatus(t: Pick<PersonalToken, 'revoked_at' | 'expires_at'>): string {
+  if (t.revoked_at) return 'revoked'
+  if (t.expires_at) return `expires ${t.expires_at.slice(0, 10)}`
+  return 'active'
+}
+```
+
+And `frontend/src/api/tokenStatus.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest'
+import { tokenStatus } from './tokenStatus'
+
+describe('tokenStatus', () => {
+  it('reports a live token with an expiry', () => {
+    expect(tokenStatus({ revoked_at: null, expires_at: '2027-03-01T00:00:00Z' })).toBe(
+      'expires 2027-03-01',
+    )
+  })
+
+  it('reports a never-expiring token as active', () => {
+    expect(tokenStatus({ revoked_at: null, expires_at: null })).toBe('active')
+  })
+
+  it('prefers revoked over expiry — a revoked token is dead regardless of its expiry', () => {
+    // This is the case that must never regress: reporting "expires 2027-03-01"
+    // for a revoked credential would tell someone it still works.
+    expect(tokenStatus({ revoked_at: '2026-09-01T00:00:00Z', expires_at: '2027-03-01T00:00:00Z' }))
+      .toBe('revoked')
+  })
+})
+```
+
+Then use `tokenStatus(t)` in the panel's Status cell instead of the inline ternary chain.
+
 - [ ] **Step 3: Write the panel**
 
 Create `frontend/src/components/settings/TokensPanel.tsx`:
@@ -819,6 +871,7 @@ Create `frontend/src/components/settings/TokensPanel.tsx`:
 ```tsx
 import { useEffect, useState } from 'react'
 import { listTokens, mintToken, revokeToken, type PersonalToken } from '@/api/tokens'
+import { tokenStatus } from '@/api/tokenStatus'
 
 /**
  * List / mint / revoke Personal Access Tokens.
@@ -944,9 +997,7 @@ export function TokensPanel() {
                 <td className="py-1.5 text-muted-foreground">
                   {t.last_used_at ? t.last_used_at.slice(0, 10) : 'never'}
                 </td>
-                <td className="py-1.5 text-muted-foreground">
-                  {t.revoked_at ? 'revoked' : t.expires_at ? `expires ${t.expires_at.slice(0, 10)}` : 'active'}
-                </td>
+                <td className="py-1.5 text-muted-foreground">{tokenStatus(t)}</td>
                 <td className="py-1.5 text-right">
                   {t.revoked_at ? null : (
                     <button

--- a/docs/superpowers/plans/2026-09-12-opening-canopy-to-other-people.md
+++ b/docs/superpowers/plans/2026-09-12-opening-canopy-to-other-people.md
@@ -42,15 +42,19 @@ for generated API types.
   `apps/<app>/tests/test_*.py` where that app already has a `tests/` package
   (`apps/workspaces/tests/` does).
 - **Frontend tests** are vitest, colocated as `<module>.test.ts(x)`. **jsdom 29 and
-  `@testing-library/react` 16 ARE installed and used** — there are ~10 component tests
-  calling `render()` (`PublicHeader.test.tsx`, `ChatSessionsPanel.test.tsx`,
-  `RunnerAssignments.test.tsx`, …), so mounting a component in a test is available to you.
-  (An earlier revision of this plan claimed otherwise, propagating a stale comment at
-  `frontend/src/workspace/resolveActiveWorkspace.ts:2`. That comment is wrong; the plan
-  was wrong for repeating it.) Still prefer extracting decision logic into a plain `.ts`
-  module and testing it directly — it is faster and less brittle than asserting on
-  rendered output — but a component test is a legitimate choice where the behaviour only
-  exists once mounted.
+  `@testing-library/react` 16 are installed and used by 26 of the 61 test files** — so
+  mounting a component, or anything else needing a DOM, is available to you.
+  **But `frontend/vite.config.ts`'s `test` block sets no `environment`, so vitest's default
+  is `node`** — a test that needs a DOM must declare it per-file with a
+  `// @vitest-environment jsdom` pragma on the first line. This applies to anything that
+  transitively imports React components, not just tests that call `render()`. Omitting it
+  produces a confusing failure that looks like a broken import rather than a missing DOM.
+  (This plan got this wrong twice: first claiming jsdom was not set up at all — a stale
+  comment at `frontend/src/workspace/resolveActiveWorkspace.ts:2` — then correcting that
+  without mentioning the pragma, which cost an implementer a debugging cycle.)
+  Still prefer extracting decision logic into a plain `.ts` module and testing it directly:
+  it needs no DOM, no pragma, and is less brittle than asserting on rendered output. A
+  component test is a legitimate choice where the behaviour only exists once mounted.
 - **A task that changes a Pydantic response schema MUST run `cd frontend && npm run build`,
   not just the backend tests.** Fields in `generated.ts` are non-optional, so adding one
   to a response model breaks every test file that constructs a mock of it — and those

--- a/docs/superpowers/plans/2026-09-12-opening-canopy-to-other-people.md
+++ b/docs/superpowers/plans/2026-09-12-opening-canopy-to-other-people.md
@@ -2089,18 +2089,55 @@ contributor that silently fails to register would report 0 forever:
 
 ```python
 def test_demos_published_comes_from_the_registry(client, db):
+    from django.contrib.auth import get_user_model
+
     from apps.walkthroughs.models import Walkthrough
 
-    # Two rows, one run package — the count must be 1, not 2.
-    Walkthrough.objects.create(title="v", kind="video", run_id="demo-2026-09-12-001")
-    Walkthrough.objects.create(title="d", kind="html", run_id="demo-2026-09-12-001")
+    owner = get_user_model().objects.create_user(username="o", email="o@dimagi.com")
+
+    def artifact(kind: str) -> None:
+        # Walkthrough has SEVEN fields with neither null/blank nor a default
+        # (verified against apps/walkthroughs/models.py): title, kind, owner,
+        # drive_file_id, drive_folder_id, content_type, size_bytes. Omitting any
+        # of them raises IntegrityError, not a validation error.
+        Walkthrough.objects.create(
+            title=f"artifact-{kind}",
+            kind=kind,
+            owner=owner,
+            drive_file_id=f"file-{kind}",
+            drive_folder_id="folder-1",
+            content_type="video/mp4" if kind == "video" else "text/html",
+            size_bytes=1,
+            run_id="demo-2026-09-12-001",
+        )
+
+    # Two artifacts, ONE run package — the count must be 1, not 2. This is the
+    # assertion that catches counting rows instead of distinct run_ids.
+    artifact("video")
+    artifact("html")
 
     body = client.get("/api/system/public-stats").json()
     assert body["demos_published"] == 1
+
+
+def test_demos_published_ignores_artifacts_with_no_run(client, db):
+    from django.contrib.auth import get_user_model
+
+    from apps.walkthroughs.models import Walkthrough
+
+    owner = get_user_model().objects.create_user(username="o2", email="o2@dimagi.com")
+    # A one-off upload carries no run_id — it is not a published package.
+    Walkthrough.objects.create(
+        title="loose", kind="html", owner=owner, drive_file_id="f2",
+        drive_folder_id="folder-1", content_type="text/html", size_bytes=1,
+    )
+
+    body = client.get("/api/system/public-stats").json()
+    assert body["demos_published"] == 0
 ```
 
-If `Walkthrough.objects.create` needs more required fields than shown, supply them —
-check `apps/walkthroughs/models.py` for non-null fields without defaults.
+`kind` must be one of `Walkthrough.KIND_CHOICES` (`apps/walkthroughs/models.py:34`) —
+check the valid values before inventing one.
 
 - [ ] **Step 9: Confirm it is genuinely anonymous end to end**
 

--- a/docs/superpowers/plans/2026-09-12-opening-canopy-to-other-people.md
+++ b/docs/superpowers/plans/2026-09-12-opening-canopy-to-other-people.md
@@ -1679,6 +1679,12 @@ companion spec ships.
 - Modify: `frontend/src/pages/AgentsPage.tsx`
 - Modify: `frontend/src/pages/ChatListPage.tsx`
 
+**Use react-router `<Link to="/guide#...">`, never a relative `<a href>`.** A relative
+href resolves differently at each route depth and ignores the `/canopy` basename: from
+`/w/:ws/chat`, `../guide` lands on `/w/guide`. `Link` with an absolute path handles the
+basename automatically and is depth-independent. Add
+`import { Link } from 'react-router-dom'` to each file if it is not already there.
+
 **Interfaces:**
 - Consumes: `USER_PATHS` (Task 7) for the copy's starting points.
 - Produces: nothing consumed by later tasks.
@@ -1708,9 +1714,9 @@ In `frontend/src/pages/AgentsPage.tsx`, where the list is empty:
   </p>
   <p className="mt-2 text-[12px] text-muted-foreground">
     You will also need a runner online to execute its turns.{' '}
-    <a href="../../guide#/w/:workspace/agents" className="text-primary hover:underline">
+    <Link to="/guide#/w/:workspace/agents" className="text-primary hover:underline">
       Read more in the guide
-    </a>
+    </Link>
     .
   </p>
 </div>
@@ -1734,9 +1740,9 @@ In `frontend/src/pages/ChatListPage.tsx`, where the session list is empty:
   </p>
   <p className="mt-2 text-[12px] text-muted-foreground">
     Nothing to chat with?{' '}
-    <a href="../guide#/w/:workspace/agents" className="text-primary hover:underline">
+    <Link to="/guide#/w/:workspace/agents" className="text-primary hover:underline">
       You need an agent first
-    </a>
+    </Link>
     .
   </p>
 </div>
@@ -1750,9 +1756,10 @@ Expected: tsc clean, tests pass.
 - [ ] **Step 5: Verify the links resolve**
 
 In the running app, open a workspace with no agents, click through to the guide from the
-empty state, and confirm it lands on the Agents entry rather than the top of the page.
-Relative hrefs under `/w/:workspace/...` are easy to get wrong by one `../` — check the
-resulting URL in the address bar.
+empty state, and confirm the address bar shows `/canopy/guide#/w/:workspace/agents` (not
+`/canopy/w/<ws>/guide...`) and that the page scrolls to the Agents entry. Do the same from
+an empty Chats list — the two pages sit at different route depths, which is exactly what
+a relative href would get wrong.
 
 - [ ] **Step 6: Commit**
 
@@ -2360,6 +2367,25 @@ In `frontend/src/router.tsx`, add to the existing `PublicLayout` children array 
 It must go in the `PublicLayout` block, **not** the `AppLayout` block — `AppLayout` fires
 authed calls that bounce anonymous visitors to login.
 
+- [ ] **Step 5b: Give `/about` a descriptor**
+
+`/about` is a real route, so `isDocumentable('/about')` is true and Task 6's coverage test
+will fail until it is described. It gets a descriptor rather than an entry in
+`NOT_DOCUMENTABLE`, which stays reserved for redirects and the catch-all. Add to
+`frontend/src/guide/surfaces.ts`:
+
+```typescript
+  {
+    path: '/about',
+    title: 'About Canopy (public)',
+    audience: 'Anyone, including people with no account',
+    what: 'The public explainer — what Canopy is, the five components it is made of, live counts, and the five ways in. No login required, so this is the link to send someone outside the team.',
+    actions: ['Send it to someone', 'See the live fleet counts'],
+  },
+```
+
+Run `npx vitest run src/guide/coverage.test.ts` and confirm it is green before moving on.
+
 - [ ] **Step 6: Allowlist the page path in the login middleware**
 
 In `apps/common/middleware.py`, add to `PUBLIC_PATH_PREFIXES`:
@@ -2402,7 +2428,7 @@ Expected: no matches.
 - [ ] **Step 10: Commit**
 
 ```bash
-git add frontend/src/guide/components.ts frontend/src/guide/components.test.ts frontend/src/api/publicStats.ts frontend/src/pages/AboutPage.tsx frontend/src/router.tsx frontend/src/pwa/navigation-fallback.ts apps/common/middleware.py
+git add frontend/src/guide/components.ts frontend/src/guide/components.test.ts frontend/src/api/publicStats.ts frontend/src/pages/AboutPage.tsx frontend/src/guide/surfaces.ts frontend/src/router.tsx frontend/src/pwa/navigation-fallback.ts apps/common/middleware.py
 git commit -m "web: public explainer at /about
 
 Chrome-less on PublicLayout, anonymous, with live aggregate counts because

--- a/docs/superpowers/plans/2026-09-12-opening-canopy-to-other-people.md
+++ b/docs/superpowers/plans/2026-09-12-opening-canopy-to-other-people.md
@@ -756,38 +756,49 @@ Create `frontend/src/api/tokens.ts`:
  * can be recovered.
  */
 import { apiV2 } from './client.v2'
+import { problemMessage } from './problem'
 import type { components } from './generated'
 
 export type PersonalToken = components['schemas']['PersonalTokenOut']
 export type MintedToken = components['schemas']['PersonalTokenCreatedOut']
 
+// Every function here branches on `res.response.ok`, NEVER on `res.error`.
+// All three token endpoints declare ONLY a success response in the OpenAPI
+// schema (200 / 201 / 204), so `res.error` narrows to `never` and
+// `if (res.error)` fails tsc. `frontend/src/api/workspaces.ts:32-36` documents
+// this trap and every function in that file follows the same rule. `res.error`
+// is still safe to READ for a message — just not to branch on.
+
 export async function listTokens(): Promise<PersonalToken[]> {
-  const { data, error } = await apiV2.GET('/api/tokens/')
-  if (error) return []
-  return data
+  const res = await apiV2.GET('/api/tokens/')
+  if (!res.response.ok || !res.data) return []
+  return res.data
 }
 
 export async function mintToken(
   label: string,
   ttlDays: number | null,
 ): Promise<MintedToken | { error: string }> {
-  const { data, error } = await apiV2.POST('/api/tokens/', {
+  const res = await apiV2.POST('/api/tokens/', {
     body: { label, ttl_days: ttlDays },
   })
-  if (error || !data) {
-    const detail = (error as { detail?: string })?.detail
-    return { error: detail || 'Could not mint a token.' }
+  if (!res.response.ok || !res.data) {
+    return { error: problemMessage(res.error, 'Could not mint a token.') }
   }
-  return data
+  return res.data
 }
 
 export async function revokeToken(id: number): Promise<boolean> {
-  const { error } = await apiV2.DELETE('/api/tokens/{pk}/', {
+  const res = await apiV2.DELETE('/api/tokens/{pk}/', {
     params: { path: { pk: id } },
   })
-  return !error
+  return res.response.ok
 }
 ```
+
+`problemMessage(error, fallback)` lives at `frontend/src/api/problem.ts:21` and already
+handles the RFC 7807 shape (prefers `detail`, falls back to `title`, then to your string) —
+use it rather than reaching into `.detail` by hand.
 
 - [ ] **Step 2: Confirm the generated types already carry these schemas**
 

--- a/docs/superpowers/plans/2026-09-12-opening-canopy-to-other-people.md
+++ b/docs/superpowers/plans/2026-09-12-opening-canopy-to-other-people.md
@@ -1596,20 +1596,76 @@ function navItemPath(item: { path: string; tenant: boolean }): string {
   return item.path ? `/w/:workspace/${item.path}` : '/w/:workspace'
 }
 
+/** The tenant index — matches only EXACTLY. See `navMatch`. */
+const TENANT_INDEX = '/w/:workspace'
+
+/**
+ * Does `surfacePath` belong under the nav item at `navPath`?
+ *
+ * Exact match, or a detail route beneath it — `/w/:workspace/chat/:id` belongs
+ * with `/w/:workspace/chat`, because a reader looking for "the chat page" wants
+ * the list and the single chat together.
+ *
+ * The tenant index is the exception. `/w/:workspace` is a prefix of every tenant
+ * route, so prefix-matching it would pull the whole app into the Projects entry.
+ */
+function navMatch(surfacePath: string, navPath: string): boolean {
+  if (surfacePath === navPath) return true
+  if (navPath === TENANT_INDEX) return false
+  return surfacePath.startsWith(`${navPath}/`)
+}
+
+/**
+ * Clusters for surfaces the nav does not name.
+ *
+ * Without these, 25 of the 41 descriptors land in one "Elsewhere" bucket — 61%
+ * of the guide in a junk drawer, which defeats the point of grouping it by the
+ * menu at all. (Measured before this existed.)
+ *
+ * These are assigned BEFORE the nav groups, which matters for exactly one case:
+ * the ten rail sections all sit under `/w/:workspace/agents/:slug/`, so nav's
+ * `/w/:workspace/agents` would otherwise absorb them into Fleet and leave this
+ * group empty.
+ */
+const CLUSTERS: Array<{ label: string; match: (path: string) => boolean }> = [
+  {
+    // One agent's left rail — ten sections under a single agent.
+    label: 'Agent workspace',
+    match: (p) => p.startsWith('/w/:workspace/agents/:slug/'),
+  },
+  {
+    // Pages someone reaches from a link you sent them, with no account.
+    label: 'Shared links (no login)',
+    match: (p) =>
+      ['/share/:token', '/storyboard/:slug', '/narrative/:slug', '/walkthrough/:id',
+       '/review/:id', '/invite/:token'].includes(p) || p.startsWith('/ddd-release/'),
+  },
+]
+
 export function guideGroups(surfaces: SurfaceDescriptor[] = SURFACES): GuideGroup[] {
   const claimed = new Set<string>()
-  const groups: GuideGroup[] = []
-
-  for (const nav of NAV_GROUPS) {
-    const wanted = nav.items.map(navItemPath)
-    const members = surfaces.filter((s) => wanted.includes(s.path))
+  const take = (pred: (p: string) => boolean) => {
+    const members = surfaces.filter((s) => !claimed.has(s.path) && pred(s.path))
     members.forEach((m) => claimed.add(m.path))
-    if (members.length) groups.push({ label: nav.label, surfaces: members })
+    return members
   }
 
+  // Assign clusters first (see CLUSTERS' note), but DISPLAY the nav groups
+  // first, because that is the order a reader already knows from the header.
+  const clusterGroups = CLUSTERS.map((c) => ({ label: c.label, surfaces: take(c.match) }))
+
+  const navGroups = NAV_GROUPS.map((nav) => {
+    const wanted = nav.items.map(navItemPath)
+    return { label: nav.label, surfaces: take((p) => wanted.some((w) => navMatch(p, w))) }
+  })
+
   const rest = surfaces.filter((s) => !claimed.has(s.path))
-  if (rest.length) groups.push({ label: 'Elsewhere', surfaces: rest })
-  return groups
+
+  return [
+    ...navGroups.filter((g) => g.surfaces.length),
+    ...clusterGroups.filter((g) => g.surfaces.length),
+    ...(rest.length ? [{ label: 'Elsewhere', surfaces: rest }] : []),
+  ]
 }
 ```
 
@@ -1633,13 +1689,50 @@ describe('guideGroups', () => {
     expect(labels).toContain('Fleet')
   })
 
-  it('never drops a surface the nav does not mention', () => {
+  it('never drops a surface, even one nothing claims', () => {
     const groups = guideGroups([
-      { path: '/share/:token', title: 'Shared session', audience: 'Anyone', what: 'x' },
+      { path: '/nowhere-at-all', title: 'Orphan', audience: 'Anyone', what: 'x' },
     ])
     expect(groups).toEqual([
-      { label: 'Elsewhere', surfaces: [expect.objectContaining({ path: '/share/:token' })] },
+      { label: 'Elsewhere', surfaces: [expect.objectContaining({ path: '/nowhere-at-all' })] },
     ])
+  })
+
+  it('clusters the agent rail rather than letting Fleet absorb it', () => {
+    // The rail sits under /w/:workspace/agents/:slug/, and nav has
+    // /w/:workspace/agents — so without cluster-first assignment all ten
+    // sections would land in Fleet and this group would be empty.
+    const rail = guideGroups().find((g) => g.label === 'Agent workspace')
+    expect(rail?.surfaces.length).toBe(10)
+    const fleet = guideGroups().find((g) => g.label === 'Fleet')
+    expect(fleet?.surfaces.map((s) => s.path)).toContain('/w/:workspace/agents')
+    expect(fleet?.surfaces.map((s) => s.path)).not.toContain('/w/:workspace/agents/:slug/inbox')
+  })
+
+  it('groups the no-login shared links together', () => {
+    const shared = guideGroups().find((g) => g.label === 'Shared links (no login)')
+    expect(shared?.surfaces.map((s) => s.path)).toEqual(
+      expect.arrayContaining(['/share/:token', '/storyboard/:slug', '/walkthrough/:id']),
+    )
+  })
+
+  it('puts a detail route with its list route', () => {
+    const chats = guideGroups().find((g) => g.surfaces.some((s) => s.path === '/w/:workspace/chat'))
+    expect(chats?.surfaces.map((s) => s.path)).toContain('/w/:workspace/chat/:id')
+  })
+
+  it('does not let the tenant index swallow every tenant path', () => {
+    // /w/:workspace prefixes every tenant route; if it prefix-matched, the group
+    // holding Projects would absorb the entire app.
+    const work = guideGroups().find((g) => g.surfaces.some((s) => s.path === '/w/:workspace'))
+    expect(work?.surfaces.map((s) => s.path)).not.toContain('/w/:workspace/members')
+  })
+
+  it('keeps Elsewhere a small remainder, not a dumping ground', () => {
+    const elsewhere = guideGroups().find((g) => g.label === 'Elsewhere')
+    // Measured at ~4 genuinely uncategorised surfaces. A jump here means a new
+    // cluster needs a rule, not that the bucket should grow.
+    expect(elsewhere?.surfaces.length ?? 0).toBeLessThanOrEqual(8)
   })
 })
 ```
@@ -1752,8 +1845,11 @@ demand it):
   },
 ```
 
-In `frontend/src/components/AppLayout/nav.ts`, add it to the last group (the
-team/admin one), so it is reachable without knowing the URL.
+In `frontend/src/components/AppLayout/nav.ts`, add it to the **`Workspace`** group (the
+last one, holding Shareouts / Timeline / Sessions / Members / Inbound / System) as
+`{ path: '/guide', label: 'Guide', tenant: false }`. That group already holds the other
+global, non-tenant reference surface (`/system`), so `/guide` sits beside its closest
+sibling and is reachable without knowing the URL.
 
 - [ ] **Step 5: Run the whole frontend suite and build**
 

--- a/docs/superpowers/plans/2026-09-12-opening-canopy-to-other-people.md
+++ b/docs/superpowers/plans/2026-09-12-opening-canopy-to-other-people.md
@@ -277,7 +277,9 @@ three-state logic, which is what `firstRun.test.ts` below covers.
 
 **Interfaces:**
 - Consumes: `MeOut.can_create_workspace` (Task 1); `useWorkspace()` from
-  `@/workspace/WorkspaceProvider` returning `{ workspaces, active, loading }`;
+  `@/workspace/WorkspaceProvider` returning `{ workspaces, active, loading, refresh }`
+  — verified: `refresh: () => Promise<void>` re-fetches the membership list and its own
+  doc comment states a page mutating the caller's workspace state must call it;
   `getMe()` from `@/api/me`.
 - Produces: `firstRunState(args) -> 'loading' | 'can-create' | 'needs-invite' | 'ready'`,
   and `createWorkspace(slug, displayName) -> Promise<WorkspaceOut>` in `api/workspaces.ts`.
@@ -387,6 +389,7 @@ Create `frontend/src/pages/FirstRunPage.tsx`:
 
 ```tsx
 import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { useWorkspace } from '@/workspace/WorkspaceProvider'
 import { getMe } from '@/api/me'
 import { createWorkspace } from '@/api/workspaces'
@@ -402,7 +405,8 @@ import { firstRunState } from './firstRun'
  * asking for a slug.
  */
 export function FirstRunPage() {
-  const { workspaces, loading } = useWorkspace()
+  const { workspaces, loading, refresh } = useWorkspace()
+  const navigate = useNavigate()
   const [canCreate, setCanCreate] = useState<boolean | null>(null)
   const [slug, setSlug] = useState('')
   const [displayName, setDisplayName] = useState('')
@@ -431,11 +435,13 @@ export function FirstRunPage() {
       setError(res.error)
       return
     }
-    // Full reload rather than client navigation: the workspace list is fetched
-    // once by WorkspaceProvider, and a brand-new membership has to be visible
-    // to every consumer (nav, switcher, tenancy resolution) before any tenant
-    // route renders.
-    window.location.assign(`${import.meta.env.BASE_URL.replace(/\/$/, '')}/w/${res.slug}`)
+    // WorkspaceProvider fetches the membership list once on mount and never
+    // invalidates it, so a brand-new membership is invisible until something
+    // re-fetches. `refresh()` is the provider's documented mechanism for exactly
+    // this ("a page that mutates the CALLER's own role in a workspace must call
+    // this afterward") — use it rather than a full page reload.
+    await refresh()
+    navigate(`/w/${res.slug}`)
   }
 
   return (

--- a/docs/superpowers/plans/2026-09-12-opening-canopy-to-other-people.md
+++ b/docs/superpowers/plans/2026-09-12-opening-canopy-to-other-people.md
@@ -1371,13 +1371,27 @@ Run: `cd frontend && npx vitest run src/guide/coverage.test.ts`
 Expected: all pass. Iterate: each failure names exactly which path is missing a
 descriptor or which descriptor names no route.
 
-- [ ] **Step 7: Confirm it is fast**
+- [ ] **Step 7: Confirm the cost is acceptable, and expect ~a second rather than milliseconds**
 
 Run: `cd frontend && npx vitest run src/guide/coverage.test.ts --reporter=verbose`
-Expected: the file's duration is milliseconds, not seconds. If it is slow, something is
-importing React components transitively — the test must only pull in `routeTable`'s
-*paths*. If `router.tsx`'s lazy imports make the import heavy, move `routeTable` into its
-own module (`frontend/src/routeTable.ts`) that holds paths and element references only.
+
+**What to expect, and why.** `router.tsx` has ~35 imports and most of them are **eager**
+page imports (`ProjectsPage`, `InsightsPage`, `SettingsPage`, `AppLayout`, …) — only the
+agent-rail sections and the chat pages are `lazy()`. So importing `routeTable` transitively
+loads most of the app's component tree. That is unavoidable: the route table's `element`
+values *are* those components, so any module holding the table holds the imports. Do not
+try to dodge it by moving `routeTable` to its own file — the imports travel with it, and
+an earlier draft of this plan wrongly suggested that as a fix.
+
+A few hundred milliseconds to about a second is fine and is the intended cost. This is
+already proven to work: `SettingsPage.presence.test.tsx` imports `SettingsPage` and renders
+it. Do NOT introduce a second source of truth for the paths to make the test faster — a
+hand-maintained path list is exactly the drift this registry exists to prevent.
+
+**If the import fails** (rather than merely being slow), the cause will be an import-time
+side effect in some page module, not the size of the graph. Mock the offending module in
+this test the way `SettingsPage.presence.test.tsx` mocks `@/api/tokens`, and say which one
+in your report — an import-time side effect in a page module is worth knowing about.
 
 - [ ] **Step 8: Commit**
 

--- a/docs/superpowers/plans/2026-09-12-opening-canopy-to-other-people.md
+++ b/docs/superpowers/plans/2026-09-12-opening-canopy-to-other-people.md
@@ -2179,15 +2179,40 @@ def _extra(name: str) -> int:
         return 0
 
 
-def public_stats() -> dict[str, int]:
+#: Short TTL on an ANONYMOUS endpoint, so an unauthenticated caller cannot turn
+#: this into a free load generator against the database. 60s is well inside what
+#: a counts display needs to be truthful. The project configures no `CACHES`, so
+#: this is Django's default per-process LocMemCache — each web process computing
+#: the counts once a minute is fine, and the pattern matches
+#: `apps/canopy_sessions/attach.py` and `apps/mcp/rate_limit.py`.
+_CACHE_KEY = "system:public-stats:v1"
+_CACHE_TTL = 60
+
+
+def _compute() -> dict[str, int]:
     return {
         "agents": Agent.objects.count(),
         "skills": _skill_count(),
         "runners_online": _runners_online(),
+        # DONE only — "turns executed" should not count failures or cancellations.
+        # Hits the ("status", "created_at") index on its leading column.
         "turns_executed": Turn.objects.filter(status=Turn.DONE).count(),
         "demos_published": _extra("demos_published"),
     }
+
+
+def public_stats() -> dict[str, int]:
+    cached = cache.get(_CACHE_KEY)
+    if cached is not None:
+        return cached
+    stats = _compute()
+    cache.set(_CACHE_KEY, stats, timeout=_CACHE_TTL)
+    return stats
 ```
+
+Add `from django.core.cache import cache` to the imports. Bump the `v1` in the cache key
+if you ever change the returned field set, so a running process cannot serve a stale shape
+to the new schema.
 
 Add `from collections.abc import Callable` to the imports (used in the annotations above).
 

--- a/docs/superpowers/specs/2026-09-12-github-backed-agent-creation-design.md
+++ b/docs/superpowers/specs/2026-09-12-github-backed-agent-creation-design.md
@@ -1,0 +1,162 @@
+# GitHub-backed agent creation — "create agent" means a real repo, from a browser
+
+**Date:** 2026-09-12
+**Status:** Design — not implemented
+**Companion:** `2026-09-12-opening-canopy-to-other-people-design.md` — first run, the
+self-documenting app, the public explainer. That spec's agents empty state is what this
+one turns into a button.
+**Builds on:** `2026-09-05-agent-credentials-design.md` — provisioning an agent without
+the box or 1Password. GitHub is the last thing that still needs a terminal.
+
+## Problem
+
+> *"It doesn't mean anything (currently) to create an agent with no repo, so yes, the
+> results of creating an agent would be creating the proper GitHub repo and properly
+> linking the agent."* — Jonathan, 2026-09-12
+
+`POST /api/agents/` exists and no UI calls it, which the companion spec records as a gap.
+But wiring a button to it would be worse than leaving it alone: an agent record with no
+repo has no persona, no domain skills and no hooks, so it cannot take a turn. The record
+is not the agent; the repo is.
+
+This is the same sentence one dependency later than the credentials spec, which opens:
+
+> *"Someone could plausibly create a completely new agent without direct access to the
+> cloud box or 1Password. A mailbox was the last thing that could not be provisioned
+> that way — minting a gog token meant a terminal, `gog auth login`, a loopback
+> listener, and then a hand-written 1Password item. This turns it into a button."*
+
+The mailbox became a button. The repo did not: the factory
+(`canopy/src/orchestrator/agent_factory.py`) does `git init` and a local commit, and
+getting that onto GitHub is still a human running `gh repo create` on a laptop.
+
+**The requirement that shapes the design:** the credential is the *user's*, and the repo
+goes wherever they point it — *"this should be designed so it's not just Dimagi users who
+can use this in theory."* So: no shared service account, no hardcoded organisation.
+
+## The auth decision, and the research behind it
+
+**A GitHub App, authorized per-user through the user-to-server web flow.** Not an OAuth
+App. GitHub's own guidance is explicit: *"In general, GitHub Apps are preferred to OAuth
+apps because they use fine-grained permissions, give more control over which repositories
+the app can access, and use short-lived tokens."*
+
+Checked against current docs on 2026-09-12, because this area moved recently and a wrong
+answer here is a credential with the wrong blast radius:
+
+| Endpoint | Permission | Token types |
+|---|---|---|
+| `POST /user/repos` — a repo under the user's own account | `Administration: write` | **UAT** |
+| `POST /orgs/{org}/repos` — a repo in any org | `Administration: write` | UAT + IAT |
+| `POST /repos/{owner}/{repo}/generate` — from a template | `Contents: write` (+ more) | UAT + IAT |
+
+So **one GitHub App with a user access token covers both personal-account and
+organisation targets.** There is no need to combine an App with an OAuth App, and no
+fallback path. Recorded because the obvious research says otherwise: GitHub's community
+thread on creating repos with an App user token is unresolved and inactive since May 2024,
+and its answer — "combine the functionality of a GitHub App and an OAuth App, using OAuth
+`repo` scope" — is wrong for our case. That thread is about someone holding only
+`Contents` permission, which was never going to create a repository.
+
+**What changed recently, and why it doesn't change the answer.** In August 2026 OAuth
+Apps gained token rotation (8-hour tokens, 6-month refresh via `offline_access`), up to
+10 redirect URIs, and wildcard redirect matching — closing the token-lifetime gap that
+used to be the main argument for Apps. It explicitly did **not** change the permission
+model: OAuth Apps still use coarse scopes. That is decisive here. We need exactly
+`Administration: write`; the OAuth route would mean `repo`, which is read and write on
+every private repository that person can see. For Dimagi staff, that is every private
+Dimagi repo, stored in canopy-web, to serve a button pressed once per agent.
+
+**Register the App as public.** Since June 2025, private and EMU-owned apps restrict
+sign-in to members of the owning organisation or enterprise. An App registered private
+under Dimagi cannot be authorized by anyone outside it, which would silently defeat the
+"not just Dimagi users" requirement. This is one checkbox at registration and it is
+confusing to diagnose afterwards.
+
+Sources: [GitHub Apps vs OAuth Apps](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/differences-between-github-apps-and-oauth-apps) ·
+[Permissions required for GitHub Apps](https://docs.github.com/en/rest/authentication/permissions-required-for-github-apps) ·
+[User access tokens](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-user-access-token-for-a-github-app) ·
+[OAuth token refresh and multiple redirect URIs, Aug 2026](https://github.blog/changelog/2026-08-14-multiple-redirect-uris-and-token-refresh-for-oauth-apps/) ·
+[Security updates for apps and API access, Jun 2025](https://github.blog/changelog/2025-06-24-security-updates-for-apps-and-api-access/)
+
+## Decisions
+
+1. **A public GitHub App with `Administration: write`, `Contents: write`, `Metadata: read`.**
+   Nothing broader. `Contents: write` is what pushes the scaffold; `Administration: write`
+   is what creates the repo.
+2. **The grant is per-user, and it does not go in the agent vault.** The credentials spec
+   puts per-user secrets explicitly out of scope — *"`chrome-sales` acts on behalf of the
+   dispatching human, not the agent… an agent vault is the wrong home and this does not
+   become one."* A human's GitHub token is exactly that case, so it gets its own per-user
+   model rather than an `AgentCredential` row. It reuses the Fernet helper
+   (`apps/common/encryption.py::encrypt_secret`) and none of the agent-vault semantics.
+   This is consistent with the amendment's rule for what canopy-web may hold at all:
+   only secrets it mints itself, which a token from its own OAuth flow is.
+3. **Store the refresh token and treat the access token as disposable.** User access
+   tokens expire in 8 hours with a 6-month refresh token. Refresh on use; a failed
+   refresh surfaces as "reconnect GitHub" in settings rather than an opaque 401 during
+   agent creation.
+4. **The owner is chosen by the user, from where they have actually installed the App.**
+   `GET /user/installations` after authorization gives the real list of accounts and orgs;
+   the create form renders it as a dropdown with an "install somewhere else" link. No
+   hardcoded org, and no asking the user to type an owner name that may not work.
+5. **The factory becomes a shared package, not a second implementation.** Extract
+   `agent_factory.py` and its templates into a library both the canopy plugin and
+   canopy-web depend on. This is the fifth instance of an established pattern here —
+   `packages/canopy_agent_runs`, `canopy_cron`, `canopy_runtime`, `canopy_transcript` are
+   already editable path deps wired through `[tool.uv.sources]`. Rejected alternatives: a
+   GitHub template repo (the scaffold would then exist twice and drift), and dispatching a
+   turn to a runner (zero new credentials, but a brand-new user has no runner, so the
+   first agent could never be created — which is the entire point of the web path).
+6. **Create the repo empty, then push the scaffold.** Keeps the GitHub call trivial and
+   keeps the scaffold's content entirely inside the factory package.
+
+## Shape
+
+1. `/settings` gains **Connect GitHub** — the user-to-server web flow, alongside the
+   existing Claude-subscription connect block, which is the same shape of thing.
+2. The callback stores the encrypted refresh token against the user and records their
+   GitHub login.
+3. `/w/:ws/agents` **Create agent** asks for: slug, display name, owner (from
+   installations), and visibility.
+4. Server side: run the factory → create the repo → push → `POST`-equivalent write of the
+   `Agent` row with its `repo_url` → return the agent's workspace URL.
+5. Failure is partial by nature (a repo can exist while the push fails). The operation
+   reports which steps completed and is safe to retry: creating an agent whose repo
+   already exists adopts it rather than erroring, matching `POST /api/agents/`'s existing
+   upsert-by-slug semantics.
+
+## What is still not a button after this
+
+The scaffold is a skeleton — the `create-agent` skill's own words. Persona and domain
+skills are written by a human with an agent, in a session, afterwards. This spec makes the
+*repo* a button, not the agent's judgment. Worth stating plainly on the success screen so
+nobody concludes their new agent is finished.
+
+## Testing
+
+- **The factory package keeps its own test suite** on extraction, plain pytest, no Django
+  — the precedent `packages/canopy_agent_runs` already sets.
+- **The GitHub calls are tested against a fake**, with one live end-to-end run recorded
+  by hand against a throwaway repo. Per `2026-08-01-clicking-does-nothing-incident.md`:
+  in-process tests with both ends faked are the right shape for seams and are exactly
+  what passes while the live chain is broken.
+- **A 30-minute live check before building the credential layer**: a throwaway App on a
+  personal account, `POST /user/repos` with a user access token. The docs say it works and
+  the permissions table above is authoritative, but this is cheap and it is the one
+  assumption the whole design rests on.
+- **Scope assertion**: a test that fails if the App's requested permission set grows
+  beyond the three declared above. Permission creep on an App thousands of repos could be
+  installed on is worth a tripwire.
+
+## Out of scope
+
+- **Anything the agent itself pushes.** After creation, the agent's own commits go through
+  its runner's `gh` auth. This credential is for provisioning only, used once.
+- **Repo settings beyond creation** — rulesets, merge queue, branch protection. The
+  factory can gain them later; `Administration: write` already permits it.
+- **Deleting or transferring repos.** Not requested, and a destructive capability on a
+  public App is worth not having.
+- **Per-user secrets generally.** This adds one per-user credential for one purpose. It is
+  not the beginning of a per-user vault, and the credentials spec's reasoning against that
+  still holds.

--- a/docs/superpowers/specs/2026-09-12-opening-canopy-to-other-people-design.md
+++ b/docs/superpowers/specs/2026-09-12-opening-canopy-to-other-people-design.md
@@ -1,0 +1,232 @@
+# Opening canopy to other people — first run, a self-documenting app, and a public explainer
+
+**Date:** 2026-09-12
+**Status:** Design — not implemented
+**Companion:** `2026-09-12-github-backed-agent-creation-design.md` — agent creation that
+produces a real repo. Deliberately a separate spec; see § "Why agent creation is not in here".
+**Builds on:** `2026-09-05-agent-credentials-design.md` (provisioning an agent from a
+browser instead of a terminal — this spec is the same thesis applied to the humans)
+
+## Problem
+
+> *"We're going from an entire platform I built myself to one that I want to start
+> opening up to Dimagi power users."* — Jonathan, 2026-09-12
+
+Three things were asked for: a public explainer of what canopy is and how it works
+(a component view, good enough to send to someone outside Dimagi), end-user docs for
+canopy-web itself, and an explanation of how the agent system works. The docs were
+asked to be "self-documenting and dynamic as much as possible", because everything
+static in this repo goes stale — the canopy plugin's own README still describes the
+system as a self-improvement loop over Claude Code sessions, which is now a small
+fraction of what it does.
+
+**The finding that reorders the work: this is a product problem before it is a
+documentation problem.** Four dead ends were confirmed by reading the code, not by
+speculating:
+
+| # | Gap | Evidence |
+|---|---|---|
+| 1 | **A new user sees a blank page.** A signed-in user with no workspace membership lands on `/`, `RootRedirect` renders `null`, and nothing appears inside the app shell. Not an error, not an empty state. `TenantRedirect` does the same for every legacy flat path. | `frontend/src/router.tsx:126`, `:135` |
+| 2 | **No way to create a workspace.** `POST /api/workspaces/` exists and works. Nothing in the frontend calls it — the only workspace writes the UI makes are invite-preview and invite-accept. | `apps/workspaces/api.py:102` vs. `frontend/src/api/workspaces.ts` |
+| 3 | **No way to create an agent.** `POST /api/agents/` (upsert by slug) exists. No frontend caller; agents exist only because the plugin POSTs them. | `apps/agents/api.py:115` |
+| 4 | **No way to see, mint, or revoke a Personal Access Token.** `POST /api/tokens/` and `DELETE /api/tokens/{pk}/` exist with zero UI. `/settings` offers the AI backend switch, Claude subscription auth, a presence toggle and debug-session minting — and nothing else. | `apps/tokens/api.py`, `frontend/src/pages/SettingsPage.tsx` |
+
+Compounding (1): the header workspace switcher returns `null` at
+`workspaces.length <= 1` (`frontend/src/components/AppLayout/AppLayout.tsx:188`), so
+a user with zero workspaces has neither a switcher nor a create affordance anywhere
+on the page.
+
+**The pattern, which matters more than the four bugs:** *every write that turns a
+person into a tenant, an agent owner, or an authenticated machine caller exists in
+the API and is missing from the UI.* Those are the first three things a new power
+user needs. They are missing for one reason — they have only ever been done from a
+shell or from the plugin, by the person who wrote them. That is the signature of a
+platform built for one operator, and it is the whole of what "opening it up" means.
+
+### A note on method, so the next person doesn't over-trust it
+
+The four gaps above were found by a mechanical diff: every `@router.post|put|patch|delete`
+across `apps/*/api.py` against every write call in `frontend/src`. **Roughly two thirds
+of that output is noise** and it must not be treated as an audit. Machine-only contracts
+(`runners/{id}/heartbeat`, `turns/{id}/finish`, `inbound/gmail/{workspace}/`) correctly
+have no UI caller, and the diff mis-attributes any app whose mount prefix differs from its
+label (`canopy_sessions` mounts at `/api/canopy-sessions`, `runs` at `/api/ddd`,
+`session_sharing` at `/api/sessions`). To become a real instrument it needs the mount map
+from `apps/api/api.py` plus an explicit machine-only classification. It is a hint
+generator. A genuine cold-start audit — a fresh account walked through every path — is
+**deliberately deferred** until the known gaps are closed, so the expensive discovery
+runs against a system that already handles the obvious cases.
+
+## Decisions
+
+1. **Fix the known gaps before documenting them.** Documentation for a path a power
+   user cannot walk is worse than none: it converts a missing feature into a broken
+   promise.
+2. **Enforce coverage; do not attempt to enforce accuracy.** A fast test proves every
+   surface is described. Proving a description is *true* means driving the live app
+   (canopy already has the machinery, via `canopy:walkthrough`), which costs minutes
+   per claim. Rejected for now on speed grounds — the loop through CI is moving too
+   fast to spend that. Revisit for the first-run path alone, where a wrong doc loses
+   a user permanently.
+3. **Descriptors are data, colocated with the routes** — not prose in a wiki, not
+   Markdown in `docs/`. Same choice, and the same reasoning, as
+   `frontend/src/pages/systemWorkflows.ts`: data can be read by a test and rendered
+   by a page; prose in another repo can be neither.
+4. **The public page and the authed guide share one registry of user paths**, so the
+   public promise cannot drift from the internal documentation. This is the only
+   structural coupling between them, and it is deliberate.
+5. **No maturity badges.** Labelling each path Solid/Rough/Planned was considered and
+   rejected: maturity changes faster than the page does, and a stale "rough" reads as
+   a live warning. What doesn't work and is fixable gets fixed instead.
+6. **No "ask the docs" chatbot.** It lets bad structure survive by papering over it,
+   and it can invent answers about a system whose failure modes matter.
+7. **The agents empty state teaches rather than offering a button.** Until the companion
+   spec ships, a web-created agent would be a record with no repo, no persona and no
+   skills — unable to take a turn. A half-created agent is worse than no button, so the
+   empty state explains what an agent is and hands over `/canopy:create-agent`.
+
+## Part A1 — first run works
+
+Four changes, all wiring endpoints that already exist and are already tested.
+
+**The first-run screen** replaces both `return null` sites. A signed-in user with no
+membership gets a real page: what a workspace is (one short paragraph — it is the
+tenant that owns agents, projects and demos), a **Create workspace** form, and the
+alternative path ("if a colleague invited you, open their `/invite/...` link"). This
+screen is the single highest-value piece of documentation in the whole spec, because
+it is the only one every new user is guaranteed to read.
+
+**Create a workspace** posts to `POST /api/workspaces/` from that screen, and from a
+persistent affordance in the header. The switcher's `workspaces.length <= 1` guard is
+split in two: hide the *switcher* when there is nothing to switch between, but always
+offer *create*. Conflating "nothing to switch to" with "nothing you can do" is what
+produced the dead end.
+
+**PAT management** on `/settings`: list tokens with their created/last-used dates,
+mint one (shown exactly once, with a copy button — the existing `CopyBlock` component
+already does this for debug sessions), and revoke. This is the gate on two of the five
+ways in — pointing another tool at canopy's MCP surface, and setting up the plugin —
+and it is currently only reachable by running a skill that requires the plugin you are
+trying to set up.
+
+**The agents empty state** explains what an agent is, links to `/guide`, and hands over
+the `create-agent` command. It becomes a button in the companion spec.
+
+## Part B — the self-documenting app
+
+**One new data file**, `frontend/src/guide/surfaces.ts`: one descriptor per route,
+keyed by the exact path string from the route table. Per surface — what it is in one
+line, who it is for, what you need before it does anything useful, and what you can do
+on it. 38 entries: the route table declares 49 paths, of which 11 are redirects or legacy
+aliases that need no descriptor.
+
+**One small enabling refactor.** `frontend/src/router.tsx` currently passes its route
+array as an inline literal to `createBrowserRouter(guarded([...]))`. Extract it to a
+named `export const routeTable`, passed in. Recovering paths from a *built* router is
+awkward; reading them from an exported array is three lines in a test. Nothing else
+about the router changes.
+
+**`/guide`** renders the descriptors grouped by `nav.ts`'s existing grouping, so the
+guide's shape matches the menu people actually look at, with the first-run sequence
+pinned at the top as an ordered list rather than a peer group. Anchors are route paths
+(`/guide#/w/:workspace/chat`) so anything can deep-link to the explanation of a
+specific surface.
+
+**One fast test.** Flatten `routeTable`, drop redirects, legacy aliases and the
+catch-all, then assert two directions: every remaining path has a descriptor, and
+every descriptor names a real path. The second direction matters as much as the first
+— it catches a descriptor orphaned by a deleted route, which is how a generated guide
+starts lying. Pure array comparison, no browser, no network, inside the existing
+`vitest run` alongside the current 58 test files.
+
+**Empty states deep-link into the guide.** The stuck-user surface and the documentation
+surface become the same content, which is what stops the guide from being a thing
+nobody opens.
+
+## Part C — the public explainer
+
+A chrome-less public page on `PublicLayout` — the pattern `/storyboard` and
+`/ddd-release` already use, mounted outside `AppLayout` so anonymous visitors are not
+bounced to login by the shell's authed calls. No Dimagi account, no plugin, no install.
+
+**Content**, in order: what canopy is in two sentences; live counts; the component view;
+the five ways in; links to the public artifacts that prove it works (a storyboard, a
+walkthrough) and to `/api/docs/` for the API.
+
+**The component view** is the piece that was actually missing. Five components and the
+one sentence that connects them:
+
+| Component | What it is |
+|---|---|
+| **canopy-web** | The system of record and every human surface. Owns workspaces, agents, turns, items, schedules, sessions and published artifacts |
+| **The canopy plugin** | The capability library — skills, agents and commands, installed into Claude Code. What an agent knows how to *do* |
+| **Runners** | The execution substrate. A paired laptop (emdash + CDP) or a cloud box (ACP). Claims turns and runs Claude Code |
+| **Agents** | Persona repos stamped from the factory — identity, domain skills, hooks. `echo`, `eva`, `hal`, `ada`, `ace` |
+| **The harness** | The control plane joining them: turn lifecycle, claim and lease, the event ledger, routing |
+
+> **A turn is the unit of work.** canopy-web owns the record of turns, runners execute
+> them wherever your compute happens to live, and the plugin is the library of what an
+> agent knows how to do.
+
+**Live counts** come from a new `GET /api/system/public-stats`, `auth=None`, aggregates
+only: number of agents, skills in the catalog, runners currently online, turns executed,
+published demo packages (DDD run releases). **No names, no slugs, no workspace or
+tenant data, no content, and nothing per-agent** — a count cannot leak what a count is of. Cached briefly so the page
+is not a free load generator. The reason to build this rather than write numbers into
+prose is that prose is wrong within a month, and "we run a fleet of agents" reads as a
+claim while `2 runners online` reads as a fact.
+
+**The five ways in** is generated from a shared `frontend/src/guide/paths.ts`, consumed
+by both this page and `/guide`:
+
+| Path | Who you are | Where you start |
+|---|---|---|
+| **You were sent a link** | An audience. No login, no install | `/storyboard/:slug`, `/narrative/:slug`, `/walkthrough/:id`, `/share/:token` |
+| **You want work done by an agent** | An operator | `/w/:ws/chat` — plus the choice of *where it runs*: a cloud runner, or your own laptop so you can jump into the terminal |
+| **You keep agents unblocked** | A supervisor | `/supervisor`, installable as a phone PWA, pushes when an agent needs you |
+| **You want canopy's skills in your own sessions** | A Claude Code user | Install the plugin; `/canopy:*`. No fleet, no runner |
+| **You want to build an agent** | A builder | `/canopy:create-agent` (a button, once the companion spec ships) |
+
+Two notes on that taxonomy, since it differs from the one we started with. "Watch a turn
+in the browser" and "watch a turn locally" were originally separate paths; they are one
+job with a deployment choice inside it, and splitting them hid the fact that the *choice*
+is the interesting part. And "you were sent a link" was missing entirely despite almost
+certainly being the highest-volume interaction anyone has with canopy.
+
+## Why agent creation is not in here
+
+Creating an agent properly means creating its GitHub repo and linking it — a bare record
+is meaningless. That needs a GitHub App, a per-user OAuth grant, an owner picker, and the
+agent factory extracted from the canopy orchestrator into a shared package. It is larger
+than A1, B and C combined and it needs a GitHub App registered before a line of it can be
+tested. Folding it in would stall the documentation work behind an app registration —
+the same trap avoided by deferring the cold-start audit.
+
+The seam is clean and nothing gets rewritten: this spec's agents empty state teaches the
+flow, and the companion spec upgrades that same empty state into a button.
+
+## Testing
+
+- **Route/descriptor coverage**, both directions, in the existing vitest suite.
+- **The first-run screen renders for a zero-workspace user** — the case that currently
+  renders `null`. A unit test on the redirect components with an empty membership list.
+- **Workspace create, PAT mint and PAT revoke** each get a happy path plus the error the
+  API actually returns (duplicate slug on create; 404 on revoking someone else's token).
+- **`public-stats` is anonymous and leaks nothing**: asserts 200 without auth, and
+  asserts the response body contains no names, slugs or ids. The second assertion is the
+  load-bearing one — an anonymous endpoint on a multi-tenant system is exactly where a
+  field gets added later without anyone re-asking whether it should be public.
+- **No new CI workflow.** Everything above runs inside the existing backend and frontend
+  test commands.
+
+## Out of scope
+
+- **The cold-start audit.** Deferred on purpose until the known gaps are closed.
+- **Accuracy verification of descriptors.** Coverage only; see Decision 2.
+- **GitHub-backed agent creation.** The companion spec.
+- **Rewriting the canopy plugin's README.** It is stale in the same direction, and it is a
+  different repo. Worth doing; not this.
+- **Anything about how the agent *system* works beyond the component view.** The public
+  page explains the five components and the turn. The deep version — routing cascades,
+  the item ledger, transcript custody — stays in `ARCHITECTURE.md` and the specs, because
+  its audience is someone changing the code, not someone deciding whether to try it.

--- a/docs/superpowers/specs/2026-09-12-opening-canopy-to-other-people-design.md
+++ b/docs/superpowers/specs/2026-09-12-opening-canopy-to-other-people-design.md
@@ -117,8 +117,9 @@ the `create-agent` command. It becomes a button in the companion spec.
 **One new data file**, `frontend/src/guide/surfaces.ts`: one descriptor per route,
 keyed by the exact path string from the route table. Per surface — what it is in one
 line, who it is for, what you need before it does anything useful, and what you can do
-on it. 38 entries: the route table declares 49 paths, of which 11 are redirects or legacy
-aliases that need no descriptor.
+on it. 43 entries, verified against `router.tsx`: 52 path literals are declared, 12 are
+redirects, legacy aliases or the catch-all and need no descriptor, leaving 40 today —
+plus the three surfaces this work adds (`/new-workspace`, `/guide`, `/about`).
 
 **One small enabling refactor.** `frontend/src/router.tsx` currently passes its route
 array as an inline literal to `createBrowserRouter(guarded([...]))`. Extract it to a

--- a/frontend/src/api/client.v2.ts
+++ b/frontend/src/api/client.v2.ts
@@ -96,7 +96,8 @@ function isPublicLinkRoute(): boolean {
     p.startsWith("/ddd-release/") ||
     p.startsWith("/storyboard/") ||
     p.startsWith("/narrative/") ||
-    p.startsWith("/invite/")
+    p.startsWith("/invite/") ||
+    p.startsWith("/about")
   );
 }
 

--- a/frontend/src/api/client.v2.ts
+++ b/frontend/src/api/client.v2.ts
@@ -97,7 +97,7 @@ function isPublicLinkRoute(): boolean {
     p.startsWith("/storyboard/") ||
     p.startsWith("/narrative/") ||
     p.startsWith("/invite/") ||
-    p.startsWith("/about")
+    p === "/about"
   );
 }
 

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -2508,9 +2508,9 @@ export interface paths {
          *     NOTE: `auth=None` is half the story — apps/common/middleware.py is
          *     default-deny, so this path is also allowlisted there. Both are required.
          *
-         *     Placement matters: declared ABOVE `detail()` (`/{kind}/{name}`), since
-         *     Ninja resolves routes in declaration order and `detail` would otherwise
-         *     capture `public-stats` as a `kind`.
+         *     Declared above `detail()` for readability. `/{kind}/{name}` is two path
+         *     segments, so it cannot capture this single-segment route — the order is
+         *     not load-bearing.
          */
         readonly get: operations["apps_system_api_public_stats"];
         readonly put?: never;

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -4675,6 +4675,11 @@ export interface components {
             readonly name: string;
             /** Avatar Url */
             readonly avatar_url: string;
+            /**
+             * Can Create Workspace
+             * @default false
+             */
+            readonly can_create_workspace: boolean;
         };
         /**
          * PresencePreferenceOut

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -2494,6 +2494,33 @@ export interface paths {
         readonly patch?: never;
         readonly trace?: never;
     };
+    readonly "/api/system/public-stats": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        /**
+         * Aggregate counts for the public explainer (anonymous)
+         * @description Anonymous, aggregates only.
+         *
+         *     NOTE: `auth=None` is half the story — apps/common/middleware.py is
+         *     default-deny, so this path is also allowlisted there. Both are required.
+         *
+         *     Placement matters: declared ABOVE `detail()` (`/{kind}/{name}`), since
+         *     Ninja resolves routes in declaration order and `detail` would otherwise
+         *     capture `public-stats` as a `kind`.
+         */
+        readonly get: operations["apps_system_api_public_stats"];
+        readonly put?: never;
+        readonly post?: never;
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
     readonly "/api/system/{kind}/{name}": {
         readonly parameters: {
             readonly query?: never;
@@ -8702,6 +8729,22 @@ export interface components {
             readonly description: string;
         };
         /**
+         * PublicStatsOut
+         * @description Aggregates for the public explainer. Integers only — see apps/system/stats.py.
+         */
+        readonly PublicStatsOut: {
+            /** Agents */
+            readonly agents: number;
+            /** Skills */
+            readonly skills: number;
+            /** Runners Online */
+            readonly runners_online: number;
+            /** Turns Executed */
+            readonly turns_executed: number;
+            /** Demos Published */
+            readonly demos_published: number;
+        };
+        /**
          * CapabilityDetailOut
          * @description Single capability — adds the full markdown body.
          */
@@ -14095,6 +14138,26 @@ export interface operations {
                 };
                 content: {
                     readonly "application/json": components["schemas"]["CapabilityCatalogOut"];
+                };
+            };
+        };
+    };
+    readonly apps_system_api_public_stats: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly requestBody?: never;
+        readonly responses: {
+            /** @description OK */
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["PublicStatsOut"];
                 };
             };
         };

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -4704,6 +4704,7 @@ export interface components {
             readonly avatar_url: string;
             /**
              * Can Create Workspace
+             * @description Whether this caller may POST /api/workspaces/. False for an invite-admitted user holding no membership — see the F1 finding in apps.workspaces.services.can_create_workspace. The first-run screen reads this so it never offers a button that 403s.
              * @default false
              */
             readonly can_create_workspace: boolean;

--- a/frontend/src/api/publicStats.ts
+++ b/frontend/src/api/publicStats.ts
@@ -1,0 +1,26 @@
+/**
+ * Aggregate counts for the public explainer. Anonymous — deliberately a bare
+ * fetch with no credentials and no CSRF, because this page is served to
+ * visitors with no session and sending cookies would gain nothing.
+ */
+import { apiUrl } from './base'
+
+export interface PublicStats {
+  agents: number
+  skills: number
+  runners_online: number
+  turns_executed: number
+  demos_published: number
+}
+
+export async function getPublicStats(): Promise<PublicStats | null> {
+  try {
+    const resp = await fetch(apiUrl('/api/system/public-stats'))
+    if (!resp.ok) return null
+    return (await resp.json()) as PublicStats
+  } catch {
+    // The page must render without numbers rather than fail — a visitor who
+    // cannot reach the API should still learn what canopy is.
+    return null
+  }
+}

--- a/frontend/src/api/tokenStatus.test.ts
+++ b/frontend/src/api/tokenStatus.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest'
+import { tokenStatus } from './tokenStatus'
+
+describe('tokenStatus', () => {
+  it('reports a live token with an expiry', () => {
+    expect(tokenStatus({ revoked_at: null, expires_at: '2027-03-01T00:00:00Z' })).toBe(
+      'expires 2027-03-01',
+    )
+  })
+
+  it('reports a never-expiring token as active', () => {
+    expect(tokenStatus({ revoked_at: null, expires_at: null })).toBe('active')
+  })
+
+  it('prefers revoked over expiry — a revoked token is dead regardless of its expiry', () => {
+    // This is the case that must never regress: reporting "expires 2027-03-01"
+    // for a revoked credential would tell someone it still works.
+    expect(tokenStatus({ revoked_at: '2026-09-01T00:00:00Z', expires_at: '2027-03-01T00:00:00Z' }))
+      .toBe('revoked')
+  })
+})

--- a/frontend/src/api/tokenStatus.ts
+++ b/frontend/src/api/tokenStatus.ts
@@ -1,0 +1,12 @@
+import type { PersonalToken } from './tokens'
+
+/**
+ * What to show in the Status column. Order matters: a revoked token may ALSO
+ * carry an expiry, and "revoked" is the answer that matters — it is the one
+ * that means "this credential is dead right now".
+ */
+export function tokenStatus(t: Pick<PersonalToken, 'revoked_at' | 'expires_at'>): string {
+  if (t.revoked_at) return 'revoked'
+  if (t.expires_at) return `expires ${t.expires_at.slice(0, 10)}`
+  return 'active'
+}

--- a/frontend/src/api/tokens.ts
+++ b/frontend/src/api/tokens.ts
@@ -1,0 +1,48 @@
+/**
+ * Personal Access Tokens. The raw value comes back from mint() exactly once —
+ * PersonalTokenCreatedOut is the only shape that carries it, and the server
+ * stores a hash. The UI must therefore show it immediately and never imply it
+ * can be recovered.
+ */
+import { apiV2 } from './client.v2'
+import { problemMessage } from './problem'
+import type { components } from './generated'
+
+export type PersonalToken = components['schemas']['PersonalTokenOut']
+export type MintedToken = components['schemas']['PersonalTokenCreatedOut']
+
+// Every function here branches on `res.response.ok`, NEVER on `res.error`.
+// All three token endpoints declare ONLY a success response in the OpenAPI
+// schema (200 / 201 / 204), so `res.error` narrows to `never` and
+// `if (res.error)` fails tsc. `frontend/src/api/workspaces.ts:32-36` documents
+// this trap and every function in that file follows the same rule. `res.error`
+// is still safe to READ for a message — just not to branch on.
+
+export async function listTokens(): Promise<PersonalToken[]> {
+  const res = await apiV2.GET('/api/tokens/')
+  if (!res.response.ok || !res.data) return []
+  // The generated response type is a readonly array; workspaces.ts's
+  // listMembers hits the same shape and casts through unknown rather than
+  // spreading, so this follows that convention.
+  return res.data as unknown as PersonalToken[]
+}
+
+export async function mintToken(
+  label: string,
+  ttlDays: number | null,
+): Promise<MintedToken | { error: string }> {
+  const res = await apiV2.POST('/api/tokens/', {
+    body: { label, ttl_days: ttlDays },
+  })
+  if (!res.response.ok || !res.data) {
+    return { error: problemMessage(res.error, 'Could not mint a token.') }
+  }
+  return res.data
+}
+
+export async function revokeToken(id: number): Promise<boolean> {
+  const res = await apiV2.DELETE('/api/tokens/{pk}/', {
+    params: { path: { pk: id } },
+  })
+  return res.response.ok
+}

--- a/frontend/src/api/workspaces.ts
+++ b/frontend/src/api/workspaces.ts
@@ -120,3 +120,28 @@ export async function acceptInvite(token: string): Promise<WorkspaceOut> {
   }
   return res.data as unknown as WorkspaceOut
 }
+
+// Used by FirstRunPage. Returns a result object rather than throwing: both
+// failure modes here (403 not-eligible, 409 slug-taken, 422 bad charset) are
+// expected user-facing outcomes the caller displays inline, not exceptional
+// conditions. This endpoint declares no error response in the OpenAPI schema
+// (see the `WorkspaceApiError` comment above), so `res.error` narrows the
+// whole result to `never` under `if (res.error)` — branching on
+// `res.response.ok` instead sidesteps that false-negative.
+export async function createWorkspace(
+  slug: string,
+  displayName: string,
+): Promise<{ slug: string } | { error: string }> {
+  const res = await apiV2.POST('/api/workspaces/', {
+    body: { slug, display_name: displayName },
+  })
+  if (!res.response.ok) {
+    // 409 = slug taken, 403 = not eligible (F1), 422 = bad slug charset.
+    // The server's problem+json `detail` is the only message worth showing:
+    // the slug rules are enforced by Workspace.SLUG_PATTERN server-side and
+    // restating them here would be a second copy free to drift.
+    const detail = (res.error as { detail?: string } | undefined)?.detail
+    return { error: detail || 'Could not create the workspace.' }
+  }
+  return { slug: (res.data as unknown as WorkspaceOut).slug }
+}

--- a/frontend/src/auth/AuthProvider.tsx
+++ b/frontend/src/auth/AuthProvider.tsx
@@ -36,7 +36,7 @@ function isPublicLinkRoute(): boolean {
     path.startsWith('/storyboard/') ||
     path.startsWith('/narrative/') ||
     path.startsWith('/invite/') ||
-    path.startsWith('/about') ||
+    path === '/about' ||
     LEGACY_WALKTHROUGH_RE.test(path)
   )
 }

--- a/frontend/src/auth/AuthProvider.tsx
+++ b/frontend/src/auth/AuthProvider.tsx
@@ -36,6 +36,7 @@ function isPublicLinkRoute(): boolean {
     path.startsWith('/storyboard/') ||
     path.startsWith('/narrative/') ||
     path.startsWith('/invite/') ||
+    path.startsWith('/about') ||
     LEGACY_WALKTHROUGH_RE.test(path)
   )
 }

--- a/frontend/src/auth/publicLinkRoutes.test.ts
+++ b/frontend/src/auth/publicLinkRoutes.test.ts
@@ -14,10 +14,17 @@ import authSrc from './AuthProvider.tsx?raw'
  * the visitor to Google. Caught by opening the link, not by any test — hence
  * this one.
  */
+// Harvests BOTH clause styles: `startsWith('/x/')` (a prefix) and
+// `=== '/x'` (an exact match, used by `/about` so a future `/about-billing`
+// or `/aboutus` route doesn't silently become public too — see C8). Missing
+// either style here would make this test a silent no-op for that clause,
+// exactly the failure mode this test exists to catch.
 function publicPrefixes(source: string): string[] {
   const fn = source.slice(source.indexOf('function isPublicLinkRoute'))
   const body = fn.slice(0, fn.indexOf('\n}'))
-  return [...body.matchAll(/startsWith\(['"]([^'"]+)['"]\)/g)].map((m) => m[1]).sort()
+  const startsWithMatches = [...body.matchAll(/startsWith\(['"]([^'"]+)['"]\)/g)].map((m) => m[1])
+  const exactMatches = [...body.matchAll(/===\s*['"]([^'"]+)['"]/g)].map((m) => m[1])
+  return [...startsWithMatches, ...exactMatches].sort()
 }
 
 describe('isPublicLinkRoute', () => {
@@ -32,5 +39,13 @@ describe('isPublicLinkRoute', () => {
     ]) {
       expect(prefixes).toContain(route)
     }
+  })
+
+  it('/about is an exact match, not a prefix', () => {
+    // Regression pin for C8: "/about" used to be startsWith, which would also
+    // admit "/about-billing" or "/aboutus".
+    expect(publicPrefixes(clientSrc)).not.toContain('/about/')
+    expect(clientSrc).toMatch(/===\s*["']\/about["']/)
+    expect(authSrc).toMatch(/===\s*["']\/about["']/)
   })
 })

--- a/frontend/src/auth/publicLinkRoutes.test.ts
+++ b/frontend/src/auth/publicLinkRoutes.test.ts
@@ -28,7 +28,7 @@ describe('isPublicLinkRoute', () => {
   it('covers every chrome-less public surface', () => {
     const prefixes = publicPrefixes(clientSrc)
     for (const route of [
-      '/review/', '/share/', '/ddd-release/', '/storyboard/', '/narrative/', '/invite/',
+      '/review/', '/share/', '/ddd-release/', '/storyboard/', '/narrative/', '/invite/', '/about',
     ]) {
       expect(prefixes).toContain(route)
     }

--- a/frontend/src/components/AppLayout/AppLayout.test.tsx
+++ b/frontend/src/components/AppLayout/AppLayout.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import type { AiStatusLegacy } from '@/api/ai'
+import type { WorkspaceOut } from '@/api/workspaces'
+
+// vi.mock is hoisted above these declarations by vitest's transform, but the
+// factory isn't *called* until the mocked modules are actually imported —
+// which happens on the dynamic imports below. Same pattern as
+// SettingsPage.presence.test.tsx / RunnerAssignments.test.tsx.
+
+const listWorkspaces = vi.fn<() => Promise<WorkspaceOut[]>>()
+vi.mock('@/api/workspaces', () => ({ listWorkspaces }))
+
+const aiStatus = vi.fn<() => Promise<AiStatusLegacy>>()
+const aiSwitch = vi.fn()
+vi.mock('@/api/ai', () => ({ aiStatus, aiSwitch }))
+
+const { AppLayout } = await import('./AppLayout')
+const { AuthContext } = await import('@/auth/AuthProvider')
+const { ThemeProvider } = await import('@/theme/ThemeProvider')
+
+function renderAs(status: 'authenticated' | 'anonymous') {
+  return render(
+    <MemoryRouter initialEntries={['/']}>
+      <ThemeProvider>
+        <AuthContext.Provider
+          value={
+            status === 'authenticated'
+              ? {
+                  status,
+                  user: {
+                    name: 'Jonathan Jackson',
+                    email: 'jj@dimagi.com',
+                    avatar_url: '',
+                    can_create_workspace: true,
+                  },
+                }
+              : { status, user: null }
+          }
+        >
+          <AppLayout />
+        </AuthContext.Provider>
+      </ThemeProvider>
+    </MemoryRouter>,
+  )
+}
+
+describe('AppLayout — WorkspaceSwitcher gating', () => {
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('hides "+ Workspace" from an anonymous visitor (public link routes reach this shell)', async () => {
+    listWorkspaces.mockResolvedValue([])
+    // UserMenu's aiStatus poll runs unconditionally in an effect, before its
+    // own auth check — mock it even though this test is the anonymous case.
+    aiStatus.mockResolvedValue({ backend: 'api', ready: true, detail: 'ok', setup_hint: null })
+
+    renderAs('anonymous')
+
+    // Let listWorkspaces' promise settle.
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(screen.queryByText('+ Workspace')).toBeNull()
+  })
+
+  it('shows "+ Workspace" to an authenticated user', async () => {
+    listWorkspaces.mockResolvedValue([])
+    aiStatus.mockResolvedValue({ backend: 'api', ready: true, detail: 'ok', setup_hint: null })
+
+    renderAs('authenticated')
+
+    expect(await screen.findByText('+ Workspace')).toBeTruthy()
+  })
+})

--- a/frontend/src/components/AppLayout/AppLayout.tsx
+++ b/frontend/src/components/AppLayout/AppLayout.tsx
@@ -179,32 +179,35 @@ function UserMenu() {
   )
 }
 
-// Tenant switcher — navigates between the caller's workspaces by rewriting the
-// :workspace URL segment. Hidden when there's nothing to switch to (the common
-// single-tenant case), so today's UI is unchanged.
+// Workspace switcher and create affordance. The switcher appears only when
+// there are multiple workspaces to choose from; create is always present.
 function WorkspaceSwitcher() {
   const { workspaces, active } = useWorkspace()
   const navigate = useNavigate()
-  // Hide the SWITCHER when there is nothing to switch between — but never hide
-  // the way to make another one. Conflating those two is what left a
-  // one-workspace user with no path to a second (and a zero-workspace user
-  // with no path at all).
-  if (workspaces.length <= 1) {
-    return <NewWorkspaceLink />
-  }
+  // TWO independent decisions, which is the entire point of this component.
+  // Whether to show a SWITCHER depends on having something to switch between.
+  // Whether to show CREATE does not depend on anything. Conflating them is what
+  // left a one-workspace user with no path to a second and a zero-workspace user
+  // with no path at all — and the first fix of it left a five-workspace user
+  // with no path to a sixth.
   return (
-    <select
-      aria-label="Workspace"
-      className="min-h-11 rounded border border-input bg-input px-2 py-1 text-[13px] text-foreground sm:min-h-0"
-      value={active ?? ''}
-      onChange={(e) => navigate(`/w/${e.target.value}/agents`)}
-    >
-      {workspaces.map((w) => (
-        <option key={w.slug} value={w.slug}>
-          {w.display_name}
-        </option>
-      ))}
-    </select>
+    <div className="flex items-center gap-2">
+      {workspaces.length > 1 ? (
+        <select
+          aria-label="Workspace"
+          className="min-h-11 rounded border border-input bg-input px-2 py-1 text-[13px] text-foreground sm:min-h-0"
+          value={active ?? ''}
+          onChange={(e) => navigate(`/w/${e.target.value}/agents`)}
+        >
+          {workspaces.map((w) => (
+            <option key={w.slug} value={w.slug}>
+              {w.display_name}
+            </option>
+          ))}
+        </select>
+      ) : null}
+      <NewWorkspaceLink />
+    </div>
   )
 }
 

--- a/frontend/src/components/AppLayout/AppLayout.tsx
+++ b/frontend/src/components/AppLayout/AppLayout.tsx
@@ -338,7 +338,7 @@ function AppShell() {
                 )
               })}
             </nav>
-            <WorkspaceSwitcher />
+            {isAuthed && <WorkspaceSwitcher />}
             {isAuthed && <PresenceHeaderBadge key={presenceReconnectNonce} />}
             <UserMenu />
             {isAuthed && (

--- a/frontend/src/components/AppLayout/AppLayout.tsx
+++ b/frontend/src/components/AppLayout/AppLayout.tsx
@@ -185,7 +185,13 @@ function UserMenu() {
 function WorkspaceSwitcher() {
   const { workspaces, active } = useWorkspace()
   const navigate = useNavigate()
-  if (workspaces.length <= 1) return null
+  // Hide the SWITCHER when there is nothing to switch between — but never hide
+  // the way to make another one. Conflating those two is what left a
+  // one-workspace user with no path to a second (and a zero-workspace user
+  // with no path at all).
+  if (workspaces.length <= 1) {
+    return <NewWorkspaceLink />
+  }
   return (
     <select
       aria-label="Workspace"
@@ -199,6 +205,19 @@ function WorkspaceSwitcher() {
         </option>
       ))}
     </select>
+  )
+}
+
+/** The one affordance that must never be conditional on how many workspaces
+ *  you already have. Routes to the first-run screen, which owns the form. */
+function NewWorkspaceLink() {
+  return (
+    <Link
+      to="/new-workspace"
+      className="text-xs text-muted-foreground hover:text-foreground"
+    >
+      + Workspace
+    </Link>
   )
 }
 

--- a/frontend/src/components/AppLayout/nav.test.ts
+++ b/frontend/src/components/AppLayout/nav.test.ts
@@ -16,7 +16,7 @@ describe('NAV_GROUPS', () => {
     const labels = NAV_GROUPS.flatMap((g) => g.items.map((i) => i.label))
     expect(labels.sort()).toEqual(
       [
-        'Activity', 'Agents', 'Chats', 'DDD', 'Inbound', 'Insights', 'Members',
+        'Activity', 'Agents', 'Chats', 'DDD', 'Guide', 'Inbound', 'Insights', 'Members',
         'Projects', 'Schedule', 'Sessions', 'Shareouts', 'Storyboards', 'Supervisor',
         'System', 'Timeline', 'Walkthroughs',
       ].sort(),
@@ -54,7 +54,7 @@ describe('resolveNavGroups', () => {
     const groups = resolveNavGroups({ isAuthed: true, active: null })
     const hrefs = groups.flatMap((g) => g.items.map((i) => i.href))
     expect(hrefs.some((h) => h.includes('/w//'))).toBe(false)
-    expect(hrefs).toEqual(['/insights', '/supervisor', '/activity', '/schedules', '/sessions', '/system'])
+    expect(hrefs).toEqual(['/insights', '/supervisor', '/activity', '/schedules', '/sessions', '/system', '/guide'])
   })
 
   it('drops a group whose items are all tenant-scoped while the workspace is unknown', () => {

--- a/frontend/src/components/AppLayout/nav.test.ts
+++ b/frontend/src/components/AppLayout/nav.test.ts
@@ -10,7 +10,7 @@ const authed = { isAuthed: true, active: 'connect' }
 
 describe('NAV_GROUPS', () => {
   it('keeps every destination the flat nav carried', () => {
-    // The row this replaced held 15 links (Storyboards is the one added since).
+    // The row this replaced held 15 links (Storyboards and Guide are the two added since).
     // Grouping is meant to reorganize the header, never to quietly drop a
     // surface out of it.
     const labels = NAV_GROUPS.flatMap((g) => g.items.map((i) => i.label))

--- a/frontend/src/components/AppLayout/nav.ts
+++ b/frontend/src/components/AppLayout/nav.ts
@@ -77,6 +77,7 @@ export const NAV_GROUPS: NavGroup[] = [
       { path: 'members', label: 'Members', tenant: true },
       { path: 'inbound', label: 'Inbound', tenant: true },
       { path: '/system', label: 'System', tenant: false },
+      { path: '/guide', label: 'Guide', tenant: false },
     ],
   },
 ]

--- a/frontend/src/components/CopyBlock.tsx
+++ b/frontend/src/components/CopyBlock.tsx
@@ -1,0 +1,21 @@
+export function CopyBlock({
+  label, value, copied, onCopy,
+}: { label: string; value: string; copied: boolean; onCopy: () => void }) {
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-1">
+        <span className="text-[10px] uppercase tracking-wider text-muted-foreground font-semibold">{label}</span>
+        <button
+          type="button"
+          onClick={onCopy}
+          className="text-xs text-primary hover:text-primary transition-colors"
+        >
+          {copied ? 'Copied' : 'Copy'}
+        </button>
+      </div>
+      <pre className="bg-background border border-border rounded-lg p-3 text-xs text-foreground-secondary font-mono overflow-x-auto whitespace-pre-wrap break-all">
+        {value}
+      </pre>
+    </div>
+  )
+}

--- a/frontend/src/components/PublicHeader.test.tsx
+++ b/frontend/src/components/PublicHeader.test.tsx
@@ -20,7 +20,12 @@ function renderAs(status: 'authenticated' | 'anonymous') {
           status === 'authenticated'
             ? {
                 status,
-                user: { name: 'Jonathan Jackson', email: 'jj@dimagi.com', avatar_url: '' },
+                user: {
+                  name: 'Jonathan Jackson',
+                  email: 'jj@dimagi.com',
+                  avatar_url: '',
+                  can_create_workspace: false,
+                },
               }
             : { status, user: null }
         }

--- a/frontend/src/components/chat/ChatSessionsPanel.test.tsx
+++ b/frontend/src/components/chat/ChatSessionsPanel.test.tsx
@@ -418,3 +418,38 @@ describe('ChatSessionsPanel — close a session', () => {
     expect(btn.closest('a')).toBeNull()
   })
 })
+
+describe('ChatSessionsPanel — empty states', () => {
+  it('says "You need an agent first" when there are zero agents and zero sessions', async () => {
+    listSlugs.mockResolvedValue([])
+    listSessions.mockResolvedValue([])
+
+    renderPanel([])
+
+    expect(await screen.findByText('No chats yet')).toBeTruthy()
+    expect(screen.getByText('You need an agent first')).toBeTruthy()
+  })
+
+  it('says "Pick an agent from New chat with… above" when there are agents but zero sessions', async () => {
+    listSlugs.mockResolvedValue([])
+    listSessions.mockResolvedValue([])
+
+    renderPanel([agent()])
+
+    expect(await screen.findByText('No chats yet')).toBeTruthy()
+    expect(screen.getByText('Pick an agent from "New chat with…" above to start one.')).toBeTruthy()
+    expect(screen.queryByText('You need an agent first')).toBeNull()
+  })
+
+  it('preserves the "No chats on a live runner" message when all sessions are parked', async () => {
+    listSlugs.mockResolvedValue([])
+    listSessions.mockResolvedValue([
+      chatSession('parked', { runner_online: false, runner_status: 'paused' }),
+    ])
+
+    renderPanel([agent()])
+
+    expect(await screen.findByText('No chats on a live runner')).toBeTruthy()
+    expect(screen.queryByText('No chats yet')).toBeNull()
+  })
+})

--- a/frontend/src/components/chat/ChatSessionsPanel.test.tsx
+++ b/frontend/src/components/chat/ChatSessionsPanel.test.tsx
@@ -430,14 +430,25 @@ describe('ChatSessionsPanel — empty states', () => {
     expect(screen.getByText('You need an agent first')).toBeTruthy()
   })
 
-  it('says "Pick an agent from New chat with… above" when there are agents but zero sessions', async () => {
+  it('says "Pick one from New chat with… above" when there are agents but zero sessions', async () => {
     listSlugs.mockResolvedValue([])
     listSessions.mockResolvedValue([])
 
     renderPanel([agent()])
 
     expect(await screen.findByText('No chats yet')).toBeTruthy()
-    expect(screen.getByText('Pick an agent from "New chat with…" above to start one.')).toBeTruthy()
+    expect(screen.getByText('Pick one from "New chat with…" above to start one.')).toBeTruthy()
+    expect(screen.queryByText('You need an agent first')).toBeNull()
+  })
+
+  it('says "Pick one from New chat with… above" when there are projects but zero agents and zero sessions', async () => {
+    listSlugs.mockResolvedValue([{ slug: 'acme', name: 'Acme', workspace: 'dimagi' } as ProjectSlug])
+    listSessions.mockResolvedValue([])
+
+    renderPanel([])
+
+    expect(await screen.findByText('No chats yet')).toBeTruthy()
+    expect(screen.getByText('Pick one from "New chat with…" above to start one.')).toBeTruthy()
     expect(screen.queryByText('You need an agent first')).toBeNull()
   })
 

--- a/frontend/src/components/chat/ChatSessionsPanel.tsx
+++ b/frontend/src/components/chat/ChatSessionsPanel.tsx
@@ -174,7 +174,7 @@ export function ChatSessionsPanel({
         // interval.
         else setSessions(await listSessions(showArchived ? 'all' : 'active'))
       } catch {
-        setCloseError("Couldn't close this session")
+        setCloseError('Couldn’t close this session')
       } finally {
         setClosingId(null)
       }
@@ -450,11 +450,17 @@ export function ChatSessionsPanel({
               picks it up and streams the reply back as it works.
             </p>
             <p className="mt-2 text-[12px] text-muted-foreground">
-              Nothing to chat with?{' '}
-              <Link to="/guide#/w/:workspace/agents" className="text-primary hover:underline">
-                You need an agent first
-              </Link>
-              .
+              {agents.length === 0 ? (
+                <>
+                  Nothing to chat with?{' '}
+                  <Link to="/guide#/w/:workspace/agents" className="text-primary hover:underline">
+                    You need an agent first
+                  </Link>
+                  .
+                </>
+              ) : (
+                <>Pick an agent from "New chat with…" above to start one.</>
+              )}
             </p>
           </div>
         )

--- a/frontend/src/components/chat/ChatSessionsPanel.tsx
+++ b/frontend/src/components/chat/ChatSessionsPanel.tsx
@@ -450,7 +450,7 @@ export function ChatSessionsPanel({
               picks it up and streams the reply back as it works.
             </p>
             <p className="mt-2 text-[12px] text-muted-foreground">
-              {agents.length === 0 ? (
+              {agents.length === 0 && projects.length === 0 ? (
                 <>
                   Nothing to chat with?{' '}
                   <Link to="/guide#/w/:workspace/agents" className="text-primary hover:underline">
@@ -459,7 +459,7 @@ export function ChatSessionsPanel({
                   .
                 </>
               ) : (
-                <>Pick an agent from "New chat with…" above to start one.</>
+                <>Pick one from "New chat with…" above to start one.</>
               )}
             </p>
           </div>

--- a/frontend/src/components/chat/ChatSessionsPanel.tsx
+++ b/frontend/src/components/chat/ChatSessionsPanel.tsx
@@ -174,7 +174,7 @@ export function ChatSessionsPanel({
         // interval.
         else setSessions(await listSessions(showArchived ? 'all' : 'active'))
       } catch {
-        setCloseError('Couldn’t close this session')
+        setCloseError("Couldn't close this session")
       } finally {
         setClosingId(null)
       }
@@ -437,14 +437,27 @@ export function ChatSessionsPanel({
       {loading ? (
         <div className="py-6 text-sm text-muted-foreground">Loading sessions…</div>
       ) : visible.length === 0 ? (
-        <div className="flex flex-col items-center justify-center gap-1 py-12 text-center">
-          <div className="text-sm text-foreground">
-            {parked.length > 0 ? 'No chats on a live runner' : 'No chats yet'}
+        parked.length > 0 ? (
+          <div className="flex flex-col items-center justify-center gap-1 py-12 text-center">
+            <div className="text-sm text-foreground">No chats on a live runner</div>
+            <div className="text-xs text-muted-foreground">{parkedSummary(parked)}</div>
           </div>
-          <div className="text-xs text-muted-foreground">
-            {parked.length > 0 ? parkedSummary(parked) : 'Start one with “New chat”.'}
+        ) : (
+          <div className="rounded-lg border border-border bg-card p-4">
+            <h2 className="text-sm font-semibold text-foreground">No chats yet</h2>
+            <p className="mt-2 text-[13px] leading-relaxed text-foreground-secondary">
+              Start a chat to hand an agent a job. Sending a message enqueues a turn, and a runner
+              picks it up and streams the reply back as it works.
+            </p>
+            <p className="mt-2 text-[12px] text-muted-foreground">
+              Nothing to chat with?{' '}
+              <Link to="/guide#/w/:workspace/agents" className="text-primary hover:underline">
+                You need an agent first
+              </Link>
+              .
+            </p>
           </div>
-        </div>
+        )
       ) : (
         <ul className="divide-y divide-border rounded-md border border-border">
           {sortSessions(visible, sort).map((s, i, rows) => {

--- a/frontend/src/components/settings/TokensPanel.test.tsx
+++ b/frontend/src/components/settings/TokensPanel.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import type { PersonalToken } from '@/api/tokens'
+
+// vi.mock is hoisted above these declarations by vitest's transform, but the
+// factory isn't *called* until the mocked modules are actually imported —
+// which happens on the dynamic import below. Same pattern as
+// SettingsPage.presence.test.tsx.
+const listTokens = vi.fn<() => Promise<PersonalToken[]>>()
+const mintToken = vi.fn()
+const revokeToken = vi.fn()
+vi.mock('@/api/tokens', () => ({ listTokens, mintToken, revokeToken }))
+
+const { TokensPanel } = await import('./TokensPanel')
+
+const TOKEN: PersonalToken = {
+  id: 1,
+  label: 'my laptop',
+  created_at: '2026-09-01T00:00:00Z',
+  last_used_at: null,
+  revoked_at: null,
+  expires_at: null,
+} as PersonalToken
+
+describe('TokensPanel — revoke confirm gate', () => {
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('does NOT call revokeToken when window.confirm is declined', async () => {
+    listTokens.mockResolvedValue([TOKEN])
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+
+    render(<TokensPanel />)
+    const revokeBtn = await screen.findByText('Revoke')
+
+    await act(async () => {
+      fireEvent.click(revokeBtn)
+      await Promise.resolve()
+    })
+
+    expect(confirmSpy).toHaveBeenCalled()
+    expect(revokeToken).not.toHaveBeenCalled()
+    confirmSpy.mockRestore()
+  })
+
+  it('DOES call revokeToken when window.confirm is accepted', async () => {
+    listTokens.mockResolvedValue([TOKEN])
+    revokeToken.mockResolvedValue(true)
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+
+    render(<TokensPanel />)
+    const revokeBtn = await screen.findByText('Revoke')
+
+    await act(async () => {
+      fireEvent.click(revokeBtn)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(revokeToken).toHaveBeenCalledWith(TOKEN.id)
+    confirmSpy.mockRestore()
+  })
+})

--- a/frontend/src/components/settings/TokensPanel.tsx
+++ b/frontend/src/components/settings/TokensPanel.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { listTokens, mintToken, revokeToken, type PersonalToken } from '@/api/tokens'
 import { tokenStatus } from '@/api/tokenStatus'
-import { CopyBlock } from '@/pages/SettingsPage'
+import { CopyBlock } from '@/components/CopyBlock'
 import { Button } from 'canopy-ui/ui'
 import { Input } from 'canopy-ui/ui'
 
@@ -22,7 +22,11 @@ export function TokensPanel() {
   const [busy, setBusy] = useState(false)
 
   async function refresh() {
-    setTokens(await listTokens())
+    try {
+      setTokens(await listTokens())
+    } catch {
+      setError('Could not load tokens.')
+    }
   }
 
   useEffect(() => {

--- a/frontend/src/components/settings/TokensPanel.tsx
+++ b/frontend/src/components/settings/TokensPanel.tsx
@@ -1,0 +1,151 @@
+import { useEffect, useState } from 'react'
+import { listTokens, mintToken, revokeToken, type PersonalToken } from '@/api/tokens'
+import { tokenStatus } from '@/api/tokenStatus'
+import { CopyBlock } from '@/pages/SettingsPage'
+import { Button } from 'canopy-ui/ui'
+import { Input } from 'canopy-ui/ui'
+
+/**
+ * List / mint / revoke Personal Access Tokens.
+ *
+ * A PAT is how a machine caller authenticates (Authorization: Bearer <raw>) —
+ * the canopy plugin, the MCP surface at /api/mcp/, and any script. It had no UI
+ * at all, so the only way to get one was a skill that needs the plugin you are
+ * trying to set up.
+ */
+export function TokensPanel() {
+  const [tokens, setTokens] = useState<PersonalToken[]>([])
+  const [label, setLabel] = useState('')
+  const [minted, setMinted] = useState<string>('')
+  const [copied, setCopied] = useState(false)
+  const [error, setError] = useState('')
+  const [busy, setBusy] = useState(false)
+
+  async function refresh() {
+    setTokens(await listTokens())
+  }
+
+  useEffect(() => {
+    void refresh()
+  }, [])
+
+  async function onMint(e: React.FormEvent) {
+    e.preventDefault()
+    setBusy(true)
+    setError('')
+    const res = await mintToken(label.trim(), null)
+    setBusy(false)
+    if ('error' in res) {
+      setError(res.error)
+      return
+    }
+    setMinted(res.raw)
+    setCopied(false)
+    setLabel('')
+    await refresh()
+  }
+
+  async function onRevoke(t: PersonalToken) {
+    if (!window.confirm(`Revoke "${t.label}"? Anything using it stops working immediately.`)) return
+    if (await revokeToken(t.id)) await refresh()
+    else setError('Could not revoke that token.')
+  }
+
+  async function copyMinted() {
+    try {
+      await navigator.clipboard.writeText(minted)
+      setCopied(true)
+    } catch {
+      // ignore
+    }
+  }
+
+  return (
+    <div className="rounded-xl border border-border bg-card p-5 space-y-4">
+      <div>
+        <h2 className="text-sm font-semibold text-foreground">Personal access tokens</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          How a machine authenticates as you — the canopy plugin, the MCP endpoint, or your
+          own scripts. Sent as <code>Authorization: Bearer &lt;token&gt;</code>.
+        </p>
+      </div>
+
+      {minted && (
+        <div className="space-y-3">
+          <div className="rounded-lg border border-warning/20 bg-warning/5 p-3 text-xs text-warning/80">
+            <strong className="text-warning">Copy this now — it is not shown again.</strong>{' '}
+            The server stores only a hash, so this value cannot be retrieved later.
+          </div>
+          <CopyBlock label="Token" value={minted} copied={copied} onCopy={() => void copyMinted()} />
+          <div className="text-right">
+            <button
+              type="button"
+              onClick={() => setMinted('')}
+              className="text-xs text-muted-foreground hover:text-foreground-secondary"
+            >
+              Done
+            </button>
+          </div>
+        </div>
+      )}
+
+      <form onSubmit={onMint} className="flex flex-wrap items-end gap-2">
+        <div className="flex-1 min-w-[200px]">
+          <label htmlFor="pat-label" className="block text-xs text-muted-foreground mb-1">
+            What is it for?
+          </label>
+          <Input
+            id="pat-label"
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            placeholder="my laptop's canopy plugin"
+            required
+          />
+        </div>
+        <Button type="submit" size="sm" disabled={busy || !label.trim()}>
+          {busy ? 'Minting…' : 'Mint token'}
+        </Button>
+      </form>
+      {error && <p className="text-sm text-destructive">{error}</p>}
+
+      {tokens.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No tokens yet.</p>
+      ) : (
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="text-left text-muted-foreground">
+              <th className="py-1 font-medium">Label</th>
+              <th className="py-1 font-medium">Created</th>
+              <th className="py-1 font-medium">Last used</th>
+              <th className="py-1 font-medium">Status</th>
+              <th />
+            </tr>
+          </thead>
+          <tbody>
+            {tokens.map((t) => (
+              <tr key={t.id} className="border-t border-border">
+                <td className="py-1.5 text-foreground-secondary">{t.label}</td>
+                <td className="py-1.5 text-muted-foreground">{t.created_at.slice(0, 10)}</td>
+                <td className="py-1.5 text-muted-foreground">
+                  {t.last_used_at ? t.last_used_at.slice(0, 10) : 'never'}
+                </td>
+                <td className="py-1.5 text-muted-foreground">{tokenStatus(t)}</td>
+                <td className="py-1.5 text-right">
+                  {t.revoked_at ? null : (
+                    <button
+                      type="button"
+                      onClick={() => void onRevoke(t)}
+                      className="text-destructive hover:underline"
+                    >
+                      Revoke
+                    </button>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/storyboard/NoteComposer.test.tsx
+++ b/frontend/src/components/storyboard/NoteComposer.test.tsx
@@ -136,7 +136,12 @@ describe('NoteComposer', () => {
       <AuthContext.Provider
         value={{
           status: 'authenticated',
-          user: { name: 'Jonathan Jackson', email: 'jj@dimagi.com', avatar_url: '' },
+          user: {
+            name: 'Jonathan Jackson',
+            email: 'jj@dimagi.com',
+            avatar_url: '',
+            can_create_workspace: false,
+          },
         }}
       >
         <NoteComposer

--- a/frontend/src/guide/components.test.ts
+++ b/frontend/src/guide/components.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest'
+import { COMPONENTS, ONE_SENTENCE } from './components'
+
+describe('COMPONENTS', () => {
+  it('names five components with unique names', () => {
+    expect(COMPONENTS).toHaveLength(5)
+    expect(new Set(COMPONENTS.map((c) => c.name)).size).toBe(5)
+  })
+
+  it('explains each one', () => {
+    for (const c of COMPONENTS) expect(c.what.length).toBeGreaterThan(20)
+  })
+
+  it('has a connecting sentence', () => {
+    expect(ONE_SENTENCE).toContain('turn')
+  })
+})

--- a/frontend/src/guide/components.ts
+++ b/frontend/src/guide/components.ts
@@ -1,0 +1,36 @@
+/**
+ * The five components of canopy, and the one sentence that connects them.
+ * This is the "component view" the public explainer is built around — the thing
+ * that was actually missing from /system, which catalogues the plugin's
+ * capabilities and never says what the system is made of.
+ */
+export interface SystemComponent {
+  name: string
+  what: string
+}
+
+export const COMPONENTS: SystemComponent[] = [
+  {
+    name: 'canopy-web',
+    what: 'The system of record and every human surface. Owns workspaces, agents, turns, items, schedules, sessions and published artifacts.',
+  },
+  {
+    name: 'The canopy plugin',
+    what: 'The capability library — skills, agents and commands, installed into Claude Code. What an agent knows how to do.',
+  },
+  {
+    name: 'Runners',
+    what: 'The execution substrate. A paired laptop or a cloud box. Claims turns and runs Claude Code.',
+  },
+  {
+    name: 'Agents',
+    what: 'Persona repos stamped from a factory — identity, domain skills, hooks.',
+  },
+  {
+    name: 'The harness',
+    what: 'The control plane joining them: turn lifecycle, claim and lease, the event ledger, routing.',
+  },
+]
+
+export const ONE_SENTENCE =
+  'A turn is the unit of work: canopy-web owns the record of turns, runners execute them wherever your compute happens to live, and the plugin is the library of what an agent knows how to do.'

--- a/frontend/src/guide/coverage.test.ts
+++ b/frontend/src/guide/coverage.test.ts
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest'
+import { routeTable } from '../router'
+import { flattenRoutePaths, isDocumentable } from './coverage'
+import { SURFACES } from './surfaces'
+
+const declared = flattenRoutePaths(routeTable).filter(isDocumentable)
+const described = new Set(SURFACES.map((s) => s.path))
+
+describe('guide coverage', () => {
+  it('finds the real routes', () => {
+    // A sanity floor: if the flattener silently returns nothing, both
+    // directions below pass vacuously and the test proves nothing.
+    expect(declared.length).toBeGreaterThan(20)
+    expect(declared).toContain('/settings')
+    expect(declared).toContain('/w/:workspace/agents')
+  })
+
+  it('documents every documentable route', () => {
+    const missing = declared.filter((p) => !described.has(p))
+    expect(missing, `routes with no descriptor in guide/surfaces.ts: ${missing.join(', ')}`).toEqual([])
+  })
+
+  it('has no descriptor for a route that does not exist', () => {
+    // The direction that catches a descriptor orphaned by a deleted route —
+    // which is how a generated guide starts lying.
+    const declaredSet = new Set(declared)
+    const orphans = [...described].filter((p) => !declaredSet.has(p))
+    expect(orphans, `descriptors naming no real route: ${orphans.join(', ')}`).toEqual([])
+  })
+
+  it('gives every descriptor the fields the guide renders', () => {
+    for (const s of SURFACES) {
+      expect(s.title, `${s.path} has no title`).toBeTruthy()
+      expect(s.what, `${s.path} has no 'what'`).toBeTruthy()
+      expect(s.audience, `${s.path} has no audience`).toBeTruthy()
+    }
+  })
+})
+
+describe('isDocumentable', () => {
+  it('excludes the catch-all and legacy aliases', () => {
+    expect(isDocumentable('*')).toBe(false)
+    expect(isDocumentable('/ddd-plans')).toBe(false)
+    expect(isDocumentable('/w/:workspace/agents/:slug/needs-you')).toBe(false)
+  })
+
+  it('includes real surfaces', () => {
+    expect(isDocumentable('/settings')).toBe(true)
+    expect(isDocumentable('/w/:workspace/chat/:id')).toBe(true)
+  })
+})

--- a/frontend/src/guide/coverage.ts
+++ b/frontend/src/guide/coverage.ts
@@ -1,0 +1,49 @@
+import type { RouteObject } from 'react-router-dom'
+
+/**
+ * Flatten the route table into absolute path strings, joining child paths onto
+ * their parent (the agent workspace's rail sections are children).
+ */
+export function flattenRoutePaths(routes: RouteObject[], parent = ''): string[] {
+  const out: string[] = []
+  for (const r of routes) {
+    const raw = (r as { path?: string }).path
+    const here =
+      raw === undefined
+        ? parent
+        : raw.startsWith('/')
+          ? raw
+          : `${parent.replace(/\/$/, '')}/${raw}`
+    if (raw !== undefined) out.push(here)
+    const kids = (r as { children?: RouteObject[] }).children
+    if (kids?.length) out.push(...flattenRoutePaths(kids, here))
+  }
+  return out
+}
+
+/**
+ * Paths that need no descriptor: the catch-all, and anything whose only job is
+ * to send the browser somewhere else. These are listed explicitly rather than
+ * detected from the element, because an explicit list fails LOUDLY when a new
+ * redirect is added (the coverage test names it) instead of silently excusing it.
+ */
+const NOT_DOCUMENTABLE = new Set([
+  '*',
+  '/',
+  '/timeline',
+  '/shareouts/*',
+  '/walkthroughs',
+  '/storyboards',
+  '/agents/*',
+  '/ddd/*',
+  '/ddd-plans',
+  '/reviews',
+  '/w/:workspace/agents/:slug/needs-you',
+  '/w/:workspace/agents/:slug',
+])
+
+export function isDocumentable(path: string): boolean {
+  if (NOT_DOCUMENTABLE.has(path)) return false
+  if (path.endsWith('/*')) return false
+  return true
+}

--- a/frontend/src/guide/grouping.test.ts
+++ b/frontend/src/guide/grouping.test.ts
@@ -35,8 +35,8 @@ describe('guideGroups', () => {
     expect(fleet?.surfaces.map((s) => s.path)).not.toContain('/w/:workspace/agents/:slug/inbox')
   })
 
-  it('groups the no-login shared links together', () => {
-    const shared = guideGroups().find((g) => g.label === 'Shared links (no login)')
+  it('groups the shared-by-link surfaces together', () => {
+    const shared = guideGroups().find((g) => g.label === 'Shared by link')
     expect(shared?.surfaces.map((s) => s.path)).toEqual(
       expect.arrayContaining(['/share/:token', '/storyboard/:slug', '/walkthrough/:id']),
     )

--- a/frontend/src/guide/grouping.test.ts
+++ b/frontend/src/guide/grouping.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import { guideGroups } from './grouping'
+import { SURFACES } from './surfaces'
+
+describe('guideGroups', () => {
+  it('places every surface in exactly one group', () => {
+    const grouped = guideGroups().flatMap((g) => g.surfaces.map((s) => s.path))
+    expect(grouped.length).toBe(SURFACES.length)
+    expect(new Set(grouped).size).toBe(SURFACES.length)
+  })
+
+  it('uses the nav group labels', () => {
+    const labels = guideGroups().map((g) => g.label)
+    expect(labels).toContain('Work')
+    expect(labels).toContain('Fleet')
+  })
+
+  it('never drops a surface, even one nothing claims', () => {
+    const groups = guideGroups([
+      { path: '/nowhere-at-all', title: 'Orphan', audience: 'Anyone', what: 'x' },
+    ])
+    expect(groups).toEqual([
+      { label: 'Elsewhere', surfaces: [expect.objectContaining({ path: '/nowhere-at-all' })] },
+    ])
+  })
+
+  it('clusters the agent rail rather than letting Fleet absorb it', () => {
+    // The rail sits under /w/:workspace/agents/:slug/, and nav has
+    // /w/:workspace/agents — so without cluster-first assignment all ten
+    // sections would land in Fleet and this group would be empty.
+    const rail = guideGroups().find((g) => g.label === 'Agent workspace')
+    expect(rail?.surfaces.length).toBe(10)
+    const fleet = guideGroups().find((g) => g.label === 'Fleet')
+    expect(fleet?.surfaces.map((s) => s.path)).toContain('/w/:workspace/agents')
+    expect(fleet?.surfaces.map((s) => s.path)).not.toContain('/w/:workspace/agents/:slug/inbox')
+  })
+
+  it('groups the no-login shared links together', () => {
+    const shared = guideGroups().find((g) => g.label === 'Shared links (no login)')
+    expect(shared?.surfaces.map((s) => s.path)).toEqual(
+      expect.arrayContaining(['/share/:token', '/storyboard/:slug', '/walkthrough/:id']),
+    )
+  })
+
+  it('puts a detail route with its list route', () => {
+    const chats = guideGroups().find((g) => g.surfaces.some((s) => s.path === '/w/:workspace/chat'))
+    expect(chats?.surfaces.map((s) => s.path)).toContain('/w/:workspace/chat/:id')
+  })
+
+  it('does not let the tenant index swallow every tenant path', () => {
+    // /w/:workspace prefixes every tenant route; if it prefix-matched, the group
+    // holding Projects would absorb the entire app.
+    const work = guideGroups().find((g) => g.surfaces.some((s) => s.path === '/w/:workspace'))
+    expect(work?.surfaces.map((s) => s.path)).not.toContain('/w/:workspace/members')
+  })
+
+  it('keeps Elsewhere a small remainder, not a dumping ground', () => {
+    const elsewhere = guideGroups().find((g) => g.label === 'Elsewhere')
+    // Measured at ~4 genuinely uncategorised surfaces. A jump here means a new
+    // cluster needs a rule, not that the bucket should grow.
+    expect(elsewhere?.surfaces.length ?? 0).toBeLessThanOrEqual(8)
+  })
+})

--- a/frontend/src/guide/grouping.ts
+++ b/frontend/src/guide/grouping.ts
@@ -49,6 +49,12 @@ function navMatch(surfacePath: string, navPath: string): boolean {
  * the ten rail sections all sit under `/w/:workspace/agents/:slug/`, so nav's
  * `/w/:workspace/agents` would otherwise absorb them into Fleet and leave this
  * group empty.
+ *
+ * This is now a THIRD hardcoded path list, beside `NOT_DOCUMENTABLE` and
+ * `nav.ts` — and unlike the coverage test, it fails SILENTLY: rename a route
+ * (or its surface) and it just relocates here to "Elsewhere" rather than
+ * erroring, which the `<= 8` cap in coverage.test.ts absorbs several times
+ * before it goes red. The cap is the only tripwire on this list going stale.
  */
 const CLUSTERS: Array<{ label: string; match: (path: string) => boolean }> = [
   {
@@ -57,8 +63,13 @@ const CLUSTERS: Array<{ label: string; match: (path: string) => boolean }> = [
     match: (p) => p.startsWith('/w/:workspace/agents/:slug/'),
   },
   {
-    // Pages someone reaches from a link you sent them, with no account.
-    label: 'Shared links (no login)',
+    // Pages someone reaches from a link you sent them, with no account of
+    // their own on the surface itself. NOT all of these are actually
+    // loginless: /invite/:token requires signing in with the invited
+    // address to accept, and a `private` walkthrough routes a logged-out
+    // visitor to sign-in — "shared by link" is the accurate claim, "no
+    // login" was not.
+    label: 'Shared by link',
     match: (p) =>
       ['/share/:token', '/storyboard/:slug', '/narrative/:slug', '/walkthrough/:id',
        '/review/:id', '/invite/:token'].includes(p) || p.startsWith('/ddd-release/'),

--- a/frontend/src/guide/grouping.ts
+++ b/frontend/src/guide/grouping.ts
@@ -1,0 +1,92 @@
+import { NAV_GROUPS } from '@/components/AppLayout/nav'
+import { SURFACES, type SurfaceDescriptor } from './surfaces'
+
+/**
+ * Group descriptors by the header's existing nav groups, so the guide's shape
+ * matches the menu people actually look at. Anything the nav does not mention
+ * (public viewers, agent rail sections) lands in a trailing "Elsewhere" group
+ * rather than being dropped — a guide that silently omits a surface is the
+ * failure this whole registry exists to prevent.
+ */
+export interface GuideGroup {
+  label: string
+  surfaces: SurfaceDescriptor[]
+}
+
+/** The route path a nav item points at, in routeTable's notation. */
+function navItemPath(item: { path: string; tenant: boolean }): string {
+  if (!item.tenant) return item.path
+  return item.path ? `/w/:workspace/${item.path}` : '/w/:workspace'
+}
+
+/** The tenant index — matches only EXACTLY. See `navMatch`. */
+const TENANT_INDEX = '/w/:workspace'
+
+/**
+ * Does `surfacePath` belong under the nav item at `navPath`?
+ *
+ * Exact match, or a detail route beneath it — `/w/:workspace/chat/:id` belongs
+ * with `/w/:workspace/chat`, because a reader looking for "the chat page" wants
+ * the list and the single chat together.
+ *
+ * The tenant index is the exception. `/w/:workspace` is a prefix of every tenant
+ * route, so prefix-matching it would pull the whole app into the Projects entry.
+ */
+function navMatch(surfacePath: string, navPath: string): boolean {
+  if (surfacePath === navPath) return true
+  if (navPath === TENANT_INDEX) return false
+  return surfacePath.startsWith(`${navPath}/`)
+}
+
+/**
+ * Clusters for surfaces the nav does not name.
+ *
+ * Without these, 25 of the 41 descriptors land in one "Elsewhere" bucket — 61%
+ * of the guide in a junk drawer, which defeats the point of grouping it by the
+ * menu at all. (Measured before this existed.)
+ *
+ * These are assigned BEFORE the nav groups, which matters for exactly one case:
+ * the ten rail sections all sit under `/w/:workspace/agents/:slug/`, so nav's
+ * `/w/:workspace/agents` would otherwise absorb them into Fleet and leave this
+ * group empty.
+ */
+const CLUSTERS: Array<{ label: string; match: (path: string) => boolean }> = [
+  {
+    // One agent's left rail — ten sections under a single agent.
+    label: 'Agent workspace',
+    match: (p) => p.startsWith('/w/:workspace/agents/:slug/'),
+  },
+  {
+    // Pages someone reaches from a link you sent them, with no account.
+    label: 'Shared links (no login)',
+    match: (p) =>
+      ['/share/:token', '/storyboard/:slug', '/narrative/:slug', '/walkthrough/:id',
+       '/review/:id', '/invite/:token'].includes(p) || p.startsWith('/ddd-release/'),
+  },
+]
+
+export function guideGroups(surfaces: SurfaceDescriptor[] = SURFACES): GuideGroup[] {
+  const claimed = new Set<string>()
+  const take = (pred: (p: string) => boolean) => {
+    const members = surfaces.filter((s) => !claimed.has(s.path) && pred(s.path))
+    members.forEach((m) => claimed.add(m.path))
+    return members
+  }
+
+  // Assign clusters first (see CLUSTERS' note), but DISPLAY the nav groups
+  // first, because that is the order a reader already knows from the header.
+  const clusterGroups = CLUSTERS.map((c) => ({ label: c.label, surfaces: take(c.match) }))
+
+  const navGroups = NAV_GROUPS.map((nav) => {
+    const wanted = nav.items.map(navItemPath)
+    return { label: nav.label, surfaces: take((p) => wanted.some((w) => navMatch(p, w))) }
+  })
+
+  const rest = surfaces.filter((s) => !claimed.has(s.path))
+
+  return [
+    ...navGroups.filter((g) => g.surfaces.length),
+    ...clusterGroups.filter((g) => g.surfaces.length),
+    ...(rest.length ? [{ label: 'Elsewhere', surfaces: rest }] : []),
+  ]
+}

--- a/frontend/src/guide/paths.test.ts
+++ b/frontend/src/guide/paths.test.ts
@@ -16,10 +16,18 @@ describe('USER_PATHS', () => {
     // The coupling that keeps the public page honest: it cannot promise a
     // surface the guide does not describe.
     const known = describedPaths()
-    const dangling = USER_PATHS.flatMap((p) =>
-      p.surfaces.filter((s) => s.startsWith('/') && !known.has(s)),
-    )
+    const dangling = USER_PATHS.flatMap((p) => p.surfaces.filter((s) => !known.has(s)))
     expect(dangling, `paths referencing undocumented surfaces: ${dangling.join(', ')}`).toEqual([])
+  })
+
+  it('every surface reference is a route, not an external entry point', () => {
+    // Filtering to `s.startsWith('/')` here would let a non-route reference
+    // (a bare command name, a domain) slip past the check above entirely —
+    // silently exempting it from "must be documented" rather than deciding
+    // that on purpose. If a genuinely external entry point is ever needed,
+    // that is a deliberate exception to carve out here, not a default.
+    const nonRoutes = USER_PATHS.flatMap((p) => p.surfaces.filter((s) => !s.startsWith('/')))
+    expect(nonRoutes, `non-route surface references: ${nonRoutes.join(', ')}`).toEqual([])
   })
 
   it('tells every path where to start', () => {

--- a/frontend/src/guide/paths.test.ts
+++ b/frontend/src/guide/paths.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { USER_PATHS } from './paths'
+import { describedPaths } from './surfaces'
+
+describe('USER_PATHS', () => {
+  it('describes the five ways in', () => {
+    expect(USER_PATHS).toHaveLength(5)
+  })
+
+  it('has unique ids', () => {
+    const ids = USER_PATHS.map((p) => p.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('only references surfaces that are actually documented', () => {
+    // The coupling that keeps the public page honest: it cannot promise a
+    // surface the guide does not describe.
+    const known = describedPaths()
+    const dangling = USER_PATHS.flatMap((p) =>
+      p.surfaces.filter((s) => s.startsWith('/') && !known.has(s)),
+    )
+    expect(dangling, `paths referencing undocumented surfaces: ${dangling.join(', ')}`).toEqual([])
+  })
+
+  it('tells every path where to start', () => {
+    for (const p of USER_PATHS) {
+      expect(p.startHere, `${p.id} has no starting point`).toBeTruthy()
+      expect(p.who, `${p.id} does not say who it is for`).toBeTruthy()
+    }
+  })
+})

--- a/frontend/src/guide/paths.ts
+++ b/frontend/src/guide/paths.ts
@@ -1,0 +1,65 @@
+/**
+ * The five ways into canopy. Rendered by BOTH the public explainer and the
+ * in-app guide, so the public promise cannot drift from the internal docs —
+ * paths.test.ts asserts every referenced surface is one the guide describes.
+ *
+ * Two notes on this taxonomy, because it differs from the obvious one.
+ * "Watch a turn in the browser" and "watch a turn on your laptop" are NOT two
+ * paths: they are one job with a deployment choice inside it, and the choice is
+ * the interesting part. And "you were sent a link" is first, because it is
+ * almost certainly the highest-volume interaction anyone has with canopy.
+ */
+export interface UserPath {
+  id: string
+  title: string
+  /** Who you are, if this is your path. */
+  who: string
+  /** The literal first thing to do. */
+  startHere: string
+  /** Route paths (from surfaces.ts) or external entry points. */
+  surfaces: string[]
+  note?: string
+}
+
+export const USER_PATHS: UserPath[] = [
+  {
+    id: 'audience',
+    title: 'You were sent a link',
+    who: 'An audience. No login, no install, nothing to set up.',
+    startHere: 'Open the link. That is the whole path.',
+    surfaces: ['/storyboard/:slug', '/narrative/:slug', '/walkthrough/:id', '/share/:token'],
+    note: 'Storyboards, narratives, demo walkthroughs and shared transcripts are all public when shared.',
+  },
+  {
+    id: 'operator',
+    title: 'You want an agent to do work',
+    who: 'An operator with a job to hand off.',
+    startHere: 'Open Chats in a workspace and start a chat with an agent.',
+    surfaces: ['/w/:workspace/chat', '/w/:workspace/chat/:id', '/w/:workspace/activity'],
+    note: 'Then choose where it runs: a cloud runner needs nothing from you, or pair your own laptop so you can jump into the terminal mid-turn.',
+  },
+  {
+    id: 'supervisor',
+    title: 'You keep agents unblocked',
+    who: 'Someone who owns agents and is not driving every turn.',
+    startHere: 'Open Supervisor, then install it as a phone app.',
+    surfaces: ['/supervisor', '/schedules'],
+    note: 'It pushes a notification when any agent you own starts waiting on you.',
+  },
+  {
+    id: 'skills',
+    title: "You want canopy's skills in your own sessions",
+    who: 'A Claude Code user who does not want to run a fleet.',
+    startHere: 'Mint a token in Settings, then install the canopy plugin.',
+    surfaces: ['/settings', '/system'],
+    note: 'No agents, no runners. Just the capability library in your own Claude Code.',
+  },
+  {
+    id: 'builder',
+    title: 'You want to build an agent',
+    who: 'A builder who needs a persona of their own.',
+    startHere: 'Run /canopy:create-agent, then register it in the workspace.',
+    surfaces: ['/w/:workspace/agents'],
+    note: 'The scaffold is a skeleton — persona and domain skills are yours to write.',
+  },
+]

--- a/frontend/src/guide/surfaces.ts
+++ b/frontend/src/guide/surfaces.ts
@@ -120,7 +120,7 @@ export const SURFACES: SurfaceDescriptor[] = [
   {
     path: '/w/:workspace/members',
     title: 'Members',
-    audience: 'Workspace owner',
+    audience: 'Any workspace member (owner-only actions)',
     what: 'Admin surface for who is in the workspace: the member list with roles, and pending invites — each invite is a copy-linkable `/invite/:token` URL (canopy sends no email itself).',
     actions: ['Invite someone by email', 'Change a member\'s role', 'Remove a member', 'Revoke a pending invite'],
   },
@@ -308,8 +308,8 @@ export const SURFACES: SurfaceDescriptor[] = [
     path: '/share/:token',
     title: 'Shared session (public)',
     audience: 'Whoever was sent the link',
-    what: 'A public, chrome-less, read-only viewer for one shared Claude Code transcript — no login required. Best-effort secret-scrubbed before sharing.',
-    actions: ['Read the transcript'],
+    what: 'A public, chrome-less, read-only viewer for a shared Claude Code transcript — or for several grouped as one arc, which lands on a clickable list of the member sessions. No login required. Best-effort secret-scrubbed before sharing.',
+    actions: ['Read the transcript', 'Open a session from a shared arc'],
   },
   {
     path: '/ddd-release/:narrative/:runId',

--- a/frontend/src/guide/surfaces.ts
+++ b/frontend/src/guide/surfaces.ts
@@ -339,6 +339,13 @@ export const SURFACES: SurfaceDescriptor[] = [
     what: "One narrative, scene by scene, for someone meeting the story for the first time — clean by default, with an optional toggle to see what changed since the last version. Editing (if allowed) opens the scene's own text directly.",
     actions: ['Read the narrative', 'Toggle "what changed"', 'Comment or suggest an edit (if the board allows it)'],
   },
+  {
+    path: '/about',
+    title: 'About Canopy (public)',
+    audience: 'Anyone, including people with no account',
+    what: 'The public explainer — what Canopy is, the five components it is made of, live counts, and the five ways in. No login required, so this is the link to send someone outside the team.',
+    actions: ['Send it to someone', 'See the live fleet counts'],
+  },
 ]
 
 export function describedPaths(): Set<string> {

--- a/frontend/src/guide/surfaces.ts
+++ b/frontend/src/guide/surfaces.ts
@@ -32,6 +32,13 @@ export const SURFACES: SurfaceDescriptor[] = [
     actions: ['Browse the catalog', 'Read a capability in full'],
   },
   {
+    path: '/guide',
+    title: 'Guide',
+    audience: 'Anyone finding their way around',
+    what: "What every surface in Canopy is for, generated from the app's own route table.",
+    actions: ['Find the page you need', 'See what a surface needs before it works'],
+  },
+  {
     path: '/insights',
     title: 'Insights',
     audience: 'Anyone watching the portfolio',

--- a/frontend/src/guide/surfaces.ts
+++ b/frontend/src/guide/surfaces.ts
@@ -1,0 +1,339 @@
+/**
+ * One descriptor per documented surface — the in-app guide's content, as DATA.
+ *
+ * Data, not prose in a wiki, for the same reason systemWorkflows.ts is data: a
+ * test can read this and a page can render it; prose in another repo can do
+ * neither. guide/coverage.test.ts asserts this file covers every route and
+ * names no route that does not exist.
+ *
+ * `path` MUST match the route path in router.tsx character for character.
+ */
+export interface SurfaceDescriptor {
+  /** Exactly the route path from routeTable. */
+  path: string
+  title: string
+  /** Who this is for, in a few words. */
+  audience: string
+  /** What it is, one line. */
+  what: string
+  /** What you need before it does anything useful. */
+  needsFirst?: string
+  /** What you can actually do here. */
+  actions?: string[]
+}
+
+export const SURFACES: SurfaceDescriptor[] = [
+  // --- Personal / global (not tenant-scoped) ---
+  {
+    path: '/system',
+    title: 'Capabilities',
+    audience: 'Anyone deciding what canopy can do',
+    what: "Every skill, agent and command the canopy plugin ships, read live from the plugin's own files, plus curated chains showing how they compose.",
+    actions: ['Browse the catalog', 'Read a capability in full'],
+  },
+  {
+    path: '/insights',
+    title: 'Insights',
+    audience: 'Anyone watching the portfolio',
+    what: 'A cross-portfolio feed of AI-generated findings (ship gaps, hygiene, patterns, stale work, opportunities, alignment), filterable by category and project, with per-item dismiss and a bulk clear.',
+    needsFirst: 'An insight-generating skill (e.g. canopy:portfolio-review) run at least once.',
+    actions: ['Filter by category or project', 'Dismiss an insight', 'Clear everything in view'],
+  },
+  {
+    path: '/sessions',
+    title: 'Shared sessions',
+    audience: 'Anyone who wants to hand someone a transcript link',
+    what: 'Claude Code transcripts you (or your agents/teammates) have shared as read-only web pages — one row per session with its visibility and link.',
+    needsFirst: 'canopy:share-session run once to upload a transcript.',
+    actions: ['Copy or open a share link', 'Rotate a link', 'Toggle private/link visibility', 'Delete a shared session'],
+  },
+  {
+    path: '/supervisor',
+    title: 'Supervisor',
+    audience: 'Someone who owns agents',
+    what: 'The cross-fleet "waiting on you" inbox, agent KPI cards and runner status. Spans every workspace, which is why it is not tenant-scoped.',
+    needsFirst: 'At least one agent you own.',
+    actions: ['Answer a blocked agent', 'See which runners are online', 'Install it as a phone app and get pushed when an agent needs you'],
+  },
+  {
+    path: '/schedules',
+    title: 'Schedules (all workspaces)',
+    audience: 'Anyone with recurring agent work',
+    what: 'A personal weekly calendar of every recurring schedule across every workspace you belong to, filterable by workspace and agent. Same calendar component as the per-workspace and per-agent views.',
+    needsFirst: 'An agent with at least one schedule configured.',
+    actions: ['See what fires this week', 'Filter by workspace or agent', 'Jump into a schedule to edit or run it'],
+  },
+  {
+    path: '/activity',
+    title: 'Activity (all workspaces)',
+    audience: 'Anyone checking "did that actually run"',
+    what: 'A read-only log of the last 20 triggered harness turns across your workspaces — time, agent, trigger, runner, status — with filters and a per-turn event-ledger drill-down. The "what DID fire" counterpart to Schedules ("what WILL fire").',
+    needsFirst: 'A turn triggered by a schedule, an inbound event, or a manual run.',
+    actions: ['Filter by agent, trigger or status', 'Expand a turn to see its raw event ledger'],
+  },
+  {
+    path: '/settings',
+    title: 'Settings',
+    audience: 'Everyone',
+    what: 'Your account and this deployment: which AI backend is in use, your Claude subscription connection, presence visibility, and your personal access tokens.',
+    actions: ['Mint a personal access token', 'Revoke a token', 'Switch AI backend', 'Toggle presence'],
+  },
+  {
+    path: '/new-workspace',
+    title: 'Create a workspace',
+    audience: 'A brand-new user with no workspace yet',
+    what: 'The first-run screen: explains what a workspace is, then either offers a create form (address + optional display name) or explains you need an invite, depending on your account\'s create eligibility.',
+    actions: ['Create a workspace (if eligible)'],
+  },
+
+  // --- Public viewers (root; self-enforce visibility) ---
+  {
+    path: '/walkthrough/:id',
+    title: 'Walkthrough viewer',
+    audience: 'Whoever was sent the link',
+    what: 'Plays a single shared walkthrough — an HTML slideshow or a video — with owner-only controls to toggle public/private, rotate the share link, or delete it. Deep-links to a scene (`#scene-N`) or a video timestamp (`#t=`) are supported. A signed-out visitor on a private link is routed to sign in rather than shown a bare error.',
+    actions: ['Watch the walkthrough', 'Copy or rotate the public link (owner)', 'Toggle visibility (owner)', 'Delete it (owner)'],
+  },
+  {
+    path: '/review/:id',
+    title: 'Narrative review',
+    audience: 'Whoever the review request was addressed to',
+    what: "The DDD narrative-review surface behind a review request: watch the cut, edit any scene's narration/features/personas inline, see grounding and gaps inline per scene, reorder the build sequence, and resolve the gate (approve / send back to redraft, or answer a findings review). External guests land here with a share token and can only suggest edits, never resolve the gate.",
+    actions: ['Watch the cut', 'Edit narration, features or personas', 'Reorder the build sequence', 'Approve, redraft, or submit findings decisions'],
+  },
+  {
+    path: '/invite/:token',
+    title: 'Accept invite',
+    audience: 'Someone invited to a workspace',
+    what: "The accept-invite landing page: previews the inviting workspace and role (masked email), then lets a signed-in matching account accept. Deliberately outside /w/:workspace — there's no tenant to scope into until the invite is accepted.",
+    actions: ['Sign in with the invited address', 'Accept the invite'],
+  },
+
+  // --- Tenant-scoped surfaces under /w/:workspace ---
+  {
+    path: '/w/:workspace',
+    title: 'Project workbench',
+    audience: 'Anyone in a workspace',
+    what: 'The workspace home — a tile per project, ranked by how many insights are waiting on it, with the top three surfaced as a hero.',
+    actions: ['Triage an insight inline', 'Open a project'],
+  },
+  {
+    path: '/w/:workspace/members',
+    title: 'Members',
+    audience: 'Workspace owner',
+    what: 'Admin surface for who is in the workspace: the member list with roles, and pending invites — each invite is a copy-linkable `/invite/:token` URL (canopy sends no email itself).',
+    actions: ['Invite someone by email', 'Change a member\'s role', 'Remove a member', 'Revoke a pending invite'],
+  },
+  {
+    path: '/w/:workspace/inbound',
+    title: 'Inbound push',
+    audience: 'Workspace owner setting up email-triggered agents',
+    what: "Configure the doorbell that lets an inbound Gmail message wake an agent: manage which mailboxes are watched, and generate the exact gcloud setup commands (project, Pub/Sub topic, service account) for the Gmail watch this depends on.",
+    actions: ['Add or remove a watched mailbox', 'Enable/disable a mailbox', 'Copy the GCP setup commands'],
+  },
+  {
+    path: '/w/:workspace/timeline',
+    title: 'Timeline',
+    audience: 'Anyone tracking cross-app activity',
+    what: 'A team activity feed of what happened across the workspace\'s apps — link-out only (each row opens the real surface it came from).',
+    actions: ['Scan recent activity', 'Open the underlying item'],
+  },
+  {
+    path: '/w/:workspace/shareouts',
+    title: 'Shareouts',
+    audience: 'Teammates catching up on what shipped',
+    what: 'Dated, teammate-facing work briefings — what shipped, why it matters, how to leverage it — posted by /canopy:shareout.',
+    needsFirst: 'canopy:shareout posted at least once.',
+    actions: ['Read a briefing', 'Open a specific dated period'],
+  },
+  {
+    path: '/w/:workspace/shareouts/:period',
+    title: 'Shareout (one period)',
+    audience: 'Teammates catching up on what shipped',
+    what: 'A single dated briefing, at a copy-linkable permalink — same content as the Shareouts feed, scoped to one period.',
+    actions: ['Read this briefing', 'Copy its permalink'],
+  },
+  {
+    path: '/w/:workspace/walkthroughs',
+    title: 'Walkthroughs',
+    audience: 'Anyone looking for a recorded demo',
+    what: 'The list of every walkthrough (HTML slideshow or video) uploaded from /canopy:walkthrough, filterable by project, kind, and "mine only".',
+    needsFirst: 'A walkthrough uploaded via canopy:walkthrough or a DDD run.',
+    actions: ['Filter by project or kind', 'Open a walkthrough'],
+  },
+  {
+    path: '/w/:workspace/storyboards',
+    title: 'Storyboards',
+    audience: 'Anyone assembling several demos into one shareable link',
+    what: 'The index of storyboards — the shared arcs — one row each: title, layout (review/reel), act count, and the token-bearing share link.',
+    needsFirst: 'A storyboard assembled from DDD narratives.',
+    actions: ['Copy a storyboard\'s share link', 'Open a storyboard'],
+  },
+  {
+    path: '/w/:workspace/agents',
+    title: 'Agents',
+    audience: 'Anyone working with the fleet',
+    what: 'The list of first-class AI agents registered in this workspace, each card showing its sync/work-product/skill counts.',
+    needsFirst: 'At least one agent registered in this workspace.',
+    actions: ['Open an agent\'s workspace'],
+  },
+  {
+    path: '/w/:workspace/schedules',
+    title: 'Schedules',
+    audience: 'Anyone with recurring agent work in this workspace',
+    what: 'The weekly calendar of recurring schedules scoped to this workspace. Same component as the personal /schedules view, without the cross-workspace filter (this route is already one workspace).',
+    needsFirst: 'An agent with at least one schedule configured.',
+    actions: ['See what fires this week', 'Jump into a schedule to edit or run it'],
+  },
+  {
+    path: '/w/:workspace/chat',
+    title: 'Chats',
+    audience: 'An operator who wants work done',
+    what: 'Your chat sessions with agents, so you can pick one up from any device.',
+    needsFirst: 'An agent in this workspace, and a runner online to execute its turns.',
+    actions: ['Start a new chat with an agent', 'Continue an existing session'],
+  },
+  {
+    path: '/w/:workspace/chat/:id',
+    title: 'One chat',
+    audience: 'An operator',
+    what: 'A live multiplayer chat with an agent. Sending enqueues a turn; the reply streams back as the agent works.',
+    needsFirst: 'A runner online and assigned to this agent.',
+    actions: ['Send a message', 'Answer a question the agent is blocked on', 'Move the session to another runner'],
+  },
+  {
+    path: '/w/:workspace/activity',
+    title: 'Activity',
+    audience: 'Anyone checking "did that actually run"',
+    what: 'The same turn log as /activity, scoped to this workspace: time, agent, trigger, runner, status, with a per-turn event-ledger drill-down.',
+    needsFirst: 'A turn triggered by a schedule, an inbound event, or a manual run.',
+    actions: ['Filter by agent, trigger or status', 'Expand a turn to see its raw event ledger'],
+  },
+  {
+    path: '/w/:workspace/agents/:slug/inbox',
+    title: 'Agent inbox',
+    audience: 'The person(s) who own this agent',
+    what: "The agent's OPEN items — reviews, then questions — each decidable right where it sits. This is the default landing section of the agent workspace, and the per-agent counterpart to Supervisor's fleet-wide inbox.",
+    actions: ['Decide an item in place (implement / skip / defer)'],
+  },
+  {
+    path: '/w/:workspace/agents/:slug/overview',
+    title: 'Agent overview',
+    audience: 'The person(s) who own this agent',
+    what: "The agent's control surface: dispatch a one-off prompt straight to it, manage its ordered runner assignment list, toggle its turn mode, and see recent syncs/tasks at a glance.",
+    actions: ['Send a quick prompt to the agent', 'Reorder or edit runner assignments', 'Toggle turn mode'],
+  },
+  {
+    path: '/w/:workspace/agents/:slug/tasks',
+    title: 'Agent tasks',
+    audience: 'The person(s) who own this agent',
+    what: 'The "who has the ball" board for this agent — its open tasks plus the command queue/history that drives them (accept / decline / dispatch / done).',
+    actions: ['Accept, decline or dispatch a task', 'Mark a task done'],
+  },
+  {
+    path: '/w/:workspace/agents/:slug/turns',
+    title: 'Agent turns',
+    audience: 'The person(s) who own this agent',
+    what: "The agent's full turn ledger — every packaged unit of work it has done, with what it advanced, what it did, its deliverables, and optionally a transcript link.",
+    actions: ['Browse past turns', 'Open a turn\'s transcript'],
+  },
+  {
+    path: '/w/:workspace/agents/:slug/items',
+    title: 'Agent items',
+    audience: 'The person(s) who own this agent',
+    what: "The full item ledger for this agent — including decided and dismissed items, not just the open ones the inbox shows. `?batch=<key>` renders one sitting (e.g. a fleet audit) as a single reviewable set.",
+    actions: ['Review a decided or dismissed item', 'Decide items from one batch in a single sitting'],
+  },
+  {
+    path: '/w/:workspace/agents/:slug/schedules',
+    title: 'Agent schedules',
+    audience: 'The person(s) who own this agent',
+    what: "A dense table of this agent's recurring activities — each row's server-computed next fire time and last outcome, plus the controls to run it off-cycle, pause it, or edit it.",
+    needsFirst: 'At least one schedule configured for this agent.',
+    actions: ['Run a schedule now', 'Pause or edit a schedule', 'Create a new schedule'],
+  },
+  {
+    path: '/w/:workspace/agents/:slug/syncs',
+    title: 'Agent syncs',
+    audience: 'The person(s) who own this agent',
+    what: "The agent's sync log — its periodic check-ins (e.g. a manager sync) recorded as cards.",
+    actions: ['Browse past syncs'],
+  },
+  {
+    path: '/w/:workspace/agents/:slug/credentials',
+    title: 'Agent credentials',
+    audience: 'The person(s) who own this agent',
+    what: "What is set and what is missing for this agent to actually run — write-only status rows (set/unset + when, never the secret itself) for each required credential, plus a vault of less-common ones collapsed by default. Answers \"what is stopping this agent from running\" without an SSH session.",
+    actions: ['Set or clear a credential', 'Mint a Google credential', 'See when each credential was last set'],
+  },
+  {
+    path: '/w/:workspace/agents/:slug/work-products',
+    title: 'Agent work products',
+    audience: 'The person(s) who own this agent, or anyone consuming its output',
+    what: "The agent's produced deliverables — the artifacts it has shipped, as cards.",
+    actions: ['Browse work products'],
+  },
+  {
+    path: '/w/:workspace/agents/:slug/skills',
+    title: 'Agent skills',
+    audience: 'The person(s) who own this agent',
+    what: "The catalog of skills this agent has available, as cards.",
+    actions: ['Browse the agent\'s skill catalog'],
+  },
+  {
+    path: '/w/:workspace/ddd',
+    title: 'DDD narratives',
+    audience: 'Anyone building or reviewing a demo',
+    what: 'The narrative gallery — pick a demo-driven-development narrative to open its landing page (story + runs).',
+    needsFirst: 'A narrative run through the canopy:ddd loop.',
+    actions: ['Browse narratives', 'Open one'],
+  },
+  {
+    path: '/w/:workspace/ddd/:narrative',
+    title: 'DDD narrative',
+    audience: 'Anyone building or reviewing a demo',
+    what: 'One narrative\'s landing page: its story plus every run against it, so you can pick a specific run\'s package.',
+    actions: ['Read the narrative\'s story', 'Open a specific run'],
+  },
+  {
+    path: '/w/:workspace/ddd/:narrative/:runId',
+    title: 'DDD run package',
+    audience: 'Anyone building or reviewing a demo',
+    what: 'One run\'s full package: rendered video, deck, narrative and links, grouped together — the operator console for that run.',
+    actions: ['Watch the rendered cut', 'Open the deck', 'Follow linked artifacts'],
+  },
+
+  // --- Public, chrome-less routes (mounted outside the app shell) ---
+  {
+    path: '/share/:token',
+    title: 'Shared session (public)',
+    audience: 'Whoever was sent the link',
+    what: 'A public, chrome-less, read-only viewer for one shared Claude Code transcript — no login required. Best-effort secret-scrubbed before sharing.',
+    actions: ['Read the transcript'],
+  },
+  {
+    path: '/ddd-release/:narrative/:runId',
+    title: 'DDD run release (public)',
+    audience: 'An external stakeholder sent the link',
+    what: "The clean, shareable face of a DDD run: title, final video and the narrative story, with no phase/gate jargon or artifact dump. A member additionally sees a link into the operator console.",
+    actions: ['Watch the release cut', 'Read the story'],
+  },
+  {
+    path: '/storyboard/:slug',
+    title: 'Storyboard (public)',
+    audience: 'An external stakeholder sent the link',
+    what: 'The shared arc — several DDD narratives shown as one link, chrome-less and token-gated, following each narrative\'s current release so the link never goes stale.',
+    actions: ['Read the arc', 'Leave a note (if the board allows comments)'],
+  },
+  {
+    path: '/narrative/:slug',
+    title: 'Narrative (public)',
+    audience: 'An external reviewer sent the link',
+    what: "One narrative, scene by scene, for someone meeting the story for the first time — clean by default, with an optional toggle to see what changed since the last version. Editing (if allowed) opens the scene's own text directly.",
+    actions: ['Read the narrative', 'Toggle "what changed"', 'Comment or suggest an edit (if the board allows it)'],
+  },
+]
+
+export function describedPaths(): Set<string> {
+  return new Set(SURFACES.map((s) => s.path))
+}

--- a/frontend/src/pages/AboutPage.tsx
+++ b/frontend/src/pages/AboutPage.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useState } from 'react'
+import { COMPONENTS, ONE_SENTENCE } from '@/guide/components'
+import { USER_PATHS } from '@/guide/paths'
+import { getPublicStats, type PublicStats } from '@/api/publicStats'
+
+/**
+ * The public explainer. Chrome-less, anonymous, mounted OUTSIDE AppLayout so
+ * the shell's authed calls cannot bounce a visitor to login.
+ *
+ * Counts are live because prose goes stale within a month — "we run a fleet of
+ * agents" reads as a claim, while "2 runners online" reads as a fact. The page
+ * renders fine without them.
+ */
+export function AboutPage() {
+  const [stats, setStats] = useState<PublicStats | null>(null)
+
+  useEffect(() => {
+    void getPublicStats().then(setStats)
+  }, [])
+
+  const figures: Array<[string, number | undefined]> = [
+    ['agents', stats?.agents],
+    ['skills', stats?.skills],
+    ['runners online', stats?.runners_online],
+    ['turns executed', stats?.turns_executed],
+    ['demos published', stats?.demos_published],
+  ]
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="mx-auto max-w-3xl px-6 py-16">
+        <h1 className="text-2xl font-semibold text-foreground">Canopy</h1>
+        <p className="mt-4 text-[15px] leading-relaxed text-foreground-secondary">
+          Canopy runs a fleet of AI agents that do real work — shipping code, triaging
+          mail, building demos — and keeps the durable record of what they did, so the
+          work survives the session it happened in.
+        </p>
+
+        {stats ? (
+          <dl className="mt-8 grid grid-cols-2 gap-4 sm:grid-cols-3">
+            {figures.map(([label, value]) => (
+              <div key={label} className="rounded-lg border border-border bg-card p-3">
+                <dd className="text-xl font-semibold text-foreground">{value ?? '—'}</dd>
+                <dt className="mt-0.5 text-[11px] uppercase tracking-wide text-muted-foreground">
+                  {label}
+                </dt>
+              </div>
+            ))}
+          </dl>
+        ) : null}
+
+        <section className="mt-12">
+          <h2 className="text-sm font-semibold text-foreground">How it fits together</h2>
+          <p className="mt-2 text-[13px] leading-relaxed text-foreground-secondary">{ONE_SENTENCE}</p>
+          <div className="mt-4 space-y-2">
+            {COMPONENTS.map((c) => (
+              <div key={c.name} className="rounded-lg border border-border bg-card p-3">
+                <h3 className="text-[13px] font-semibold text-foreground">{c.name}</h3>
+                <p className="mt-1 text-[13px] leading-relaxed text-foreground-secondary">{c.what}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="mt-12">
+          <h2 className="text-sm font-semibold text-foreground">Five ways in</h2>
+          <div className="mt-4 space-y-3">
+            {USER_PATHS.map((p) => (
+              <div key={p.id} className="rounded-lg border border-border bg-card p-4">
+                <h3 className="text-[13px] font-semibold text-foreground">{p.title}</h3>
+                <p className="mt-0.5 text-[12px] text-muted-foreground">{p.who}</p>
+                <p className="mt-2 text-[13px] text-foreground-secondary">{p.startHere}</p>
+                {p.note ? <p className="mt-1 text-[12px] text-foreground-subtle">{p.note}</p> : null}
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <footer className="mt-12 border-t border-border pt-6 text-[12px] text-muted-foreground">
+          <a href="./api/docs/" className="text-primary hover:underline">
+            API reference
+          </a>
+        </footer>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/AboutPage.tsx
+++ b/frontend/src/pages/AboutPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { COMPONENTS, ONE_SENTENCE } from '@/guide/components'
 import { USER_PATHS } from '@/guide/paths'
 import { getPublicStats, type PublicStats } from '@/api/publicStats'
+import { apiUrl } from '@/api/base'
 
 /**
  * The public explainer. Chrome-less, anonymous, mounted OUTSIDE AppLayout so
@@ -71,13 +72,26 @@ export function AboutPage() {
                 <p className="mt-0.5 text-[12px] text-muted-foreground">{p.who}</p>
                 <p className="mt-2 text-[13px] text-foreground-secondary">{p.startHere}</p>
                 {p.note ? <p className="mt-1 text-[12px] text-foreground-subtle">{p.note}</p> : null}
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {p.surfaces.map((s) => (
+                    // Plain text, deliberately not a link — these are route
+                    // TEMPLATES (e.g. /w/:workspace/chat), not URLs an
+                    // anonymous visitor could actually navigate to.
+                    <code
+                      key={s}
+                      className="rounded border border-border bg-muted px-1.5 py-0.5 text-[11px] text-foreground-secondary"
+                    >
+                      {s}
+                    </code>
+                  ))}
+                </div>
               </div>
             ))}
           </div>
         </section>
 
         <footer className="mt-12 border-t border-border pt-6 text-[12px] text-muted-foreground">
-          <a href="./api/docs/" className="text-primary hover:underline">
+          <a href={apiUrl('/api/docs/')} className="text-primary hover:underline">
             API reference
           </a>
         </footer>

--- a/frontend/src/pages/AgentsPage.tsx
+++ b/frontend/src/pages/AgentsPage.tsx
@@ -158,10 +158,19 @@ export function AgentsPage() {
       )}
 
       {!loading && !error && agents.length === 0 && (
-        <div className="flex flex-col items-center justify-center h-48 text-center">
-          <p className="text-sm text-muted-foreground mb-1">No agents yet.</p>
-          <p className="text-xs text-foreground-subtle">
-            Agents appear here once they publish their first sync.
+        <div className="rounded-lg border border-border bg-card p-4">
+          <h2 className="text-sm font-semibold text-foreground">No agents in this workspace</h2>
+          <p className="mt-2 text-[13px] leading-relaxed text-foreground-secondary">
+            An agent is a persona with its own git repo — skills, hooks and an identity. It is
+            not created here: run <code className="text-primary">/canopy:create-agent</code> in
+            Claude Code, which scaffolds the repo, then it appears in this list.
+          </p>
+          <p className="mt-2 text-[12px] text-muted-foreground">
+            You will also need a runner online to execute its turns.{' '}
+            <Link to="/guide#/w/:workspace/agents" className="text-primary hover:underline">
+              Read more in the guide
+            </Link>
+            .
           </p>
         </div>
       )}

--- a/frontend/src/pages/AgentsPage.tsx
+++ b/frontend/src/pages/AgentsPage.tsx
@@ -163,7 +163,10 @@ export function AgentsPage() {
           <p className="mt-2 text-[13px] leading-relaxed text-foreground-secondary">
             An agent is a persona with its own git repo — skills, hooks and an identity. It is
             not created here: run <code className="text-primary">/canopy:create-agent</code> in
-            Claude Code, which scaffolds the repo, then it appears in this list.
+            Claude Code, which scaffolds the repo, then register it in this workspace for it
+            to appear in this list. That command needs the canopy plugin installed, which
+            needs a Personal Access Token — mint one from{' '}
+            <Link to="/settings" className="text-primary hover:underline">Settings</Link>.
           </p>
           <p className="mt-2 text-[12px] text-muted-foreground">
             You will also need a runner online to execute its turns.{' '}

--- a/frontend/src/pages/FirstRunPage.tsx
+++ b/frontend/src/pages/FirstRunPage.tsx
@@ -14,7 +14,7 @@ import { firstRunState } from './firstRun'
  * guaranteed to read, so it explains what a workspace IS rather than just
  * asking for a slug.
  */
-export function FirstRunPage() {
+export function FirstRunPage({ alwaysOfferForm = false }: { alwaysOfferForm?: boolean }) {
   const { workspaces, loading, refresh } = useWorkspace()
   const { user } = useAuth()
   const navigate = useNavigate()
@@ -36,7 +36,12 @@ export function FirstRunPage() {
     canCreate,
   })
 
-  if (state === 'loading' || state === 'ready') return null
+  if (state === 'loading') return null
+  if (state === 'ready' && !alwaysOfferForm) return null
+  // On /new-workspace an eligible user sees the form even though they already
+  // belong somewhere; `needs-invite` still applies, because eligibility is the
+  // server's call either way.
+  const offerForm = alwaysOfferForm ? canCreate : state === 'can-create'
 
   async function submit(e: React.FormEvent) {
     e.preventDefault()
@@ -66,7 +71,7 @@ export function FirstRunPage() {
         <span className="font-medium text-foreground">workspace</span>. You are not in one yet.
       </p>
 
-      {state === 'can-create' ? (
+      {offerForm ? (
         <form onSubmit={submit} className="mt-8 space-y-4">
           <div>
             <label htmlFor="ws-slug" className="block text-xs font-medium text-foreground-secondary">

--- a/frontend/src/pages/FirstRunPage.tsx
+++ b/frontend/src/pages/FirstRunPage.tsx
@@ -62,13 +62,30 @@ export function FirstRunPage({ alwaysOfferForm = false }: { alwaysOfferForm?: bo
     navigate(`/w/${res.slug}`)
   }
 
+  // `state === 'ready'` means the caller already belongs to a workspace —
+  // the primary way to reach this page IS `/new-workspace` now that it and
+  // the header link exist, so the copy must not tell an existing member they
+  // have no workspace (that was the C2 regression).
+  const alreadyAMember = state === 'ready'
+
   return (
     <div className="mx-auto max-w-xl px-6 py-16">
-      <h1 className="text-lg font-semibold text-foreground">Welcome to Canopy</h1>
+      <h1 className="text-lg font-semibold text-foreground">
+        {alreadyAMember ? 'New workspace' : 'Welcome to Canopy'}
+      </h1>
       <p className="mt-3 text-[13px] leading-relaxed text-foreground-secondary">
-        Canopy runs a fleet of AI agents and keeps the record of what they do. Everything
-        that belongs to a team — projects, agents, chats, demos — lives inside a{' '}
-        <span className="font-medium text-foreground">workspace</span>. You are not in one yet.
+        {alreadyAMember ? (
+          <>
+            Workspaces keep separate teams&apos; projects, agents and demos apart.
+            Create another below.
+          </>
+        ) : (
+          <>
+            Canopy runs a fleet of AI agents and keeps the record of what they do. Everything
+            that belongs to a team — projects, agents, chats, demos — lives inside a{' '}
+            <span className="font-medium text-foreground">workspace</span>. You are not in one yet.
+          </>
+        )}
       </p>
 
       {offerForm ? (
@@ -109,9 +126,11 @@ export function FirstRunPage({ alwaysOfferForm = false }: { alwaysOfferForm?: bo
           >
             {busy ? 'Creating…' : 'Create workspace'}
           </button>
-          <p className="text-[12px] text-muted-foreground">
-            Already invited to one? Open the /invite/… link a colleague sent you instead.
-          </p>
+          {!alreadyAMember && (
+            <p className="text-[12px] text-muted-foreground">
+              Already invited to one? Open the /invite/… link a colleague sent you instead.
+            </p>
+          )}
         </form>
       ) : (
         <div className="mt-8 rounded-lg border border-border bg-card p-4">

--- a/frontend/src/pages/FirstRunPage.tsx
+++ b/frontend/src/pages/FirstRunPage.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useWorkspace } from '@/workspace/WorkspaceProvider'
-import { getMe } from '@/api/me'
+import { useAuth } from '@/auth/AuthProvider'
 import { createWorkspace } from '@/api/workspaces'
 import { firstRunState } from './firstRun'
 
@@ -16,16 +16,19 @@ import { firstRunState } from './firstRun'
  */
 export function FirstRunPage() {
   const { workspaces, loading, refresh } = useWorkspace()
+  const { user } = useAuth()
   const navigate = useNavigate()
-  const [canCreate, setCanCreate] = useState<boolean | null>(null)
   const [slug, setSlug] = useState('')
   const [displayName, setDisplayName] = useState('')
   const [error, setError] = useState('')
   const [busy, setBusy] = useState(false)
 
-  useEffect(() => {
-    void getMe().then((me) => setCanCreate(me?.can_create_workspace ?? false))
-  }, [])
+  // AuthProvider resolves `useAuth()` before any route mounts (it gates on
+  // `status === 'loading'` itself), so `user` is always the real MeOut here —
+  // no second fetch, no null-while-pending state to represent. `?? false`
+  // stays fail-closed: defaulting an unresolved eligibility to "can create"
+  // would offer a form that 403s (the F1 gate this screen exists to respect).
+  const canCreate = user?.can_create_workspace ?? false
 
   const state = firstRunState({
     loading,

--- a/frontend/src/pages/FirstRunPage.tsx
+++ b/frontend/src/pages/FirstRunPage.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { useWorkspace } from '@/workspace/WorkspaceProvider'
 import { useAuth } from '@/auth/AuthProvider'
 import { createWorkspace } from '@/api/workspaces'
-import { firstRunState } from './firstRun'
+import { firstRunState, shouldOfferCreateForm } from './firstRun'
 
 /**
  * What a brand-new user sees. Replaces the two `return null` sites in
@@ -41,7 +41,7 @@ export function FirstRunPage({ alwaysOfferForm = false }: { alwaysOfferForm?: bo
   // On /new-workspace an eligible user sees the form even though they already
   // belong somewhere; `needs-invite` still applies, because eligibility is the
   // server's call either way.
-  const offerForm = alwaysOfferForm ? canCreate : state === 'can-create'
+  const offerForm = shouldOfferCreateForm({ state, canCreate, alwaysOfferForm })
 
   async function submit(e: React.FormEvent) {
     e.preventDefault()

--- a/frontend/src/pages/FirstRunPage.tsx
+++ b/frontend/src/pages/FirstRunPage.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useWorkspace } from '@/workspace/WorkspaceProvider'
+import { getMe } from '@/api/me'
+import { createWorkspace } from '@/api/workspaces'
+import { firstRunState } from './firstRun'
+
+/**
+ * What a brand-new user sees. Replaces the two `return null` sites in
+ * router.tsx, which rendered a blank page for anyone with no workspace
+ * membership — the first screen of the power-user rollout.
+ *
+ * Doubles as documentation: this is the only page every new user is
+ * guaranteed to read, so it explains what a workspace IS rather than just
+ * asking for a slug.
+ */
+export function FirstRunPage() {
+  const { workspaces, loading, refresh } = useWorkspace()
+  const navigate = useNavigate()
+  const [canCreate, setCanCreate] = useState<boolean | null>(null)
+  const [slug, setSlug] = useState('')
+  const [displayName, setDisplayName] = useState('')
+  const [error, setError] = useState('')
+  const [busy, setBusy] = useState(false)
+
+  useEffect(() => {
+    void getMe().then((me) => setCanCreate(me?.can_create_workspace ?? false))
+  }, [])
+
+  const state = firstRunState({
+    loading,
+    workspaceCount: workspaces.length,
+    canCreate,
+  })
+
+  if (state === 'loading' || state === 'ready') return null
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault()
+    setBusy(true)
+    setError('')
+    const res = await createWorkspace(slug.trim(), displayName.trim() || slug.trim())
+    setBusy(false)
+    if ('error' in res) {
+      setError(res.error)
+      return
+    }
+    // WorkspaceProvider fetches the membership list once on mount and never
+    // invalidates it, so a brand-new membership is invisible until something
+    // re-fetches. `refresh()` is the provider's documented mechanism for exactly
+    // this ("a page that mutates the CALLER's own role in a workspace must call
+    // this afterward") — use it rather than a full page reload.
+    await refresh()
+    navigate(`/w/${res.slug}`)
+  }
+
+  return (
+    <div className="mx-auto max-w-xl px-6 py-16">
+      <h1 className="text-lg font-semibold text-foreground">Welcome to Canopy</h1>
+      <p className="mt-3 text-[13px] leading-relaxed text-foreground-secondary">
+        Canopy runs a fleet of AI agents and keeps the record of what they do. Everything
+        that belongs to a team — projects, agents, chats, demos — lives inside a{' '}
+        <span className="font-medium text-foreground">workspace</span>. You are not in one yet.
+      </p>
+
+      {state === 'can-create' ? (
+        <form onSubmit={submit} className="mt-8 space-y-4">
+          <div>
+            <label htmlFor="ws-slug" className="block text-xs font-medium text-foreground-secondary">
+              Workspace address
+            </label>
+            <input
+              id="ws-slug"
+              value={slug}
+              onChange={(e) => setSlug(e.target.value)}
+              placeholder="acme"
+              required
+              className="mt-1 w-full rounded border border-input bg-input px-2 py-1.5 text-[13px] text-foreground"
+            />
+            <p className="mt-1 text-[11px] text-muted-foreground">
+              Used in every URL: /w/&lt;address&gt;. Lowercase letters, numbers and dashes.
+            </p>
+          </div>
+          <div>
+            <label htmlFor="ws-name" className="block text-xs font-medium text-foreground-secondary">
+              Display name <span className="text-muted-foreground">(optional)</span>
+            </label>
+            <input
+              id="ws-name"
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              placeholder="Acme"
+              className="mt-1 w-full rounded border border-input bg-input px-2 py-1.5 text-[13px] text-foreground"
+            />
+          </div>
+          {error ? <p className="text-[13px] text-destructive">{error}</p> : null}
+          <button
+            type="submit"
+            disabled={busy || !slug.trim()}
+            className="rounded bg-primary px-3 py-1.5 text-[13px] font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+          >
+            {busy ? 'Creating…' : 'Create workspace'}
+          </button>
+          <p className="text-[12px] text-muted-foreground">
+            Already invited to one? Open the /invite/… link a colleague sent you instead.
+          </p>
+        </form>
+      ) : (
+        <div className="mt-8 rounded-lg border border-border bg-card p-4">
+          <h2 className="text-sm font-semibold text-foreground">You need an invite</h2>
+          <p className="mt-2 text-[13px] leading-relaxed text-foreground-secondary">
+            Your account can join a workspace but cannot create one. Ask a workspace owner
+            to invite you — they can do it from their workspace&apos;s Members page — and open
+            the /invite/… link they send you.
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react'
+import { useLocation } from 'react-router-dom'
 import { guideGroups } from '@/guide/grouping'
 import { USER_PATHS } from '@/guide/paths'
 
@@ -8,6 +10,19 @@ import { USER_PATHS } from '@/guide/paths'
  * surface and the documentation surface are the same content.
  */
 export function GuidePage() {
+  const { hash } = useLocation()
+
+  // React Router navigates with pushState, which does NOT trigger the browser's
+  // native fragment scrolling — so a /guide#<route-path> link from an empty state
+  // would land at the top of the page and silently do nothing. Anchor ids are
+  // route paths ('/w/:workspace/agents'), so they MUST be looked up with
+  // getElementById: '#/w/:workspace/agents' is not a valid CSS selector and
+  // querySelector would throw.
+  useEffect(() => {
+    if (!hash) return
+    const el = document.getElementById(decodeURIComponent(hash.slice(1)))
+    el?.scrollIntoView({ block: 'start' })
+  }, [hash])
   return (
     <div className="mx-auto max-w-4xl px-6 py-8">
       <h1 className="text-lg font-semibold text-foreground">Guide</h1>

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -1,0 +1,75 @@
+import { guideGroups } from '@/guide/grouping'
+import { USER_PATHS } from '@/guide/paths'
+
+/**
+ * The in-app guide: what every surface is, generated from guide/surfaces.ts and
+ * grouped by the header nav. A coverage test guarantees nothing is missing;
+ * empty states deep-link here with #<route-path> anchors, so the stuck-user
+ * surface and the documentation surface are the same content.
+ */
+export function GuidePage() {
+  return (
+    <div className="mx-auto max-w-4xl px-6 py-8">
+      <h1 className="text-lg font-semibold text-foreground">Guide</h1>
+      <p className="mt-2 text-[13px] leading-relaxed text-foreground-secondary">
+        What each part of Canopy is for. Generated from the app&apos;s own route table, so
+        it cannot quietly miss a page.
+      </p>
+
+      <section className="mt-8">
+        <h2 className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+          Start here
+        </h2>
+        <ol className="mt-3 space-y-3">
+          {USER_PATHS.map((p, i) => (
+            <li key={p.id} className="flex gap-3 rounded-lg border border-border bg-card p-3">
+              <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-muted text-[10px] font-semibold text-muted-foreground">
+                {i + 1}
+              </span>
+              <div>
+                <h3 className="text-sm font-semibold text-foreground">{p.title}</h3>
+                <p className="mt-0.5 text-[12px] text-muted-foreground">{p.who}</p>
+                <p className="mt-1.5 text-[13px] text-foreground-secondary">{p.startHere}</p>
+                {p.note ? <p className="mt-1 text-[12px] text-foreground-subtle">{p.note}</p> : null}
+              </div>
+            </li>
+          ))}
+        </ol>
+      </section>
+
+      {guideGroups().map((group) => (
+        <section key={group.label} className="mt-8">
+          <h2 className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+            {group.label}
+          </h2>
+          <div className="mt-3 space-y-3">
+            {group.surfaces.map((s) => (
+              <article
+                key={s.path}
+                id={s.path}
+                className="scroll-mt-20 rounded-lg border border-border bg-card p-4"
+              >
+                <div className="flex items-baseline justify-between gap-3">
+                  <h3 className="text-sm font-semibold text-foreground">{s.title}</h3>
+                  <code className="shrink-0 text-[11px] text-foreground-subtle">{s.path}</code>
+                </div>
+                <p className="mt-1 text-[12px] text-muted-foreground">{s.audience}</p>
+                <p className="mt-2 text-[13px] leading-relaxed text-foreground-secondary">{s.what}</p>
+                {s.needsFirst ? (
+                  <p className="mt-2 text-[12px] text-warning">Needs first: {s.needsFirst}</p>
+                ) : null}
+                {s.actions?.length ? (
+                  <ul className="mt-2 list-disc space-y-0.5 pl-5 text-[12px] text-foreground-secondary">
+                    {s.actions.map((a) => (
+                      <li key={a}>{a}</li>
+                    ))}
+                  </ul>
+                ) : null}
+              </article>
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { useLocation } from 'react-router-dom'
+import { Link, useLocation } from 'react-router-dom'
 import { guideGroups } from '@/guide/grouping'
 import { USER_PATHS } from '@/guide/paths'
 
@@ -33,23 +33,29 @@ export function GuidePage() {
 
       <section className="mt-8">
         <h2 className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-          Start here
+          Five ways in — pick the one that&apos;s you
         </h2>
-        <ol className="mt-3 space-y-3">
-          {USER_PATHS.map((p, i) => (
-            <li key={p.id} className="flex gap-3 rounded-lg border border-border bg-card p-3">
-              <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-muted text-[10px] font-semibold text-muted-foreground">
-                {i + 1}
-              </span>
-              <div>
-                <h3 className="text-sm font-semibold text-foreground">{p.title}</h3>
-                <p className="mt-0.5 text-[12px] text-muted-foreground">{p.who}</p>
-                <p className="mt-1.5 text-[13px] text-foreground-secondary">{p.startHere}</p>
-                {p.note ? <p className="mt-1 text-[12px] text-foreground-subtle">{p.note}</p> : null}
+        <ul className="mt-3 space-y-3">
+          {USER_PATHS.map((p) => (
+            <li key={p.id} className="rounded-lg border border-border bg-card p-3">
+              <h3 className="text-sm font-semibold text-foreground">{p.title}</h3>
+              <p className="mt-0.5 text-[12px] text-muted-foreground">{p.who}</p>
+              <p className="mt-1.5 text-[13px] text-foreground-secondary">{p.startHere}</p>
+              {p.note ? <p className="mt-1 text-[12px] text-foreground-subtle">{p.note}</p> : null}
+              <div className="mt-2 flex flex-wrap gap-2">
+                {p.surfaces.map((s) => (
+                  <Link
+                    key={s}
+                    to={'#' + s}
+                    className="rounded border border-border bg-muted px-1.5 py-0.5 text-[11px] text-foreground-secondary hover:text-foreground"
+                  >
+                    {s}
+                  </Link>
+                ))}
               </div>
             </li>
           ))}
-        </ol>
+        </ul>
       </section>
 
       {guideGroups().map((group) => (

--- a/frontend/src/pages/SettingsPage.presence.test.tsx
+++ b/frontend/src/pages/SettingsPage.presence.test.tsx
@@ -29,6 +29,12 @@ const getPresencePreference = vi.fn<() => Promise<PresencePreferenceOut>>()
 const setPresencePreference = vi.fn<(next: boolean) => Promise<PresencePreferenceOut>>()
 vi.mock('@/api/presence', () => ({ getPresencePreference, setPresencePreference }))
 
+// TokensPanel (mounted between Presence and DebugAccessPanel) fetches on
+// mount. Mocked here purely so rendering the full SettingsPage in these
+// presence-focused tests doesn't also hit the (unmocked, jsdom-unreachable)
+// tokens endpoint.
+vi.mock('@/api/tokens', () => ({ listTokens: vi.fn().mockResolvedValue([]) }))
+
 const { SettingsPage } = await import('./SettingsPage')
 const { PRESENCE_PREFERENCE_CHANGED_EVENT } = await import('@/presence/events')
 const { usePresenceReconnectNonce } = await import('@/presence/usePresenceReconnectNonce')

--- a/frontend/src/pages/SettingsPage.presence.test.tsx
+++ b/frontend/src/pages/SettingsPage.presence.test.tsx
@@ -33,7 +33,11 @@ vi.mock('@/api/presence', () => ({ getPresencePreference, setPresencePreference 
 // mount. Mocked here purely so rendering the full SettingsPage in these
 // presence-focused tests doesn't also hit the (unmocked, jsdom-unreachable)
 // tokens endpoint.
-vi.mock('@/api/tokens', () => ({ listTokens: vi.fn().mockResolvedValue([]) }))
+vi.mock('@/api/tokens', () => ({
+  listTokens: vi.fn().mockResolvedValue([]),
+  mintToken: vi.fn(),
+  revokeToken: vi.fn(),
+}))
 
 const { SettingsPage } = await import('./SettingsPage')
 const { PRESENCE_PREFERENCE_CHANGED_EVENT } = await import('@/presence/events')

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -4,6 +4,7 @@ import { aiStatus as fetchAiStatus, aiAuthStart, aiAuthComplete, aiAuthPoll } fr
 import { getPresencePreference, setPresencePreference } from '@/api/presence'
 import { notifyPresencePreferenceChanged } from '@/presence/events'
 import { TokensPanel } from '@/components/settings/TokensPanel'
+import { CopyBlock } from '@/components/CopyBlock'
 import { Button } from 'canopy-ui/ui'
 import { Input } from 'canopy-ui/ui'
 
@@ -368,28 +369,6 @@ function DebugAccessPanel() {
           </div>
         </div>
       )}
-    </div>
-  )
-}
-
-export function CopyBlock({
-  label, value, copied, onCopy,
-}: { label: string; value: string; copied: boolean; onCopy: () => void }) {
-  return (
-    <div>
-      <div className="flex items-center justify-between mb-1">
-        <span className="text-[10px] uppercase tracking-wider text-muted-foreground font-semibold">{label}</span>
-        <button
-          type="button"
-          onClick={onCopy}
-          className="text-xs text-primary hover:text-primary transition-colors"
-        >
-          {copied ? 'Copied' : 'Copy'}
-        </button>
-      </div>
-      <pre className="bg-background border border-border rounded-lg p-3 text-xs text-foreground-secondary font-mono overflow-x-auto whitespace-pre-wrap break-all">
-        {value}
-      </pre>
     </div>
   )
 }

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -3,6 +3,7 @@ import { mintDebugSession, type MintDebugSessionResponse } from '@/api/debug'
 import { aiStatus as fetchAiStatus, aiAuthStart, aiAuthComplete, aiAuthPoll } from '@/api/ai'
 import { getPresencePreference, setPresencePreference } from '@/api/presence'
 import { notifyPresencePreferenceChanged } from '@/presence/events'
+import { TokensPanel } from '@/components/settings/TokensPanel'
 import { Button } from 'canopy-ui/ui'
 import { Input } from 'canopy-ui/ui'
 
@@ -252,6 +253,8 @@ export function SettingsPage() {
         </div>
       </div>
 
+      <TokensPanel />
+
       <DebugAccessPanel />
     </div>
   )
@@ -369,7 +372,7 @@ function DebugAccessPanel() {
   )
 }
 
-function CopyBlock({
+export function CopyBlock({
   label, value, copied, onCopy,
 }: { label: string; value: string; copied: boolean; onCopy: () => void }) {
   return (

--- a/frontend/src/pages/firstRun.test.ts
+++ b/frontend/src/pages/firstRun.test.ts
@@ -2,9 +2,12 @@ import { describe, it, expect } from 'vitest'
 import { firstRunState } from './firstRun'
 
 describe('firstRunState', () => {
-  it('is loading while either the workspace list or me is unresolved', () => {
-    expect(firstRunState({ loading: true, workspaceCount: 0, canCreate: null })).toBe('loading')
-    expect(firstRunState({ loading: false, workspaceCount: 0, canCreate: null })).toBe('loading')
+  it('is loading while the workspace list is unresolved, regardless of eligibility', () => {
+    // Two cases with opposite `canCreate` values, both loading — this is the
+    // mutation guard: deleting the `loading` check entirely would make the
+    // first of these return 'can-create' instead.
+    expect(firstRunState({ loading: true, workspaceCount: 0, canCreate: true })).toBe('loading')
+    expect(firstRunState({ loading: true, workspaceCount: 0, canCreate: false })).toBe('loading')
   })
 
   it('is ready once the user has at least one workspace', () => {
@@ -23,5 +26,11 @@ describe('firstRunState', () => {
     // Guards the ordering: an eligible user WITH a workspace must be routed on,
     // not parked on the first-run screen.
     expect(firstRunState({ loading: false, workspaceCount: 2, canCreate: true })).toBe('ready')
+  })
+
+  it('prefers loading over ready when the workspace list has not resolved yet', () => {
+    // Even though workspaceCount > 0 would normally mean 'ready', a still-loading
+    // list means that count isn't trustworthy yet.
+    expect(firstRunState({ loading: true, workspaceCount: 1, canCreate: true })).toBe('loading')
   })
 })

--- a/frontend/src/pages/firstRun.test.ts
+++ b/frontend/src/pages/firstRun.test.ts
@@ -33,4 +33,10 @@ describe('firstRunState', () => {
     // list means that count isn't trustworthy yet.
     expect(firstRunState({ loading: true, workspaceCount: 1, canCreate: true })).toBe('loading')
   })
+
+  it('still reports ready for a member — /new-workspace opts out via a prop, not this fn', () => {
+    // Documents the seam: firstRunState stays a pure description of the user's
+    // standing. The route decides whether to show a form anyway.
+    expect(firstRunState({ loading: false, workspaceCount: 3, canCreate: true })).toBe('ready')
+  })
 })

--- a/frontend/src/pages/firstRun.test.ts
+++ b/frontend/src/pages/firstRun.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { firstRunState } from './firstRun'
+import { firstRunState, shouldOfferCreateForm } from './firstRun'
 
 describe('firstRunState', () => {
   it('is loading while the workspace list is unresolved, regardless of eligibility', () => {
@@ -33,10 +33,31 @@ describe('firstRunState', () => {
     // list means that count isn't trustworthy yet.
     expect(firstRunState({ loading: true, workspaceCount: 1, canCreate: true })).toBe('loading')
   })
+})
 
-  it('still reports ready for a member — /new-workspace opts out via a prop, not this fn', () => {
-    // Documents the seam: firstRunState stays a pure description of the user's
-    // standing. The route decides whether to show a form anyway.
-    expect(firstRunState({ loading: false, workspaceCount: 3, canCreate: true })).toBe('ready')
+describe('shouldOfferCreateForm', () => {
+  it('respects eligibility even when alwaysOfferForm is true (the F1 gate)', () => {
+    // An invite-admitted user holding no membership may not create a workspace.
+    // On /new-workspace, passing alwaysOfferForm=true should NOT bypass the
+    // eligibility check — offering a form would 403.
+    expect(shouldOfferCreateForm({ state: 'ready', canCreate: false, alwaysOfferForm: true })).toBe(
+      false,
+    )
+  })
+
+  it('offers the form on /new-workspace to an eligible user who already belongs somewhere', () => {
+    expect(shouldOfferCreateForm({ state: 'ready', canCreate: true, alwaysOfferForm: true })).toBe(
+      true,
+    )
+  })
+
+  it('offers the form to an eligible user with no workspace', () => {
+    expect(shouldOfferCreateForm({ state: 'can-create', canCreate: true, alwaysOfferForm: false }))
+      .toBe(true)
+  })
+
+  it('does not offer the form to an ineligible user with no workspace', () => {
+    expect(shouldOfferCreateForm({ state: 'needs-invite', canCreate: false, alwaysOfferForm: false }))
+      .toBe(false)
   })
 })

--- a/frontend/src/pages/firstRun.test.ts
+++ b/frontend/src/pages/firstRun.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { firstRunState } from './firstRun'
+
+describe('firstRunState', () => {
+  it('is loading while either the workspace list or me is unresolved', () => {
+    expect(firstRunState({ loading: true, workspaceCount: 0, canCreate: null })).toBe('loading')
+    expect(firstRunState({ loading: false, workspaceCount: 0, canCreate: null })).toBe('loading')
+  })
+
+  it('is ready once the user has at least one workspace', () => {
+    expect(firstRunState({ loading: false, workspaceCount: 1, canCreate: false })).toBe('ready')
+  })
+
+  it('offers creation to an eligible user with no workspace', () => {
+    expect(firstRunState({ loading: false, workspaceCount: 0, canCreate: true })).toBe('can-create')
+  })
+
+  it('asks an ineligible user for an invite instead of offering a button that 403s', () => {
+    expect(firstRunState({ loading: false, workspaceCount: 0, canCreate: false })).toBe('needs-invite')
+  })
+
+  it('prefers ready over creation when the user already belongs somewhere', () => {
+    // Guards the ordering: an eligible user WITH a workspace must be routed on,
+    // not parked on the first-run screen.
+    expect(firstRunState({ loading: false, workspaceCount: 2, canCreate: true })).toBe('ready')
+  })
+})

--- a/frontend/src/pages/firstRun.ts
+++ b/frontend/src/pages/firstRun.ts
@@ -1,23 +1,27 @@
 /**
- * Which first-run state applies. Extracted as a pure function because this
- * project has no jsdom/testing-library — logic in a .ts module is the only
- * thing unit-testable here (same reason as workspace/resolveActiveWorkspace.ts).
+ * Which first-run state applies. Extracted as a pure function so it stays
+ * unit-testable independent of the component tree (same reason as
+ * workspace/resolveActiveWorkspace.ts).
  *
  * There are THREE zero-workspace states, not one. An invite-admitted user who
  * holds no membership may not create a workspace (the F1 finding — see
- * apps/workspaces/services.py::can_create_workspace), so offering them a button
- * would 403. `canCreate: null` means /api/me/ has not answered yet.
+ * apps/workspaces/services.py::can_create_workspace), so offering them a
+ * button would 403. `canCreate` is a plain boolean, not nullable: the caller
+ * (FirstRunPage) reads it from `useAuth()`, which is resolved before any
+ * route mounts (AuthProvider gates on `status === 'loading'` itself), so
+ * there is no "auth not answered yet" state to represent here — only
+ * `loading` from `useWorkspace()`, which genuinely resolves on its own timer.
  */
 export interface FirstRunInput {
   loading: boolean
   workspaceCount: number
-  canCreate: boolean | null
+  canCreate: boolean
 }
 
 export type FirstRunState = 'loading' | 'can-create' | 'needs-invite' | 'ready'
 
 export function firstRunState({ loading, workspaceCount, canCreate }: FirstRunInput): FirstRunState {
+  if (loading) return 'loading'
   if (workspaceCount > 0) return 'ready'
-  if (loading || canCreate === null) return 'loading'
   return canCreate ? 'can-create' : 'needs-invite'
 }

--- a/frontend/src/pages/firstRun.ts
+++ b/frontend/src/pages/firstRun.ts
@@ -1,0 +1,23 @@
+/**
+ * Which first-run state applies. Extracted as a pure function because this
+ * project has no jsdom/testing-library — logic in a .ts module is the only
+ * thing unit-testable here (same reason as workspace/resolveActiveWorkspace.ts).
+ *
+ * There are THREE zero-workspace states, not one. An invite-admitted user who
+ * holds no membership may not create a workspace (the F1 finding — see
+ * apps/workspaces/services.py::can_create_workspace), so offering them a button
+ * would 403. `canCreate: null` means /api/me/ has not answered yet.
+ */
+export interface FirstRunInput {
+  loading: boolean
+  workspaceCount: number
+  canCreate: boolean | null
+}
+
+export type FirstRunState = 'loading' | 'can-create' | 'needs-invite' | 'ready'
+
+export function firstRunState({ loading, workspaceCount, canCreate }: FirstRunInput): FirstRunState {
+  if (workspaceCount > 0) return 'ready'
+  if (loading || canCreate === null) return 'loading'
+  return canCreate ? 'can-create' : 'needs-invite'
+}

--- a/frontend/src/pages/firstRun.ts
+++ b/frontend/src/pages/firstRun.ts
@@ -25,3 +25,24 @@ export function firstRunState({ loading, workspaceCount, canCreate }: FirstRunIn
   if (workspaceCount > 0) return 'ready'
   return canCreate ? 'can-create' : 'needs-invite'
 }
+
+/**
+ * Whether to render the create FORM (as opposed to the needs-invite panel).
+ *
+ * `/new-workspace` passes `alwaysOfferForm` so a user who already belongs
+ * somewhere still sees the form — but eligibility is still consulted, never
+ * bypassed: an invite-admitted user holding no membership may not create a
+ * workspace (the F1 finding, apps/workspaces/services.py::can_create_workspace),
+ * and offering them a form would render a button that 403s.
+ */
+export function shouldOfferCreateForm({
+  state,
+  canCreate,
+  alwaysOfferForm,
+}: {
+  state: FirstRunState
+  canCreate: boolean
+  alwaysOfferForm: boolean
+}): boolean {
+  return alwaysOfferForm ? canCreate : state === 'can-create'
+}

--- a/frontend/src/pwa/navigation-fallback.test.ts
+++ b/frontend/src/pwa/navigation-fallback.test.ts
@@ -32,6 +32,8 @@ describe('navigate-fallback ownership', () => {
       '/w/connect/ddd/nutrition-demo/nutrition-demo-2026-07-22-004',
       `/walkthrough/${UUID}`, // viewer shell (no /content)
       '/about', // public explainer
+      '/guide', // self-documenting descriptor registry
+      '/new-workspace', // FirstRunPage's alwaysOfferForm route
     ]
     for (const p of spaPaths) {
       it(p, () => expect(shouldServeShell(p)).toBe(true))
@@ -118,6 +120,8 @@ describe('the matcher workbox inlines into the SW', () => {
     '/w/connect/ddd/nutrition-demo/nutrition-demo-2026-07-22-004',
     `/walkthrough/${UUID}`,
     '/about',
+    '/guide',
+    '/new-workspace',
     '/api/ddd/runs/x',
     '/accounts/google/login/',
     '/admin/',

--- a/frontend/src/pwa/navigation-fallback.test.ts
+++ b/frontend/src/pwa/navigation-fallback.test.ts
@@ -31,6 +31,7 @@ describe('navigate-fallback ownership', () => {
       '/w/connect',
       '/w/connect/ddd/nutrition-demo/nutrition-demo-2026-07-22-004',
       `/walkthrough/${UUID}`, // viewer shell (no /content)
+      '/about', // public explainer
     ]
     for (const p of spaPaths) {
       it(p, () => expect(shouldServeShell(p)).toBe(true))
@@ -52,6 +53,11 @@ describe('navigate-fallback ownership', () => {
     for (const p of serverPaths) {
       it(p, () => expect(shouldServeShell(p)).toBe(false))
     }
+  })
+
+  it('the public explainer is handled, an API path is not', () => {
+    expect(shouldServeShell('/about')).toBe(true)
+    expect(shouldServeShell('/api/whatever')).toBe(false)
   })
 
   it('an unknown path fails safe (network, not shell)', () => {
@@ -111,6 +117,7 @@ describe('the matcher workbox inlines into the SW', () => {
     '/w/connect',
     '/w/connect/ddd/nutrition-demo/nutrition-demo-2026-07-22-004',
     `/walkthrough/${UUID}`,
+    '/about',
     '/api/ddd/runs/x',
     '/accounts/google/login/',
     '/admin/',

--- a/frontend/src/pwa/navigation-fallback.ts
+++ b/frontend/src/pwa/navigation-fallback.ts
@@ -68,6 +68,7 @@ export const NAVIGATE_FALLBACK_ALLOWLIST: RegExp[] = [
   /^\/(canopy\/)?walkthrough\//, // /walkthrough/:id VIEWER shell (…/content denied below)
   /^\/(canopy\/)?share\//, // /share/:token public viewer
   /^\/(canopy\/)?invite\//, // /invite/:token accept page
+  /^\/(canopy\/)?about/, // /about public explainer (chrome-less, anonymous)
 ]
 
 /**

--- a/frontend/src/pwa/navigation-fallback.ts
+++ b/frontend/src/pwa/navigation-fallback.ts
@@ -69,6 +69,8 @@ export const NAVIGATE_FALLBACK_ALLOWLIST: RegExp[] = [
   /^\/(canopy\/)?share\//, // /share/:token public viewer
   /^\/(canopy\/)?invite\//, // /invite/:token accept page
   /^\/(canopy\/)?about/, // /about public explainer (chrome-less, anonymous)
+  /^\/(canopy\/)?guide/, // /guide — self-documenting descriptor registry
+  /^\/(canopy\/)?new-workspace/, // /new-workspace — FirstRunPage's alwaysOfferForm route
 ]
 
 /**

--- a/frontend/src/router.test.tsx
+++ b/frontend/src/router.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import type { WorkspaceOut } from '@/api/workspaces'
+
+// vi.mock is hoisted above these declarations by vitest's transform, but the
+// factory isn't *called* until the mocked modules are actually imported —
+// which happens on the dynamic imports below. Same pattern as
+// SettingsPage.presence.test.tsx / AppLayout.test.tsx.
+const listWorkspaces = vi.fn<() => Promise<WorkspaceOut[]>>()
+vi.mock('@/api/workspaces', () => ({ listWorkspaces }))
+
+const { RootRedirect, TenantRedirect } = await import('./router')
+const { AuthContext } = await import('@/auth/AuthProvider')
+const { WorkspaceProvider } = await import('@/workspace/WorkspaceProvider')
+
+/**
+ * Pins the branch's headline fix: a zero-workspace user used to render `null`
+ * at both `RootRedirect` (bare "/") and `TenantRedirect` (legacy flat tenant
+ * paths). Revert either back to `return null` and this test fails — see the
+ * fix-wave report for the revert-and-observe evidence.
+ */
+function renderWithEmptyWorkspaces(node: React.ReactElement) {
+  return render(
+    <MemoryRouter initialEntries={['/']}>
+      <AuthContext.Provider
+        value={{
+          status: 'authenticated',
+          user: {
+            name: 'Jonathan Jackson',
+            email: 'jj@dimagi.com',
+            avatar_url: '',
+            can_create_workspace: true,
+          },
+        }}
+      >
+        <WorkspaceProvider urlSlug={null}>{node}</WorkspaceProvider>
+      </AuthContext.Provider>
+    </MemoryRouter>,
+  )
+}
+
+describe('the first-run screen renders for a zero-workspace user', () => {
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('RootRedirect ("/") renders FirstRunPage rather than a blank page', async () => {
+    listWorkspaces.mockResolvedValue([])
+
+    renderWithEmptyWorkspaces(<RootRedirect />)
+
+    expect(await screen.findByText('Welcome to Canopy')).toBeTruthy()
+  })
+
+  it('TenantRedirect (legacy flat tenant path) renders FirstRunPage rather than a blank page', async () => {
+    listWorkspaces.mockResolvedValue([])
+
+    renderWithEmptyWorkspaces(<TenantRedirect to="agents" />)
+
+    expect(await screen.findByText('Welcome to Canopy')).toBeTruthy()
+  })
+})

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -176,7 +176,15 @@ function guarded(routes: RouteObject[]): RouteObject[] {
   })) as RouteObject[]
 }
 
-export const router = createBrowserRouter(guarded([
+/**
+ * The route table, as data.
+ *
+ * Exported so the guide's coverage test can read it: every documented surface
+ * must have a descriptor in guide/surfaces.ts, and every descriptor must name a
+ * real route. Extracting paths from a BUILT router is awkward; reading them from
+ * this array is three lines.
+ */
+export const routeTable: RouteObject[] = [
   {
     element: <AppLayout />,
     children: [
@@ -292,7 +300,9 @@ export const router = createBrowserRouter(guarded([
       { path: '/narrative/:slug', element: <NarrativeReviewPage /> },
     ],
   },
-]), {
+]
+
+export const router = createBrowserRouter(guarded(routeTable), {
   // "/" at root, "/canopy" as a labs tenant — keeps every route + <Link> under
   // the deployment's path prefix (from Vite's import.meta.env.BASE_URL).
   basename: import.meta.env.BASE_URL.replace(/\/$/, '') || '/',

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -31,6 +31,7 @@ import StoryboardPage from './pages/StoryboardPage'
 import StoryboardsPage from './pages/StoryboardsPage'
 import NarrativeReviewPage from './pages/NarrativeReviewPage'
 import { PublicLayout } from './components/PublicLayout'
+import { AboutPage } from './pages/AboutPage'
 import SupervisorPage from '@/pages/SupervisorPage'
 import ActivityPage from '@/pages/ActivityPage'
 import SchedulesPage from './pages/SchedulesPage'
@@ -300,6 +301,9 @@ export const routeTable: RouteObject[] = [
       // One narrative, scene by scene, for an outsider. `?b=<board>` carries the
       // storyboard whose token gates it — the narrative itself has no token.
       { path: '/narrative/:slug', element: <NarrativeReviewPage /> },
+      // The public explainer — anyone, no login. Mounted here (not AppLayout)
+      // for the same reason as its siblings above.
+      { path: '/about', element: <AboutPage /> },
     ],
   },
 ]

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -6,6 +6,7 @@ import { FirstRunPage } from './pages/FirstRunPage'
 import { AppLayout } from './components/AppLayout/AppLayout'
 import { RouteErrorBoundary } from './components/RouteErrorBoundary'
 import { NotFound } from './components/NotFound'
+import { GuidePage } from './pages/GuidePage'
 import { ShareRouteErrorBoundary } from './components/ShareRouteErrorBoundary'
 import { lazyRoute } from './pwa/staleChunk'
 import { ProjectsPage } from './pages/ProjectsPage'
@@ -190,6 +191,7 @@ export const routeTable: RouteObject[] = [
     children: [
       // --- Personal / global (not tenant-scoped) ---
       { path: '/system', element: <SystemPage /> },
+      { path: '/guide', element: <GuidePage /> },
       { path: '/insights', element: <InsightsPage /> },
       { path: '/sessions', element: <SessionsPage /> },
       { path: '/supervisor', element: <SupervisorPage /> },

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -188,6 +188,7 @@ export const router = createBrowserRouter(guarded([
       { path: '/schedules', element: <SchedulesPage /> },
       { path: '/activity', element: <ActivityPage /> },
       { path: '/settings', element: <SettingsPage /> },
+      { path: '/new-workspace', element: <FirstRunPage alwaysOfferForm /> },
       // --- Public viewers (root; self-enforce visibility) ---
       { path: '/walkthrough/:id', element: <WalkthroughViewerPage /> },
       { path: '/review/:id', element: <ReviewPage /> },

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -122,7 +122,7 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 
 // Legacy flat tenant surface (e.g. /agents, /ddd/foo) → the active workspace's
 // scoped path. Waits for the workspace list so `active` is known.
-function TenantRedirect({ to }: { to: string }) {
+export function TenantRedirect({ to }: { to: string }) {
   const { active, loading } = useWorkspace()
   const { '*': tail } = useParams()
   if (loading) return null
@@ -132,7 +132,7 @@ function TenantRedirect({ to }: { to: string }) {
 }
 
 // Bare "/" → the active workspace's workbench.
-function RootRedirect() {
+export function RootRedirect() {
   const { active, loading } = useWorkspace()
   if (loading) return null
   if (!active) return <FirstRunPage />

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -2,6 +2,7 @@ import { lazy, Suspense } from 'react'
 import type { RouteObject } from 'react-router-dom'
 import { createBrowserRouter, Navigate, useLocation, useParams } from 'react-router-dom'
 import { useWorkspace } from './workspace/WorkspaceProvider'
+import { FirstRunPage } from './pages/FirstRunPage'
 import { AppLayout } from './components/AppLayout/AppLayout'
 import { RouteErrorBoundary } from './components/RouteErrorBoundary'
 import { NotFound } from './components/NotFound'
@@ -123,7 +124,7 @@ function TenantRedirect({ to }: { to: string }) {
   const { active, loading } = useWorkspace()
   const { '*': tail } = useParams()
   if (loading) return null
-  if (!active) return null // no membership yet; nothing to route to
+  if (!active) return <FirstRunPage /> // no membership yet — explain, don't blank
   const suffix = tail ? `/${tail}` : ''
   return <Navigate to={`/w/${active}/${to}${suffix}`} replace />
 }
@@ -132,7 +133,7 @@ function TenantRedirect({ to }: { to: string }) {
 function RootRedirect() {
   const { active, loading } = useWorkspace()
   if (loading) return null
-  if (!active) return null
+  if (!active) return <FirstRunPage />
   return <Navigate to={`/w/${active}`} replace />
 }
 

--- a/frontend/src/workspace/resolveActiveWorkspace.ts
+++ b/frontend/src/workspace/resolveActiveWorkspace.ts
@@ -1,5 +1,7 @@
 // Pure workspace-selection logic, extracted so it can be unit-tested without a
-// React renderer (the app has no jsdom/testing-library set up).
+// React renderer (jsdom + @testing-library/react ARE installed and used by
+// other test files — this stays a plain function because it doesn't need
+// one, not because a renderer is unavailable).
 
 export interface WorkspaceLike {
   slug: string

--- a/tests/test_me_can_create_workspace.py
+++ b/tests/test_me_can_create_workspace.py
@@ -1,0 +1,43 @@
+"""GET /api/me/ reports whether the caller may create a workspace.
+
+The first-run screen needs this to avoid offering a button that 403s. The gate
+itself is apps.workspaces.services.can_create_workspace (the F1 finding).
+"""
+import pytest
+from django.contrib.auth import get_user_model
+
+from apps.workspaces.models import Workspace, WorkspaceMembership
+
+User = get_user_model()
+
+
+@pytest.fixture
+def allowlisted(db):
+    return User.objects.create_user(username="ally", email="ally@dimagi.com")
+
+
+@pytest.fixture
+def invited(db):
+    return User.objects.create_user(username="guest", email="guest@example.org")
+
+
+def test_allowlisted_domain_may_create(client, allowlisted):
+    client.force_login(allowlisted)
+    body = client.get("/api/me/").json()
+    assert body["can_create_workspace"] is True
+
+
+def test_invite_admitted_with_no_membership_may_not_create(client, invited):
+    client.force_login(invited)
+    body = client.get("/api/me/").json()
+    assert body["can_create_workspace"] is False
+
+
+def test_invite_admitted_with_a_membership_may_create(client, invited):
+    ws = Workspace.objects.create(slug="acme", display_name="Acme", created_by=invited)
+    WorkspaceMembership.objects.create(
+        workspace=ws, user=invited, role=WorkspaceMembership.OWNER
+    )
+    client.force_login(invited)
+    body = client.get("/api/me/").json()
+    assert body["can_create_workspace"] is True

--- a/tests/test_public_routes_reachable.py
+++ b/tests/test_public_routes_reachable.py
@@ -67,6 +67,7 @@ PUBLIC_PATHS = [
     "/api/storyboards/ecf-supply",
     "/api/storyboards/ecf-supply/narratives/verified-monitoring",
     "/api/storyboards/ecf-supply/feedback",
+    "/about",
 ]
 
 

--- a/tests/test_public_routes_reachable.py
+++ b/tests/test_public_routes_reachable.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import pytest
 
 from apps.common.middleware import (
+    _is_about,
     _is_ddd_release_link,
     _is_invite_link,
     _is_public,
@@ -46,6 +47,7 @@ def _allowlisted(path: str, method: str = "GET") -> bool:
     request = _Req(path, method)
     return (
         _is_public(path)
+        or _is_about(path)
         or _is_walkthrough_link(request)
         or _is_review_link(path)
         or _is_share_link(path)
@@ -68,6 +70,7 @@ PUBLIC_PATHS = [
     "/api/storyboards/ecf-supply/narratives/verified-monitoring",
     "/api/storyboards/ecf-supply/feedback",
     "/about",
+    "/api/system/public-stats",
 ]
 
 
@@ -90,6 +93,10 @@ GATED_PATHS = [
     "/ddd/verified-monitoring",
     "/api/agents/",
     "/api/feedback/",
+    # "/about" is an EXACT match, not a prefix — a future route that merely
+    # begins "/about" must not become public as a side effect (C8).
+    "/about-billing",
+    "/aboutus",
 ]
 
 

--- a/tests/test_public_stats.py
+++ b/tests/test_public_stats.py
@@ -1,0 +1,111 @@
+"""GET /api/system/public-stats — anonymous, aggregates only.
+
+The leak assertion is the load-bearing one. An anonymous endpoint on a
+multi-tenant system is exactly where a field gets added later without anyone
+re-asking whether it should be public, so the test asserts the SHAPE is closed
+rather than only that today's fields are fine.
+"""
+import pytest
+from django.core.cache import cache
+
+ALLOWED_KEYS = {
+    "agents",
+    "skills",
+    "runners_online",
+    "turns_executed",
+    "demos_published",
+}
+
+
+@pytest.fixture(autouse=True)
+def _clear_public_stats_cache():
+    # public_stats() caches for 60s (apps/system/stats.py) so an anonymous
+    # caller can't turn this into a load generator — but that means a value
+    # computed by an EARLIER test would otherwise leak into a later one within
+    # the same process. Same pattern as test_attach_registry.py /
+    # test_token_exchange.py.
+    cache.clear()
+    yield
+    cache.clear()
+
+
+def test_reachable_without_authentication(client, db):
+    resp = client.get("/api/system/public-stats")
+    assert resp.status_code == 200, resp.content
+
+
+def test_returns_only_integer_aggregates(client, db):
+    body = client.get("/api/system/public-stats").json()
+    assert set(body) == ALLOWED_KEYS
+    for key, value in body.items():
+        assert isinstance(value, int), f"{key} is {type(value)}, not an int"
+
+
+def test_leaks_no_names_slugs_or_ids(client, db):
+    # A count cannot leak what it is a count of. Anything that is not an int
+    # could — so the guard is on the type, not on a denylist of field names.
+    body = client.get("/api/system/public-stats").json()
+    assert not any(isinstance(v, (str, list, dict)) for v in body.values())
+
+
+def test_counts_reflect_reality(client, db):
+    from apps.agents.models import Agent
+    from apps.workspaces.testing import a_workspace
+
+    # Workspace.created_by is NOT NULL, so a bare Workspace.objects.create(...)
+    # (no created_by) raises IntegrityError on an in-memory test DB — use the
+    # shared tenancy fixture helper (apps/workspaces/testing.py) instead.
+    ws = a_workspace(slug="acme")
+    Agent.objects.create(slug="a1", name="A1", workspace=ws)
+    Agent.objects.create(slug="a2", name="A2", workspace=ws)
+
+    body = client.get("/api/system/public-stats").json()
+    assert body["agents"] == 2
+
+
+def test_demos_published_comes_from_the_registry(client, db):
+    from django.contrib.auth import get_user_model
+
+    from apps.walkthroughs.models import Walkthrough
+
+    owner = get_user_model().objects.create_user(username="o", email="o@dimagi.com")
+
+    def artifact(kind: str) -> None:
+        # Walkthrough has SEVEN fields with neither null/blank nor a default
+        # (verified against apps/walkthroughs/models.py): title, kind, owner,
+        # drive_file_id, drive_folder_id, content_type, size_bytes. Omitting any
+        # of them raises IntegrityError, not a validation error.
+        Walkthrough.objects.create(
+            title=f"artifact-{kind}",
+            kind=kind,
+            owner=owner,
+            drive_file_id=f"file-{kind}",
+            drive_folder_id="folder-1",
+            content_type="video/mp4" if kind == "video" else "text/html",
+            size_bytes=1,
+            run_id="demo-2026-09-12-001",
+        )
+
+    # Two artifacts, ONE run package — the count must be 1, not 2. This is the
+    # assertion that catches counting rows instead of distinct run_ids.
+    artifact("video")
+    artifact("html")
+
+    body = client.get("/api/system/public-stats").json()
+    assert body["demos_published"] == 1
+
+
+def test_demos_published_ignores_artifacts_with_no_run(client, db):
+    from django.contrib.auth import get_user_model
+
+    from apps.walkthroughs.models import Walkthrough
+
+    owner = get_user_model().objects.create_user(username="o2", email="o2@dimagi.com")
+    # A one-off upload carries no run_id — it is not a published package.
+    Walkthrough.objects.create(
+        title="loose", kind="html", owner=owner, drive_file_id="f2",
+        drive_folder_id="folder-1", content_type="text/html", size_bytes=1,
+    )
+
+    body = client.get("/api/system/public-stats").json()
+    assert body["demos_published"] == 0

--- a/tests/test_public_stats.py
+++ b/tests/test_public_stats.py
@@ -7,6 +7,7 @@ rather than only that today's fields are fine.
 """
 import pytest
 from django.core.cache import cache
+from django.test import Client, override_settings
 
 ALLOWED_KEYS = {
     "agents",
@@ -41,11 +42,54 @@ def test_returns_only_integer_aggregates(client, db):
         assert isinstance(value, int), f"{key} is {type(value)}, not an int"
 
 
+@override_settings(REQUIRE_AUTH=True)
+def test_public_stats_is_public_through_the_login_middleware(db):
+    # The allowlist half of the gate. REQUIRE_AUTH is False suite-wide
+    # (config/settings/test.py:24), so without this override
+    # LoginRequiredMiddleware is inert and the whole suite proves only that
+    # auth=None took on the route — apps/common/middleware.py's
+    # PUBLIC_PATH_PREFIXES entry could be deleted and every other test here
+    # would stay green while production 302s every anonymous visitor to
+    # Google. This is the test that actually exercises that allowlist.
+    assert Client().get("/api/system/public-stats").status_code == 200
+
+
+@override_settings(REQUIRE_AUTH=True)
+def test_sibling_system_routes_are_not_public(db):
+    # PUBLIC_PATH_PREFIXES is a PREFIX match (middleware._is_public), so it
+    # also admits /api/system/public-stats/foo — which Ninja routes to
+    # detail(kind="public-stats", name="foo"), not public_stats(). Pin that
+    # Ninja's own session_auth still gates that path, since the middleware
+    # allowlist does not distinguish it from the real public route.
+    assert Client().get("/api/system/public-stats/foo").status_code == 401
+
+
 def test_leaks_no_names_slugs_or_ids(client, db):
-    # A count cannot leak what it is a count of. Anything that is not an int
-    # could — so the guard is on the type, not on a denylist of field names.
-    body = client.get("/api/system/public-stats").json()
-    assert not any(isinstance(v, (str, list, dict)) for v in body.values())
+    # A count cannot leak what it is a count of — but that claim is only
+    # tested if something with a name/slug/id actually exists in the DB and
+    # is confirmed absent from the response, and if the response can't
+    # authenticate an anonymous caller into a session either. Asserting only
+    # "every value is an int" (test_returns_only_integer_aggregates) already
+    # implies this — and isinstance(True, int) is True, so that assertion is
+    # even weaker than it reads — so this test earns its name by checking the
+    # actual leak claim instead of restating the type check.
+    from apps.agents.models import Agent
+    from apps.workspaces.testing import a_workspace
+
+    ws = a_workspace(slug="leak-canary-workspace")
+    Agent.objects.create(slug="leak-canary-agent", name="Leak Canary", workspace=ws)
+
+    # A bare integer pk is deliberately NOT checked here: with a response this
+    # small (five single-digit counts), a small autoincrement id is likely to
+    # coincidentally match one of them, which would make this assertion flaky
+    # rather than meaningful. The distinctive slugs/name are the real signal.
+    resp = client.get("/api/system/public-stats")
+    raw = resp.content.decode()
+    assert "leak-canary-workspace" not in raw  # Workspace.slug (its pk)
+    assert "leak-canary-agent" not in raw
+    assert "Leak Canary" not in raw
+    # An anonymous read must not mint or extend a session either.
+    assert "Set-Cookie" not in resp.headers
 
 
 def test_counts_reflect_reality(client, db):

--- a/tests/test_public_stats.py
+++ b/tests/test_public_stats.py
@@ -119,6 +119,7 @@ def test_demos_published_comes_from_the_registry(client, db):
         # (verified against apps/walkthroughs/models.py): title, kind, owner,
         # drive_file_id, drive_folder_id, content_type, size_bytes. Omitting any
         # of them raises IntegrityError, not a validation error.
+        # visibility=link: demos_published excludes private packages (below).
         Walkthrough.objects.create(
             title=f"artifact-{kind}",
             kind=kind,
@@ -128,6 +129,7 @@ def test_demos_published_comes_from_the_registry(client, db):
             content_type="video/mp4" if kind == "video" else "text/html",
             size_bytes=1,
             run_id="demo-2026-09-12-001",
+            visibility=Walkthrough.VISIBILITY_LINK,
         )
 
     # Two artifacts, ONE run package — the count must be 1, not 2. This is the
@@ -137,6 +139,31 @@ def test_demos_published_comes_from_the_registry(client, db):
 
     body = client.get("/api/system/public-stats").json()
     assert body["demos_published"] == 1
+
+
+def test_demos_published_excludes_private_packages(client, db):
+    # A public counter spanning every tenant must not disclose ANOTHER
+    # tenant's private demo packages, even as a bare count — canopy is now
+    # open to a second tenant, so this is no longer a hypothetical.
+    from django.contrib.auth import get_user_model
+
+    from apps.walkthroughs.models import Walkthrough
+
+    owner = get_user_model().objects.create_user(username="o3", email="o3@dimagi.com")
+    Walkthrough.objects.create(
+        title="private-artifact",
+        kind="html",
+        owner=owner,
+        drive_file_id="f3",
+        drive_folder_id="folder-1",
+        content_type="text/html",
+        size_bytes=1,
+        run_id="demo-2026-09-12-002",
+        visibility=Walkthrough.VISIBILITY_PRIVATE,
+    )
+
+    body = client.get("/api/system/public-stats").json()
+    assert body["demos_published"] == 0
 
 
 def test_demos_published_ignores_artifacts_with_no_run(client, db):


### PR DESCRIPTION
Implements `docs/superpowers/specs/2026-09-12-opening-canopy-to-other-people-design.md`.

Canopy has been a platform built for one operator. This makes it usable by someone else: a new
user is no longer dead-ended, the app documents itself, and there is a public page you can send
to somebody outside Dimagi.

## A — first run works

A signed-in user with no workspace membership landed on `/` and saw **a blank page** — `router.tsx`
returned `null`. That was the literal first screen of the power-user rollout.

They now get a real first-run screen with **three** states, not two: the third matters because an
invite-admitted user holding no membership *cannot* create a workspace (the F1 finding — otherwise
invite-admission becomes transitively delegable), so `/api/me/` now reports eligibility and the
screen asks them for an invite instead of offering a button that 403s.

Also: `+ Workspace` is always reachable from the header (the old guard conflated "nothing to switch
to" with "nothing you can do"), and PATs can be listed, minted and revoked from `/settings` — which
was previously only possible by running a skill that requires the token you were trying to create.

## B — the app documents itself

A descriptor registry (`frontend/src/guide/surfaces.ts`) keyed to the route table, rendered at
`/guide` grouped the way the header menu is grouped, with empty states deep-linking into it so the
stuck-user surface and the documentation are the same content.

The coverage test runs in **both** directions: every documented route has a descriptor, **and** every
descriptor names a real route. The second direction is what catches a descriptor orphaned by a
deleted route, which is how a generated guide starts lying. It carries a sanity floor so it cannot
pass vacuously.

## C — a public explainer

`/about` — chrome-less, anonymous, with the five-component view, the five ways in, and live counts
from a new `GET /api/system/public-stats`.

That endpoint is the only unauthenticated route here, on a multi-tenant system. It is safe for one
reason — *a count cannot leak what it is a count of* — and every guard follows from it: integers only,
the response shape closed **by type** rather than by a denylist of field names (the realistic failure
is a helpful field added months from now, which no denylist anticipates), a 60s cache so it cannot
become a free load generator, and an exclusion so it never counts another tenant's private packages.
Both halves of the public gate are independently tested — `auth=None` **and** the middleware allowlist,
the latter with `@override_settings(REQUIRE_AUTH=True)`, because `REQUIRE_AUTH=False` makes that
middleware inert suite-wide and the allowlist was otherwise deletable with CI green.

## Deliberately not here

**GitHub-backed agent creation.** A web-created agent would be a record with no repo, persona or
skills — unable to take a turn — so the agents empty state *teaches* `/canopy:create-agent` rather
than offering a button. That work is its own spec
(`docs/superpowers/specs/2026-09-12-github-backed-agent-creation-design.md`), because it needs a
GitHub App registered before a line of it can be tested. The seam is clean: that spec upgrades the
same empty state into a button without rewriting anything.

## Verification

2471 backend tests (1 skipped), 836 frontend tests, clean `tsc`/vite/PWA build. A live anonymous
`curl` returns `200` for `/about` and five integers for the stats endpoint — the only check that
proves both halves of the gate took, since the Django test client cannot distinguish a missing
allowlist entry from a missing `auth=None`.

Not verified here, and worth a human eye: the rendered page in a browser in both themes.

## Known residuals

- `demos_published` now counts only explicitly-shared packages. Since `Walkthrough.visibility`
  defaults to `private`, that figure may read low in production — honest, but possibly unimpressive.
- Five monotonic counters pollable at 60s reveal fleet *activity* (throughput, whether any box is up)
  even though they reveal no identity. Documented as accepted in `apps/system/stats.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
