### PR TITLE
feat(widget): the host-side loader — three modes, and the credential path

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1827,6 +1827,10 @@
       "resolved": "packages/canopy-client",
       "link": true
     },
+    "node_modules/@canopy/widget": {
+      "resolved": "packages/canopy-widget",
+      "link": true
+    },
     "node_modules/@csstools/color-helpers": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
@@ -14274,6 +14278,10 @@
           "optional": true
         }
       }
+    },
+    "packages/canopy-widget": {
+      "name": "@canopy/widget",
+      "version": "0.1.0"
     },
     "packages/workbench": {
       "name": "canopy-ui",

--- a/frontend/packages/canopy-widget/package.json
+++ b/frontend/packages/canopy-widget/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@canopy/widget",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Drop-in canopy agent widget: one script tag, overlay / inline / docked, framework-free.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dimagi-internal/canopy-web.git",
+    "directory": "frontend/packages/canopy-widget"
+  },
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org",
+    "access": "public"
+  },
+  "files": [
+    "src"
+  ]
+}

--- a/frontend/packages/canopy-widget/src/chrome.ts
+++ b/frontend/packages/canopy-widget/src/chrome.ts
@@ -1,0 +1,169 @@
+/**
+ * The host-side chrome: container, launcher, and the three display modes.
+ *
+ * An iframe cannot paint outside its own box, so the launcher bubble and the
+ * panel frame are host DOM wrapping the iframe — the standard shape for this
+ * class of widget. That host DOM lives in a **shadow root**, because the whole
+ * promise is "drop this on any page": a host's `button { … }` or a global
+ * `* { box-sizing: … }` must not be able to reach in and deform the launcher,
+ * and our styles must not leak out onto the host either.
+ *
+ * The three modes differ only in how the container is positioned:
+ *
+ *   overlay — fixed bubble bottom-right, floating panel above it. Host layout
+ *             untouched, so this is the mode that works on a page nobody
+ *             modified.
+ *   docked  — fixed full-height rail on the right. Proven in connect-labs,
+ *             whose workflow runner already docks its own chat with `mr-96`.
+ *   inline  — fills a host-provided element, no launcher and always open. The
+ *             host owns placement and sizing.
+ */
+
+export type DisplayMode = 'overlay' | 'inline' | 'docked'
+
+export interface ChromeOptions {
+  mode: DisplayMode
+  /** Required for `inline`: a selector or element to fill. */
+  target?: string | Element
+  launcherLabel: string
+  title: string
+  /** Panel width for overlay/docked, in px. */
+  width: number
+  zIndex: number
+  onToggle: (open: boolean) => void
+}
+
+export interface Chrome {
+  iframe: HTMLIFrameElement
+  open(): void
+  close(): void
+  toggle(): void
+  isOpen(): boolean
+  setHeight(px: number): void
+  destroy(): void
+}
+
+const STYLES = `
+  :host { all: initial; }
+  * { box-sizing: border-box; }
+  .panel {
+    position: fixed; right: 16px; bottom: 84px;
+    width: var(--w); height: min(640px, calc(100vh - 120px));
+    border: 1px solid rgba(255,255,255,.12); border-radius: 12px;
+    overflow: hidden; background: #1c1917;
+    box-shadow: 0 12px 40px rgba(0,0,0,.45);
+    display: none;
+  }
+  .panel[data-open="true"] { display: block; }
+  .panel[data-mode="docked"] {
+    right: 0; top: 0; bottom: 0; width: var(--w);
+    height: 100vh; border-radius: 0; border-width: 0 0 0 1px;
+  }
+  .panel[data-mode="inline"] {
+    position: static; right: auto; bottom: auto;
+    width: 100%; height: 100%; border-radius: 0; border-width: 0;
+    box-shadow: none; display: block;
+  }
+  iframe { width: 100%; height: 100%; border: 0; display: block; }
+  .launcher {
+    position: fixed; right: 16px; bottom: 16px;
+    height: 48px; padding: 0 18px; border-radius: 24px;
+    border: 0; cursor: pointer;
+    background: #c2410c; color: #fff;
+    font: 500 14px/1 system-ui, sans-serif;
+    box-shadow: 0 6px 20px rgba(0,0,0,.35);
+  }
+  .launcher:hover { background: #9a3412; }
+  .launcher:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+`
+
+function resolveTarget(target: string | Element | undefined): Element {
+  if (!target) {
+    throw new Error(
+      "canopy: mode 'inline' needs a `target` element to fill. " +
+        "Use mode 'overlay' or 'docked' to have the widget position itself.",
+    )
+  }
+  const el = typeof target === 'string' ? document.querySelector(target) : target
+  if (!el) {
+    throw new Error(`canopy: no element matches target ${JSON.stringify(target)}`)
+  }
+  return el
+}
+
+export function createChrome(src: string, options: ChromeOptions): Chrome {
+  const inline = options.mode === 'inline'
+  const mount = inline ? resolveTarget(options.target) : document.body
+
+  const host = document.createElement('div')
+  host.setAttribute('data-canopy-widget', '')
+  if (!inline) host.style.zIndex = String(options.zIndex)
+  const root = host.attachShadow({ mode: 'open' })
+
+  const style = document.createElement('style')
+  style.textContent = STYLES
+  root.appendChild(style)
+
+  const panel = document.createElement('div')
+  panel.className = 'panel'
+  panel.dataset.mode = options.mode
+  panel.style.setProperty('--w', `${options.width}px`)
+  // Inline is always open: there is no launcher to open it with, and a host that
+  // asked for it in their own layout has already decided it should be visible.
+  panel.dataset.open = String(inline)
+
+  const iframe = document.createElement('iframe')
+  iframe.src = src
+  iframe.title = options.title
+  // A cross-origin frame needs these explicitly, and nothing more: scripts to
+  // run, same-origin so it can reach its own canopy APIs and storage, and forms
+  // for the composer. Deliberately NOT allow-top-navigation — a widget must not
+  // be able to navigate the page it is embedded in.
+  iframe.setAttribute('sandbox', 'allow-scripts allow-same-origin allow-forms allow-popups')
+  panel.appendChild(iframe)
+  root.appendChild(panel)
+
+  let launcher: HTMLButtonElement | null = null
+  if (!inline) {
+    launcher = document.createElement('button')
+    launcher.type = 'button'
+    launcher.className = 'launcher'
+    launcher.textContent = options.launcherLabel
+    launcher.setAttribute('aria-expanded', 'false')
+    launcher.addEventListener('click', () => api.toggle())
+    root.appendChild(launcher)
+  }
+
+  mount.appendChild(host)
+
+  const api: Chrome = {
+    iframe,
+    isOpen: () => panel.dataset.open === 'true',
+    open() {
+      if (api.isOpen()) return
+      panel.dataset.open = 'true'
+      launcher?.setAttribute('aria-expanded', 'true')
+      options.onToggle(true)
+    },
+    close() {
+      // Inline has no closed state — the host removed the launcher by choosing
+      // this mode, so closing would leave no way back.
+      if (inline || !api.isOpen()) return
+      panel.dataset.open = 'false'
+      launcher?.setAttribute('aria-expanded', 'false')
+      options.onToggle(false)
+    },
+    toggle() {
+      api.isOpen() ? api.close() : api.open()
+    },
+    setHeight(px: number) {
+      if (inline) return // the host owns layout here
+      panel.style.height = `${px}px`
+    },
+    destroy() {
+      host.remove()
+    },
+  }
+
+  return api
+}

