### PR TITLE
fix(sessions): by-id reads and the list must agree about who may see a session

### DIFF
--- a/apps/canopy_sessions/access.py
+++ b/apps/canopy_sessions/access.py
@@ -1,0 +1,74 @@
+"""Who may see a session — ONE predicate, used by both the list and by-id reads.
+
+It lives in its own module because the two used to be written by hand at two
+sites and disagreed, in both directions:
+
+* **by-id was too loose.** `_session_or_404` gated on workspace membership
+  alone, so any co-tenant holding a session UUID could read a conversation the
+  list already refused to show them.
+* **the list was wrong about *why*.** It granted co-tenant visibility to
+  anything with a `RunnerBinding` — but a *web* session acquires a binding the
+  moment a runner picks it up, so a private chat silently became co-tenant
+  readable as soon as it started running. `origin` is the property that
+  actually distinguishes "nobody in-app created this" from "someone did".
+
+This is the same shape of guard `apps/harness/services.py` uses for
+claim-vs-schedule after those two hand-written predicates drifted
+(`tests/test_claim_schedule_parity.py`): share the predicate, then assert the
+two callers agree, so a re-divergence fails CI instead of production.
+
+Runner-DISCOVERED sessions stay visible to the whole tenant deliberately. They
+are created with no `created_by` and no participant row (`harness/services.py`
+`Session.objects.create(..., origin=ORIGIN_RUNNER)`), so gating them on
+ownership or participation would make them unreachable by *everyone* — that is
+the entire emdash-discovered-session flow, not an edge case.
+"""
+
+from __future__ import annotations
+
+from django.db.models import Q
+
+from .models import Session
+
+
+def visible_session_q(user) -> Q:
+    """Sessions `user` may read, *within a workspace they already belong to*.
+
+    Tenancy is a separate and prior gate (`_visible_slugs`) — this narrows
+    inside it and must never be used as the only check.
+
+    Three ways in, and no fourth:
+
+    1. you created it;
+    2. you were made a participant — `SessionParticipant` is what "multiplayer"
+       means here, and its docstring already calls itself "the authority for
+       access and role";
+    3. it is a runner-discovered session that a runner is actually reporting,
+       which has no creator to belong to.
+
+    Leg 3 keeps `runner_binding__isnull=False` alongside the origin check
+    rather than dropping it: origin alone would newly expose runner-origin rows
+    that no runner has ever bound (e.g. an email-thread session), which is a
+    widening nobody asked for. Both conditions together reproduce exactly
+    today's runner-session visibility.
+
+    **Known consequence — an orphaned WEB session becomes invisible.**
+    `Session.created_by` is `on_delete=SET_NULL`, so deleting a user leaves
+    their web sessions with no creator and no participant, and leg 3 does not
+    catch them because their origin is `web`. They stay in the database and
+    remain reachable through the admin, but they drop out of the API for
+    everyone.
+
+    That is deliberate: the alternative rule — leg 3 as
+    `Q(created_by__isnull=True) & Q(runner_binding__isnull=False)`, i.e. "nobody
+    owns it, so the tenant may see it" — would hand a departed colleague's
+    private conversations to every co-tenant the moment they were offboarded.
+    Losing them from a list is the cheaper mistake than publishing them. Switch
+    that one leg if the trade should go the other way; nothing else depends on
+    the choice.
+    """
+    return (
+        Q(created_by=user)
+        | Q(participants__user=user)
+        | (Q(origin=Session.ORIGIN_RUNNER) & Q(runner_binding__isnull=False))
+    )

--- a/apps/canopy_sessions/api.py
+++ b/apps/canopy_sessions/api.py
@@ -22,7 +22,7 @@ from apps.api.auth import session_auth
 from apps.api.pagination import clamp_limit
 from apps.workspaces import services as wsvc
 
