### PR TITLE
docs: embedded agent widget v2 — a drop-in widget for any canopy user

### DIFF
--- a/docs/superpowers/specs/2026-09-12-embedded-agent-widget-design.md
+++ b/docs/superpowers/specs/2026-09-12-embedded-agent-widget-design.md
@@ -1,6 +1,13 @@
 # Embedded agent widget — canopy as a cross-product chat substrate
 
-**Status:** Draft for review · **Date:** 2026-09-12 · **Author:** Jonathan + Claude
+**Status:** SUPERSEDED by
+[`2026-09-12-embedded-agent-widget-v2-design.md`](2026-09-12-embedded-agent-widget-v2-design.md)
+· **Date:** 2026-09-12 · **Author:** Jonathan + Claude
+
+> **Superseded the same day it merged.** Reading the target codebase invalidated
+> §2 (one agent per host), §3 (`npm install canopy-ui` — labs is React 18, and
+> is not a React SPA) and §5 (deferring a generic embed). Kept as the record of
+> how the design got there; v2 is the current one.
 
 > Generalizes the ace-web ↔ canopy-web chat cutover
 > (`2026-07-25-ace-web-canopy-chat-cutover-design.md`) into a repeatable pattern

--- a/docs/superpowers/specs/2026-09-12-embedded-agent-widget-v2-design.md
+++ b/docs/superpowers/specs/2026-09-12-embedded-agent-widget-v2-design.md
@@ -1,0 +1,292 @@
+# Embedded agent widget v2 — canopy as a drop-in agent surface for any product
+
+**Status:** Draft for review · **Date:** 2026-09-12 · **Author:** Jonathan + Claude
+
+> **Supersedes `2026-09-12-embedded-agent-widget-design.md`** (merged as #745).
+> Three of that spec's five sections turned out to be wrong once the target
+> codebase was read: §2 (one agent per host), §3 (`npm install canopy-ui`), §5
+> (non-React embed deferred). This replaces it rather than patching it.
+
+## What changed, and why
+
+v1 designed a **React component integration** — `npm install canopy-ui`, mount
+`<ChatPanel>`, host wires a token endpoint — and deferred a generic embed on the
+grounds that "both current hosts are React apps." Every clause of that is
+load-bearing and two are false:
+
+- **connect-labs is not a React SPA.** It is Django templates plus `alpinejs`
+  and `htmx.org` with **13 `createRoot` islands** and 63 `.tsx` files. A
+  script-tag widget drops onto any labs page; a React component reaches only the
+  islands.
+- **`canopy-ui` cannot be installed there.** It declares `react: ^19.0.0`
+  (also `lucide-react ^1.8.0`, `tailwind-merge ^3.5.0`); labs is on React
+  `^18.2.0`, `lucide-react ^0.263.1`, `tailwind-merge ^2.6.0`.
+- **One agent per host was never a design, just a default.** ace-web picks its
+  agent in its own env (`CANOPY_AGENT_SLUG = env(..., default="ace")`). canopy
+  has no record of which agents may operate in which host, so it cannot answer
+  "which agents do I have here" — the question a widget's picker must answer.
+
+The goal is therefore restated: **a self-contained widget any product can embed
+with one script tag, serving any canopy user — not a React integration recipe.**
+Dimagi is not a design input; it is a deployment policy (see §5).
+
+## 1. Four layers, so "go native" is supported rather than a fallback
+
+| Layer | What | Status |
+| --- | --- | --- |
+| **0 — wire** | REST + WS protocol, any language | exists (`docs/architecture/api-surface.md`) |
+| **1 — `@canopy/client`** | framework-free TS: token cache + refresh, REST, WS reconnect | **new** |
+| **2 — `canopy-ui/chat`** | React 19 components | exists, published |
+| **3 — `widget.js`** | drop-in IIFE, own bundled React, iframe-isolated | **new** |
+
+Layer 1 is the enabling piece and it is mostly a **move, not a write**:
+ace-web's `frontend/src/canopy/{token,api,ws}.ts` is ~390 lines with **zero
+React imports** — already framework-free, just trapped inside one host. Both the
+widget and any native host want it, and today only ace-web has it.
+
+The context/action contract (§6) is defined **once** as plain interfaces at
+layer 1. The widget's `postMessage` transport is one implementation of it; a
+native host calls the same functions directly. That is what keeps the native
+path first-class instead of a downgrade.
+
+## 2. One bundle, three display modes
+
+An iframe cannot paint outside its own box, so the launcher and panel chrome are
+host-DOM elements (in a shadow root, so host CSS cannot bleed in) wrapping the
+iframe — the standard approach for this class of widget.
+
+```js
+canopy.init({ mode: 'overlay' })                  // launcher bubble + floating panel
+canopy.init({ mode: 'inline', target: '#pane' })  // fills a host element, no launcher
+canopy.init({ mode: 'docked' })                   // right-hand rail
+```
+
+Same iframe in all three; only the container's positioning differs. `docked` is
+already proven in labs — `workflow-runner.tsx` docks its own edit-mode chat with
+`mr-96`.
+
+## 3. Credential path: issuance unchanged, delivery and refresh new
+
+Unchanged: the host backend holds the `AppCredential` and calls
+`POST /api/auth/token-exchange`. That cannot move into the browser — the
+credential is a secret — so "one script tag" always means *plus one backend
+endpoint* for authenticated users. A genuinely zero-backend embed is only
+possible for anonymous sessions, which is out of scope here.
+
+What the origin boundary changes:
+
+- **Delivery is `postMessage`, never the iframe URL.** A `#token=` fragment
+  lands in `document.location`, history, and potentially a referrer. The host
+  fetches the token same-origin (cookie + CSRF, unchanged) and posts it in with
+  an explicit `targetOrigin` — never `*`.
+- **Refresh becomes a bridge round-trip.** The iframe has no cookies and cannot
+  mint. ace-web's `getCanopyToken(true)` force-refresh becomes a request
+  message: the widget reports 401/near-expiry, the host re-fetches and posts a
+  fresh token.
+- **Origin validation is load-bearing in both directions** — a surface that does
+  not exist in the npm-component model.
+
+**Framing must be opened first, narrowly.** `config/settings/base.py:121`
+enables `XFrameOptionsMiddleware` with no `X_FRAME_OPTIONS` override, so
+Django's default `DENY` applies and *every canopy page currently refuses to be
+framed*. The embed route gets `@xframe_options_exempt` **plus**
+`Content-Security-Policy: frame-ancestors` built from origins registered on the
+`AppCredential`. Done that way it is stricter than a blanket exempt: only
+registered hosts can frame it, and the allowlist is server-side data rather than
+a setting someone edits.
+
+The embed route serves a **minimal shell**, not the app bundle — no service
+worker, no PWA shell. Per the PWA navigate-fallback rule (fail-safe allowlist),
+an unknown route already goes to the network, so the embed route is excluded by
+construction; it must not be added to `NAVIGATE_FALLBACK_ALLOWLIST`.
+
+## 4. No JWT
+
+`DelegatedToken`'s own docstring already settled this: *"DB-backed (not JWT) so
+it is revocable and the table is the audit trail."* A JWT freezes its claims at
+mint time, so a membership revoked mid-life still passes until expiry. The
+current design re-resolves against the live DB on every request —
+`secrets.token_urlsafe(32)` opaque, stored as sha256, `lookup()` filtering
+`expires_at__gt=now` with `select_related("user")`.
+
+So "everything resolves to the user's login/ACL" is already true *per request*
+rather than per mint, and introducing JWT would weaken exactly that property.
+A signed host assertion (HMAC/JWS) would only earn its keep for a host that
+cannot make a server-to-server call; neither host needs that.
+
+## 5. Identity for any user — the host is the identity provider
+
+A widget user **never logs into canopy-web.** They authenticate to the host
+(labs users via Connect/CommCareHQ OAuth), and the host — which holds the
+`AppCredential` secret — vouches for them via `acting_as_email`. canopy already
+supports this end to end: JIT creation is domain-agnostic
+(`User.objects.create_user(username=email, email=email)`, plus a verified
+allauth `EmailAddress` so a later real login connects to the same user instead
+of forking).
+
+**One conjunct is all that makes this Dimagi-only:**
+
+```python
+if domain not in app_domains or domain not in _allowed_login_domains():
+    raise HttpError(403, "delegation not allowed for this domain")
+```
+
+The second clause is canopy's *login* allowlist — it answers "who may log into
+canopy-web directly," a different question from "whom may a registered app vouch
+for." Delegated exchange should be governed by the **per-credential**
+`allowed_delegation_domains` only, which an admin grants explicitly per app.
+
+The fail-closed property the original docstring was protecting survives intact:
+an app with `allowed_delegation_domains: []` is still denied by the *first*
+clause, so an unconfigured credential grants nothing. For a host that genuinely
+serves any domain, a wildcard must be **explicit and opt-in** (`["*"]`) — never
+"empty means any", repeating the `provision_role` lesson that this is an
+allowlist, not a denylist.
+
+This is independent of removing canopy-web's own login gate.
+`BearerTokenAuthMiddleware` resolves delegated tokens upstream of
+`LoginRequiredMiddleware`, so widget users work whether that gate stays or goes.
+
+## 6. Tenancy: user-driven, with provisioning as onboarding
+
+Two things were conflated in early drafting and must stay separate:
+
+- **Which tenant a session lives in** follows the **user's** memberships.
+  `_visible_slugs(request)` → `user_workspace_slugs(request.user)` is computed
+  live per request, so a user in three tenants sees across all three and nothing
+  in that path is product-specific. A host must **not** pin a workspace: that
+  would override the user's own tenancy with the product's.
+- **A brand-new user has no memberships at all**, and `current_workspace` raises
+  `ValueError("no unambiguous workspace for user; specify one")` for both 0 and
+  2+. So onboarding needs an answer or the first session cannot be created.
+
+`AppCredential.provision_workspace` is that answer, and it is safe for this
+because it is **additive**: `ensure_member` is `get_or_create` and *"an existing
+member's role is never raised or lowered by an app."* It grants a landing tenant
+to someone who has none; it cannot repin someone who already has their own.
+
+Resolution order for a new session, therefore: the user's sole membership if
+they have exactly one → **ask them** if they have several (`GET /api/workspaces/`
+already exists to populate the picker) → the provisioned landing tenant if they
+have none. Never a host-pinned constant.
+
+## 7. Agent permissioning is a triple, and none of it exists yet
+
+"Which agents do I have that are permissioned to operate here" is three-way:
+**agent × host × user**. Nothing models it. `AppCredential` covers app×tenant
+(`name`, `token_hash`, `allowed_delegation_domains`, `provision_workspace`,
+`provision_role`, …) with **no agent relation at all**; `Agent.workspace`
+(NOT NULL) covers agent×tenant.
+
+v2 adds the missing edge as **explicit server-side rows on the `AppCredential`**
+— which agents this app may target. Host-fixed, never client input, following
+`provision_workspace`'s discipline and `RunnerAssignment`'s lesson that explicit
+rows beat a self-declared capability string.
+
+The widget's picker then shows the **intersection** of that allowlist with the
+user's workspace memberships — both conditions, neither sufficient alone, which
+is exactly the question as posed. Surfaced as `GET /api/embed/agents`.
+
+## 8. Context comes over the bridge, deliberately
+
+The agent does **not** run as you — it runs on a runner under its own identity
+(its own `AgentCredential` slots). So "the agent knows my context" has three
+possible answers:
+
+| | How | Verdict |
+| --- | --- | --- |
+| **a** | Host pushes it: the browser holds the user's host session, so the host reads with **the user's** ACL and hands the agent a snapshot over the bridge | **v1 of this spec.** Correct ACL by construction |
+| **b** | Agent holds a per-user delegated host credential | The general answer. `2026-07-31-server-side-gmail-watch-custody` already worked this shape out (per-mailbox grant, weakest sufficient scope, DWD rejected outright) |
+| **c** | Host mints a user-scoped token *for* the agent — exchange in reverse | Symmetric, but makes the host an identity provider to canopy: a second auth direction to secure |
+
+**(a) is chosen on its merits, not as a compromise:** the agent's view of your
+context is exactly what you can see on the page you are looking at. "The agent
+sees what you see" is an ACL story that cannot leak, because nothing is resolved
+outside your own session.
+
+Canopy holds **no host context** and should not: it would become a stale mirror
+of every host's permission model. This follows the references-not-values
+instinct already in `Agent.runtime_secrets` ("secret-reference NAMES … never
+values") and `AgentCredential`.
+
+For connect-labs the bridge has a real seam to attach to. Workflow render code
+receives `{definition, instance, workers, pipelines, links, actions,
+onUpdateState, view}` as live props — including in-progress state no saved run
+has frozen — so reads and one gated write both already exist as props. The host
+adapter is called from `workflow-runner.tsx` with those props:
+
+```js
+canopy.provideContext(() => ({ instance, definition, state: view.state }))
+canopy.registerAction('updateState', (patch) => onUpdateState(patch))
+```
+
+Template authors opt in per template (a `context_manifest`, in the spirit of
+saved-runs' `snapshot_inputs`) — a snapshot at session-open, not a continuously
+synced channel. Continuous sync (CopilotKit's `useCopilotReadable` is the
+reference shape) is future work and is not needed to prove this.
+
+## 9. ACL prerequisite: participation must gate by-id reads
+
+`_session_or_404` checks the workspace and nothing else:
+
+```python
+if session.workspace_id not in _visible_slugs(request):
+    raise HttpError(404, "session not found")
+```
+
+So any member of a workspace can read any session in it by UUID — while the
+**list** is already correctly narrowed to
+`Q(created_by=request.user) | Q(runner_binding__isnull=False)`. `SessionParticipant`,
+whose own docstring calls it *"the authority for access and role"*, is never
+consulted there.
+
+In-app that may have been intentional: canopy sessions are deliberately
+multiplayer (co-edited draft, presence). But *multiplayer by invitation* and
+*readable by any co-tenant holding the id* are different things, and a widget
+dropped into a host product widens who holds session UUIDs enormously — while
+users of a chat bubble will assume privacy. **Enforcing `SessionParticipant` on
+by-id reads is a prerequisite**, not a follow-up, and it uses a primitive that
+already exists.
+
+## 10. Honest limits of v1
+
+These are consequences of the design, and should be documented on the embed
+surface rather than discovered:
+
+- **Actions require the page to be open.** The bridge executes in your browser
+  with your host session — excellent for ACL, but close the tab and the agent
+  cannot act. Action is scoped to the life of your visit. Server-side action is
+  case (b)/(c) above.
+- **A turn needs a runner online and assigned.** `claim_next_turn` gates on the
+  **pairing human's** workspaces (`user_workspace_slugs(runner.paired_by)`), so
+  the runner must be paired by someone in the agent's workspace or the turn sits
+  QUEUED forever. This took prod down once (4 of 5 agents wedged).
+- **The agent does not remember prior conversations.** You can see and resume
+  them — `Q(created_by=request.user)` + `origin_key` + agent is already exactly
+  that query — but canopy has no cross-session memory concept, and each session
+  is its own Claude Code session with its own transcript. A fresh conversation
+  starts cold unless the agent carries its own memory.
+
+## 11. Non-goals
+
+- **Cross-system bridging** (one session reasoning across two external systems)
+  — unchanged from v1: no concrete second consumer, and the credential resolver
+  keyed by tenant+system has no standard to lean on.
+- **Continuous context sync** — snapshot at session-open only (§8).
+- **Anonymous / zero-backend embed** — authenticated users need the host-side
+  token endpoint (§3).
+- **Replacing labs' `workflow_*` MCP tools** — those remain right for persisted
+  and historical workflow data. This adds a live, in-session surface for the
+  instance currently open.
+- **Replacing labs' edit-mode workflow chat** (`workflow_agent.py`) — that
+  authors workflow JSX; this reasons about a live run. They coexist.
+
+## 12. Open questions
+
+- Whether `frame-ancestors` origins live on `AppCredential` as a list column or
+  a related table — a host with many embedding domains argues for the latter.
+- Whether the agent allowlist should support a per-agent default so a host can
+  express "this one unless the user picks otherwise", avoiding a picker in the
+  common single-agent case.
+- Whether `GET /api/embed/agents` belongs on a new `embed` router or extends the
+  existing agents router with an `app=` scope.


### PR DESCRIPTION
Supersedes the v1 spec merged hours ago in #745, rather than patching it — reading connect-labs and canopy's own auth/tenancy code invalidated three of its five sections.

## What v1 got wrong

| § | Claim | Reality |
|---|---|---|
| §3 | `npm install canopy-ui` | `canopy-ui` declares `react: ^19.0.0`; labs is on `^18.2.0`. And labs isn't a React SPA — Django templates + `alpinejs` + `htmx`, 13 `createRoot` islands, so a script-tag widget reaches pages a React component can't |
| §2 | One agent per host | Never a design, just ace-web's `CANOPY_AGENT_SLUG` env default. canopy has **no** agent relation on `AppCredential`, so it can't answer "which agents do I have here" — the question a picker must answer |
| §5 | Generic embed deferred | It's the requirement |

## What v2 designs

- **Four layers**, so going native is first-class: wire → framework-free `@canopy/client` → `canopy-ui/chat` → drop-in `widget.js`. Layer 1 is mostly a *move*: ace-web's `token/api/ws.ts` is ~390 lines with zero React imports, already framework-free and trapped in one host.
- **Three display modes** off one bundle — overlay, inline, docked.
- **Credential path**: issuance unchanged; delivery becomes `postMessage` (never a `#token=` fragment — it lands in history and referrers), refresh becomes a bridge round-trip.
- **Framing, which is currently impossible**: `base.py:121` enables `XFrameOptionsMiddleware` with no override, so Django's `DENY` default means every canopy page refuses to be framed. Opened narrowly via `frame-ancestors` from origins registered on the `AppCredential` — stricter than a blanket exempt.
- **The agent × host × user triple**, as explicit server-side rows, intersected with the user's memberships.
- **Context over the bridge, deliberately** — "the agent sees what you see" is an ACL story that can't leak.

## Two corrections recorded, because both were nearly shipped as design

- **No JWT.** `DelegatedToken` is already deliberately DB-backed — *"so it is revocable and the table is the audit trail."* A JWT freezes claims at mint time and would weaken the exact per-request ACL resolution it was meant to strengthen.
- **`provision_workspace` is additive** (`ensure_member` is `get_or_create`; *"an existing member's role is never raised or lowered by an app"*). So it's the wrong tool for isolating hosts, but the right one for onboarding — drop it and a brand-new non-Dimagi user has zero memberships, `current_workspace` raises, and the first session can't be created.

## Dimagi stops being a design input

One conjunct makes the whole thing Dimagi-only. Delegated exchange should be governed by per-credential `allowed_delegation_domains` alone — canopy's *login* allowlist answers a different question ("who may log into canopy-web directly"). Fail-closed survives: an app with no granted domains is still denied by the first clause, and a wildcard must be explicit (`["*"]`), never empty-means-any.

## One prerequisite, not a follow-up

`_session_or_404` gates by-id reads on workspace only — never on `SessionParticipant`, the model whose own docstring calls it *"the authority for access and role"* — while the **list** is already narrowed to the caller's own sessions. A widget widens who holds session UUIDs enormously, and chat-bubble users assume privacy.

§10 documents the honest limits: actions need the page open, turns need a runner paired into that workspace, and the agent has no cross-session memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)