### PR TITLE
Keep maintainer rationale out of the public OpenAPI description (follow-up to #756)

### DIFF
--- a/apps/agents/api.py
+++ b/apps/agents/api.py
@@ -861,14 +861,14 @@ def post_bootstrap_report(request: HttpRequest, slug: str,
     this agent routes to may report for it. A readiness signal anyone could
     write is a readiness signal nobody can trust — and this one is meant to be
     trusted over the control plane's own record of what it stored.
-
-    Deliberately NOT `_agent_for_write` on top of that. `caller_runs_agent` is
-    strictly tighter than any role check, so a role gate here adds no security
-    — but it does add a way for readiness reporting to start 403-ing: a runner
-    whose pairing human happens to hold `viewer` would go silent, and a machine
-    saying "I could not materialize this" is exactly the signal you least want
-    to lose. Reporting what a box observed is not reshaping the agent.
     """
+    # Membership + `caller_runs_agent`, and deliberately NOT `_agent_for_write`
+    # on top: `caller_runs_agent` is strictly tighter than any role check, so a
+    # role gate adds no security here — but it does add a way for readiness
+    # reporting to start 403-ing, when a runner's pairing human happens to hold
+    # `viewer`. A machine saying "I could not materialize this" is the last
+    # signal to lose, and reporting what a box observed is not reshaping the
+    # agent.
     agent = _get_agent_or_404(request, slug)
     if not services.caller_runs_agent(request.user, agent):
         raise HttpError(403, "no live runner you pair is assigned to this agent")

--- a/apps/shareouts/api.py
+++ b/apps/shareouts/api.py
@@ -68,11 +68,14 @@ def create_shareouts(
     """Create a batch of briefings. Re-posting the same period from the same
     source replaces the prior rows (see services.upsert_shareouts).
 
-    Rows are assigned to a workspace the caller is ALREADY in — the /w{ws}
-    prefix pins it, else the org default when they are a member of it, else
-    their sole membership (`wsvc.creation_workspace`). This used to call
-    `ensure_member`, which made posting a shareout a way to BECOME an editor of
-    the org default; see that helper's docstring."""
+    Rows are assigned to a workspace you already belong to: the `/w/{ws}` prefix
+    pins it, otherwise it resolves to your default. 422 if you belong to none.
+    """
+    # Resolution is `wsvc.creation_workspace`, which only ever returns a tenant
+    # the caller is already in. This used to be `pinned or
+    # ensure_default_workspace()` followed by `ensure_member(ws, request.user)`
+    # — which on the flat mount made posting a shareout a way to BECOME an
+    # editor of the org default. See that helper's docstring for the full shape.
     ws = wsvc.creation_workspace(request)
     if ws is None:
         raise ProblemError(

--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -1234,9 +1234,8 @@ export interface paths {
          * @description Create a batch of briefings. Re-posting the same period from the same
          *     source replaces the prior rows (see services.upsert_shareouts).
          *
-         *     Rows are assigned to the request's workspace (the /w/{ws} prefix, or the org
-         *     default when unspecified) and the creator is kept a member so their own
-         *     listing keeps showing what they just posted.
+         *     Rows are assigned to a workspace you already belong to: the `/w/{ws}` prefix
+         *     pins it, otherwise it resolves to your default. 422 if you belong to none.
          */
         readonly post: operations["apps_shareouts_api_create_shareouts"];
         readonly delete?: never;

--- a/tests/test_no_implicit_enrolment.py
+++ b/tests/test_no_implicit_enrolment.py
@@ -232,8 +232,8 @@ def test_ensure_member_is_no_longer_called_from_any_create_path():
     three places — the deliberate ways into a workspace — and this fails on a
     new caller rather than waiting for the next audit to find it.
     """
+    import ast
     import pathlib
-    import re
 
     root = pathlib.Path(__file__).resolve().parent.parent
     allowed = {
@@ -255,8 +255,19 @@ def test_ensure_member_is_no_longer_called_from_any_create_path():
         rel = str(path.relative_to(root))
         if rel in allowed or "/migrations/" in rel or "/tests/" in rel:
             continue
-        if re.search(r"\bensure_member\s*\(", path.read_text()):
-            offenders.append(rel)
+        # Parsed, not grepped. A regex over source text also matches the word
+        # inside a comment or docstring — and the comments explaining why this
+        # rule exists necessarily quote the call they are about, so a text
+        # search fails on the very files that document the fix. Only a real
+        # Call node counts.
+        tree = ast.parse(path.read_text(), filename=rel)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            fn = node.func
+            name = fn.attr if isinstance(fn, ast.Attribute) else getattr(fn, "id", None)
+            if name == "ensure_member":
+                offenders.append(f"{rel}:{node.lineno}")
     assert not offenders, (
         f"{offenders} call ensure_member outside the deliberate join paths — "
         "creating a row must not be a way to join a workspace. Use "


### PR DESCRIPTION
Follow-up to #756, which merged with `frontend/src/api/generated.ts` stale — the
`regen-openapi` check failed but is **not required**, so the merge queue took the PR anyway.
That is the failure mode CLAUDE.md already documents (observed 2026-08-01, #575 → fixed by
#576); this is the same shape again.

## The actual problem the stale check surfaced

A route's docstring **is** its OpenAPI `description`, so two comments #756 added were about
to be published to every API consumer:

- `POST /api/shareouts/` — "this used to call `ensure_member`, which made posting a shareout
  a way to BECOME an editor of the org default"
- `POST /api/agents/{slug}/bootstrap-report` — "deliberately NOT `_agent_for_write` …
  `caller_runs_agent` is strictly tighter"

Both are maintainer reasoning about internal helpers. A consumer of the shareouts endpoint
needs to know which workspace their rows land in and that a 422 is possible; they do not need
the history of the gate, and naming `ensure_member` in a public schema describes internals
that are free to change.

Both move to `#` comments directly above the code, which is where whoever edits the function
next will actually read them. The shareouts description now states the contract; the
bootstrap-report description keeps only the trust boundary, which a caller genuinely does need.
`generated.ts` regenerated — the one schema-visible change left is consumer-facing.

Same class of mistake as publishing a false route-ordering invariant into the schema earlier
in this work: a docstring is the wrong place for a note to a maintainer.

## Also: the structural test tripped its own rule

`test_ensure_member_is_no_longer_called_from_any_create_path` grepped source text for
`ensure_member(`, which also matches the word inside a comment — and the comments explaining
why the rule exists necessarily quote the call they are about. So it failed on exactly the
file it was protecting. It now parses and counts only a real `ast.Call`, and reports
`file:line`. Verified it still fails on a genuine reintroduction (re-added the call to
`apps/shareouts/api.py` and it named `apps/shareouts/api.py:80`).

## Test plan

- `uv run pytest` — 2592 passed, 1 skipped.
- Schema dumped and `npm run gen:api:local` run: working tree clean, so `generated.ts` is
  genuinely fresh rather than merely regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