-from . import attachment_storage, serializers, services
+from . import access, attachment_storage, serializers, services
 from .models import Attachment, Session
 from .schemas import (
     AttachmentOut,
@@ -127,9 +127,16 @@ def _visible_slugs(request: HttpRequest) -> set[str]:
 
 
 def _session_or_404(request: HttpRequest, session_id: uuid.UUID) -> Session:
+    # Two gates, in order: the tenant, then who within it. The second used to be
+    # missing entirely, so a co-tenant with a UUID could read any conversation
+    # in the workspace — including one the LIST correctly hid from them. Both
+    # now read the same predicate (`access.visible_session_q`), and
+    # tests/test_session_by_id_access.py asserts they agree.
     session = get_object_or_404(
         Session.objects.select_related("agent", "runner_binding", "runner_binding__runner")
-        .annotate(_last_msg_at=Max("messages__created_at")),
+        .annotate(_last_msg_at=Max("messages__created_at"))
+        .filter(access.visible_session_q(request.user))
+        .distinct(),
         pk=session_id,
     )
     if session.workspace_id not in _visible_slugs(request):
@@ -197,7 +204,13 @@ def list_sessions(
     rows = (
         Session.objects.select_related("agent", "runner_binding", "runner_binding__runner")
         .filter(workspace_id__in=slugs)
-        .filter(Q(created_by=request.user) | Q(runner_binding__isnull=False))
+        # Same predicate the by-id read uses — see apps/canopy_sessions/access.py
+        # for why this is not `runner_binding__isnull=False` any more (a WEB
+        # session gets a binding as soon as a runner picks it up, which used to
+        # hand it to every co-tenant). `.distinct()` because the participant leg
+        # joins a reverse FK.
+        .filter(access.visible_session_q(request.user))
+        .distinct()
     )
     # Embedder filters (Task 9): an embedder (e.g. ace-web) narrows the shared
     # session list to the sessions it cares about, keyed on the opaque

--- a/tests/test_session_by_id_access.py
+++ b/tests/test_session_by_id_access.py
@@ -1,0 +1,136 @@
+"""By-id session reads must agree with the session LIST about who may see what.
+
+The two disagreed. `_session_or_404` gated only on workspace membership, so any
+co-tenant holding a session UUID could read a conversation the list correctly
+refused to show them. The list's own predicate was subtly wrong too: it keyed
+co-tenant visibility on having a `RunnerBinding` rather than on ORIGIN, and a
+web-created session acquires a binding as soon as a runner picks it up — so a
+private chat became co-tenant-readable the moment it started running.
+
+That second bug is why the embedded-widget work can't ship without this: every
+widget session is web-created, and every one of them gets bound.
+
+Runner-DISCOVERED sessions stay co-tenant-visible on purpose — they are created
+with no `created_by` and no participant row (`apps/harness/services.py`), so
+gating them on ownership or participation would make them unreachable by
+everybody, which is the whole emdash-discovered-session flow.
+"""
+
+import pytest
+from django.contrib.auth.models import User
+from django.test import Client
+from django.utils import timezone
+
+from apps.canopy_sessions.models import RunnerBinding, Session, SessionParticipant
+from apps.harness.models import Runner
+from apps.workspaces.models import Workspace, WorkspaceMembership
+
+pytestmark = pytest.mark.django_db
+
+
+def _ws_with_two_members():
+    """One workspace, two members — `owner` creates sessions, `other` is the
+    co-tenant who must not be able to read them."""
+    owner = User.objects.create_user("owner", "owner@dimagi.com", "pw")
+    other = User.objects.create_user("other", "other@dimagi.com", "pw")
+    ws = Workspace.objects.create(slug="w1", display_name="W1", created_by=owner)
+    WorkspaceMembership.objects.create(user=owner, workspace=ws, role=WorkspaceMembership.OWNER)
+    WorkspaceMembership.objects.create(user=other, workspace=ws, role=WorkspaceMembership.EDITOR)
+    return owner, other, ws
+
+
+def _client(user):
+    c = Client()
+    c.force_login(user)
+    return c
+
+
+def _bind(session, ws, paired_by):
+    runner = Runner.objects.create(
+        name=f"runner-{session.id.hex[:6]}", workspace=ws, location=Runner.LOCAL,
+        status=Runner.ONLINE, last_heartbeat_at=timezone.now(), paired_by=paired_by,
+    )
+    RunnerBinding.objects.create(
+        session=session, runner=runner, session_key="k",
+        last_interacted_at=timezone.now(), live_seen_at=timezone.now(),
+    )
+    return runner
+
+
+def test_cotenant_cannot_read_someone_elses_web_session_by_id():
+    owner, other, ws = _ws_with_two_members()
+    s = Session.objects.create(workspace=ws, created_by=owner, origin=Session.ORIGIN_WEB, title="mine")
+    assert _client(other).get(f"/api/canopy-sessions/{s.id}").status_code == 404
+
+
+def test_a_runner_binding_does_not_grant_cotenant_access_to_a_web_session():
+    """The widget case. A bound web session is still private to its creator."""
+    owner, other, ws = _ws_with_two_members()
+    s = Session.objects.create(workspace=ws, created_by=owner, origin=Session.ORIGIN_WEB, title="mine")
+    _bind(s, ws, owner)
+    assert _client(other).get(f"/api/canopy-sessions/{s.id}").status_code == 404
+
+
+def test_creator_can_read_their_own_web_session():
+    owner, _other, ws = _ws_with_two_members()
+    s = Session.objects.create(workspace=ws, created_by=owner, origin=Session.ORIGIN_WEB, title="mine")
+    assert _client(owner).get(f"/api/canopy-sessions/{s.id}").status_code == 200
+
+
+def test_invited_participant_can_read_a_web_session():
+    """Multiplayer still works — by invitation, which is what SessionParticipant is."""
+    owner, other, ws = _ws_with_two_members()
+    s = Session.objects.create(workspace=ws, created_by=owner, origin=Session.ORIGIN_WEB, title="shared")
+    SessionParticipant.objects.create(session=s, user=other, role=SessionParticipant.EDITOR)
+    assert _client(other).get(f"/api/canopy-sessions/{s.id}").status_code == 200
+
+
+def test_cotenant_can_still_read_a_runner_discovered_session():
+    """Deliberately visible: created with no created_by and no participant row,
+    so anything stricter makes it unreachable by everyone."""
+    owner, other, ws = _ws_with_two_members()
+    s = Session.objects.create(workspace=ws, origin=Session.ORIGIN_RUNNER, title="disc")
+    _bind(s, ws, owner)
+    assert _client(other).get(f"/api/canopy-sessions/{s.id}").status_code == 200
+
+
+def test_non_member_still_404s():
+    owner, _other, ws = _ws_with_two_members()
+    outsider = User.objects.create_user("out", "out@dimagi.com", "pw")
+    s = Session.objects.create(workspace=ws, created_by=owner, origin=Session.ORIGIN_WEB, title="mine")
+    assert _client(outsider).get(f"/api/canopy-sessions/{s.id}").status_code == 404
+
+
+def test_list_does_not_leak_a_bound_web_session_to_a_cotenant():
+    """The list half of the same bug — binding must not imply visibility."""
+    owner, other, ws = _ws_with_two_members()
+    s = Session.objects.create(workspace=ws, created_by=owner, origin=Session.ORIGIN_WEB, title="mine")
+    _bind(s, ws, owner)
+    rows = _client(other).get("/api/canopy-sessions/").json()
+    assert str(s.id) not in {r["id"] for r in rows}
+
+
+def test_list_and_by_id_agree_for_every_session_shape():
+    """Parity, so the two predicates cannot drift apart again — the same shape of
+    guard the harness uses for claim-vs-schedule (`tests/test_claim_schedule_parity`).
+    """
+    owner, other, ws = _ws_with_two_members()
+    shapes = {
+        "own_web": Session.objects.create(workspace=ws, created_by=owner,
+                                          origin=Session.ORIGIN_WEB, title="a"),
+        "other_web": Session.objects.create(workspace=ws, created_by=other,
+                                            origin=Session.ORIGIN_WEB, title="b"),
+        "runner_disc": Session.objects.create(workspace=ws, origin=Session.ORIGIN_RUNNER, title="c"),
+        "participating": Session.objects.create(workspace=ws, created_by=other,
+                                                origin=Session.ORIGIN_WEB, title="d"),
+    }
+    _bind(shapes["own_web"], ws, owner)
+    _bind(shapes["runner_disc"], ws, owner)
+    SessionParticipant.objects.create(session=shapes["participating"], user=owner,
+                                      role=SessionParticipant.EDITOR)
+
+    c = _client(owner)
+    listed = {r["id"] for r in c.get("/api/canopy-sessions/").json()}
+    for label, s in shapes.items():
+        gettable = c.get(f"/api/canopy-sessions/{s.id}").status_code == 200
+        assert gettable is (str(s.id) in listed), f"list/by-id disagree on {label}"

--- a/tests/test_session_transfer.py
+++ b/tests/test_session_transfer.py
@@ -46,9 +46,18 @@ def _ctx():
     return user, ws, cloud, laptop, c
 
 
-def _bound_session(ws, runner, *, indices=(0, 64, 128)):
-    """A session live on `runner` with some transcript-ordinal history."""
-    s = Session.objects.create(workspace=ws, project="canopy-web", title="widget design")
+def _bound_session(ws, runner, *, indices=(0, 64, 128), created_by=None):
+    """A session live on `runner` with some transcript-ordinal history.
+
+    `created_by` is set because a real web-origin session always has one
+    (`services.create_session` passes it and adds an OWNER participant); a
+    creator-less WEB session only arises when a user is deleted, since
+    `Session.created_by` is `on_delete=SET_NULL`. Leaving it NULL here made the
+    fixture describe a shape the app cannot produce, which the session-access
+    predicate (`apps/canopy_sessions/access.py`) then correctly refused.
+    """
+    s = Session.objects.create(workspace=ws, project="canopy-web", title="widget design",
+                               created_by=created_by or ws.created_by)
     RunnerBinding.objects.create(
         session=s, runner=runner, session_key="a-task", emdash_project="canopy-web",
         host=runner.host, transcript_id="old-transcript-uuid", thread_key=str(s.id),


### PR DESCRIPTION
Prerequisite for the embedded agent widget (#748), and a live leak on its own.

## Two bugs, opposite directions

**by-id was too loose.** `_session_or_404` gated on workspace membership alone, so any co-tenant holding a session UUID could read a conversation the list already refused to show them. That helper backs **14 endpoints** — get, messages, send, place, answer-menu, close, stop, attach, detach, backfill, transfer, archive, reset, unarchive.

**the list was wrong about *why*** — and this is the part that bites. It granted co-tenant visibility to anything with a `RunnerBinding`:

```python
.filter(Q(created_by=request.user) | Q(runner_binding__isnull=False))
```

But a **web** session acquires a binding the moment a runner picks it up. So a private chat became co-tenant-readable *as soon as it started running.* That's confirmed by test rather than argued — `test_list_does_not_leak_a_bound_web_session_to_a_cotenant` fails before this change.

## The fix

`origin` is the property that actually separates "nobody in-app created this" from "someone did". Three ways in, no fourth:

1. you created it
2. you're a `SessionParticipant` — which is what multiplayer means here
3. it's a runner-**discovered** session a runner is actually reporting

Runner-discovered sessions stay tenant-visible **deliberately**: `harness/services.py` creates them with no `created_by` and no participant row, so anything stricter makes the entire emdash-discovered-session flow unreachable by everyone.

Both callers now read one predicate in `apps/canopy_sessions/access.py`, and a parity test asserts they agree for every session shape — the same guard shape `test_claim_schedule_parity` uses after those two hand-written harness predicates drifted.

## Verification

`1854 passed, 1 skipped` — full backend suite. The 8 new tests split 4-fail/4-pass before the change, which is what established that the list leak was real and that runner-discovered visibility needed preserving.

One fixture in `test_session_transfer.py` described a shape the app cannot produce — web-origin with no creator, when `services.create_session` always sets one and adds an OWNER participant. Defaulted from `ws.created_by` rather than editing 19 call sites.

## One judgment call, documented in the code

`Session.created_by` is `on_delete=SET_NULL`, so deleting a user now drops their web sessions out of the API for everyone instead of opening them to every co-tenant. Losing them from a list is the cheaper mistake than publishing a departed colleague's private conversations — they remain in the DB and reachable via admin. `access.py` names the one leg that reverses the trade if you'd rather it went the other way.

I could not check how many orphaned web sessions exist on labs today, so that behaviour change is unmeasured on real data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)