--- a/frontend/packages/canopy-widget/src/dependency-free.test.ts
+++ b/frontend/packages/canopy-widget/src/dependency-free.test.ts
@@ -1,0 +1,59 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+/**
+ * The loader must stay dependency-free, for a stricter reason than the client.
+ *
+ * This code runs on SOMEBODY ELSE'S PAGE. Anything it imports is shipped into a
+ * host we do not control, where it can collide with whatever that page already
+ * loads — connect-labs alone carries React 18, alpine, htmx and a dozen Radix
+ * packages. The chat UI's React lives inside the iframe precisely so it cannot
+ * meet any of that; a dependency added here would undo the isolation the iframe
+ * exists to provide.
+ */
+
+const SRC = dirname(fileURLToPath(import.meta.url))
+
+function shippedFiles(): string[] {
+  return readdirSync(SRC).filter((f) => f.endsWith('.ts') && !f.endsWith('.test.ts'))
+}
+
+describe('the loader ships with no dependencies', () => {
+  it('declares none in package.json', () => {
+    const pkg = JSON.parse(readFileSync(join(SRC, '..', 'package.json'), 'utf8'))
+    expect(pkg.dependencies).toBeUndefined()
+    expect(pkg.peerDependencies).toBeUndefined()
+    expect(pkg.devDependencies).toBeUndefined()
+  })
+
+  it('imports nothing but its own modules', () => {
+    const bare = /from\s+['"]([^.'"][^'"]*)['"]/g
+    const offenders: string[] = []
+
+    for (const file of shippedFiles()) {
+      const source = readFileSync(join(SRC, file), 'utf8')
+      for (const [, spec] of source.matchAll(bare)) {
+        offenders.push(`${file} imports ${spec}`)
+      }
+    }
+
+    expect(offenders).toEqual([])
+  })
+
+  it('covers every shipped module, so a new file cannot slip past the check', () => {
+    expect(shippedFiles().sort()).toEqual(['chrome.ts', 'index.ts', 'protocol.ts'])
+  })
+
+  it('never posts to a wildcard target origin', () => {
+    // The token crosses this boundary. A '*' targetOrigin would hand it to
+    // whatever is in the frame if its src were ever redirected — so the literal
+    // must not appear in a postMessage call at all.
+    for (const file of shippedFiles()) {
+      const source = readFileSync(join(SRC, file), 'utf8')
+      expect(source).not.toMatch(/postMessage\([^)]*['"]\*['"]/)
+    }
+  })
+})

--- a/frontend/packages/canopy-widget/src/index.ts
+++ b/frontend/packages/canopy-widget/src/index.ts
@@ -1,0 +1,281 @@
+/**
+ * `@canopy/widget` — layer 3 of the embedded-agent SDK (v2 spec §1, §2, §3).
+ *
+ * One script tag, a launcher, and a canopy agent that can read the page it is
+ * on. Framework-free and dependency-free on the host side: the chat UI runs
+ * inside the iframe with its own bundled React, so the host's framework — or
+ * absence of one — is irrelevant. That is what makes this usable on
+ * connect-labs, which is React 18, Django templates, alpine and htmx.
+ *
+ * ## The credential path
+ *
+ * Issuance is unchanged from ace-web's integration: the HOST backend holds the
+ * `AppCredential` and exchanges it. That cannot move into a browser, so "one
+ * script tag" always means *plus one host endpoint*.
+ *
+ * What the origin boundary changes is DELIVERY. The token is never in the
+ * iframe URL — a `#token=` fragment lands in `document.location`, history and
+ * potentially a referrer. The host fetches it same-origin (cookie + CSRF,
+ * untouched) and posts it in with an explicit `targetOrigin`.
+ *
+ * And REFRESH becomes a round trip: the frame has no cookies and cannot mint,
+ * so it asks and the host answers.
+ *
+ * ## Origin discipline
+ *
+ * `targetOrigin` is the canopy origin derived from `baseUrl`, never `'*'`, on
+ * every message. Inbound, a message is dropped unless `event.origin` is that
+ * same origin AND `event.source` is our own iframe's window — origin alone
+ * would accept a message from any other frame that happens to share it.
+ * Messages are also filtered by KIND: the host issues `init`/`token`/…, so one
+ * of those arriving *at* the host is impersonation, not input.
+ *
+ * ## The honest limit
+ *
+ * Context and actions run in the user's own session, which is what makes the
+ * ACL story airtight — the agent can only see and do what this user could. It
+ * also means both need the page open. Close the tab and the agent cannot read
+ * or act; there is no server-side path. Action is scoped to the life of the
+ * visit.
+ */
+
+import { createChrome, type Chrome, type DisplayMode } from './chrome'
+import { SOURCE, isFrameMessage, originOf, type HostMessage } from './protocol'
+
+export type { DisplayMode } from './chrome'
+
+export interface CanopyWidgetOptions {
+  /** Where canopy lives, browser-facing. Absolute for a cross-origin canopy
+   *  (the usual embedded case), or a path prefix if same-origin. */
+  baseUrl: string
+  /** The registered `AppCredential` name — selects the framing policy canopy
+   *  serves. It cannot widen anything: the browser enforces the
+   *  `frame-ancestors` canopy returns for it. */
+  app: string
+  /** Host endpoint that mints a delegated token for the signed-in user.
+   *  Must return `{ token, expires_at }`. Called same-origin with credentials,
+   *  so the host's normal session auth applies. */
+  tokenUrl: string
+  mode?: DisplayMode
+  /** Required for `inline`. */
+  target?: string | Element
+  /** Preselect an agent, skipping the picker. Must be one the app is allowed
+   *  to offer AND the user can reach — canopy decides, not this. */
+  agent?: string
+  /** Opaque metadata stamped on sessions this widget creates. */
+  metadata?: Record<string, unknown>
+  launcherLabel?: string
+  title?: string
+  width?: number
+  zIndex?: number
+  /** Open immediately rather than waiting for the launcher. */
+  open?: boolean
+}
+
+export type ContextProvider = () => unknown | Promise<unknown>
+export type HostAction = (args: Record<string, unknown>) => unknown | Promise<unknown>
+
+export interface CanopyWidget {
+  open(): void
+  close(): void
+  toggle(): void
+  isOpen(): boolean
+  /** What the agent may read off this page. Pulled when a session opens, not
+   *  subscribed to — see `@canopy/client/bridge` for why. */
+  provideContext(provider: ContextProvider): void
+  /** Offer one named action. Re-registering a name replaces it, so a
+   *  re-rendering host can call this freely. */
+  registerAction(name: string, action: HostAction): void
+  unregisterAction(name: string): void
+  /** Remove the widget and stop listening. Idempotent. */
+  destroy(): void
+}
+
+interface TokenResponse {
+  token: string
+  expires_at?: string
+}
+
+export function init(options: CanopyWidgetOptions): CanopyWidget {
+  const mode = options.mode ?? 'overlay'
+  const pageOrigin =
+    typeof window !== 'undefined' ? window.location.origin : 'http://localhost'
+  const canopyOrigin = originOf(options.baseUrl, pageOrigin)
+
+  const base = options.baseUrl.replace(/\/$/, '')
+  const src = `${base}/embed/chat?app=${encodeURIComponent(options.app)}`
+
+  let provider: ContextProvider | null = null
+  const actions = new Map<string, HostAction>()
+  let destroyed = false
+
+  const chrome: Chrome = createChrome(src, {
+    mode,
+    target: options.target,
+    launcherLabel: options.launcherLabel ?? 'Ask Canopy',
+    title: options.title ?? 'Canopy assistant',
+    width: options.width ?? 400,
+    zIndex: options.zIndex ?? 2147483000,
+    onToggle: (open) => post({ source: SOURCE, type: 'visibility', open }),
+  })
+
+  function post(message: HostMessage): void {
+    // Explicit targetOrigin on every single message. '*' would broadcast the
+    // token to whatever happens to be in the frame if the src were ever
+    // redirected.
+    chrome.iframe.contentWindow?.postMessage(message, canopyOrigin)
+  }
+
+  async function mintToken(): Promise<string> {
+    const response = await fetch(options.tokenUrl, {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json', ...csrfHeader() },
+      body: '{}',
+    })
+    if (!response.ok) {
+      throw new Error(`token endpoint returned ${response.status}`)
+    }
+    const body = (await response.json()) as TokenResponse
+    if (!body?.token) throw new Error('token endpoint returned no token')
+    return body.token
+  }
+
+  /** Django's CSRF cookie, if the host uses one. Read rather than required, so
+   *  a host with a different scheme (or none, for a `@csrf_exempt` mint) is not
+   *  forced into ours. */
+  function csrfHeader(): Record<string, string> {
+    if (typeof document === 'undefined') return {}
+    const match = /(?:^|;\s*)csrftoken=([^;]+)/.exec(document.cookie)
+    return match ? { 'X-CSRFToken': decodeURIComponent(match[1]) } : {}
+  }
+
+  async function onMessage(event: MessageEvent): Promise<void> {
+    if (destroyed) return
+    // Both checks are required. Origin alone would accept a message from any
+    // other frame served from canopy's origin; source alone would accept one
+    // from our frame after a redirect elsewhere.
+    if (event.origin !== canopyOrigin) return
+    if (event.source !== chrome.iframe.contentWindow) return
+    if (!isFrameMessage(event.data)) return
+
+    const message = event.data
+    switch (message.type) {
+      case 'ready': {
+        try {
+          post({
+            source: SOURCE,
+            type: 'init',
+            token: await mintToken(),
+            agent: options.agent,
+            metadata: options.metadata,
+            actions: [...actions.keys()].sort(),
+          })
+        } catch (error) {
+          // The frame is up but unusable. Tell it so it can say so, rather than
+          // sit on a spinner the user cannot interpret.
+          post({
+            source: SOURCE,
+            type: 'token-error',
+            id: 'init',
+            message: error instanceof Error ? error.message : 'could not mint a token',
+          })
+        }
+        return
+      }
+      case 'token-request': {
+        try {
+          post({ source: SOURCE, type: 'token', id: message.id, token: await mintToken() })
+        } catch (error) {
+          post({
+            source: SOURCE,
+            type: 'token-error',
+            id: message.id,
+            message: error instanceof Error ? error.message : 'could not mint a token',
+          })
+        }
+        return
+      }
+      case 'context-request': {
+        // A host that lends no context is a legitimate host; `{}` rather than
+        // an error.
+        let context: Record<string, unknown> = {}
+        try {
+          context = ((await provider?.()) as Record<string, unknown>) ?? {}
+        } catch {
+          // A throwing provider must not take the conversation down with it.
+          context = {}
+        }
+        post({ source: SOURCE, type: 'context', id: message.id, context })
+        return
+      }
+      case 'action-request': {
+        const action = actions.get(message.name)
+        if (!action) {
+          // Never a silent no-op: to an agent that is indistinguishable from
+          // success, and it will carry on as though the page changed.
+          post({
+            source: SOURCE,
+            type: 'action-error',
+            id: message.id,
+            message: `no host action named ${JSON.stringify(message.name)} is registered`,
+          })
+          return
+        }
+        try {
+          const result = await action(message.args ?? {})
+          post({ source: SOURCE, type: 'action-result', id: message.id, result })
+        } catch (error) {
+          post({
+            source: SOURCE,
+            type: 'action-error',
+            id: message.id,
+            message: error instanceof Error ? error.message : 'the host refused the action',
+          })
+        }
+        return
+      }
+      case 'close': {
+        chrome.close()
+        return
+      }
+      case 'resize': {
+        chrome.setHeight(message.height)
+        return
+      }
+    }
+  }
+
+  const listener = (event: MessageEvent) => void onMessage(event)
+  window.addEventListener('message', listener)
+
+  if (options.open) chrome.open()
+
+  return {
+    open: () => chrome.open(),
+    close: () => chrome.close(),
+    toggle: () => chrome.toggle(),
+    isOpen: () => chrome.isOpen(),
+    provideContext(next) {
+      provider = next
+    },
+    registerAction(name, action) {
+      actions.set(name, action)
+      // Tell an already-open frame, so an action registered after mount becomes
+      // callable without reopening the panel.
+      post({ source: SOURCE, type: 'actions', actions: [...actions.keys()].sort() })
+    },
+    unregisterAction(name) {
+      actions.delete(name)
+      post({ source: SOURCE, type: 'actions', actions: [...actions.keys()].sort() })
+    },
+    destroy() {
+      if (destroyed) return
+      destroyed = true
+      window.removeEventListener('message', listener)
+      chrome.destroy()
+    },
+  }
+}
+
+export default { init }

--- a/frontend/packages/canopy-widget/src/protocol.ts
+++ b/frontend/packages/canopy-widget/src/protocol.ts
@@ -1,0 +1,78 @@
+/**
+ * The host ↔ frame message protocol.
+ *
+ * Shared by both ends so the two cannot disagree about a field name — the frame
+ * imports this same module. Every message is tagged `source: "canopy-widget"`
+ * because a page's `message` handler hears everything anyone posts to that
+ * window, including other widgets, extensions and ad frames; without a tag the
+ * host would try to interpret them.
+ *
+ * **Direction matters for security, not just clarity.** The host sends the
+ * token; the frame never sends one. So a `host→frame` message arriving *at the
+ * host* is either a bug or an attempt, and is dropped by kind rather than
+ * merely ignored by origin.
+ */
+
+export const SOURCE = 'canopy-widget' as const
+
+/** frame → host */
+export type FrameMessage =
+  /** "I exist" — the only message posted before origins are known, and the only
+   *  one that carries nothing. See the shell in apps/tokens/views_embed.py. */
+  | { source: typeof SOURCE; type: 'ready' }
+  /** The frame's token was rejected or is near expiry; mint another. */
+  | { source: typeof SOURCE; type: 'token-request'; id: string }
+  /** Read the host page's current state. */
+  | { source: typeof SOURCE; type: 'context-request'; id: string }
+  /** Run one of the host's registered actions. */
+  | {
+      source: typeof SOURCE
+      type: 'action-request'
+      id: string
+      name: string
+      args?: Record<string, unknown>
+    }
+  /** The frame wants the panel closed (the user hit its close button). */
+  | { source: typeof SOURCE; type: 'close' }
+  /** Desired panel height in `inline` mode, where the host owns layout. */
+  | { source: typeof SOURCE; type: 'resize'; height: number }
+
+/** host → frame */
+export type HostMessage =
+  | {
+      source: typeof SOURCE
+      type: 'init'
+      token: string
+      agent?: string
+      metadata?: Record<string, unknown>
+      actions: string[]
+    }
+  | { source: typeof SOURCE; type: 'token'; id: string; token: string }
+  | { source: typeof SOURCE; type: 'token-error'; id: string; message: string }
+  | { source: typeof SOURCE; type: 'context'; id: string; context: Record<string, unknown> }
+  | { source: typeof SOURCE; type: 'action-result'; id: string; result: unknown }
+  | { source: typeof SOURCE; type: 'action-error'; id: string; message: string }
+  /** The set of callable actions changed while the panel was open. */
+  | { source: typeof SOURCE; type: 'actions'; actions: string[] }
+  | { source: typeof SOURCE; type: 'visibility'; open: boolean }
+
+export function isFrameMessage(data: unknown): data is FrameMessage {
+  if (typeof data !== 'object' || data === null) return false
+  const m = data as Record<string, unknown>
+  if (m.source !== SOURCE || typeof m.type !== 'string') return false
+  // Only kinds the FRAME may send. A host-bound message ('init', 'token', …)
+  // arriving here is not something to interpret — the host is the only party
+  // that issues those, so seeing one means something is impersonating it.
+  return ['ready', 'token-request', 'context-request', 'action-request', 'close', 'resize'].includes(
+    m.type,
+  )
+}
+
+/** The origin half of a `baseUrl`, which is the only value we will postMessage
+ *  to or accept messages from.
+ *
+ *  A relative base (`/canopy`, the same-origin deployment) resolves against the
+ *  current page, which is correct: the frame really is same-origin then. */
+export function originOf(baseUrl: string, pageOrigin: string): string {
+  return new URL(baseUrl, pageOrigin).origin
+}

--- a/frontend/packages/canopy-widget/src/widget.test.ts
+++ b/frontend/packages/canopy-widget/src/widget.test.ts
@@ -1,0 +1,413 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { init } from './index'
+import { SOURCE, originOf } from './protocol'
+
+const CANOPY = 'https://canopy.example.com'
+const TOKEN_URL = '/labs/canopy/token'
+
+/**
+ * The frame is cross-origin in reality, so the tests drive it the way a real
+ * frame would: by dispatching `message` events with an origin and a source, and
+ * reading what the host posted back. The frame window is a stand-in (see
+ * below), which is what the host checks `event.source` against.
+ */
+function widgetHarness(overrides: Record<string, unknown> = {}) {
+  const posted: Array<{ message: Record<string, unknown>; targetOrigin: string }> = []
+
+  const widget = init({
+    baseUrl: CANOPY,
+    app: 'connect-labs',
+    tokenUrl: TOKEN_URL,
+    ...overrides,
+  } as Parameters<typeof init>[0])
+
+  const host = document.querySelector('[data-canopy-widget]') as HTMLElement
+  const root = host.shadowRoot!
+  const iframe = root.querySelector('iframe') as HTMLIFrameElement
+
+  // jsdom gives an iframe inside a shadow root no browsing context, so
+  // `contentWindow` is null and there is nothing real to post to. Stand in a
+  // fake frame window: it captures what the host sends, and — because the host
+  // checks `event.source` against exactly this object — it is also what lets
+  // the origin/source discipline be tested at all.
+  const frameWindow = {
+    postMessage: (message: Record<string, unknown>, targetOrigin: string) => {
+      posted.push({ message, targetOrigin })
+    },
+  }
+  Object.defineProperty(iframe, 'contentWindow', { value: frameWindow, configurable: true })
+
+  /** Speak as the frame. */
+  async function fromFrame(data: unknown, opts: { origin?: string; source?: unknown } = {}) {
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data,
+        origin: opts.origin ?? CANOPY,
+        source: (opts.source === undefined ? frameWindow : opts.source) as Window,
+      }),
+    )
+    // Let the host's async handler settle (it awaits fetch / the provider).
+    await new Promise((r) => setTimeout(r, 0))
+  }
+
+  const sent = (type: string) => posted.filter((p) => p.message.type === type)
+
+  return { widget, host, root, iframe, posted, sent, fromFrame }
+}
+
+beforeEach(() => {
+  document.body.innerHTML = ''
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ token: 'delegated-tok', expires_at: 'later' }),
+    })),
+  )
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('mounting and the three display modes', () => {
+  it('overlay adds a launcher and a closed panel, leaving host layout alone', () => {
+    const { root } = widgetHarness({ mode: 'overlay' })
+    expect(root.querySelector('.launcher')).not.toBeNull()
+    expect((root.querySelector('.panel') as HTMLElement).dataset.open).toBe('false')
+  })
+
+  it('docked positions a full-height rail', () => {
+    const { root } = widgetHarness({ mode: 'docked' })
+    expect((root.querySelector('.panel') as HTMLElement).dataset.mode).toBe('docked')
+    expect(root.querySelector('.launcher')).not.toBeNull()
+  })
+
+  it('inline fills a host element, with no launcher and already open', () => {
+    const slot = document.createElement('div')
+    slot.id = 'slot'
+    document.body.appendChild(slot)
+
+    const { root, host } = widgetHarness({ mode: 'inline', target: '#slot' })
+
+    expect(host.parentElement).toBe(slot)
+    expect(root.querySelector('.launcher')).toBeNull()
+    expect((root.querySelector('.panel') as HTMLElement).dataset.open).toBe('true')
+  })
+
+  it('inline refuses to guess when the host named no target', () => {
+    expect(() => widgetHarness({ mode: 'inline' })).toThrow(/needs a `target`/)
+  })
+
+  it('inline says which selector missed rather than mounting nowhere', () => {
+    expect(() => widgetHarness({ mode: 'inline', target: '#nope' })).toThrow(/#nope/)
+  })
+
+  it('puts its chrome in a shadow root so host CSS cannot deform it', () => {
+    const { host } = widgetHarness()
+    expect(host.shadowRoot).not.toBeNull()
+    // Nothing of ours in the host's own tree to be styled by the host.
+    expect(document.querySelector('.launcher')).toBeNull()
+  })
+
+  it('points the frame at the embed shell for this app', () => {
+    const { iframe } = widgetHarness()
+    expect(iframe.src).toBe(`${CANOPY}/embed/chat?app=connect-labs`)
+  })
+
+  it('sandboxes the frame without letting it navigate the host page', () => {
+    const { iframe } = widgetHarness()
+    const sandbox = iframe.getAttribute('sandbox') ?? ''
+    expect(sandbox).toContain('allow-scripts')
+    expect(sandbox).toContain('allow-same-origin')
+    expect(sandbox).not.toContain('allow-top-navigation')
+  })
+})
+
+describe('open/close', () => {
+  it('the launcher toggles the panel and tracks aria-expanded', () => {
+    const { root } = widgetHarness()
+    const launcher = root.querySelector('.launcher') as HTMLButtonElement
+    const panel = root.querySelector('.panel') as HTMLElement
+
+    launcher.click()
+    expect(panel.dataset.open).toBe('true')
+    expect(launcher.getAttribute('aria-expanded')).toBe('true')
+
+    launcher.click()
+    expect(panel.dataset.open).toBe('false')
+    expect(launcher.getAttribute('aria-expanded')).toBe('false')
+  })
+
+  it('inline cannot be closed — there would be no way back', () => {
+    const slot = document.createElement('div')
+    slot.id = 'slot'
+    document.body.appendChild(slot)
+    const { widget, root } = widgetHarness({ mode: 'inline', target: '#slot' })
+
+    widget.close()
+
+    expect((root.querySelector('.panel') as HTMLElement).dataset.open).toBe('true')
+  })
+
+  it('honours open:true so a host can start expanded', () => {
+    const { widget } = widgetHarness({ open: true })
+    expect(widget.isOpen()).toBe(true)
+  })
+
+  it('lets the frame ask to be closed', async () => {
+    const { widget, fromFrame } = widgetHarness({ open: true })
+    await fromFrame({ source: SOURCE, type: 'close' })
+    expect(widget.isOpen()).toBe(false)
+  })
+
+  it('lets the frame set its own height in overlay mode', async () => {
+    const { root, fromFrame } = widgetHarness()
+    await fromFrame({ source: SOURCE, type: 'resize', height: 300 })
+    expect((root.querySelector('.panel') as HTMLElement).style.height).toBe('300px')
+  })
+})
+
+describe('the credential path', () => {
+  it('mints on ready and posts the token to the canopy origin, never *', async () => {
+    const { fromFrame, sent } = widgetHarness()
+
+    await fromFrame({ source: SOURCE, type: 'ready' })
+
+    const [init_] = sent('init')
+    expect(init_.message.token).toBe('delegated-tok')
+    expect(init_.targetOrigin).toBe(CANOPY)
+    expect(init_.targetOrigin).not.toBe('*')
+  })
+
+  it('never puts the token in the iframe URL', async () => {
+    const { iframe, fromFrame } = widgetHarness()
+    await fromFrame({ source: SOURCE, type: 'ready' })
+    // A fragment or query token would land in document.location, history and
+    // potentially a referrer.
+    expect(iframe.src).not.toContain('delegated-tok')
+    expect(iframe.src).not.toContain('token')
+  })
+
+  it('calls the host token endpoint same-origin with credentials', async () => {
+    const { fromFrame } = widgetHarness()
+    await fromFrame({ source: SOURCE, type: 'ready' })
+
+    const [url, init_] = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0]
+    expect(url).toBe(TOKEN_URL)
+    expect(init_.credentials).toBe('same-origin')
+    expect(init_.method).toBe('POST')
+  })
+
+  it('sends the CSRF header when the host uses a csrftoken cookie', async () => {
+    document.cookie = 'csrftoken=abc123'
+    const { fromFrame } = widgetHarness()
+    await fromFrame({ source: SOURCE, type: 'ready' })
+
+    const [, init_] = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0]
+    expect(init_.headers['X-CSRFToken']).toBe('abc123')
+  })
+
+  it('answers a refresh request with a fresh mint, keyed by id', async () => {
+    const { fromFrame, sent } = widgetHarness()
+    await fromFrame({ source: SOURCE, type: 'token-request', id: 'r1' })
+
+    const [token] = sent('token')
+    expect(token.message).toMatchObject({ id: 'r1', token: 'delegated-tok' })
+  })
+
+  it('tells the frame when minting fails, instead of leaving it on a spinner', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 403, json: async () => ({}) })))
+    const { fromFrame, sent } = widgetHarness()
+
+    await fromFrame({ source: SOURCE, type: 'ready' })
+
+    expect(sent('init')).toHaveLength(0)
+    expect(sent('token-error')[0].message.message).toContain('403')
+  })
+
+  it('treats a 200 with no token as a failure', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, status: 200, json: async () => ({}) })))
+    const { fromFrame, sent } = widgetHarness()
+
+    await fromFrame({ source: SOURCE, type: 'ready' })
+
+    expect(sent('token-error')[0].message.message).toContain('no token')
+  })
+})
+
+describe('origin discipline', () => {
+  it('ignores a message from another origin', async () => {
+    const { fromFrame, sent } = widgetHarness()
+    await fromFrame({ source: SOURCE, type: 'ready' }, { origin: 'https://evil.example' })
+    expect(sent('init')).toHaveLength(0)
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('ignores a right-origin message from a different frame', async () => {
+    // Origin alone is not enough: any other frame served from canopy's origin
+    // would otherwise be able to ask the host to mint a token.
+    const { fromFrame, sent } = widgetHarness()
+    await fromFrame({ source: SOURCE, type: 'ready' }, { source: {} })
+    expect(sent('init')).toHaveLength(0)
+  })
+
+  it('ignores messages that are not ours', async () => {
+    const { fromFrame, sent } = widgetHarness()
+    await fromFrame({ type: 'ready' })
+    await fromFrame({ source: 'some-other-widget', type: 'ready' })
+    await fromFrame('a string')
+    await fromFrame(null)
+    expect(sent('init')).toHaveLength(0)
+  })
+
+  it('refuses to interpret a HOST-bound message arriving at the host', async () => {
+    // The host is the only party that issues `init`/`token`; one arriving here
+    // is impersonation, not input.
+    const { fromFrame, posted } = widgetHarness()
+    await fromFrame({ source: SOURCE, type: 'init', token: 'attacker', actions: [] })
+    await fromFrame({ source: SOURCE, type: 'token', id: 'x', token: 'attacker' })
+    expect(posted).toHaveLength(0)
+  })
+
+  it('derives the canopy origin from a relative base as the page origin', () => {
+    // The same-origin deployment: /canopy really is this page's origin.
+    expect(originOf('/canopy', 'https://labs.connect.dimagi.com')).toBe(
+      'https://labs.connect.dimagi.com',
+    )
+    expect(originOf('https://canopy.example.com/canopy', 'https://labs.x')).toBe(CANOPY)
+  })
+})
+
+describe('context', () => {
+  it('reads the page state at request time, not at registration', async () => {
+    const { widget, fromFrame, sent } = widgetHarness()
+    let step = 1
+    widget.provideContext(() => ({ step }))
+
+    await fromFrame({ source: SOURCE, type: 'context-request', id: 'c1' })
+    expect(sent('context')[0].message.context).toEqual({ step: 1 })
+
+    step = 2
+    await fromFrame({ source: SOURCE, type: 'context-request', id: 'c2' })
+    expect(sent('context')[1].message.context).toEqual({ step: 2 })
+  })
+
+  it('answers {} when the host lends no context', async () => {
+    const { fromFrame, sent } = widgetHarness()
+    await fromFrame({ source: SOURCE, type: 'context-request', id: 'c1' })
+    expect(sent('context')[0].message.context).toEqual({})
+  })
+
+  it('awaits an async provider', async () => {
+    const { widget, fromFrame, sent } = widgetHarness()
+    widget.provideContext(async () => ({ loaded: true }))
+    await fromFrame({ source: SOURCE, type: 'context-request', id: 'c1' })
+    expect(sent('context')[0].message.context).toEqual({ loaded: true })
+  })
+
+  it('a throwing provider does not take the conversation down', async () => {
+    const { widget, fromFrame, sent } = widgetHarness()
+    widget.provideContext(() => {
+      throw new Error('host bug')
+    })
+    await fromFrame({ source: SOURCE, type: 'context-request', id: 'c1' })
+    expect(sent('context')[0].message.context).toEqual({})
+  })
+})
+
+describe('actions', () => {
+  it('runs a registered action and returns its result', async () => {
+    const { widget, fromFrame, sent } = widgetHarness()
+    const onUpdateState = vi.fn().mockResolvedValue({ saved: true })
+    widget.registerAction('updateState', onUpdateState)
+
+    await fromFrame({
+      source: SOURCE,
+      type: 'action-request',
+      id: 'a1',
+      name: 'updateState',
+      args: { status: 'reviewed' },
+    })
+
+    expect(onUpdateState).toHaveBeenCalledWith({ status: 'reviewed' })
+    expect(sent('action-result')[0].message).toMatchObject({ id: 'a1', result: { saved: true } })
+  })
+
+  it('errors on an unknown action instead of silently doing nothing', async () => {
+    const { fromFrame, sent } = widgetHarness()
+    await fromFrame({ source: SOURCE, type: 'action-request', id: 'a1', name: 'nope' })
+    expect(sent('action-error')[0].message.message).toContain('nope')
+  })
+
+  it('reports a host refusal as an error the agent can read', async () => {
+    const { widget, fromFrame, sent } = widgetHarness()
+    widget.registerAction('act', () => {
+      throw new Error('not allowed on a completed run')
+    })
+    await fromFrame({ source: SOURCE, type: 'action-request', id: 'a1', name: 'act' })
+    expect(sent('action-error')[0].message.message).toBe('not allowed on a completed run')
+  })
+
+  it('declares the action list on init', async () => {
+    const { widget, fromFrame, sent } = widgetHarness()
+    widget.registerAction('b', vi.fn())
+    widget.registerAction('a', vi.fn())
+
+    await fromFrame({ source: SOURCE, type: 'ready' })
+
+    expect(sent('init')[0].message.actions).toEqual(['a', 'b'])
+  })
+
+  it('tells an open frame when the action set changes', async () => {
+    const { widget, sent } = widgetHarness()
+    widget.registerAction('a', vi.fn())
+    expect(sent('actions')[0].message.actions).toEqual(['a'])
+
+    widget.unregisterAction('a')
+    expect(sent('actions')[1].message.actions).toEqual([])
+  })
+
+  it('re-registering replaces the handler rather than stacking', async () => {
+    const { widget, fromFrame } = widgetHarness()
+    const stale = vi.fn()
+    const fresh = vi.fn()
+    widget.registerAction('act', stale)
+    widget.registerAction('act', fresh)
+
+    await fromFrame({ source: SOURCE, type: 'action-request', id: 'a1', name: 'act' })
+
+    expect(stale).not.toHaveBeenCalled()
+    expect(fresh).toHaveBeenCalledOnce()
+  })
+})
+
+describe('destroy', () => {
+  it('removes the chrome and stops listening', async () => {
+    const { widget, fromFrame, posted } = widgetHarness()
+    widget.destroy()
+
+    expect(document.querySelector('[data-canopy-widget]')).toBeNull()
+    await fromFrame({ source: SOURCE, type: 'ready' })
+    expect(posted).toHaveLength(0)
+  })
+
+  it('is idempotent', () => {
+    const { widget } = widgetHarness()
+    widget.destroy()
+    expect(() => widget.destroy()).not.toThrow()
+  })
+
+  it('two widgets on one page do not interfere', () => {
+    const a = widgetHarness()
+    const b = widgetHarness()
+    expect(document.querySelectorAll('[data-canopy-widget]')).toHaveLength(2)
+    a.widget.destroy()
+    expect(document.querySelectorAll('[data-canopy-widget]')).toHaveLength(1)
+    b.widget.destroy()
+  })
+})


### PR DESCRIPTION
Layer 3 of the SDK (spec §1–§3): the half that runs on **somebody else's page**.

## Dependency-free, for a stricter reason than `@canopy/client`

Anything imported here is shipped into a host we don't control, where it can collide with whatever that page already loads — connect-labs alone carries React 18, alpine, htmx and a dozen Radix packages. The chat UI's React lives inside the iframe *precisely* so it can't meet any of that; a dependency here would undo the isolation the iframe exists to provide. A guard test pins it.

## Three modes off one bundle

| Mode | Shape | Why |
|---|---|---|
| `overlay` | fixed bubble + floating panel | host layout untouched — works on a page nobody modified |
| `docked` | full-height right rail | the shape connect-labs' workflow runner already uses (`mr-96`) |
| `inline` | fills a host element, no launcher | the host owns layout |

An iframe can't paint outside its box, so launcher and panel are host DOM wrapping it — in a **shadow root**, because "drop this on any page" fails the moment a host's `button {}` or a global `* { box-sizing }` can reach in.

Inline is deliberately **not closable** (closing would leave no launcher to reopen it) and **refuses to guess a target** (mounting nowhere is worse than an error naming the selector that missed).

## The credential path is the point

Issuance is unchanged — the host backend holds the `AppCredential` — so "one script tag" always means *plus one host endpoint*. What the origin boundary changes is **delivery** and **refresh**: the token is posted in, never put in the iframe URL (a `#token=` fragment lands in `document.location`, history and potentially a referrer), and since the frame has no cookies and can't mint, refresh is a round trip it asks for.

## Origin discipline, three layers deep

- **Every** outbound message carries the canopy origin as `targetOrigin`. Never `'*'` — that would hand the token to whatever is in the frame if its `src` were ever redirected. A test greps the source for the literal, because the review that catches this needs to be automatic.
- Inbound requires **both** `event.origin === canopyOrigin` **and** `event.source === ` our own frame's window. Origin alone accepts any other frame sharing that origin; source alone accepts ours after a redirect elsewhere.
- Messages are filtered by **kind**. The host is the only party that issues `init`/`token`/`context`/`action-result`, so one arriving *at* the host is impersonation, not input — dropped rather than interpreted.

## Failures are reported, never swallowed

A mint that 403s (or returns 200 with no token) sends `token-error` so the frame can say so rather than sit on a spinner. An unknown or refused action sends `action-error`, **never a silent no-op** — to an agent those are indistinguishable from success and it carries on as though the page changed. A throwing context provider yields `{}` instead of taking the conversation down.

The frame is sandboxed `allow-scripts allow-same-origin allow-forms allow-popups` and deliberately **not** `allow-top-navigation`: a widget must not be able to navigate the page it's embedded in.

## Not yet a literal script tag

The IIFE build and the in-frame chat app land **together** in the next change, because a servable `widget.js` today would load a shell that renders "Starting…" forever. `FRONTEND_DIST_DIR` is where that bundle will go.

## Verification

- **42** package tests (38 behavioural + 4 guards) in jsdom, driving the frame the way a real one would — dispatching `message` events with an origin and a source, reading what the host posted back
- 222 tests across `frontend/packages`
- `npm run build` green (`tsc -b && vite build`)

One test-harness note: jsdom gives an iframe inside a shadow root no browsing context, so `contentWindow` is null. The tests stand in a fake frame window — which is also what makes the `event.source` check testable at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)